### PR TITLE
feat: add passive asset quality system

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Online Hustle Simulator is a browser-based incremental game about orchestrating 
 ## Gameplay Loop & Systems
 - **Daily Time Budget** – Every in-game day begins with 14 base hours (plus permanent bonuses). Hustles, knowledge study, asset setup, and upkeep all consume this pool. Assistants can be hired (up to four) for +2 hours each, but payroll hits every morning; you can always fire them if cash or time dips too low. Turbo coffee grants up to three one-hour boosts per day.
 - **Setup & Maintenance Allocation** – When a day ends, each asset checks whether you funded the required setup/maintenance hours **and** any daily cash cost. Funded instances progress (or earn income); unfunded ones pause. The next morning, the scheduler automatically earmarks required hours until you run out.
+- **Asset Quality Ladder** – Every passive asset launches at Quality 0 and can be upgraded by investing time (and sometimes cash) into bespoke quality actions. Quality milestones unlock higher payout ranges, steadier log messages, and whimsical celebrations when tiers are reached.
 - **Knowledge Tracks** – Study hustles (e.g., Outline Mastery, E-Commerce Playbook) require a fixed number of days at specific hour costs. Completing them unlocks advanced assets and generates celebratory log entries; skipping a day after you start produces gentle warnings.
 - **Daily Recap Log** – Every launch, maintenance result, payout, and study milestone is written to the log so you can reconstruct exactly what happened during busy streaks.
 
@@ -24,13 +25,13 @@ Online Hustle Simulator is a browser-based incremental game about orchestrating 
 - **Automation Architecture Course** – Study 3h/day for 7 days to earn SaaS-ready engineering chops.
 
 ### Passive Assets (Daily Payouts)
-Each asset supports multiple instances, tracks setup progress, and rolls a daily income range once active.
-- **Personal Blog Network** – Setup 1 day × 3h ($25). Requires 1h/day + $2 maintenance. Base daily income ~$70 with ±25% variance; Automation Course boosts payouts by 50%.
-- **Weekly Vlog Channel** – Setup 3 days × 4h ($180) with Camera upgrade. Maintenance 1.5h/day + $5. Base daily income ~$140 with ±35% variance.
-- **Digital E-Book Series** – Setup 4 days × 3h ($60) after completing Outline Mastery. Maintenance 0.5h/day. Base daily income ~$120 with ±30% variance.
-- **Stock Photo Gallery** – Setup 3 days × 2h (no cost) with Camera + Lighting Kit and Photo Catalog knowledge. Maintenance 1h/day. Base daily income ~$95 with ±45% variance.
-- **Dropshipping Storefront** – Setup 3 days × 4h ($500) after E-Commerce Playbook and two active blogs. Maintenance 2h/day. Base daily income ~$260 with ±50% variance.
-- **SaaS Micro-App** – Setup 7 days × 5h ($1500) after Automation Architecture plus experience running a dropshipping store and e-book line. Maintenance 3h/day. Base daily income ~$620 with ±60% variance.
+Each asset supports multiple instances, tracks setup progress, and rolls a daily income range once active. Quality actions unique to each asset increase payouts and stability.
+- **Personal Blog Network** – Setup 1 day × 3h ($25). Requires 1h/day + $2 maintenance. Quality actions include drafting posts, SEO sprints, and backlink outreach; Quality 0 drips $1–$3/day while Quality 3 hits $70–$120/day (Automation Course still adds +50%).
+- **Weekly Vlog Channel** – Setup 3 days × 4h ($180) with Camera upgrade. Maintenance 1.5h/day + $5. Record episodes, polish edits, and run promo blasts to climb from $2–$6/day at Quality 0 to $150–$260/day at Quality 3, with viral spikes possible at higher tiers.
+- **Digital E-Book Series** – Setup 4 days × 3h ($60) after completing Outline Mastery. Maintenance 0.5h/day. Write chapters, commission cover art, and rally reviews to move from $3–$6/day drafts to $110–$160/day fandom favorites.
+- **Stock Photo Gallery** – Setup 3 days × 2h (no cost) with Camera + Lighting Kit and Photo Catalog knowledge. Maintenance 1h/day. Shoot themed packs, keyword them, and pitch marketplaces; quality progression raises royalties from $4–$8/day to $70–$140/day.
+- **Dropshipping Storefront** – Setup 3 days × 4h ($500) after E-Commerce Playbook and two active blogs. Maintenance 2h/day. Add listings, tune pages, and run ad bursts so profits scale from $8–$15/day to $170–$260/day.
+- **SaaS Micro-App** – Setup 7 days × 5h ($1500) after Automation Architecture plus experience running a dropshipping store and e-book line. Maintenance 3h/day. Squash bugs, ship features, and host support sprints to grow subscriptions from $10–$20/day to $220–$320/day.
 
 ### Upgrades & Boosts
 - **Hire Virtual Assistant** – $180 per hire, up to four assistants. Each adds +2h daily but costs $30/day in payroll; fire assistants anytime to cut wages (and hours).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,3 +10,4 @@
 - Expanded the virtual assistant upgrade into a four-person team with daily payroll, hire/fire controls, and log messaging.
 - Added cash-based maintenance costs for blogs ($2/day) and vlogs ($5/day) that block payouts when funds are unavailable.
 - Wired a daily metrics ledger into the snapshot so time invested, cash earned, and spending breakdowns reflect the current day’s actions.
+- Introduced an asset quality ladder with bespoke actions, UI panels, and level-based payout scaling for every passive income stream.

--- a/docs/features/asset-quality-system.md
+++ b/docs/features/asset-quality-system.md
@@ -1,0 +1,26 @@
+# Passive Asset Quality System
+
+## Goals
+- Add a progression ladder inside each passive asset so players choose between launching breadth and deepening quality.
+- Tie quality upgrades to thematic actions (posts, edits, bug fixes) instead of generic "upgrade" clicks.
+- Surface quality requirements and actions directly on asset cards with encouraging UI copy.
+
+## Player Impact
+- Every new asset instance starts at Quality 0 and earns a tiny trickle until the player invests in quality actions.
+- Quality actions consume daily hours (and sometimes cash), forcing trade-offs against maintenance, hustles, or study time.
+- Reaching a new quality tier bumps payout ranges, triggers celebratory log lines, and unlocks asset-specific perks (e.g., vlog viral chances, course synergy for blogs).
+
+## Key Systems & Tuning
+- **Quality Definitions** – Each asset definition now includes:
+  - `tracks`: named progress counters (e.g., `posts`, `seo`, `support`).
+  - `levels`: ordered tiers with income ranges and cumulative requirements. Example: blogs climb from $1–$3/day at Quality 0 to $70–$120/day at Quality 3.
+  - `actions`: time/cash investments that advance one or more tracks with whimsical log feedback.
+  - Optional `messages.levelUp` hooks for flavourful celebration copy.
+- **Income Calculation** – Daily payouts pull the income band for the instance’s current quality level before running the existing variance roll and modifiers (Automation Course still multiplies blog income; high-quality vlogs gain a viral spike chance).
+- **UI Panel** – Asset cards render a “Quality Actions” panel listing owned instances, their current quality, progress toward the next tier, and clickable action buttons. Buttons are disabled when setup isn’t complete or resources are insufficient.
+- **Metrics & Logs** – Quality actions record time/cash contributions under a new `quality` category and emit upbeat log entries, while level-ups post passive-style milestone messages.
+
+## Open Questions / Next Steps
+- Tune hour/cash costs once broader playtest data arrives (particularly for late-game SaaS quality actions).
+- Explore assistant or upgrade interactions that automate specific quality actions or reduce requirements.
+- Consider diminishing returns or prestige bonuses for maintaining multiple high-quality instances in the same asset family.

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -79,6 +79,22 @@ export function normalizeAssetInstance(definition, instance = {}) {
   const createdOnDay = Number(normalized.createdOnDay);
   normalized.createdOnDay = Number.isFinite(createdOnDay) ? Math.max(1, createdOnDay) : (state?.day ?? 1);
 
+  const quality = normalized.quality || {};
+  const level = Number(quality.level);
+  const normalizedLevel = Number.isFinite(level) ? Math.max(0, Math.floor(level)) : 0;
+  const progressEntries = Object.entries(quality.progress || {});
+  const normalizedProgress = {};
+  for (const [key, value] of progressEntries) {
+    const numericValue = Number(value);
+    if (Number.isFinite(numericValue) && numericValue > 0) {
+      normalizedProgress[key] = numericValue;
+    }
+  }
+  normalized.quality = {
+    level: normalizedLevel,
+    progress: normalizedProgress
+  };
+
   return normalized;
 }
 
@@ -92,7 +108,11 @@ export function createAssetInstance(definition, overrides = {}) {
     maintenanceFundedToday: false,
     lastIncome: 0,
     totalIncome: 0,
-    createdOnDay: state?.day ?? 1
+    createdOnDay: state?.day ?? 1,
+    quality: {
+      level: 0,
+      progress: {}
+    }
   };
   const merged = { ...baseInstance, ...structuredClone(overrides) };
   if (merged.status === 'active') {

--- a/src/game/assets/definitions/blog.js
+++ b/src/game/assets/definitions/blog.js
@@ -6,6 +6,8 @@ import {
   latestYieldDetail,
   maintenanceDetail,
   ownedDetail,
+  qualityProgressDetail,
+  qualitySummaryDetail,
   setupCostDetail,
   setupDetail
 } from '../helpers.js';
@@ -19,12 +21,80 @@ const blogDefinition = {
   setup: { days: 1, hoursPerDay: 3, cost: 25 },
   maintenance: { hours: 1, cost: 2 },
   income: {
-    base: 70,
+    base: 95,
     variance: 0.25,
     logType: 'passive',
     modifier: amount => {
       const automation = getUpgradeState('course').purchased ? 1.5 : 1;
       return amount * automation;
+    }
+  },
+  quality: {
+    summary: 'Draft posts, tune SEO, and rally backlinks to climb from skeleton sites to a thriving blog constellation.',
+    tracks: {
+      posts: { label: 'Long-form posts', shortLabel: 'posts' },
+      seo: { label: 'SEO boosts', shortLabel: 'SEO boosts' },
+      outreach: { label: 'Backlink outreach', shortLabel: 'backlink runs' }
+    },
+    levels: [
+      {
+        level: 0,
+        name: 'Skeleton Drafts',
+        description: 'Bare pages with placeholder copy and sleepy earnings.',
+        income: { min: 1, max: 3 },
+        requirements: {}
+      },
+      {
+        level: 1,
+        name: 'Content Sprout',
+        description: 'Three polished posts that finally catch organic clicks.',
+        income: { min: 10, max: 20 },
+        requirements: { posts: 3 }
+      },
+      {
+        level: 2,
+        name: 'SEO Groove',
+        description: 'Evergreen articles plus SEO sweeps pull in steady readers.',
+        income: { min: 30, max: 60 },
+        requirements: { posts: 9, seo: 2 }
+      },
+      {
+        level: 3,
+        name: 'Authority Hub',
+        description: 'Backlinks and authority content turn ad clicks into a gush.',
+        income: { min: 70, max: 120 },
+        requirements: { posts: 19, seo: 4, outreach: 3 }
+      }
+    ],
+    actions: [
+      {
+        id: 'writePost',
+        label: 'Write Post',
+        time: 3,
+        progressKey: 'posts',
+        progressAmount: context => (context.upgrade('course')?.purchased ? 2 : 1),
+        log: ({ label }) => `${label} published a sparkling post. Subscribers sip the fresh ideas!`
+      },
+      {
+        id: 'seoSprint',
+        label: 'SEO Sprint',
+        time: 2,
+        cost: 15,
+        progressKey: 'seo',
+        log: ({ label }) => `${label} ran an SEO tune-up. Keywords now shimmy to the top.`
+      },
+      {
+        id: 'outreachPush',
+        label: 'Backlink Outreach',
+        time: 1.5,
+        cost: 12,
+        progressKey: 'outreach',
+        log: ({ label }) => `${label} charmed partners into fresh backlinks. Authority climbs!`
+      }
+    ],
+    messages: {
+      levelUp: ({ label, level, levelDef }) =>
+        `${label} reached Quality ${level} — ${levelDef?.name || 'new tier'}! Ad pennies upgrade to chunky stacks.`
     }
   },
   messages: {
@@ -43,6 +113,8 @@ blogDefinition.details = [
   () => setupDetail(blogDefinition),
   () => setupCostDetail(blogDefinition),
   () => maintenanceDetail(blogDefinition),
+  () => qualitySummaryDetail(blogDefinition),
+  () => qualityProgressDetail(blogDefinition),
   () => incomeDetail(blogDefinition),
   () => latestYieldDetail(blogDefinition)
 ];

--- a/src/game/assets/definitions/dropshipping.js
+++ b/src/game/assets/definitions/dropshipping.js
@@ -5,6 +5,8 @@ import {
   latestYieldDetail,
   maintenanceDetail,
   ownedDetail,
+  qualityProgressDetail,
+  qualitySummaryDetail,
   setupCostDetail,
   setupDetail
 } from '../helpers.js';
@@ -18,11 +20,82 @@ const dropshippingDefinition = {
   description: 'Spin up a storefront, source trending products, and let fulfillment partners handle the rest.',
   setup: { days: 3, hoursPerDay: 4, cost: 500 },
   maintenance: { hours: 2, cost: 0 },
-  income: { base: 260, variance: 0.5, logType: 'passive' },
+  income: {
+    base: 210,
+    variance: 0.4,
+    logType: 'passive'
+  },
   requirements: [
     { type: 'knowledge', id: 'ecomPlaybook' },
     { type: 'experience', assetId: 'blog', count: 2 }
   ],
+  quality: {
+    summary: 'Add listings, tune pages, and fund ad bursts to transform a fragile storefront into a conversion machine.',
+    tracks: {
+      listings: { label: 'Product listings', shortLabel: 'listings' },
+      optimization: { label: 'Page optimizations', shortLabel: 'optimizations' },
+      ads: { label: 'Ad bursts', shortLabel: 'ads' }
+    },
+    levels: [
+      {
+        level: 0,
+        name: 'Bare Shelves',
+        description: 'A tiny catalog with wobbly funnels ekes out pocket change.',
+        income: { min: 8, max: 15 },
+        requirements: {}
+      },
+      {
+        level: 1,
+        name: 'Curated Offerings',
+        description: 'A handful of optimized listings convert curious scrollers.',
+        income: { min: 40, max: 70 },
+        requirements: { listings: 4 }
+      },
+      {
+        level: 2,
+        name: 'Ad Funnel Maestro',
+        description: 'Paid campaigns and optimized pages fuel reliable revenue.',
+        income: { min: 90, max: 150 },
+        requirements: { listings: 8, ads: 3 }
+      },
+      {
+        level: 3,
+        name: 'Fulfillment Powerhouse',
+        description: 'Dialed-in logistics handle waves of loyal customers.',
+        income: { min: 170, max: 260 },
+        requirements: { listings: 12, ads: 6, optimization: 4 }
+      }
+    ],
+    actions: [
+      {
+        id: 'addListing',
+        label: 'Add Listing',
+        time: 2,
+        cost: 15,
+        progressKey: 'listings',
+        log: ({ label }) => `${label} launched a trending product listing with glossy mockups.`
+      },
+      {
+        id: 'optimizePage',
+        label: 'Optimize Page',
+        time: 1,
+        progressKey: 'optimization',
+        log: ({ label }) => `${label} rewrote copy and tightened funnels. Conversion rate hums!`
+      },
+      {
+        id: 'runAdBurst',
+        label: 'Run Ad Burst',
+        time: 1.5,
+        cost: 30,
+        progressKey: 'ads',
+        log: ({ label }) => `${label} funded a laser-targeted ad burst. Traffic surges in.`
+      }
+    ],
+    messages: {
+      levelUp: ({ label, level, levelDef }) =>
+        `${label} leveled to Quality ${level}! ${levelDef?.name || 'New playbook'} keeps carts overflowing.`
+    }
+  },
   messages: {
     setupStarted: label => `${label} is onboarding suppliers. Your product list already looks spicy.`,
     setupProgress: (label, completed, total) => `${label} refined logistics (${completed}/${total} setup days banked).`,
@@ -40,6 +113,8 @@ dropshippingDefinition.details = [
   () => setupCostDetail(dropshippingDefinition),
   () => maintenanceDetail(dropshippingDefinition),
   () => renderAssetRequirementDetail('dropshipping'),
+  () => qualitySummaryDetail(dropshippingDefinition),
+  () => qualityProgressDetail(dropshippingDefinition),
   () => incomeDetail(dropshippingDefinition),
   () => latestYieldDetail(dropshippingDefinition)
 ];

--- a/src/game/assets/definitions/ebook.js
+++ b/src/game/assets/definitions/ebook.js
@@ -5,6 +5,8 @@ import {
   latestYieldDetail,
   maintenanceDetail,
   ownedDetail,
+  qualityProgressDetail,
+  qualitySummaryDetail,
   setupCostDetail,
   setupDetail
 } from '../helpers.js';
@@ -18,8 +20,79 @@ const ebookDefinition = {
   description: 'Package your expertise into downloadable page-turners that sell while you snooze.',
   setup: { days: 4, hoursPerDay: 3, cost: 60 },
   maintenance: { hours: 0.5, cost: 0 },
-  income: { base: 120, variance: 0.3, logType: 'passive' },
+  income: {
+    base: 150,
+    variance: 0.25,
+    logType: 'passive'
+  },
   requirements: [{ type: 'knowledge', id: 'outlineMastery' }],
+  quality: {
+    summary: 'Draft chapters, commission covers, and gather reviews so royalties snowball as quality climbs.',
+    tracks: {
+      chapters: { label: 'Chapters drafted', shortLabel: 'chapters' },
+      cover: { label: 'Cover upgrades', shortLabel: 'cover art' },
+      reviews: { label: 'Reader reviews', shortLabel: 'reviews' }
+    },
+    levels: [
+      {
+        level: 0,
+        name: 'Rough Manuscript',
+        description: 'A handful of notes generate only trickle royalties.',
+        income: { min: 3, max: 6 },
+        requirements: {}
+      },
+      {
+        level: 1,
+        name: 'Polished Draft',
+        description: 'Six chapters stitched into a bingeable volume.',
+        income: { min: 25, max: 40 },
+        requirements: { chapters: 6 }
+      },
+      {
+        level: 2,
+        name: 'Collector Edition',
+        description: 'A premium cover and full season keep fans engaged.',
+        income: { min: 60, max: 90 },
+        requirements: { chapters: 12, cover: 1 }
+      },
+      {
+        level: 3,
+        name: 'Fandom Favorite',
+        description: 'Glowing reviews lock in bestseller status.',
+        income: { min: 110, max: 160 },
+        requirements: { chapters: 18, cover: 1, reviews: 5 }
+      }
+    ],
+    actions: [
+      {
+        id: 'writeChapter',
+        label: 'Write Chapter',
+        time: 2.5,
+        progressKey: 'chapters',
+        log: ({ label }) => `${label} gained another gripping chapter. Cliffhangers everywhere!`
+      },
+      {
+        id: 'designCover',
+        label: 'Commission Cover',
+        time: 1.5,
+        cost: 45,
+        progressKey: 'cover',
+        log: ({ label }) => `${label} unveiled a shiny cover mockup. Bookstores swoon.`
+      },
+      {
+        id: 'rallyReviews',
+        label: 'Rally Reviews',
+        time: 1,
+        cost: 5,
+        progressKey: 'reviews',
+        log: ({ label }) => `${label} nudged superfans for reviews. Star ratings climb skyward!`
+      }
+    ],
+    messages: {
+      levelUp: ({ label, level, levelDef }) =>
+        `${label} celebrated Quality ${level}! ${levelDef?.name || 'New milestone'} unlocks tastier royalties.`
+    }
+  },
   messages: {
     setupStarted: label => `${label} outline is locked! Next up: polishing chapters and cover art.`,
     setupProgress: (label, completed, total) => `${label} drafting sprint is ${completed}/${total} days complete.`,
@@ -37,6 +110,8 @@ ebookDefinition.details = [
   () => setupCostDetail(ebookDefinition),
   () => maintenanceDetail(ebookDefinition),
   () => renderAssetRequirementDetail('ebook'),
+  () => qualitySummaryDetail(ebookDefinition),
+  () => qualityProgressDetail(ebookDefinition),
   () => incomeDetail(ebookDefinition),
   () => latestYieldDetail(ebookDefinition)
 ];

--- a/src/game/assets/definitions/saas.js
+++ b/src/game/assets/definitions/saas.js
@@ -5,6 +5,8 @@ import {
   latestYieldDetail,
   maintenanceDetail,
   ownedDetail,
+  qualityProgressDetail,
+  qualitySummaryDetail,
   setupCostDetail,
   setupDetail
 } from '../helpers.js';
@@ -18,12 +20,81 @@ const saasDefinition = {
   description: 'Ship a tidy micro-SaaS that collects subscriptions from superfans of your niche tools.',
   setup: { days: 7, hoursPerDay: 5, cost: 1500 },
   maintenance: { hours: 3, cost: 0 },
-  income: { base: 620, variance: 0.6, logType: 'passive' },
+  income: {
+    base: 280,
+    variance: 0.25,
+    logType: 'passive'
+  },
   requirements: [
     { type: 'knowledge', id: 'automationCourse' },
     { type: 'experience', assetId: 'dropshipping', count: 1 },
     { type: 'experience', assetId: 'ebook', count: 1 }
   ],
+  quality: {
+    summary: 'Squash bugs, ship features, and host support sprints so your app graduates into a churn-proof subscription machine.',
+    tracks: {
+      fixes: { label: 'Bug fixes', shortLabel: 'bug fixes' },
+      features: { label: 'Feature releases', shortLabel: 'features' },
+      support: { label: 'Support sessions', shortLabel: 'support calls' }
+    },
+    levels: [
+      {
+        level: 0,
+        name: 'Beta Build',
+        description: 'Early adopters tolerate quirks for pocket change revenue.',
+        income: { min: 10, max: 20 },
+        requirements: {}
+      },
+      {
+        level: 1,
+        name: 'Reliable Release',
+        description: 'Critical bug fixes calm churn and boost sign-ups.',
+        income: { min: 45, max: 70 },
+        requirements: { fixes: 3 }
+      },
+      {
+        level: 2,
+        name: 'Feature Favorite',
+        description: 'Steady features keep subscriptions renewing.',
+        income: { min: 110, max: 160 },
+        requirements: { fixes: 8, features: 3 }
+      },
+      {
+        level: 3,
+        name: 'Support Legend',
+        description: 'Dedicated support squads crush churn and win raves.',
+        income: { min: 220, max: 320 },
+        requirements: { fixes: 12, features: 6, support: 6 }
+      }
+    ],
+    actions: [
+      {
+        id: 'squashBugs',
+        label: 'Squash Bugs',
+        time: 2,
+        progressKey: 'fixes',
+        log: ({ label }) => `${label} closed a cluster of bugs. Error logs finally exhale.`
+      },
+      {
+        id: 'shipFeature',
+        label: 'Ship Feature',
+        time: 3,
+        progressKey: 'features',
+        log: ({ label }) => `${label} rolled out a shiny feature. Users spam the applause emoji.`
+      },
+      {
+        id: 'supportSprint',
+        label: 'Support Sprint',
+        time: 1.5,
+        progressKey: 'support',
+        log: ({ label }) => `${label} hosted a support sprint. Churn gremlins retreat.`
+      }
+    ],
+    messages: {
+      levelUp: ({ label, level, levelDef }) =>
+        `${label} advanced to Quality ${level}! ${levelDef?.name || 'New stature'} locks in recurring revenue.`
+    }
+  },
   messages: {
     setupStarted: label => `${label} sprint kicked off with wireframes and caffeine-fueled commits.`,
     setupProgress: (label, completed, total) => `${label} completed another release sprint (${completed}/${total}).`,
@@ -41,6 +112,8 @@ saasDefinition.details = [
   () => setupCostDetail(saasDefinition),
   () => maintenanceDetail(saasDefinition),
   () => renderAssetRequirementDetail('saas'),
+  () => qualitySummaryDetail(saasDefinition),
+  () => qualityProgressDetail(saasDefinition),
   () => incomeDetail(saasDefinition),
   () => latestYieldDetail(saasDefinition)
 ];

--- a/src/game/assets/definitions/stockPhotos.js
+++ b/src/game/assets/definitions/stockPhotos.js
@@ -5,6 +5,8 @@ import {
   latestYieldDetail,
   maintenanceDetail,
   ownedDetail,
+  qualityProgressDetail,
+  qualitySummaryDetail,
   setupDetail
 } from '../helpers.js';
 import { renderAssetRequirementDetail, updateAssetCardLock } from '../../requirements.js';
@@ -17,12 +19,83 @@ const stockPhotosDefinition = {
   description: 'Curate vibrant photo packs that designers license in surprising numbers.',
   setup: { days: 3, hoursPerDay: 2, cost: 0 },
   maintenance: { hours: 1, cost: 0 },
-  income: { base: 95, variance: 0.45, logType: 'passive' },
+  income: {
+    base: 140,
+    variance: 0.35,
+    logType: 'passive'
+  },
   requirements: [
     { type: 'equipment', id: 'camera' },
     { type: 'equipment', id: 'studio' },
     { type: 'knowledge', id: 'photoLibrary' }
   ],
+  quality: {
+    summary: 'Shoot new packs, keyword diligently, and pitch marketplaces so galleries enjoy evergreen demand.',
+    tracks: {
+      packs: { label: 'Photo packs', shortLabel: 'packs' },
+      keywords: { label: 'Keyword sessions', shortLabel: 'keywords' },
+      outreach: { label: 'Marketplace outreach', shortLabel: 'outreach' }
+    },
+    levels: [
+      {
+        level: 0,
+        name: 'Dusty Portfolio',
+        description: 'A tiny gallery with generic tags earns a trickle.',
+        income: { min: 4, max: 8 },
+        requirements: {}
+      },
+      {
+        level: 1,
+        name: 'Fresh Packs',
+        description: 'Multiple themed packs attract steady design searches.',
+        income: { min: 12, max: 24 },
+        requirements: { packs: 4 }
+      },
+      {
+        level: 2,
+        name: 'Tagged Treasure',
+        description: 'Meticulous keywords vault photos to top results.',
+        income: { min: 30, max: 60 },
+        requirements: { packs: 9, keywords: 4 }
+      },
+      {
+        level: 3,
+        name: 'Marketplace Darling',
+        description: 'Partnerships and outreach keep royalties compounding.',
+        income: { min: 70, max: 140 },
+        requirements: { packs: 15, keywords: 8, outreach: 3 }
+      }
+    ],
+    actions: [
+      {
+        id: 'shootPack',
+        label: 'Shoot Pack',
+        time: 2.5,
+        progressKey: 'packs',
+        log: ({ label }) => `${label} captured a fresh themed pack. Lightroom presets sparkle!`
+      },
+      {
+        id: 'keywordSession',
+        label: 'Keyword Session',
+        time: 1,
+        cost: 5,
+        progressKey: 'keywords',
+        log: ({ label }) => `${label} tagged every shot with laser-focused keywords.`
+      },
+      {
+        id: 'portfolioOutreach',
+        label: 'Pitch Marketplace',
+        time: 1.5,
+        cost: 12,
+        progressKey: 'outreach',
+        log: ({ label }) => `${label} pitched new bundles to marketplaces. Visibility surges!`
+      }
+    ],
+    messages: {
+      levelUp: ({ label, level, levelDef }) =>
+        `${label} blossomed to Quality ${level}! ${levelDef?.name || 'New spotlight'} opens stronger long-tail sales.`
+    }
+  },
   messages: {
     setupStarted: label => `${label} scouting trip kicked off—lens caps off and inspiration flowing.`,
     setupProgress: (label, completed, total) => `${label} catalogued more shots (${completed}/${total} curation days done).`,
@@ -39,6 +112,8 @@ stockPhotosDefinition.details = [
   () => setupDetail(stockPhotosDefinition),
   () => maintenanceDetail(stockPhotosDefinition),
   () => renderAssetRequirementDetail('stockPhotos'),
+  () => qualitySummaryDetail(stockPhotosDefinition),
+  () => qualityProgressDetail(stockPhotosDefinition),
   () => incomeDetail(stockPhotosDefinition),
   () => latestYieldDetail(stockPhotosDefinition)
 ];

--- a/src/game/assets/definitions/vlog.js
+++ b/src/game/assets/definitions/vlog.js
@@ -5,6 +5,8 @@ import {
   latestYieldDetail,
   maintenanceDetail,
   ownedDetail,
+  qualityProgressDetail,
+  qualitySummaryDetail,
   setupCostDetail,
   setupDetail
 } from '../helpers.js';
@@ -18,8 +20,86 @@ const vlogDefinition = {
   description: 'Film upbeat vlogs, edit late-night montages, and ride the algorithmic rollercoaster.',
   setup: { days: 3, hoursPerDay: 4, cost: 180 },
   maintenance: { hours: 1.5, cost: 5 },
-  income: { base: 140, variance: 0.35, logType: 'passive' },
+  income: {
+    base: 200,
+    variance: 0.3,
+    logType: 'passive',
+    modifier: (amount, { instance }) => {
+      const qualityLevel = instance?.quality?.level || 0;
+      if (qualityLevel >= 3 && Math.random() < 0.18) {
+        return Math.round(amount * 3);
+      }
+      return amount;
+    }
+  },
   requirements: [{ type: 'equipment', id: 'camera' }],
+  quality: {
+    summary: 'Film episodes, polish edits, and promote premieres to unlock higher quality payouts and viral chances.',
+    tracks: {
+      videos: { label: 'Episodes filmed', shortLabel: 'episodes' },
+      edits: { label: 'Editing upgrades', shortLabel: 'edits' },
+      promotion: { label: 'Promo pushes', shortLabel: 'promo pushes' }
+    },
+    levels: [
+      {
+        level: 0,
+        name: 'Camera Shy',
+        description: 'Footage trickles in with shaky vlogs and tiny ad pennies.',
+        income: { min: 2, max: 6 },
+        requirements: {}
+      },
+      {
+        level: 1,
+        name: 'Weekly Rhythm',
+        description: 'A trio of uploads keeps subscribers checking in.',
+        income: { min: 35, max: 60 },
+        requirements: { videos: 3 }
+      },
+      {
+        level: 2,
+        name: 'Studio Shine',
+        description: 'Crisp edits and pacing win over binge-watchers.',
+        income: { min: 80, max: 140 },
+        requirements: { videos: 7, edits: 3 }
+      },
+      {
+        level: 3,
+        name: 'Algorithm Darling',
+        description: 'Hyped launches and collaborations unlock viral bursts.',
+        income: { min: 150, max: 260 },
+        requirements: { videos: 12, edits: 6, promotion: 3 }
+      }
+    ],
+    actions: [
+      {
+        id: 'shootEpisode',
+        label: 'Film Episode',
+        time: 4,
+        progressKey: 'videos',
+        log: ({ label }) => `${label} filmed an energetic episode. B-roll glitter everywhere!`
+      },
+      {
+        id: 'polishEdit',
+        label: 'Polish Edit',
+        time: 2,
+        cost: 10,
+        progressKey: 'edits',
+        log: ({ label }) => `${label} tightened jump cuts and color graded every frame.`
+      },
+      {
+        id: 'hypePush',
+        label: 'Promo Blast',
+        time: 1.5,
+        cost: 18,
+        progressKey: 'promotion',
+        log: ({ label }) => `${label} teased the drop on socials. Chat bubbles explode with hype!`
+      }
+    ],
+    messages: {
+      levelUp: ({ label, level, levelDef }) =>
+        `${label} is now Quality ${level}! ${levelDef?.name || 'New buzz'} unlocks juicier sponsorships.`
+    }
+  },
   messages: {
     setupStarted: label => `${label} is in production! Your storyboard is taped across the wall.`,
     setupProgress: (label, completed, total) => `${label} captured more footage (${completed}/${total} shoot days complete).`,
@@ -37,6 +117,8 @@ vlogDefinition.details = [
   () => setupCostDetail(vlogDefinition),
   () => maintenanceDetail(vlogDefinition),
   () => renderAssetRequirementDetail('vlog'),
+  () => qualitySummaryDetail(vlogDefinition),
+  () => qualityProgressDetail(vlogDefinition),
   () => incomeDetail(vlogDefinition),
   () => latestYieldDetail(vlogDefinition)
 ];

--- a/src/game/assets/helpers.js
+++ b/src/game/assets/helpers.js
@@ -12,6 +12,12 @@ import { checkDayEnd } from '../lifecycle.js';
 import { spendTime } from '../time.js';
 import { assetRequirementsMetById } from '../requirements.js';
 import { recordCostContribution, recordTimeContribution } from '../metrics.js';
+import {
+  getInstanceQualityRange,
+  getOverallQualityRange,
+  getQualityLevelSummary,
+  getQualityTracks
+} from './quality.js';
 
 export function buildAssetAction(definition, labels = {}) {
   return {
@@ -147,9 +153,7 @@ export function maintenanceDetail(definition) {
 
 export function incomeDetail(definition) {
   const { min, max } = getDailyIncomeRange(definition);
-  return `💸 Income: <strong>$${formatMoney(min)} - $${formatMoney(max)} / day</strong> per ${
-    definition.singular || 'asset'
-  }`;
+  return `💸 Income: <strong>$${formatMoney(min)} - $${formatMoney(max)} / day</strong> (quality-scaled)`;
 }
 
 export function latestYieldDetail(definition) {
@@ -168,18 +172,11 @@ export function instanceLabel(definition, index) {
 }
 
 export function getDailyIncomeRange(definition) {
-  const base = Math.max(0, Number(definition.income?.base) || 0);
-  const variance = Math.max(0, Number(definition.income?.variance) || 0);
-  const min = definition.income?.floor ?? Math.round(base * (1 - variance));
-  const max = definition.income?.ceiling ?? Math.round(base * (1 + variance));
-  return {
-    min: Math.max(0, min),
-    max: Math.max(Math.max(0, min), max)
-  };
+  return getOverallQualityRange(definition);
 }
 
 export function rollDailyIncome(definition, assetState, instance) {
-  const { min, max } = getDailyIncomeRange(definition);
+  const { min, max } = getInstanceQualityRange(definition, instance);
   const roll = min + Math.random() * Math.max(0, max - min);
   const rounded = Math.round(roll);
   if (typeof definition.income?.modifier === 'function') {
@@ -192,6 +189,45 @@ export function getIncomeRangeForDisplay(assetId) {
   const definition = getAssetDefinition(assetId);
   if (!definition) return { min: 0, max: 0 };
   return getDailyIncomeRange(definition);
+}
+
+export function qualitySummaryDetail(definition) {
+  const tracks = getQualityTracks(definition);
+  const summary = getQualityLevelSummary(definition);
+  if (!summary.length) return '';
+  const highest = summary.at(-1);
+  const lowest = summary[0];
+  const incomeRange = getDailyIncomeRange(definition);
+  const pieces = [`⭐ Quality ${lowest.level} starts at <strong>$${formatMoney(Math.round(incomeRange.min))}/day</strong>`];
+  if (highest && highest.level !== lowest.level) {
+    pieces.push(
+      `Quality ${highest.level} can reach <strong>$${formatMoney(Math.round(highest.income?.max || incomeRange.max))}/day</strong>`
+    );
+  }
+  const trackNames = Object.values(tracks).map(track => track.shortLabel || track.label);
+  const trackDetail = trackNames.length ? `Progress via ${formatList(trackNames)}` : '';
+  const note = [pieces.join(' · '), trackDetail].filter(Boolean).join(' · ');
+  return `✨ Quality: ${note}`;
+}
+
+export function qualityProgressDetail(definition) {
+  const summary = getQualityLevelSummary(definition);
+  if (!summary.length) return '';
+  const tracks = getQualityTracks(definition);
+  const lines = summary
+    .map(level => {
+      const requirementEntries = Object.entries(level.requirements || {});
+      if (!requirementEntries.length) {
+        return `Quality ${level.level}: ${level.name}`;
+      }
+      const parts = requirementEntries.map(([key, value]) => {
+        const label = tracks[key]?.shortLabel || tracks[key]?.label || key;
+        return `${value} ${label}`;
+      });
+      return `Quality ${level.level}: ${level.name} (${parts.join(', ')})`;
+    })
+    .join(' • ');
+  return `📈 Roadmap: ${lines}`;
 }
 
 export { assetActionLabel, isAssetPurchaseDisabled, startAsset };

--- a/src/game/assets/index.js
+++ b/src/game/assets/index.js
@@ -1,13 +1,35 @@
 import { ASSETS } from './registry.js';
 import { allocateAssetMaintenance, closeOutDay } from './lifecycle.js';
 import { getIncomeRangeForDisplay } from './helpers.js';
+import {
+  performQualityAction,
+  getQualityLevel,
+  getQualityLevelSummary,
+  getQualityActions,
+  getQualityTracks
+} from './quality.js';
 
 const assetsSystem = {
   list: ASSETS,
   allocateMaintenance: allocateAssetMaintenance,
   closeOutDay,
-  getIncomeRangeForDisplay
+  getIncomeRangeForDisplay,
+  performQualityAction,
+  getQualityLevel,
+  getQualityLevelSummary,
+  getQualityActions,
+  getQualityTracks
 };
 
 export default assetsSystem;
-export { ASSETS, allocateAssetMaintenance, closeOutDay, getIncomeRangeForDisplay };
+export {
+  ASSETS,
+  allocateAssetMaintenance,
+  closeOutDay,
+  getIncomeRangeForDisplay,
+  performQualityAction,
+  getQualityLevel,
+  getQualityLevelSummary,
+  getQualityActions,
+  getQualityTracks
+};

--- a/src/game/assets/quality.js
+++ b/src/game/assets/quality.js
@@ -1,0 +1,309 @@
+import { formatHours, formatMoney } from '../../core/helpers.js';
+import { addLog } from '../../core/log.js';
+import { getAssetDefinition, getAssetState, getState, getUpgradeState } from '../../core/state.js';
+import { executeAction } from '../actions.js';
+import { spendMoney } from '../currency.js';
+import { checkDayEnd } from '../lifecycle.js';
+import { recordCostContribution, recordTimeContribution } from '../metrics.js';
+import { spendTime } from '../time.js';
+
+const QUALITY_LEVEL_CACHE = new WeakMap();
+
+function ensureInstanceQuality(definition, instance) {
+  if (!instance.quality) {
+    instance.quality = { level: 0, progress: {} };
+  } else {
+    if (!Number.isFinite(Number(instance.quality.level))) {
+      instance.quality.level = 0;
+    } else {
+      instance.quality.level = Math.max(0, Math.floor(Number(instance.quality.level)));
+    }
+    if (!instance.quality.progress || typeof instance.quality.progress !== 'object') {
+      instance.quality.progress = {};
+    }
+  }
+  return instance.quality;
+}
+
+export function getQualityConfig(definition) {
+  return definition?.quality || null;
+}
+
+function getSortedLevels(definition) {
+  if (!definition) return [];
+  if (!QUALITY_LEVEL_CACHE.has(definition)) {
+    const config = getQualityConfig(definition);
+    if (!config?.levels?.length) {
+      QUALITY_LEVEL_CACHE.set(definition, []);
+    } else {
+      const sorted = [...config.levels].sort((a, b) => (a.level ?? 0) - (b.level ?? 0));
+      QUALITY_LEVEL_CACHE.set(definition, sorted);
+    }
+  }
+  return QUALITY_LEVEL_CACHE.get(definition);
+}
+
+export function getQualityLevel(definition, level) {
+  const levels = getSortedLevels(definition);
+  return levels.find(entry => entry.level === level) || null;
+}
+
+export function getNextQualityLevel(definition, level) {
+  const levels = getSortedLevels(definition);
+  return levels.find(entry => entry.level === level + 1) || null;
+}
+
+export function getHighestQualityLevel(definition) {
+  const levels = getSortedLevels(definition);
+  if (!levels.length) return null;
+  return levels.at(-1);
+}
+
+export function getQualityProgress(definition, instance) {
+  const quality = ensureInstanceQuality(definition, instance);
+  return quality.progress;
+}
+
+function meetsRequirements(progress, requirements = {}) {
+  if (!requirements || !Object.keys(requirements).length) {
+    return true;
+  }
+  for (const [key, value] of Object.entries(requirements)) {
+    const target = Number(value) || 0;
+    if (target <= 0) continue;
+    const current = Number(progress?.[key]) || 0;
+    if (current < target) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function calculateEligibleQualityLevel(definition, progress = {}) {
+  const levels = getSortedLevels(definition);
+  if (!levels.length) return 0;
+  let eligible = 0;
+  for (const level of levels) {
+    if (meetsRequirements(progress, level.requirements)) {
+      eligible = level.level;
+    } else {
+      break;
+    }
+  }
+  return eligible;
+}
+
+function resolveProgressAmount(action, context) {
+  if (typeof action.progressAmount === 'function') {
+    return Number(action.progressAmount(context)) || 0;
+  }
+  if (Number.isFinite(Number(action.progressAmount))) {
+    return Number(action.progressAmount);
+  }
+  return action.progressKey ? 1 : 0;
+}
+
+function getActionLabel(definition, assetState, instance) {
+  const base = definition.singular || definition.name || 'Asset';
+  const index = assetState.instances.indexOf(instance);
+  const number = index >= 0 ? index + 1 : 1;
+  return `${base} #${number}`;
+}
+
+function runQualityAction(definition, instanceId, actionId) {
+  const state = getState();
+  if (!state) return;
+  const assetState = getAssetState(definition.id);
+  const instance = assetState.instances.find(item => item.id === instanceId);
+  if (!instance) return;
+  if (instance.status !== 'active') {
+    const label = getActionLabel(definition, assetState, instance);
+    addLog(`${label} needs to finish setup before quality work will stick.`, 'warning');
+    return;
+  }
+  const config = getQualityConfig(definition);
+  const action = config?.actions?.find(entry => entry.id === actionId);
+  if (!action) return;
+
+  const timeCost = Math.max(0, Number(action.time) || 0);
+  const moneyCost = Math.max(0, Number(action.cost) || 0);
+  if (timeCost > 0 && state.timeLeft < timeCost) {
+    addLog(`You need ${formatHours(timeCost)} free before diving into that quality push.`, 'warning');
+    return;
+  }
+  if (moneyCost > 0 && state.money < moneyCost) {
+    addLog(`You need $${formatMoney(moneyCost)} ready for that quality push.`, 'warning');
+    return;
+  }
+
+  if (moneyCost > 0) {
+    spendMoney(moneyCost);
+    recordCostContribution({
+      key: `asset:${definition.id}:quality:${action.id}:cost`,
+      label: `✨ ${definition.singular || definition.name} quality`,
+      amount: moneyCost,
+      category: 'quality'
+    });
+  }
+  if (timeCost > 0) {
+    spendTime(timeCost);
+    recordTimeContribution({
+      key: `asset:${definition.id}:quality:${action.id}:time`,
+      label: `✨ ${definition.singular || definition.name} quality`,
+      hours: timeCost,
+      category: 'quality'
+    });
+  }
+
+  const quality = ensureInstanceQuality(definition, instance);
+  const progressKey = action.progressKey;
+  if (progressKey) {
+    const amount = resolveProgressAmount(action, {
+      state,
+      definition,
+      instance,
+      quality,
+      upgrade: id => getUpgradeState(id)
+    });
+    if (amount !== 0) {
+      const current = Number(quality.progress[progressKey]) || 0;
+      quality.progress[progressKey] = Math.max(0, current + amount);
+    }
+  }
+
+  if (typeof action.onComplete === 'function') {
+    action.onComplete({ state, definition, instance, quality });
+  }
+
+  const label = getActionLabel(definition, assetState, instance);
+  if (typeof action.log === 'function') {
+    const message = action.log({
+      label,
+      definition,
+      instance,
+      quality,
+      timeCost,
+      moneyCost
+    });
+    if (message) {
+      addLog(message, 'quality');
+    }
+  } else {
+    const parts = [];
+    if (timeCost > 0) parts.push(`${formatHours(timeCost)} invested`);
+    if (moneyCost > 0) parts.push(`$${formatMoney(moneyCost)} spent`);
+    const summary = parts.length ? ` (${parts.join(', ')})` : '';
+    addLog(`${label} received focused quality work${summary}.`, 'quality');
+  }
+
+  updateQualityLevel(definition, assetState, instance, quality);
+}
+
+function updateQualityLevel(definition, assetState, instance, quality) {
+  const previous = quality.level || 0;
+  const progress = quality.progress || {};
+  const eligible = calculateEligibleQualityLevel(definition, progress);
+  if (eligible === previous) return;
+
+  const highest = getHighestQualityLevel(definition);
+  quality.level = Math.min(eligible, highest?.level ?? eligible);
+  const label = getActionLabel(definition, assetState, instance);
+  const levelDef = getQualityLevel(definition, quality.level);
+  const config = getQualityConfig(definition);
+  if (typeof config?.messages?.levelUp === 'function') {
+    const message = config.messages.levelUp({
+      level: quality.level,
+      levelDef,
+      label,
+      definition,
+      instance,
+      progress
+    });
+    if (message) {
+      addLog(message, 'passive');
+    }
+  } else {
+    const title = levelDef?.name ? ` (${levelDef.name})` : '';
+    addLog(`${label} advanced to Quality ${quality.level}${title}.`, 'passive');
+  }
+}
+
+export function performQualityAction(assetId, instanceId, actionId) {
+  const definition = getAssetDefinition(assetId);
+  if (!definition) return;
+  executeAction(() => {
+    runQualityAction(definition, instanceId, actionId);
+  });
+  checkDayEnd();
+}
+
+export function getOverallQualityRange(definition) {
+  const levels = getSortedLevels(definition);
+  if (!levels.length) {
+    const income = definition?.income || {};
+    const base = Math.max(0, Number(income.base) || 0);
+    const variance = Math.max(0, Number(income.variance) || 0);
+    const min = income.floor ?? Math.round(base * (1 - variance));
+    const max = income.ceiling ?? Math.round(base * (1 + variance));
+    return {
+      min: Math.max(0, min),
+      max: Math.max(Math.max(0, min), max)
+    };
+  }
+  const min = levels.reduce((value, level) => Math.min(value, Number(level.income?.min) || 0), Infinity);
+  const max = levels.reduce((value, level) => Math.max(value, Number(level.income?.max) || 0), 0);
+  return {
+    min: Number.isFinite(min) ? Math.max(0, min) : 0,
+    max: Math.max(0, max)
+  };
+}
+
+export function getInstanceQualityRange(definition, instance) {
+  const quality = ensureInstanceQuality(definition, instance);
+  const levelDef = getQualityLevel(definition, quality.level);
+  if (levelDef?.income) {
+    return {
+      min: Math.max(0, Number(levelDef.income.min) || 0),
+      max: Math.max(0, Number(levelDef.income.max) || 0)
+    };
+  }
+  const overall = getOverallQualityRange(definition);
+  return overall;
+}
+
+export function canPerformQualityAction(definition, instance, action, state = getState()) {
+  if (!definition || !instance || !action) return false;
+  if (!state) return false;
+  if (instance.status !== 'active') return false;
+  const timeCost = Math.max(0, Number(action.time) || 0);
+  const moneyCost = Math.max(0, Number(action.cost) || 0);
+  if (timeCost > 0 && state.timeLeft < timeCost) return false;
+  if (moneyCost > 0 && state.money < moneyCost) return false;
+  return true;
+}
+
+export function getQualityActions(definition) {
+  const config = getQualityConfig(definition);
+  return config?.actions || [];
+}
+
+export function getQualityTracks(definition) {
+  const config = getQualityConfig(definition);
+  return config?.tracks || {};
+}
+
+export function getQualityLevelSummary(definition) {
+  const levels = getSortedLevels(definition);
+  return levels.map(level => ({
+    level: level.level,
+    name: level.name,
+    description: level.description,
+    income: level.income,
+    requirements: level.requirements
+  }));
+}
+
+export function getQualityNextRequirements(definition, level) {
+  const next = getNextQualityLevel(definition, level);
+  return next?.requirements || null;
+}

--- a/src/ui/cards.js
+++ b/src/ui/cards.js
@@ -1,5 +1,6 @@
 import elements from './elements.js';
 import { getState } from '../core/state.js';
+import { attachQualityPanel, updateQualityPanel } from './quality.js';
 
 const ASSET_CATEGORY_KEYS = {
   foundation: 'foundation',
@@ -45,6 +46,9 @@ export function updateCard(definition) {
   }
   if (typeof definition.update === 'function') {
     definition.update(state, definition.ui);
+  }
+  if (definition.quality && definition.ui?.extra?.quality) {
+    updateQualityPanel(definition, definition.ui.extra.quality);
   }
 }
 
@@ -166,7 +170,11 @@ function createCard(definition, container, metadata = {}) {
     card.appendChild(button);
   }
 
-  const extra = typeof definition.extraContent === 'function' ? (definition.extraContent(card, state) || {}) : {};
+  let extra = typeof definition.extraContent === 'function' ? definition.extraContent(card, state) || {} : {};
+  if (definition.quality) {
+    const qualityUI = attachQualityPanel(card, definition);
+    extra = { ...extra, quality: qualityUI };
+  }
 
   container.appendChild(card);
   definition.ui = {
@@ -175,6 +183,9 @@ function createCard(definition, container, metadata = {}) {
     details: detailEntries,
     extra
   };
+  if (definition.quality && definition.ui.extra?.quality) {
+    updateQualityPanel(definition, definition.ui.extra.quality);
+  }
 }
 
 function normalizeCategory(label = '') {

--- a/src/ui/quality.js
+++ b/src/ui/quality.js
@@ -1,0 +1,145 @@
+import { formatHours, formatMoney } from '../core/helpers.js';
+import { getAssetState, getState } from '../core/state.js';
+import {
+  canPerformQualityAction,
+  getQualityActions,
+  getQualityLevel,
+  getQualityNextRequirements,
+  getQualityTracks,
+  performQualityAction
+} from '../game/assets/quality.js';
+
+function createEmptyMessage(container, message) {
+  container.innerHTML = '';
+  const note = document.createElement('p');
+  note.className = 'quality-empty';
+  note.textContent = message;
+  container.appendChild(note);
+}
+
+export function attachQualityPanel(card, definition) {
+  const panel = document.createElement('div');
+  panel.className = 'quality-panel';
+
+  const header = document.createElement('div');
+  header.className = 'quality-panel__header';
+  const title = document.createElement('h4');
+  title.textContent = 'Quality Actions';
+  header.appendChild(title);
+  panel.appendChild(header);
+
+  if (definition.quality?.summary) {
+    const summary = document.createElement('p');
+    summary.className = 'quality-panel__summary';
+    summary.textContent = definition.quality.summary;
+    panel.appendChild(summary);
+  }
+
+  const list = document.createElement('div');
+  list.className = 'quality-panel__instances';
+  panel.appendChild(list);
+
+  card.appendChild(panel);
+
+  return { panel, list };
+}
+
+export function updateQualityPanel(definition, panelState) {
+  if (!panelState?.list) return;
+  const state = getState();
+  const assetState = getAssetState(definition.id);
+  const instances = assetState.instances;
+
+  if (!instances.length) {
+    createEmptyMessage(panelState.list, 'No active assets yet. Launch one to begin quality work.');
+    return;
+  }
+
+  panelState.list.innerHTML = '';
+  const tracks = getQualityTracks(definition);
+  const actions = getQualityActions(definition);
+
+  instances.forEach((instance, index) => {
+    const item = document.createElement('div');
+    item.className = 'quality-instance';
+
+    const header = document.createElement('div');
+    header.className = 'quality-instance__header';
+    const label = document.createElement('strong');
+    const name = definition.singular || definition.name || 'Asset';
+    label.textContent = `${name} #${index + 1}`;
+    header.appendChild(label);
+
+    const status = document.createElement('span');
+    status.className = 'quality-instance__status';
+    if (instance.status !== 'active') {
+      status.textContent = 'In setup';
+      status.classList.add('is-muted');
+    } else {
+      const level = instance.quality?.level || 0;
+      const levelDef = getQualityLevel(definition, level);
+      const title = levelDef?.name ? ` · ${levelDef.name}` : '';
+      status.textContent = `Quality ${level}${title}`;
+    }
+    header.appendChild(status);
+    item.appendChild(header);
+
+    if (instance.status === 'active') {
+      const progressWrap = document.createElement('div');
+      progressWrap.className = 'quality-instance__progress';
+      const nextRequirements = getQualityNextRequirements(definition, instance.quality?.level || 0) || {};
+      Object.entries(tracks).forEach(([key, track]) => {
+        const row = document.createElement('div');
+        row.className = 'quality-progress-row';
+        const current = Number(instance.quality?.progress?.[key]) || 0;
+        const target = Number(nextRequirements[key]) || null;
+        if (target && target > current) {
+          row.textContent = `${track.label || key}: ${current} / ${target}`;
+        } else {
+          row.textContent = `${track.label || key}: ${current}`;
+        }
+        progressWrap.appendChild(row);
+      });
+      if (progressWrap.childElementCount) {
+        item.appendChild(progressWrap);
+      }
+
+      const actionsRow = document.createElement('div');
+      actionsRow.className = 'quality-instance__actions';
+      actions.forEach(action => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'quality-action';
+        const details = [];
+        if (action.time) {
+          details.push(`⏳ ${formatHours(action.time)}`);
+        }
+        if (action.cost) {
+          details.push(`💵 $${formatMoney(action.cost)}`);
+        }
+        const suffix = details.length ? ` (${details.join(' · ')})` : '';
+        button.textContent = `${action.label}${suffix}`;
+        button.disabled = !canPerformQualityAction(definition, instance, action, state);
+        button.addEventListener('click', () => {
+          if (button.disabled) return;
+          performQualityAction(definition.id, instance.id, action.id);
+        });
+        actionsRow.appendChild(button);
+      });
+      if (!actions.length) {
+        const note = document.createElement('span');
+        note.className = 'quality-action__none';
+        note.textContent = 'No quality actions configured.';
+        actionsRow.appendChild(note);
+      }
+      item.appendChild(actionsRow);
+    } else {
+      const note = document.createElement('p');
+      note.className = 'quality-instance__note';
+      note.textContent = 'Quality work unlocks once setup wraps.';
+      item.appendChild(note);
+    }
+
+    panelState.list.appendChild(item);
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -479,6 +479,126 @@ body {
   list-style: none;
 }
 
+.quality-panel {
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 16px;
+  padding: 0.85rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.quality-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.quality-panel__header h4 {
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.quality-panel__summary {
+  font-size: 0.85rem;
+  color: rgba(203, 213, 225, 0.8);
+}
+
+.quality-panel__instances {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.quality-instance {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  padding: 0.75rem;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(56, 189, 248, 0.15);
+}
+
+.quality-instance__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.quality-instance__header strong {
+  font-size: 0.95rem;
+}
+
+.quality-instance__status {
+  font-size: 0.8rem;
+  color: rgba(56, 189, 248, 0.85);
+}
+
+.quality-instance__status.is-muted {
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.quality-instance__progress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.quality-progress-row {
+  display: flex;
+  justify-content: space-between;
+}
+
+.quality-instance__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.quality-action {
+  align-self: flex-start;
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  border: none;
+  background: rgba(56, 189, 248, 0.16);
+  color: var(--text);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.quality-action:hover:not(:disabled),
+.quality-action:focus-visible:not(:disabled) {
+  background: rgba(56, 189, 248, 0.28);
+  transform: translateY(-1px);
+}
+
+.quality-action:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.quality-action__none,
+.quality-empty,
+.quality-instance__note {
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.quality-empty {
+  text-align: center;
+  padding: 0.6rem 0;
+}
+
 .card button {
   align-self: flex-start;
   padding: 0.65rem 1.1rem;

--- a/tests/assetsFlow.test.js
+++ b/tests/assetsFlow.test.js
@@ -19,7 +19,8 @@ const {
 const {
   allocateAssetMaintenance,
   closeOutDay,
-  getIncomeRangeForDisplay
+  getIncomeRangeForDisplay,
+  performQualityAction
 } = assetsModule;
 
 const { spendMoney } = currencyModule;
@@ -107,10 +108,10 @@ test('closing out the day advances setup and pays income when funded', () => {
   }
 });
 
-test('income range for display reflects definition variance', () => {
+test('income range for display reflects quality floor and ceiling', () => {
   const range = getIncomeRangeForDisplay('blog');
-  assert.equal(range.min, Math.round(blogDefinition.income.base * (1 - blogDefinition.income.variance)));
-  assert.equal(range.max, Math.round(blogDefinition.income.base * (1 + blogDefinition.income.variance)));
+  assert.equal(range.min, 1);
+  assert.equal(range.max, 120);
 });
 
 test('spending money during maintenance does not go negative', () => {
@@ -118,4 +119,45 @@ test('spending money during maintenance does not go negative', () => {
   state.money = 10;
   spendMoney(25);
   assert.equal(state.money, 0);
+});
+
+test('quality actions invest resources and unlock stronger income tiers', () => {
+  const originalRandom = Math.random;
+  Math.random = () => 0;
+
+  try {
+    const state = getState();
+    state.money = 200;
+    state.timeLeft = 24;
+
+    const blogState = getAssetState('blog');
+    const instance = createAssetInstance(blogDefinition, { status: 'active' });
+    blogState.instances = [instance];
+    const instanceId = instance.id;
+
+    // Baseline payout at quality 0
+    instance.maintenanceFundedToday = true;
+    closeOutDay();
+    let updatedInstance = getAssetState('blog').instances.find(item => item.id === instanceId);
+    assert.equal(updatedInstance.quality.level, 0);
+    assert.equal(updatedInstance.lastIncome, 1);
+
+    // Invest in posts to reach Quality 1
+    performQualityAction('blog', instanceId, 'writePost');
+    performQualityAction('blog', instanceId, 'writePost');
+    performQualityAction('blog', instanceId, 'writePost');
+
+    updatedInstance = getAssetState('blog').instances.find(item => item.id === instanceId);
+    assert.equal(updatedInstance.quality.level, 1);
+    assert.equal(state.timeLeft, 24 - 9, 'quality actions should spend time');
+
+    // Next payout reflects new tier
+    updatedInstance.maintenanceFundedToday = true;
+    closeOutDay();
+    updatedInstance = getAssetState('blog').instances.find(item => item.id === instanceId);
+    assert.equal(updatedInstance.lastIncome, 10);
+    assert.ok(state.log.some(entry => /Quality 1/.test(entry.message)));
+  } finally {
+    Math.random = originalRandom;
+  }
 });

--- a/tests/gameLifecycle.test.js
+++ b/tests/gameLifecycle.test.js
@@ -19,7 +19,7 @@ const {
   getAssetState,
   createAssetInstance
 } = stateModule;
-const { allocateAssetMaintenance, closeOutDay, ASSETS } = assetsModule;
+const { allocateAssetMaintenance, closeOutDay, ASSETS, getIncomeRangeForDisplay } = assetsModule;
 const { HUSTLES } = hustlesModule;
 const { UPGRADES } = upgradesModule;
 const { advanceKnowledgeTracks, markKnowledgeStudied, getKnowledgeProgress } = requirementsModule;
@@ -72,20 +72,21 @@ test('maintenance funding yields end-of-day payouts', () => {
       daysCompleted: blogDefinition.setup.days,
       maintenanceFundedToday: false
     })];
+    const instanceId = blogState.instances[0].id;
     state.timeLeft = 10;
     state.money = 10;
 
     allocateAssetMaintenance();
 
-    let updatedInstance = getAssetState('blog').instances[0];
+    let updatedInstance = getAssetState('blog').instances.find(item => item.id === instanceId);
     assert.equal(updatedInstance.maintenanceFundedToday, true, 'maintenance should be funded when hours remain');
     assert.equal(state.timeLeft, 9, 'maintenance should consume daily hours');
     assert.equal(state.money, 8, 'maintenance should deduct upkeep cash');
 
     closeOutDay();
 
-    const expectedMinimumIncome = Math.round(blogDefinition.income.base * (1 - blogDefinition.income.variance));
-    updatedInstance = getAssetState('blog').instances[0];
+    const expectedMinimumIncome = getIncomeRangeForDisplay('blog').min;
+    updatedInstance = getAssetState('blog').instances.find(item => item.id === instanceId);
     assert.equal(updatedInstance.lastIncome, expectedMinimumIncome, 'lastIncome should reflect deterministic payout');
     assert.equal(state.money, expectedMinimumIncome + 8, 'daily payout should add to post-upkeep balance');
   } finally {


### PR DESCRIPTION
## Summary
- add a shared quality engine for passive assets, including per-action resource tracking and level-based income scaling
- extend each passive asset definition with quality tracks, requirements, and UI details while wiring new quality panels into the cards
- document the asset quality system in README and design notes with updated changelog entry

## Testing
- npm test
- Manual QA: not run (headless environment)


------
https://chatgpt.com/codex/tasks/task_e_68d98cbb13f8832cbf223aa84a8e107b