### PR TITLE
Add assistant payroll and maintenance costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 Online Hustle Simulator is a browser-based incremental game about orchestrating your side-hustle empire one in-world day at a time. Each morning you receive a fresh stack of hours, decide how to divide them between quick gigs, study tracks, and asset upkeep, then close the day to trigger payouts. The loop rewards planning, lighthearted experimentation, and a healthy obsession with passive income spreadsheets.
 
 ## Gameplay Loop & Systems
-- **Daily Time Budget** – Every in-game day begins with 14 base hours (plus permanent bonuses). Hustles, knowledge study, asset setup, and upkeep all consume this pool. Assistants add +2 hours permanently; turbo coffee grants up to three one-hour boosts per day.
-- **Setup & Maintenance Allocation** – When a day ends, each asset checks whether you funded the required setup/maintenance hours. Funded instances progress (or earn income); unfunded ones pause. The next morning, the scheduler automatically earmarks required hours until you run out.
+- **Daily Time Budget** – Every in-game day begins with 14 base hours (plus permanent bonuses). Hustles, knowledge study, asset setup, and upkeep all consume this pool. Assistants can be hired (up to four) for +2 hours each, but payroll hits every morning; you can always fire them if cash or time dips too low. Turbo coffee grants up to three one-hour boosts per day.
+- **Setup & Maintenance Allocation** – When a day ends, each asset checks whether you funded the required setup/maintenance hours **and** any daily cash cost. Funded instances progress (or earn income); unfunded ones pause. The next morning, the scheduler automatically earmarks required hours until you run out.
 - **Knowledge Tracks** – Study hustles (e.g., Outline Mastery, E-Commerce Playbook) require a fixed number of days at specific hour costs. Completing them unlocks advanced assets and generates celebratory log entries; skipping a day after you start produces gentle warnings.
 - **Daily Recap Log** – Every launch, maintenance result, payout, and study milestone is written to the log so you can reconstruct exactly what happened during busy streaks.
 
@@ -19,15 +19,15 @@ Online Hustle Simulator is a browser-based incremental game about orchestrating 
 
 ### Passive Assets (Daily Payouts)
 Each asset supports multiple instances, tracks setup progress, and rolls a daily income range once active.
-- **Personal Blog Network** – Setup 1 day × 3h ($25). Requires 1h/day maintenance. Base daily income ~$70 with ±25% variance; Automation Course boosts payouts by 50%.
-- **Weekly Vlog Channel** – Setup 3 days × 4h ($180) with Camera upgrade. Maintenance 1.5h/day. Base daily income ~$140 with ±35% variance.
+- **Personal Blog Network** – Setup 1 day × 3h ($25). Requires 1h/day + $2 maintenance. Base daily income ~$70 with ±25% variance; Automation Course boosts payouts by 50%.
+- **Weekly Vlog Channel** – Setup 3 days × 4h ($180) with Camera upgrade. Maintenance 1.5h/day + $5. Base daily income ~$140 with ±35% variance.
 - **Digital E-Book Series** – Setup 4 days × 3h ($60) after completing Outline Mastery. Maintenance 0.5h/day. Base daily income ~$120 with ±30% variance.
 - **Stock Photo Gallery** – Setup 3 days × 2h (no cost) with Camera + Lighting Kit and Photo Catalog knowledge. Maintenance 1h/day. Base daily income ~$95 with ±45% variance.
 - **Dropshipping Storefront** – Setup 3 days × 4h ($500) after E-Commerce Playbook and two active blogs. Maintenance 2h/day. Base daily income ~$260 with ±50% variance.
 - **SaaS Micro-App** – Setup 7 days × 5h ($1500) after Automation Architecture plus experience running a dropshipping store and e-book line. Maintenance 3h/day. Base daily income ~$620 with ±60% variance.
 
 ### Upgrades & Boosts
-- **Hire Virtual Assistant** – $180 for a permanent +2h to the daily cap.
+- **Hire Virtual Assistant** – $180 per hire, up to four assistants. Each adds +2h daily but costs $30/day in payroll; fire assistants anytime to cut wages (and hours).
 - **Turbo Coffee** – $40 per cup, up to three per day, each adding +1h for the current day.
 - **Buy Camera** – $200, unlocks Vlog Channels and Stock Photo Galleries.
 - **Lighting Kit** – $220, unlocks Stock Photo Galleries after you buy the camera.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,3 +6,5 @@
 - Introduced knowledge study tracks with daily commitments that gate advanced assets alongside equipment and experience requirements.
 - Refreshed UI copy, card details, and styling to surface asset counts, income bands, and requirement progress.
 - Reworked upgrades (camera, lighting kit, automation course) to align with the new asset ecosystem.
+- Expanded the virtual assistant upgrade into a four-person team with daily payroll, hire/fire controls, and log messaging.
+- Added cash-based maintenance costs for blogs ($2/day) and vlogs ($5/day) that block payouts when funds are unavailable.

--- a/docs/features/assistant-squad.md
+++ b/docs/features/assistant-squad.md
@@ -1,0 +1,17 @@
+# Assistant Staffing System
+
+## Goals
+- Expand the upgrade loop into a light workforce management layer that trades cash for daily time.
+- Reinforce ongoing money sinks so late-game stockpiles remain meaningful.
+- Introduce reversible decisions (firing assistants) with immediate scheduling consequences.
+
+## Player Impact
+- Players can hire up to four virtual assistants; each adds +2h to the daily schedule but introduces $30/day in payroll.
+- Assistants are paid before the daily maintenance allocator runs, reducing the cash available for asset upkeep.
+- Firing an assistant instantly removes their bonus hours, which can push the player into negative time and cause end-of-day auto wrap-ups if nothing remains.
+
+## Key Systems & Tuning
+- **Hiring Cost** – $180 upfront per assistant. Hiring is blocked if the player cannot afford the fee or already has four assistants.
+- **Payroll** – $15/hour, with each assistant covering 2h daily. Payroll is charged at the dawn of each day. If funds are insufficient the balance drops to zero and a warning log fires.
+- **Time Budget Changes** – Bonus time is tracked in `state.bonusTime`. Firing subtracts the 2h contribution immediately, potentially driving `timeLeft` below zero. Negative time prevents additional maintenance from funding.
+- **UI Feedback** – Upgrade card shows team size, per-assistant payroll, and total daily payroll. A secondary button enables firing assistants at any time.

--- a/docs/features/day-driven-assets.md
+++ b/docs/features/day-driven-assets.md
@@ -11,7 +11,7 @@
 - New knowledge hustles provide deterministic paths to unlock late-game assets without random drops or grindy loops.
 
 ## Key Systems & Tuning
-- **Asset Scheduling** – Each asset definition includes `setup.days`, `setup.hoursPerDay`, and `maintenance.hours`. Setup time is auto-reserved at day start when hours are available; otherwise progress pauses.
+- **Asset Scheduling** – Each asset definition includes `setup.days`, `setup.hoursPerDay`, and `maintenance` requirements (hours plus optional cash cost). Setup time is auto-reserved at day start when hours are available; upkeep only proceeds when you have both time and the required maintenance budget.
 - **Daily Income Curves** – Assets roll payouts using `income.base` with a per-asset variance. Example ranges:
   - Blog: base 70, ±25% variance (modifier: +50% with Automation Course).
   - Vlog: base 140, ±35% variance.

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
       <article class="summary-card" id="summary-cost-card">
         <h3>Daily Costs</h3>
         <p id="summary-cost" class="summary-value">$0/day</p>
-        <span id="summary-cost-detail" class="summary-detail">Maintenance $0</span>
+        <span id="summary-cost-detail" class="summary-detail">Maintenance &amp; payroll $0</span>
       </article>
       <article class="summary-card" id="summary-study-card">
         <h3>Study Momentum</h3>

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -129,6 +129,19 @@ export function ensureStateShape(target = state) {
     const defaults = structuredClone(def.defaultState || {});
     const existing = target.upgrades[def.id];
     target.upgrades[def.id] = existing ? { ...defaults, ...existing } : defaults;
+    if (def.id === 'assistant') {
+      const assistantState = target.upgrades[def.id];
+      const storedCount = Number(assistantState.count);
+      if (!Number.isFinite(storedCount)) {
+        assistantState.count = assistantState.purchased ? 1 : 0;
+      } else {
+        assistantState.count = Math.max(0, storedCount);
+      }
+      if (assistantState.purchased && assistantState.count === 0) {
+        assistantState.count = 1;
+      }
+      delete assistantState.purchased;
+    }
   }
 
   target.progress = target.progress || {};

--- a/src/core/storage.js
+++ b/src/core/storage.js
@@ -122,7 +122,8 @@ function migrateLegacyState(saved, defaultState) {
   }
 
   if (saved.assistantHired) {
-    getUpgradeState('assistant', migrated).purchased = true;
+    const assistant = getUpgradeState('assistant', migrated);
+    assistant.count = Math.max(1, Number(assistant.count) || 0);
   }
 
   getUpgradeState('coffee', migrated).usedToday = saved.coffeesToday || 0;

--- a/src/game/assistant.js
+++ b/src/game/assistant.js
@@ -1,0 +1,102 @@
+import { formatMoney } from '../core/helpers.js';
+import { addLog } from '../core/log.js';
+import { getState, getUpgradeState } from '../core/state.js';
+import { spendMoney } from './currency.js';
+import { gainTime } from './time.js';
+
+export const ASSISTANT_CONFIG = {
+  hiringCost: 180,
+  hourlyRate: 15,
+  hoursPerAssistant: 2,
+  maxAssistants: 4
+};
+
+function getAssistantState(target = getState()) {
+  return getUpgradeState('assistant', target);
+}
+
+export function getAssistantCount(target = getState()) {
+  const state = getAssistantState(target);
+  const count = Number(state.count) || 0;
+  return Math.max(0, Math.min(ASSISTANT_CONFIG.maxAssistants, count));
+}
+
+export function getAssistantDailyCost(target = getState()) {
+  return (
+    getAssistantCount(target) *
+    ASSISTANT_CONFIG.hoursPerAssistant *
+    ASSISTANT_CONFIG.hourlyRate
+  );
+}
+
+export function canHireAssistant(target = getState()) {
+  const state = target || getState();
+  if (!state) return false;
+  if (getAssistantCount(state) >= ASSISTANT_CONFIG.maxAssistants) return false;
+  return state.money >= ASSISTANT_CONFIG.hiringCost;
+}
+
+export function hireAssistant() {
+  const state = getState();
+  if (!state) return false;
+  const upgrade = getAssistantState(state);
+  const currentCount = getAssistantCount(state);
+  if (currentCount >= ASSISTANT_CONFIG.maxAssistants) return false;
+  if (state.money < ASSISTANT_CONFIG.hiringCost) {
+    addLog('You need more cash before onboarding another assistant.', 'warning');
+    return false;
+  }
+
+  spendMoney(ASSISTANT_CONFIG.hiringCost);
+  upgrade.count = currentCount + 1;
+  state.bonusTime += ASSISTANT_CONFIG.hoursPerAssistant;
+  gainTime(ASSISTANT_CONFIG.hoursPerAssistant);
+  addLog(
+    `You hired a virtual assistant! They add +${ASSISTANT_CONFIG.hoursPerAssistant}h and expect $${ASSISTANT_CONFIG.hourlyRate}/hr.`,
+    'upgrade'
+  );
+  return true;
+}
+
+export function canFireAssistant(target = getState()) {
+  return getAssistantCount(target) > 0;
+}
+
+export function fireAssistant() {
+  const state = getState();
+  if (!state) return false;
+  const upgrade = getAssistantState(state);
+  const currentCount = getAssistantCount(state);
+  if (currentCount <= 0) return false;
+
+  upgrade.count = currentCount - 1;
+  state.bonusTime = Math.max(0, state.bonusTime - ASSISTANT_CONFIG.hoursPerAssistant);
+  state.timeLeft -= ASSISTANT_CONFIG.hoursPerAssistant;
+  addLog(
+    `You let an assistant go. Daily support drops by ${ASSISTANT_CONFIG.hoursPerAssistant}h, but payroll eases a bit.`,
+    'info'
+  );
+  return true;
+}
+
+export function processAssistantPayroll() {
+  const state = getState();
+  if (!state) return;
+  const count = getAssistantCount(state);
+  if (count <= 0) return;
+
+  const totalCost = getAssistantDailyCost(state);
+  if (totalCost <= 0) return;
+
+  const hadFunds = state.money >= totalCost;
+  spendMoney(totalCost);
+  const formatted = formatMoney(totalCost);
+  if (hadFunds) {
+    addLog(`Assistant payroll cleared at $${formatted} for ${count} teammate${count === 1 ? '' : 's'}.`, 'info');
+  } else {
+    addLog(
+      `Assistant payroll of $${formatted} came due, but your balance ran dry. They still handled tasks—just no savings left.`,
+      'warning'
+    );
+  }
+}

--- a/src/game/lifecycle.js
+++ b/src/game/lifecycle.js
@@ -2,6 +2,7 @@ import { addLog } from '../core/log.js';
 import { getState, getUpgradeState } from '../core/state.js';
 import { saveState } from '../core/storage.js';
 import { allocateAssetMaintenance, closeOutDay } from './assets.js';
+import { processAssistantPayroll } from './assistant.js';
 import { getTimeCap } from './time.js';
 import { updateUI } from '../ui/update.js';
 import { advanceKnowledgeTracks } from './requirements.js';
@@ -20,6 +21,7 @@ export function endDay(auto = false) {
   state.dailyBonusTime = 0;
   getUpgradeState('coffee').usedToday = 0;
   state.timeLeft = getTimeCap();
+  processAssistantPayroll();
   allocateAssetMaintenance();
   updateUI();
   saveState();

--- a/src/game/summary.js
+++ b/src/game/summary.js
@@ -1,6 +1,7 @@
 import { getState, getAssetState } from '../core/state.js';
 import { formatHours } from '../core/helpers.js';
 import { ASSETS, getDailyIncomeRange } from './assets.js';
+import { getAssistantDailyCost } from './assistant.js';
 import { KNOWLEDGE_TRACKS, getKnowledgeProgress } from './requirements.js';
 
 export function computeDailySummary(state = getState()) {
@@ -62,6 +63,8 @@ export function computeDailySummary(state = getState()) {
       knowledgePendingToday += 1;
     }
   }
+
+  maintenanceCost += getAssistantDailyCost(state);
 
   return {
     setupHours,

--- a/src/game/time.js
+++ b/src/game/time.js
@@ -9,7 +9,7 @@ export function getTimeCap() {
 export function spendTime(hours) {
   const state = getState();
   if (!state) return;
-  state.timeLeft = Math.max(0, state.timeLeft - hours);
+  state.timeLeft -= hours;
 }
 
 export function gainTime(hours) {

--- a/src/ui/dashboard.js
+++ b/src/ui/dashboard.js
@@ -44,7 +44,9 @@ export function renderSummary(summary) {
   safeText(elements.summaryCost, `$${formatMoney(maintenanceCost)} / day`);
   safeText(
     elements.summaryCostDetail,
-    maintenanceCost ? 'Maintenance costs to keep everything humming' : 'No upkeep costs today'
+    maintenanceCost
+      ? 'Maintenance and staffing costs to keep everything humming'
+      : 'No upkeep or payroll costs today'
   );
 
   const studyLabel = knowledgeInProgress === 1 ? 'track' : 'tracks';

--- a/styles.css
+++ b/styles.css
@@ -312,6 +312,16 @@ main {
   cursor: not-allowed;
 }
 
+.inline-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.inline-actions button {
+  flex: 1 1 0;
+}
+
 .primary:not(:disabled):hover,
 .primary:not(:disabled):focus-visible,
 .secondary:not(:disabled):hover,

--- a/tests/helpers/gameTestHarness.js
+++ b/tests/helpers/gameTestHarness.js
@@ -15,6 +15,7 @@ export async function getGameTestHarness() {
   const lifecycleModule = await import('../../src/game/lifecycle.js');
   const timeModule = await import('../../src/game/time.js');
   const currencyModule = await import('../../src/game/currency.js');
+  const assistantModule = await import('../../src/game/assistant.js');
   const actionsModule = await import('../../src/game/actions.js');
   const logModule = await import('../../src/core/log.js');
   const storageModule = await import('../../src/core/storage.js');
@@ -58,6 +59,7 @@ export async function getGameTestHarness() {
     lifecycleModule,
     timeModule,
     currencyModule,
+    assistantModule,
     actionsModule,
     logModule,
     storageModule,

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -69,7 +69,7 @@ test('legacy saves migrate to new asset structure', () => {
   assert.equal(result.returning, true);
   assert.equal(state.money, 500);
   assert.equal(getAssetState('blog').instances.length, 2);
-  assert.ok(getUpgradeState('assistant').purchased);
+  assert.equal(getUpgradeState('assistant').count, 1);
   assert.equal(getUpgradeState('coffee').usedToday, 2);
   assert.ok(state.log.some(entry => entry.message === 'Legacy entry'));
 });


### PR DESCRIPTION
## Summary
- add a dedicated assistant module with hire/fire logic, daily payroll, and UI updates for the upgrade card
- require blogs and vlogs to spend cash during maintenance and adjust logs/summary messaging for the new upkeep costs
- refresh docs, README, and tests to document the staffing system and new maintenance rules

## Testing
- npm test
- python -m http.server 8000 (manual Playwright check of index.html)


------
https://chatgpt.com/codex/tasks/task_e_68d967a98420832c80662031acd15a77