### PR TITLE
feat: overhaul dashboard layout and filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ Online Hustle Simulator is a browser-based incremental game about orchestrating 
 - **Knowledge Tracks** – Study hustles (e.g., Outline Mastery, E-Commerce Playbook) require a fixed number of days at specific hour costs. Completing them unlocks advanced assets and generates celebratory log entries; skipping a day after you start produces gentle warnings.
 - **Daily Recap Log** – Every launch, maintenance result, payout, and study milestone is written to the log so you can reconstruct exactly what happened during busy streaks.
 
+### Interface Overview
+- **Top Bar & Snapshot** – Money, time, and day stay pinned at the top. A collapsible Daily Snapshot panel lets you peek at per-stat breakdowns (time reserved, projected payouts, daily costs, study momentum) without overwhelming the main view.
+- **Tabbed Workspace** – Hustles, Education, Passive Assets, and Upgrades each live in their own tab with dedicated copy and per-tab filters. Global toggles hide locked or completed cards, and you can spotlight only actionable options.
+- **Categorised Collections** – Passive assets surface in Foundation, Creative, Commerce, and Advanced groupings with a collapsed-card option for rapid scanning. Upgrades split into Equipment, Automation, Consumables, and a catch-all bucket with a quick search bar.
+- **Event Log Controls** – The log dock keeps its running commentary but now includes a summary/detailed toggle when you want a lighter feed during long sessions.
+
 ### Hustles & Study Tracks
 - **Freelance Writing** – Spend 2h to earn $18 instantly.
 - **eBay Flips** – Spend 4h and $20; complete 30 seconds later for $48 (multiple flips queue).
@@ -42,7 +48,7 @@ Each asset supports multiple instances, tracks setup progress, and rolls a daily
 - Six passive asset types with multi-instance tracking, setup states, maintenance funding, and dynamic daily income rolls.
 - Knowledge study hustles that gate advanced assets and remember streak progress across days.
 - Equipment and experience requirements surfaced directly on asset cards with live progress indicators.
-- Responsive card grid with upbeat copy, income ranges, latest yield summaries, and lock styling for unmet requirements.
+- Responsive card grids with upbeat copy, tabbed navigation, filters, and search so players can focus on the work-in-progress that matters most.
 - Persistent save/load, offline hustle resolution, and flavourful log output to keep players oriented.
 
 ## Running the Project Locally

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Major UI redesign with a collapsible daily snapshot, tabbed workspace, asset categories, filter toggles, and upgrade search for smoother planning.
 - Shifted passive asset income to a day-driven scheduler with multi-day setup tracking and maintenance allocation.
 - Added expanded asset catalog (Blogs, Vlog Channels, E-Book Series, Stock Photo Galleries, Dropshipping Storefronts, SaaS Micro-App) with per-instance state and dynamic income ranges.
 - Introduced knowledge study tracks with daily commitments that gate advanced assets alongside equipment and experience requirements.

--- a/docs/features/ui-redesign.md
+++ b/docs/features/ui-redesign.md
@@ -1,0 +1,23 @@
+# UI Redesign Notes
+
+## Overview
+The workspace layout now mirrors the design brief: a clean dashboard that keeps vital stats visible while letting players dive into detail on demand. Navigation consolidates the core activities—daily hustles, education, passive assets, and upgrades—into a tabbed experience with contextual filters.
+
+## Goals
+- Surface daily pacing information without overwhelming the player.
+- Separate instant hustles from longer-term study commitments.
+- Reduce passive asset clutter via categories and collapsed cards.
+- Provide global toggles so locked/completed content can stay out of the way.
+- Support growth of the upgrade catalog with grouping and search.
+
+## Key Elements
+- **Daily Snapshot Panel** – Collapsible wrapper with per-stat breakdown lists (time reserved, projected payouts, daily costs, study momentum).
+- **Tabbed Workspace** – Sidebar/top navigation that swaps between Hustles, Education, Passive Assets, and Upgrades while preserving the top bar and stats.
+- **Filter Toolbars** – Global controls for hide locked/completed/show active, plus per-tab filters (available hustles, active study tracks, collapsed asset view, upgrade search).
+- **Categorised Grids** – Passive assets appear under Foundation, Creative, Commerce, or Advanced headers; upgrades live inside Equipment, Automation, Consumables, and Other buckets.
+- **Event Log Toggle** – Summary/detailed switch keeps the recap readable during long play sessions.
+
+## Future Considerations
+- Add persistent user preferences for filter states via saved settings.
+- Introduce iconography and progress bars to reinforce course duration and asset setup progress within collapsed cards.
+- Explore responsive tweaks for mobile-first layouts once card interactions are optimised for touch.

--- a/index.html
+++ b/index.html
@@ -32,62 +32,216 @@
       <button id="end-day" class="end-day">End Day</button>
     </header>
 
-    <section class="summary-bar" id="summary-bar">
-      <article class="summary-card" id="summary-time-card">
-        <h3>Time Reserved</h3>
-        <p id="summary-time" class="summary-value">0h</p>
-        <span id="summary-time-detail" class="summary-detail">Setup 0h • Upkeep 0h</span>
-      </article>
-      <article class="summary-card" id="summary-income-card">
-        <h3>Projected Payout</h3>
-        <p id="summary-income" class="summary-value">$0/day</p>
-        <span id="summary-income-detail" class="summary-detail">Range: $0 – $0</span>
-      </article>
-      <article class="summary-card" id="summary-cost-card">
-        <h3>Daily Costs</h3>
-        <p id="summary-cost" class="summary-value">$0/day</p>
-        <span id="summary-cost-detail" class="summary-detail">Maintenance &amp; payroll $0</span>
-      </article>
-      <article class="summary-card" id="summary-study-card">
-        <h3>Study Momentum</h3>
-        <p id="summary-study" class="summary-value">0 tracks</p>
-        <span id="summary-study-detail" class="summary-detail">0 waiting for today</span>
-      </article>
+    <section class="stats-panel" id="stats-panel" data-collapsed="true">
+      <div class="stats-toolbar">
+        <div>
+          <h2>Daily Snapshot</h2>
+          <p>Keep the overview lean, then pop open a stat to audit the fine print.</p>
+        </div>
+        <button id="stats-toggle" class="toggle-button" aria-expanded="false">Expand breakdowns</button>
+      </div>
+      <div class="stats-grid">
+        <details class="stat-card" id="summary-time-card">
+          <summary>
+            <div class="stat-heading">
+              <h3>Time Reserved</h3>
+              <span id="summary-time" class="stat-value">0h</span>
+            </div>
+            <p id="summary-time-caption" class="stat-caption">Setup 0h • Upkeep 0h</p>
+          </summary>
+          <ul id="summary-time-breakdown" class="stat-breakdown" aria-live="polite"></ul>
+        </details>
+        <details class="stat-card" id="summary-income-card">
+          <summary>
+            <div class="stat-heading">
+              <h3>Projected Payout</h3>
+              <span id="summary-income" class="stat-value">$0/day</span>
+            </div>
+            <p id="summary-income-caption" class="stat-caption">No passive payouts yet</p>
+          </summary>
+          <ul id="summary-income-breakdown" class="stat-breakdown" aria-live="polite"></ul>
+        </details>
+        <details class="stat-card" id="summary-cost-card">
+          <summary>
+            <div class="stat-heading">
+              <h3>Daily Costs</h3>
+              <span id="summary-cost" class="stat-value">$0/day</span>
+            </div>
+            <p id="summary-cost-caption" class="stat-caption">No upkeep or payroll costs today</p>
+          </summary>
+          <ul id="summary-cost-breakdown" class="stat-breakdown" aria-live="polite"></ul>
+        </details>
+        <details class="stat-card" id="summary-study-card">
+          <summary>
+            <div class="stat-heading">
+              <h3>Study Momentum</h3>
+              <span id="summary-study" class="stat-value">0 tracks</span>
+            </div>
+            <p id="summary-study-caption" class="stat-caption">All study goals are on track</p>
+          </summary>
+          <ul id="summary-study-breakdown" class="stat-breakdown" aria-live="polite"></ul>
+        </details>
+      </div>
     </section>
 
-    <main>
-      <section class="panel hustles">
-        <div class="panel-header">
-          <h2>Daily Hustles</h2>
-          <p>Spend your hours on instant gigs or study sessions. When you run out, wrap the day to evolve.</p>
-        </div>
-        <div class="card-grid" id="hustle-grid"></div>
+    <main class="workspace">
+      <nav class="workspace-nav" id="workspace-nav" aria-label="Main">
+        <button class="nav-button is-active" data-view="hustles" id="nav-hustles">Daily Hustles</button>
+        <button class="nav-button" data-view="education" id="nav-education">Education</button>
+        <button class="nav-button" data-view="assets" id="nav-assets">Passive Assets</button>
+        <button class="nav-button" data-view="upgrades" id="nav-upgrades">Upgrades &amp; Boosts</button>
+      </nav>
+
+      <section class="global-filters" aria-label="Global filters">
+        <label class="filter-toggle">
+          <input type="checkbox" id="filter-hide-locked" />
+          <span>Hide locked</span>
+        </label>
+        <label class="filter-toggle">
+          <input type="checkbox" id="filter-hide-completed" />
+          <span>Hide completed</span>
+        </label>
+        <label class="filter-toggle">
+          <input type="checkbox" id="filter-show-active" />
+          <span>Show only active</span>
+        </label>
       </section>
 
-      <section class="panel assets">
-        <div class="panel-header">
-          <h2>Passive Assets</h2>
-          <p>Queue multi-day builds and daily upkeep to keep the money arriving at sunrise.</p>
-        </div>
-        <div class="card-grid" id="asset-grid"></div>
-      </section>
+      <section class="workspace-panels" id="workspace-panels">
+        <section class="view is-active" data-view="hustles" aria-labelledby="nav-hustles">
+          <header class="view-header">
+            <div>
+              <h2>Daily Hustles</h2>
+              <p>Quick-hit gigs for instant cash flow. Spend the hours, bank the wins.</p>
+            </div>
+            <div class="view-controls">
+              <label class="filter-toggle">
+                <input type="checkbox" id="filter-hustles-available" />
+                <span>Show only available gigs</span>
+              </label>
+            </div>
+          </header>
+          <div class="card-grid" id="hustle-grid"></div>
+        </section>
 
-      <section class="panel upgrades">
-        <div class="panel-header">
-          <h2>Upgrades & Boosts</h2>
-          <p>Snag gear, coffee, and automation that expand your daily bandwidth.</p>
-        </div>
-        <div class="card-grid" id="upgrade-grid"></div>
-      </section>
+        <section class="view" data-view="education" aria-labelledby="nav-education">
+          <header class="view-header">
+            <div>
+              <h2>Education</h2>
+              <p>Courses, playbooks, and study tracks that unlock new mastery.</p>
+            </div>
+            <div class="view-controls">
+              <label class="filter-toggle">
+                <input type="checkbox" id="filter-education-active" />
+                <span>Show only active tracks</span>
+              </label>
+              <label class="filter-toggle">
+                <input type="checkbox" id="filter-education-hide-complete" />
+                <span>Hide completed</span>
+              </label>
+            </div>
+          </header>
+          <div class="card-grid" id="education-grid"></div>
+        </section>
 
-      <section class="panel log">
-        <div class="panel-header">
+        <section class="view" data-view="assets" aria-labelledby="nav-assets">
+          <header class="view-header">
+            <div>
+              <h2>Passive Assets</h2>
+              <p>Launch builds, manage upkeep, and keep payouts humming with lean cards.</p>
+            </div>
+            <div class="view-controls">
+              <label class="filter-toggle">
+                <input type="checkbox" id="filter-assets-collapsed" checked />
+                <span>Collapsed card view</span>
+              </label>
+              <label class="filter-toggle">
+                <input type="checkbox" id="filter-assets-hide-locked" />
+                <span>Hide unavailable</span>
+              </label>
+            </div>
+          </header>
+          <div class="asset-categories" id="asset-grid">
+            <section class="asset-category" data-category="foundation">
+              <header>
+                <h3>Foundation</h3>
+              </header>
+              <div class="card-grid" id="asset-grid-foundation"></div>
+            </section>
+            <section class="asset-category" data-category="creative">
+              <header>
+                <h3>Creative</h3>
+              </header>
+              <div class="card-grid" id="asset-grid-creative"></div>
+            </section>
+            <section class="asset-category" data-category="commerce">
+              <header>
+                <h3>Commerce</h3>
+              </header>
+              <div class="card-grid" id="asset-grid-commerce"></div>
+            </section>
+            <section class="asset-category" data-category="advanced">
+              <header>
+                <h3>Advanced</h3>
+              </header>
+              <div class="card-grid" id="asset-grid-advanced"></div>
+            </section>
+          </div>
+        </section>
+
+        <section class="view" data-view="upgrades" aria-labelledby="nav-upgrades">
+          <header class="view-header">
+            <div>
+              <h2>Upgrades &amp; Boosts</h2>
+              <p>Equipment, automation, and consumables. Stack them to scale.</p>
+            </div>
+            <div class="view-controls">
+              <label class="filter-toggle search">
+                <span class="sr-only" id="upgrade-search-label">Search upgrades</span>
+                <input type="search" id="upgrade-search" placeholder="Search upgrades" aria-labelledby="upgrade-search-label" />
+              </label>
+            </div>
+          </header>
+          <div class="upgrade-groups">
+            <section class="upgrade-group" data-upgrade-group="equipment">
+              <header>
+                <h3>Equipment</h3>
+              </header>
+              <div class="card-grid" id="upgrade-grid-equipment"></div>
+            </section>
+            <section class="upgrade-group" data-upgrade-group="automation">
+              <header>
+                <h3>Automation</h3>
+              </header>
+              <div class="card-grid" id="upgrade-grid-automation"></div>
+            </section>
+            <section class="upgrade-group" data-upgrade-group="consumables">
+              <header>
+                <h3>Consumables</h3>
+              </header>
+              <div class="card-grid" id="upgrade-grid-consumables"></div>
+            </section>
+            <section class="upgrade-group" data-upgrade-group="misc">
+              <header>
+                <h3>Other Boosts</h3>
+              </header>
+              <div class="card-grid" id="upgrade-grid"></div>
+            </section>
+          </div>
+        </section>
+      </section>
+    </main>
+
+    <section class="panel log" aria-label="Event log">
+      <div class="panel-header">
+        <div>
           <h2>Event Log</h2>
           <p id="log-tip">Welcome! Invest time to queue builds and watch the recap at daybreak.</p>
         </div>
-        <div id="log-feed" class="log-feed"></div>
-      </section>
-    </main>
+        <button id="log-toggle" class="toggle-button" aria-expanded="false">Detailed view</button>
+      </div>
+      <div id="log-feed" class="log-feed"></div>
+    </section>
   </div>
 
   <template id="log-template">

--- a/src/game/assets/definitions/ebook.js
+++ b/src/game/assets/definitions/ebook.js
@@ -14,7 +14,7 @@ const ebookDefinition = {
   id: 'ebook',
   name: 'Digital E-Book Series',
   singular: 'E-Book',
-  tag: { label: 'Knowledge', type: 'passive' },
+  tag: { label: 'Creative', type: 'passive' },
   description: 'Package your expertise into downloadable page-turners that sell while you snooze.',
   setup: { days: 4, hoursPerDay: 3, cost: 60 },
   maintenance: { hours: 0.5, cost: 0 },

--- a/src/game/hustles.js
+++ b/src/game/hustles.js
@@ -188,9 +188,12 @@ function createKnowledgeHustles() {
       }
     },
     cardState: (_state, card) => {
-      const progress = getKnowledgeProgress(track.id);
       if (!card) return;
+      const progress = getKnowledgeProgress(track.id);
       card.classList.toggle('completed', progress.completed);
+      const inProgress = progress.daysCompleted > 0 || progress.studiedToday;
+      card.dataset.inProgress = inProgress ? 'true' : 'false';
+      card.dataset.studiedToday = progress.studiedToday ? 'true' : 'false';
     }
   }));
 }

--- a/src/game/summary.js
+++ b/src/game/summary.js
@@ -1,5 +1,5 @@
 import { getState, getAssetState } from '../core/state.js';
-import { formatHours } from '../core/helpers.js';
+import { formatHours, formatMoney } from '../core/helpers.js';
 import { ASSETS } from './assets/index.js';
 import { getDailyIncomeRange } from './assets/helpers.js';
 import { getAssistantDailyCost } from './assistant.js';
@@ -16,7 +16,11 @@ export function computeDailySummary(state = getState()) {
       activeCount: 0,
       setupCount: 0,
       knowledgeInProgress: 0,
-      knowledgePendingToday: 0
+      knowledgePendingToday: 0,
+      timeBreakdown: [],
+      payoutBreakdown: [],
+      costBreakdown: [],
+      studyBreakdown: []
     };
   }
 
@@ -28,6 +32,11 @@ export function computeDailySummary(state = getState()) {
   let activeCount = 0;
   let setupCount = 0;
 
+  const setupMap = new Map();
+  const upkeepMap = new Map();
+  const incomeMap = new Map();
+  const costMap = new Map();
+
   for (const definition of ASSETS) {
     const assetState = getAssetState(definition.id, state);
     if (!assetState?.instances?.length) continue;
@@ -36,36 +45,90 @@ export function computeDailySummary(state = getState()) {
     const maintenancePerDay = Math.max(0, Number(definition.maintenance?.hours) || 0);
     const maintenanceMoney = Math.max(0, Number(definition.maintenance?.cost) || 0);
     const range = getDailyIncomeRange(definition);
+    const label = definition.singular || definition.name;
 
     for (const instance of assetState.instances) {
       if (instance.status === 'setup') {
         setupCount += 1;
         setupHours += setupPerDay;
+        if (setupPerDay > 0) {
+          setupMap.set(label, (setupMap.get(label) || 0) + setupPerDay);
+        }
       } else if (instance.status === 'active') {
         activeCount += 1;
         maintenanceHours += maintenancePerDay;
         maintenanceCost += maintenanceMoney;
         incomeMin += range.min;
         incomeMax += range.max;
+
+        if (maintenancePerDay > 0) {
+          upkeepMap.set(label, (upkeepMap.get(label) || 0) + maintenancePerDay);
+        }
+
+        const incomeEntry = incomeMap.get(label) || { min: 0, max: 0, count: 0 };
+        incomeEntry.min += range.min;
+        incomeEntry.max += range.max;
+        incomeEntry.count += 1;
+        incomeMap.set(label, incomeEntry);
+
+        if (maintenanceMoney > 0) {
+          costMap.set(label, (costMap.get(label) || 0) + maintenanceMoney);
+        }
       }
     }
   }
 
+  const assistantCost = getAssistantDailyCost(state);
+  maintenanceCost += assistantCost;
+
+  const timeBreakdown = [];
+  for (const [label, hours] of setupMap.entries()) {
+    timeBreakdown.push({ label: `🚀 ${label} prep`, value: `${formatHours(hours)} / day` });
+  }
+  for (const [label, hours] of upkeepMap.entries()) {
+    timeBreakdown.push({ label: `🛠️ ${label} upkeep`, value: `${formatHours(hours)} / day` });
+  }
+
+  const payoutBreakdown = Array.from(incomeMap.entries()).map(([label, values]) => {
+    const min = formatMoney(values.min);
+    const max = formatMoney(values.max);
+    const suffix = values.min === values.max ? `/day` : `/day range`;
+    const amount = values.min === values.max ? `$${min}` : `$${min} – $${max}`;
+    return { label: `💰 ${label}`, value: `${amount} ${suffix}` };
+  });
+
+  const costBreakdown = Array.from(costMap.entries()).map(([label, value]) => ({
+    label: `🔧 ${label} upkeep`,
+    value: `$${formatMoney(value)} / day`
+  }));
+  if (assistantCost > 0) {
+    costBreakdown.push({ label: '🤖 Assistant squad', value: `$${formatMoney(assistantCost)} / day` });
+  }
+
   let knowledgeInProgress = 0;
   let knowledgePendingToday = 0;
+  const studyBreakdown = [];
 
   for (const track of Object.values(KNOWLEDGE_TRACKS)) {
     const progress = getKnowledgeProgress(track.id, state);
     if (progress.completed) continue;
-    if (progress.daysCompleted > 0 || progress.studiedToday) {
+    const inProgress = progress.daysCompleted > 0 || progress.studiedToday;
+    if (inProgress) {
       knowledgeInProgress += 1;
     }
     if (!progress.studiedToday) {
       knowledgePendingToday += 1;
     }
-  }
 
-  maintenanceCost += getAssistantDailyCost(state);
+    if (inProgress) {
+      const remainingDays = Math.max(0, track.days - progress.daysCompleted);
+      const status = progress.studiedToday ? 'studied' : 'waiting';
+      studyBreakdown.push({
+        label: `📘 ${track.name}`,
+        value: `${formatHours(track.hoursPerDay)} / day • ${remainingDays} day${remainingDays === 1 ? '' : 's'} left (${status})`
+      });
+    }
+  }
 
   return {
     setupHours,
@@ -76,7 +139,11 @@ export function computeDailySummary(state = getState()) {
     activeCount,
     setupCount,
     knowledgeInProgress,
-    knowledgePendingToday
+    knowledgePendingToday,
+    timeBreakdown,
+    payoutBreakdown,
+    costBreakdown,
+    studyBreakdown
   };
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import { configureRegistry } from './core/state.js';
 import { loadState, saveState } from './core/storage.js';
 import elements from './ui/elements.js';
 import { renderCards, updateUI } from './ui/update.js';
+import { initLayoutControls } from './ui/layout.js';
 import { registry } from './game/registry.js';
 import { endDay } from './game/lifecycle.js';
 import { resetTick, startGameLoop } from './game/loop.js';
@@ -17,6 +18,7 @@ if (returning) {
 renderLog();
 renderCards();
 updateUI();
+initLayoutControls();
 startGameLoop();
 
 elements.endDayButton.addEventListener('click', () => endDay(false));

--- a/src/ui/dashboard.js
+++ b/src/ui/dashboard.js
@@ -1,13 +1,39 @@
 import elements from './elements.js';
 import { formatHours, formatMoney } from '../core/helpers.js';
 
-function safeText(element, text) {
+function setText(element, text) {
   if (!element) return;
   element.textContent = text;
 }
 
+function renderBreakdown(listElement, items = []) {
+  if (!listElement) return;
+  listElement.innerHTML = '';
+  if (!items.length) {
+    const empty = document.createElement('li');
+    empty.textContent = 'No details to show yet.';
+    listElement.appendChild(empty);
+    return;
+  }
+
+  for (const item of items) {
+    const li = document.createElement('li');
+    if (item.value) {
+      const label = document.createElement('span');
+      label.textContent = item.label;
+      const value = document.createElement('span');
+      value.textContent = item.value;
+      li.append(label, value);
+    } else {
+      li.textContent = item.label;
+    }
+    listElement.appendChild(li);
+  }
+}
+
 export function renderSummary(summary) {
-  if (!elements.summaryBar) return;
+  if (!elements.summaryPanel) return;
+
   const {
     setupHours,
     maintenanceHours,
@@ -17,44 +43,52 @@ export function renderSummary(summary) {
     activeCount,
     setupCount,
     knowledgeInProgress,
-    knowledgePendingToday
+    knowledgePendingToday,
+    timeBreakdown,
+    payoutBreakdown,
+    costBreakdown,
+    studyBreakdown
   } = summary;
 
   const totalReserved = setupHours + maintenanceHours;
   const setupLabel = setupCount === 1 ? 'build' : 'builds';
   const upkeepLabel = activeCount === 1 ? 'asset' : 'assets';
 
-  safeText(elements.summaryTime, `${formatHours(totalReserved)} reserved`);
-  safeText(
-    elements.summaryTimeDetail,
+  setText(elements.summaryTime, `${formatHours(totalReserved)} reserved`);
+  setText(
+    elements.summaryTimeCaption,
     `${setupCount} ${setupLabel} in prep (${formatHours(setupHours)}) • ${activeCount} active ${upkeepLabel} (${formatHours(maintenanceHours)})`
   );
+  renderBreakdown(elements.summaryTimeBreakdown, timeBreakdown);
 
   const minMoney = formatMoney(incomeMin);
   const maxMoney = formatMoney(incomeMax);
   const incomeLabel = incomeMin === incomeMax
     ? `$${minMoney} / day`
     : `$${minMoney} – $${maxMoney} / day`;
-  safeText(elements.summaryIncome, incomeLabel);
-  safeText(
-    elements.summaryIncomeDetail,
+  setText(elements.summaryIncome, incomeLabel);
+  setText(
+    elements.summaryIncomeCaption,
     activeCount ? `Projected from ${activeCount} active ${upkeepLabel}` : 'No passive payouts yet'
   );
+  renderBreakdown(elements.summaryIncomeBreakdown, payoutBreakdown);
 
-  safeText(elements.summaryCost, `$${formatMoney(maintenanceCost)} / day`);
-  safeText(
-    elements.summaryCostDetail,
+  setText(elements.summaryCost, `$${formatMoney(maintenanceCost)} / day`);
+  setText(
+    elements.summaryCostCaption,
     maintenanceCost
       ? 'Maintenance and staffing costs to keep everything humming'
       : 'No upkeep or payroll costs today'
   );
+  renderBreakdown(elements.summaryCostBreakdown, costBreakdown);
 
   const studyLabel = knowledgeInProgress === 1 ? 'track' : 'tracks';
-  safeText(elements.summaryStudy, `${knowledgeInProgress} ${studyLabel}`);
-  safeText(
-    elements.summaryStudyDetail,
+  setText(elements.summaryStudy, `${knowledgeInProgress} ${studyLabel}`);
+  setText(
+    elements.summaryStudyCaption,
     knowledgePendingToday
       ? `${knowledgePendingToday} waiting for study time today`
       : 'All study goals are on track'
   );
+  renderBreakdown(elements.summaryStudyBreakdown, studyBreakdown);
 }

--- a/src/ui/elements.js
+++ b/src/ui/elements.js
@@ -7,18 +7,57 @@ const elements = {
   logTemplate: document.getElementById('log-template'),
   logTip: document.getElementById('log-tip'),
   hustleGrid: document.getElementById('hustle-grid'),
-  assetGrid: document.getElementById('asset-grid'),
+  educationGrid: document.getElementById('education-grid'),
+  assetGridRoot: document.getElementById('asset-grid'),
+  assetCategoryGrids: {
+    foundation: document.getElementById('asset-grid-foundation'),
+    creative: document.getElementById('asset-grid-creative'),
+    commerce: document.getElementById('asset-grid-commerce'),
+    advanced: document.getElementById('asset-grid-advanced')
+  },
   upgradeGrid: document.getElementById('upgrade-grid'),
+  upgradeGroupGrids: {
+    equipment: document.getElementById('upgrade-grid-equipment'),
+    automation: document.getElementById('upgrade-grid-automation'),
+    consumables: document.getElementById('upgrade-grid-consumables'),
+    misc: document.getElementById('upgrade-grid')
+  },
   endDayButton: document.getElementById('end-day'),
-  summaryBar: document.getElementById('summary-bar'),
+  summaryPanel: document.getElementById('stats-panel'),
   summaryTime: document.getElementById('summary-time'),
-  summaryTimeDetail: document.getElementById('summary-time-detail'),
+  summaryTimeCaption: document.getElementById('summary-time-caption'),
+  summaryTimeBreakdown: document.getElementById('summary-time-breakdown'),
   summaryIncome: document.getElementById('summary-income'),
-  summaryIncomeDetail: document.getElementById('summary-income-detail'),
+  summaryIncomeCaption: document.getElementById('summary-income-caption'),
+  summaryIncomeBreakdown: document.getElementById('summary-income-breakdown'),
   summaryCost: document.getElementById('summary-cost'),
-  summaryCostDetail: document.getElementById('summary-cost-detail'),
+  summaryCostCaption: document.getElementById('summary-cost-caption'),
+  summaryCostBreakdown: document.getElementById('summary-cost-breakdown'),
   summaryStudy: document.getElementById('summary-study'),
-  summaryStudyDetail: document.getElementById('summary-study-detail')
+  summaryStudyCaption: document.getElementById('summary-study-caption'),
+  summaryStudyBreakdown: document.getElementById('summary-study-breakdown'),
+  statsToggle: document.getElementById('stats-toggle'),
+  logToggle: document.getElementById('log-toggle'),
+  navButtons: Array.from(document.querySelectorAll('.nav-button')),
+  views: Array.from(document.querySelectorAll('.view')),
+  workspacePanels: document.getElementById('workspace-panels'),
+  globalFilters: {
+    hideLocked: document.getElementById('filter-hide-locked'),
+    hideCompleted: document.getElementById('filter-hide-completed'),
+    showActive: document.getElementById('filter-show-active')
+  },
+  hustlesFilters: {
+    availableOnly: document.getElementById('filter-hustles-available')
+  },
+  educationFilters: {
+    activeOnly: document.getElementById('filter-education-active'),
+    hideComplete: document.getElementById('filter-education-hide-complete')
+  },
+  assetsFilters: {
+    collapsed: document.getElementById('filter-assets-collapsed'),
+    hideLocked: document.getElementById('filter-assets-hide-locked')
+  },
+  upgradeSearch: document.getElementById('upgrade-search')
 };
 
 export default elements;

--- a/src/ui/layout.js
+++ b/src/ui/layout.js
@@ -1,0 +1,202 @@
+import elements from './elements.js';
+
+export function initLayoutControls() {
+  setupNavigation();
+  setupStatsPanel();
+  setupLogToggle();
+  setupGlobalFilters();
+  setupHustleFilter();
+  setupEducationFilters();
+  setupAssetFilters();
+  setupUpgradeSearch();
+  applyCardFilters();
+}
+
+export function applyCardFilters() {
+  applyHustleFilter();
+  applyEducationFilters();
+  applyUpgradeSearchFilter();
+}
+
+function setupNavigation() {
+  if (!elements.navButtons?.length || !elements.views?.length) return;
+  const viewMap = new Map(elements.views.map(view => [view.dataset.view, view]));
+
+  const setActiveView = target => {
+    if (!target || !viewMap.has(target)) return;
+    for (const button of elements.navButtons) {
+      button.classList.toggle('is-active', button.dataset.view === target);
+    }
+    for (const [key, view] of viewMap.entries()) {
+      view.classList.toggle('is-active', key === target);
+    }
+  };
+
+  for (const button of elements.navButtons) {
+    button.addEventListener('click', () => setActiveView(button.dataset.view));
+  }
+
+  const activeButton = elements.navButtons.find(button => button.classList.contains('is-active'));
+  setActiveView(activeButton?.dataset.view || elements.views[0].dataset.view);
+}
+
+function setupStatsPanel() {
+  const panel = elements.summaryPanel;
+  const toggle = elements.statsToggle;
+  if (!panel || !toggle) return;
+
+  const update = expanded => {
+    panel.dataset.collapsed = expanded ? 'false' : 'true';
+    toggle.setAttribute('aria-expanded', String(expanded));
+    toggle.textContent = expanded ? 'Collapse breakdowns' : 'Expand breakdowns';
+    if (!expanded) {
+      const details = panel.querySelectorAll('details');
+      details.forEach(detail => {
+        detail.open = false;
+      });
+    }
+  };
+
+  toggle.addEventListener('click', () => {
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    update(!expanded);
+  });
+
+  update(false);
+}
+
+function setupLogToggle() {
+  const toggle = elements.logToggle;
+  const feed = elements.logFeed;
+  if (!toggle || !feed) return;
+  const panel = feed.closest('.log');
+  if (!panel) return;
+
+  const update = expanded => {
+    toggle.setAttribute('aria-expanded', String(expanded));
+    toggle.textContent = expanded ? 'Summary view' : 'Detailed view';
+    panel.classList.toggle('summary', !expanded);
+  };
+
+  toggle.addEventListener('click', () => {
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    update(!expanded);
+  });
+
+  update(false);
+}
+
+function setupGlobalFilters() {
+  const filters = elements.globalFilters;
+  const container = elements.workspacePanels;
+  if (!filters || !container) return;
+
+  const apply = () => {
+    container.classList.toggle('hide-locked', Boolean(filters.hideLocked?.checked));
+    container.classList.toggle('hide-completed', Boolean(filters.hideCompleted?.checked));
+    container.classList.toggle('show-active-only', Boolean(filters.showActive?.checked));
+    applyCardFilters();
+  };
+
+  Object.values(filters).forEach(input => {
+    if (!input) return;
+    input.addEventListener('change', apply);
+  });
+
+  apply();
+}
+
+function setupHustleFilter() {
+  const checkbox = elements.hustlesFilters?.availableOnly;
+  if (!checkbox) return;
+  checkbox.addEventListener('change', applyHustleFilter);
+}
+
+function applyHustleFilter() {
+  const checkbox = elements.hustlesFilters?.availableOnly;
+  const shouldFilter = Boolean(checkbox?.checked);
+  const cards = elements.hustleGrid?.querySelectorAll('.card') || [];
+  cards.forEach(card => {
+    if (!shouldFilter) {
+      card.classList.remove('is-filtered');
+      return;
+    }
+    const button = card.querySelector('button');
+    const available = button ? !button.disabled : true;
+    card.classList.toggle('is-filtered', !available);
+  });
+}
+
+function setupEducationFilters() {
+  const { activeOnly, hideComplete } = elements.educationFilters || {};
+  if (activeOnly) activeOnly.addEventListener('change', applyEducationFilters);
+  if (hideComplete) hideComplete.addEventListener('change', applyEducationFilters);
+}
+
+function applyEducationFilters() {
+  const cards = elements.educationGrid?.querySelectorAll('.card') || [];
+  const activeOnly = Boolean(elements.educationFilters?.activeOnly?.checked);
+  const hideComplete = Boolean(elements.educationFilters?.hideComplete?.checked);
+
+  cards.forEach(card => {
+    let hidden = false;
+    const completed = card.classList.contains('completed');
+    const inProgress = card.dataset.inProgress === 'true';
+
+    if (hideComplete && completed) {
+      hidden = true;
+    }
+    if (activeOnly && !inProgress) {
+      hidden = true;
+    }
+
+    card.classList.toggle('is-filtered', hidden);
+  });
+}
+
+function setupAssetFilters() {
+  const { collapsed, hideLocked } = elements.assetsFilters || {};
+  const view = elements.views?.find(section => section.dataset.view === 'assets');
+  if (!view) return;
+
+  const apply = () => {
+    if (collapsed) {
+      view.classList.toggle('is-collapsed', Boolean(collapsed.checked));
+    }
+    if (hideLocked) {
+      view.classList.toggle('hide-locked', Boolean(hideLocked.checked));
+    }
+  };
+
+  if (collapsed) collapsed.addEventListener('change', apply);
+  if (hideLocked) hideLocked.addEventListener('change', apply);
+
+  apply();
+}
+
+function setupUpgradeSearch() {
+  const input = elements.upgradeSearch;
+  if (!input) return;
+  input.addEventListener('input', applyUpgradeSearchFilter);
+}
+
+function applyUpgradeSearchFilter() {
+  const term = (elements.upgradeSearch?.value || '').trim().toLowerCase();
+  const containers = elements.upgradeGroupGrids ? Object.values(elements.upgradeGroupGrids) : [];
+
+  containers.forEach(container => {
+    if (!container) return;
+    const cards = container.querySelectorAll('.card');
+    let visibleCount = 0;
+    cards.forEach(card => {
+      const text = card.textContent.toLowerCase();
+      const match = !term || text.includes(term);
+      card.classList.toggle('is-filtered', !match);
+      if (match) visibleCount += 1;
+    });
+    const group = container.closest('.upgrade-group');
+    if (group) {
+      group.classList.toggle('is-empty', visibleCount === 0);
+    }
+  });
+}

--- a/src/ui/update.js
+++ b/src/ui/update.js
@@ -6,9 +6,23 @@ import { getTimeCap } from '../game/time.js';
 import { registry } from '../game/registry.js';
 import { computeDailySummary } from '../game/summary.js';
 import { renderSummary } from './dashboard.js';
+import { applyCardFilters } from './layout.js';
+
+function buildCollections() {
+  const hustles = registry.hustles.filter(hustle => hustle.tag?.type !== 'study');
+  const education = registry.hustles.filter(hustle => hustle.tag?.type === 'study');
+  return {
+    hustles,
+    education,
+    assets: registry.assets,
+    upgrades: registry.upgrades
+  };
+}
 
 export function renderCards() {
-  renderCardCollections(registry);
+  const collections = buildCollections();
+  renderCardCollections(collections);
+  applyCardFilters();
 }
 
 export function updateUI() {
@@ -23,8 +37,10 @@ export function updateUI() {
   const percent = cap === 0 ? 0 : Math.min(100, Math.max(0, (state.timeLeft / cap) * 100));
   elements.timeProgress.style.width = `${percent}%`;
 
-  updateAllCards(registry);
+  const collections = buildCollections();
+  updateAllCards(collections);
 
   const summary = computeDailySummary(state);
   renderSummary(summary);
+  applyCardFilters();
 }

--- a/styles.css
+++ b/styles.css
@@ -9,7 +9,8 @@
   --success: #4ade80;
   --warning: #f97316;
   --danger: #f87171;
-  --shadow: 0 16px 30px rgba(15, 23, 42, 0.2);
+  --border: rgba(148, 163, 184, 0.16);
+  --shadow: 0 16px 30px rgba(15, 23, 42, 0.25);
   font-family: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
@@ -21,7 +22,7 @@
 
 body {
   min-height: 100vh;
-  background: radial-gradient(circle at 10% 20%, #1e293b 0%, #0f172a 45%, #020617 100%);
+  background: radial-gradient(circle at 12% 18%, #1e293b 0%, #0f172a 45%, #020617 100%);
   color: var(--text);
   display: flex;
   justify-content: center;
@@ -29,7 +30,7 @@ body {
 }
 
 .app {
-  width: min(1100px, 100%);
+  width: min(1200px, 100%);
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
@@ -37,7 +38,7 @@ body {
 
 .top-bar {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 1rem;
   background: var(--panel-bg);
   backdrop-filter: blur(20px);
@@ -45,41 +46,6 @@ body {
   border-radius: 18px;
   box-shadow: var(--shadow);
   align-items: center;
-}
-
-.summary-bar {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
-}
-
-.summary-card {
-  background: rgba(15, 23, 42, 0.7);
-  border-radius: 18px;
-  padding: 1rem 1.2rem;
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12);
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.summary-card h3 {
-  font-size: 0.9rem;
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  color: rgba(148, 163, 184, 0.75);
-}
-
-.summary-value {
-  font-size: 1.4rem;
-  font-weight: 700;
-  color: var(--text);
-}
-
-.summary-detail {
-  font-size: 0.85rem;
-  color: var(--muted);
 }
 
 .stat {
@@ -110,10 +76,6 @@ body {
   color: var(--danger);
 }
 
-.time {
-  position: relative;
-}
-
 .time-wrapper {
   display: flex;
   flex-direction: column;
@@ -142,7 +104,7 @@ body {
   border: none;
   font-weight: 600;
   font-size: 0.95rem;
-  background: rgba(56, 189, 248, 0.1);
+  background: rgba(56, 189, 248, 0.12);
   color: var(--accent);
   cursor: pointer;
   transition: transform 0.2s ease, background 0.2s ease;
@@ -150,36 +112,271 @@ body {
 
 .end-day:hover,
 .end-day:focus-visible {
-  background: rgba(56, 189, 248, 0.2);
+  background: rgba(56, 189, 248, 0.24);
   transform: translateY(-2px);
 }
 
-main {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-.panel {
+.stats-panel {
   background: var(--panel-bg);
   border-radius: 24px;
   padding: 1.5rem;
   box-shadow: var(--shadow);
   backdrop-filter: blur(18px);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
 }
 
-.panel-header {
-  margin-bottom: 1rem;
+.stats-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
 }
 
-.panel-header h2 {
-  font-size: 1.6rem;
-  margin-bottom: 0.2rem;
+.stats-toolbar h2 {
+  font-size: 1.4rem;
+  margin-bottom: 0.25rem;
 }
 
-.panel-header p {
+.stats-toolbar p {
   color: var(--muted);
   font-size: 0.95rem;
+}
+
+.toggle-button {
+  align-self: flex-start;
+  border: 1px solid var(--border);
+  background: rgba(56, 189, 248, 0.08);
+  color: var(--accent);
+  border-radius: 999px;
+  padding: 0.55rem 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.toggle-button[aria-expanded="true"],
+.toggle-button:hover,
+.toggle-button:focus-visible {
+  background: rgba(14, 165, 233, 0.18);
+  color: var(--accent-strong);
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.stat-card {
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 18px;
+  padding: 1rem 1.25rem;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.14);
+}
+
+.stat-card[open] {
+  box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.35);
+}
+
+.stat-card summary {
+  list-style: none;
+  cursor: pointer;
+}
+
+.stat-card summary::-webkit-details-marker {
+  display: none;
+}
+
+.stat-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.stat-heading h3 {
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.stat-value {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.stat-caption {
+  margin-top: 0.4rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.stat-breakdown {
+  margin-top: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.stat-breakdown li {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.stat-breakdown li span {
+  color: var(--muted);
+}
+
+.stats-panel[data-collapsed="true"] .stat-card {
+  pointer-events: none;
+}
+
+.stats-panel[data-collapsed="true"] .stat-card summary {
+  cursor: default;
+}
+
+.workspace {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.workspace-nav {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+.nav-button {
+  border: 1px solid transparent;
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--muted);
+  border-radius: 999px;
+  padding: 0.65rem 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border 0.2s ease;
+}
+
+.nav-button.is-active {
+  color: var(--text);
+  border-color: rgba(56, 189, 248, 0.5);
+  background: rgba(56, 189, 248, 0.12);
+}
+
+.global-filters,
+.view-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.global-filters {
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 18px;
+  padding: 0.9rem 1.1rem;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12);
+}
+
+.filter-toggle {
+  display: inline-flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.filter-toggle input[type='checkbox'] {
+  accent-color: var(--accent-strong);
+  width: 1rem;
+  height: 1rem;
+}
+
+.filter-toggle.search {
+  background: rgba(15, 23, 42, 0.55);
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+}
+
+.filter-toggle.search input[type='search'] {
+  background: transparent;
+  border: none;
+  color: var(--text);
+  font-size: 0.9rem;
+  outline: none;
+  width: 200px;
+}
+
+.filter-toggle.search input::placeholder {
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.workspace-panels {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.workspace-panels.hide-locked .card.locked,
+.workspace-panels.show-active-only .card.locked,
+.workspace-panels.hide-completed .card.completed,
+.workspace-panels.show-active-only .card.completed,
+.workspace-panels.show-active-only .card.unavailable {
+  display: none !important;
+}
+
+.view[data-view='assets'].hide-locked .card.locked {
+  display: none !important;
+}
+
+.card.is-filtered {
+  display: none !important;
+}
+
+.view {
+  background: var(--panel-bg);
+  border-radius: 24px;
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+  display: none;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.view.is-active {
+  display: flex;
+}
+
+.view-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.view-header h2 {
+  font-size: 1.6rem;
+  margin-bottom: 0.35rem;
+}
+
+.view-header p {
+  color: var(--muted);
+  font-size: 0.95rem;
+  max-width: 520px;
 }
 
 .card-grid {
@@ -201,263 +398,229 @@ main {
 }
 
 .card:hover {
-  transform: translateY(-3px);
-  box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.3);
+  transform: translateY(-4px);
+  box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.25);
 }
 
-.card.locked {
-  opacity: 0.6;
+.card.locked::before {
+  content: '🔒 Locked';
+  position: absolute;
+  top: 0.85rem;
+  right: 0.95rem;
+  font-size: 0.8rem;
+  color: var(--warning);
 }
 
-.card.locked button {
-  pointer-events: none;
-}
-
-.card.completed {
-  border: 1px solid rgba(52, 211, 153, 0.35);
-  opacity: 0.85;
+.card.completed::before {
+  content: '✅ Complete';
+  position: absolute;
+  top: 0.85rem;
+  right: 0.95rem;
+  font-size: 0.8rem;
+  color: var(--success);
 }
 
 .card-header {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   justify-content: space-between;
   gap: 0.5rem;
 }
 
 .card-header h3 {
-  font-size: 1.15rem;
-}
-
-.tag {
-  font-size: 0.7rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  padding: 0.25rem 0.6rem;
-  border-radius: 999px;
-  background: rgba(148, 163, 184, 0.15);
-  color: var(--muted);
+  font-size: 1.1rem;
   font-weight: 700;
 }
 
-.tag.instant {
-  color: var(--success);
-  background: rgba(74, 222, 128, 0.12);
+.tag {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  color: rgba(226, 232, 240, 0.9);
 }
 
 .tag.passive {
-  color: #facc15;
-  background: rgba(250, 204, 21, 0.12);
+  background: rgba(56, 189, 248, 0.12);
+  color: var(--accent);
+}
+
+.tag.instant {
+  background: rgba(74, 222, 128, 0.15);
+  color: var(--success);
 }
 
 .tag.delayed {
-  color: var(--accent);
-  background: rgba(14, 165, 233, 0.12);
-}
-
-.tag.unlock {
-  color: #c084fc;
-  background: rgba(192, 132, 252, 0.12);
-}
-
-.tag.boost {
+  background: rgba(249, 115, 22, 0.15);
   color: var(--warning);
-  background: rgba(249, 115, 22, 0.12);
 }
 
 .tag.study {
-  color: #34d399;
-  background: rgba(52, 211, 153, 0.16);
+  background: rgba(165, 180, 252, 0.18);
+  color: #c4b5fd;
+}
+
+.card p {
+  color: rgba(226, 232, 240, 0.85);
+  line-height: 1.4;
 }
 
 .details {
-  list-style: none;
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  color: var(--muted);
+  gap: 0.45rem;
   font-size: 0.9rem;
+  color: rgba(203, 213, 225, 0.85);
 }
 
-.primary,
-.secondary {
-  padding: 0.75rem;
-  border-radius: 12px;
+.details li {
+  list-style: none;
+}
+
+.card button {
+  align-self: flex-start;
+  padding: 0.65rem 1.1rem;
+  border-radius: 999px;
   border: none;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
-.primary {
-  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+.card button.primary {
+  background: linear-gradient(90deg, var(--accent), var(--accent-strong));
   color: #0f172a;
-  box-shadow: 0 10px 20px rgba(14, 165, 233, 0.25);
 }
 
-.primary:disabled {
-  opacity: 0.6;
+.card button.secondary {
+  background: rgba(148, 163, 184, 0.2);
+  color: var(--text);
+}
+
+.card button:disabled {
   cursor: not-allowed;
+  opacity: 0.6;
   box-shadow: none;
 }
 
-.secondary {
-  background: rgba(148, 163, 184, 0.12);
-  color: var(--text);
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
-}
-
-.secondary:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-}
-
-.inline-actions {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-}
-
-.inline-actions button {
-  flex: 1 1 0;
-}
-
-.primary:not(:disabled):hover,
-.primary:not(:disabled):focus-visible,
-.secondary:not(:disabled):hover,
-.secondary:not(:disabled):focus-visible {
-  transform: translateY(-2px);
-}
-
-.pending {
-  font-size: 0.85rem;
-  color: var(--muted);
-}
-
-.asset-instances {
+.asset-categories {
   display: flex;
   flex-direction: column;
+  gap: 1.5rem;
+}
+
+.asset-category header h3,
+.upgrade-group header h3 {
+  font-size: 1.1rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.8);
+  margin-bottom: 0.6rem;
+}
+
+.view[data-view='assets'].is-collapsed .card {
   gap: 0.5rem;
 }
 
-.instance-empty {
-  font-size: 0.85rem;
-  color: var(--muted);
+.view[data-view='assets'].is-collapsed .card p,
+.view[data-view='assets'].is-collapsed .details {
+  display: none;
 }
 
-.instance-list {
-  list-style: none;
+.view[data-view='assets'].is-collapsed .card button {
+  margin-top: 0.5rem;
+}
+
+.upgrade-group.is-empty {
+  display: none;
+}
+
+.upgrade-groups {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 1.5rem;
 }
 
-.instance-row {
+.log {
+  background: var(--panel-bg);
+  border-radius: 24px;
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  background: rgba(148, 163, 184, 0.08);
-  border-radius: 12px;
-  padding: 0.5rem 0.75rem;
-  font-size: 0.85rem;
-}
-
-.instance-label {
-  font-weight: 600;
-  color: var(--text);
-}
-
-.instance-status {
-  color: var(--muted);
+  flex-direction: column;
+  gap: 1.2rem;
 }
 
 .log-feed {
   display: flex;
   flex-direction: column;
+  gap: 0.75rem;
   max-height: 280px;
   overflow-y: auto;
-  gap: 0.75rem;
-  padding-top: 0.5rem;
+  padding-right: 0.5rem;
 }
 
 .log-entry {
-  background: rgba(148, 163, 184, 0.08);
-  padding: 0.8rem 1rem;
-  border-radius: 12px;
   display: grid;
-  grid-template-columns: minmax(70px, auto) 1fr;
-  gap: 0.6rem;
-  align-items: center;
-  border-left: 3px solid rgba(148, 163, 184, 0.35);
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 0.75rem;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.85);
 }
 
 .log-entry .timestamp {
-  font-size: 0.75rem;
-  letter-spacing: 0.08em;
+  font-family: 'Manrope', monospace;
   color: rgba(148, 163, 184, 0.7);
-  text-transform: uppercase;
 }
 
-.log-entry .message {
-  font-size: 0.95rem;
-  line-height: 1.4;
+.log.summary .log-entry .message {
+  display: inline-block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 48ch;
 }
 
-.log-entry.type-info {
-  border-left-color: var(--accent);
+.panel-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
 }
 
-.log-entry.type-passive {
-  border-left-color: #facc15;
+.panel-header p {
+  color: var(--muted);
 }
 
-.log-entry.type-delayed {
-  border-left-color: var(--accent-strong);
-}
-
-.log-entry.type-upgrade {
-  border-left-color: #c084fc;
-}
-
-.log-entry.type-boost {
-  border-left-color: var(--warning);
-}
-
-.log-entry.type-warning {
-  border-left-color: var(--warning);
-  background: rgba(251, 191, 36, 0.12);
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 @media (max-width: 768px) {
   body {
-    padding: 1.5rem 0.75rem 2.5rem;
+    padding: 1.5rem 0.75rem 2rem;
   }
 
-  .top-bar {
-    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
-    gap: 0.75rem;
+  .stats-grid {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   }
 
-  .panel {
-    padding: 1.25rem;
+  .card-grid {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   }
 
-  .card {
-    padding: 1rem;
-  }
-
-  .log-entry {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (max-width: 480px) {
-  .top-bar {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .end-day {
-    grid-column: 1 / -1;
-    width: 100%;
+  .filter-toggle.search input[type='search'] {
+    width: 160px;
   }
 }

--- a/tests/helpers/setupDom.js
+++ b/tests/helpers/setupDom.js
@@ -7,46 +7,99 @@ export function ensureTestDom() {
   if (dom) return dom;
   dom = new JSDOM(
     `<!DOCTYPE html><html><body>
-      <header>
-        <span id="money"></span>
-        <span id="time"></span>
-        <div id="time-progress"></div>
-        <span id="day"></span>
-        <button id="end-day"></button>
-      </header>
-      <section id="summary-bar">
-        <div>
-          <span id="summary-time"></span>
-          <span id="summary-time-detail"></span>
-        </div>
-        <div>
-          <span id="summary-income"></span>
-          <span id="summary-income-detail"></span>
-        </div>
-        <div>
-          <span id="summary-cost"></span>
-          <span id="summary-cost-detail"></span>
-        </div>
-        <div>
-          <span id="summary-study"></span>
-          <span id="summary-study-detail"></span>
-        </div>
-      </section>
-      <main>
-        <div id="hustle-grid"></div>
-        <div id="asset-grid"></div>
-        <div id="upgrade-grid"></div>
-      </main>
-      <section>
-        <div id="log-tip"></div>
-        <div id="log-feed"></div>
-        <template id="log-template">
-          <div class="log-entry">
-            <span class="timestamp"></span>
-            <p class="message"></p>
+      <div class="app">
+        <header class="top-bar">
+          <span id="money"></span>
+          <span id="time"></span>
+          <div id="time-progress"></div>
+          <span id="day"></span>
+          <button id="end-day"></button>
+        </header>
+        <section id="stats-panel" data-collapsed="true">
+          <button id="stats-toggle"></button>
+          <div>
+            <details id="summary-time-card">
+              <summary>
+                <span id="summary-time"></span>
+                <span id="summary-time-caption"></span>
+              </summary>
+              <ul id="summary-time-breakdown"></ul>
+            </details>
+            <details id="summary-income-card">
+              <summary>
+                <span id="summary-income"></span>
+                <span id="summary-income-caption"></span>
+              </summary>
+              <ul id="summary-income-breakdown"></ul>
+            </details>
+            <details id="summary-cost-card">
+              <summary>
+                <span id="summary-cost"></span>
+                <span id="summary-cost-caption"></span>
+              </summary>
+              <ul id="summary-cost-breakdown"></ul>
+            </details>
+            <details id="summary-study-card">
+              <summary>
+                <span id="summary-study"></span>
+                <span id="summary-study-caption"></span>
+              </summary>
+              <ul id="summary-study-breakdown"></ul>
+            </details>
           </div>
-        </template>
-      </section>
+        </section>
+        <main class="workspace">
+          <nav class="workspace-nav">
+            <button class="nav-button is-active" data-view="hustles" id="nav-hustles"></button>
+            <button class="nav-button" data-view="education" id="nav-education"></button>
+            <button class="nav-button" data-view="assets" id="nav-assets"></button>
+            <button class="nav-button" data-view="upgrades" id="nav-upgrades"></button>
+          </nav>
+          <section class="global-filters">
+            <input type="checkbox" id="filter-hide-locked" />
+            <input type="checkbox" id="filter-hide-completed" />
+            <input type="checkbox" id="filter-show-active" />
+          </section>
+          <section id="workspace-panels" class="workspace-panels">
+            <section class="view is-active" data-view="hustles">
+              <div id="hustle-grid"></div>
+            </section>
+            <section class="view" data-view="education">
+              <input type="checkbox" id="filter-education-active" />
+              <input type="checkbox" id="filter-education-hide-complete" />
+              <div id="education-grid"></div>
+            </section>
+            <section class="view" data-view="assets">
+              <input type="checkbox" id="filter-assets-collapsed" />
+              <input type="checkbox" id="filter-assets-hide-locked" />
+              <div id="asset-grid">
+                <div id="asset-grid-foundation"></div>
+                <div id="asset-grid-creative"></div>
+                <div id="asset-grid-commerce"></div>
+                <div id="asset-grid-advanced"></div>
+              </div>
+            </section>
+            <section class="view" data-view="upgrades">
+              <input type="search" id="upgrade-search" />
+              <div id="upgrade-grid-equipment"></div>
+              <div id="upgrade-grid-automation"></div>
+              <div id="upgrade-grid-consumables"></div>
+              <div id="upgrade-grid"></div>
+            </section>
+          </section>
+        </main>
+        <section class="log">
+          <div id="log-tip"></div>
+          <button id="log-toggle"></button>
+          <div id="log-feed"></div>
+        </section>
+      </div>
+      <template id="log-template">
+        <div class="log-entry">
+          <span class="timestamp"></span>
+          <p class="message"></p>
+        </div>
+      </template>
     </body></html>`,
     { url: 'https://example.com' }
   );


### PR DESCRIPTION
## Summary
- rebuild the dashboard with a collapsible daily snapshot, tabbed workspace, and global filters per the redesign brief
- group passive assets and upgrades into category buckets with collapsible cards, availability toggles, and search controls
- document the new interface structure, refresh the test DOM scaffolding, and add a UI redesign feature note

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d97f62465c832caebfa07084226695