### PR TITLE
Revamp passive asset dashboard and briefing

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Overhauled the passive asset board with stat-rich cards, upgrade shortcuts, per-instance earnings, and a briefing modal for nailing new launches.
 - Replaced the tabbed workspace with a sticky header navigation that scrolls to each section, refreshed section styling, and removed duplicate passive asset cards.
 - Major UI redesign with a collapsible daily snapshot, tabbed workspace, asset categories, filter toggles, and upgrade search for smoother planning.
 - Shifted passive asset income to a day-driven scheduler with multi-day setup tracking and maintenance allocation.

--- a/docs/features/passive-asset-dashboard.md
+++ b/docs/features/passive-asset-dashboard.md
@@ -1,0 +1,24 @@
+# Passive Asset Dashboard Refresh
+
+## Summary
+The passive asset workspace now presents each asset as a management card that highlights ownership counts, yesterday's earnings, income potential, and upkeep at a glance. Cards surface quick actions to launch new builds, open quality upgrades, and sell individual instances without digging through secondary panels.
+
+## Goals
+- Give players immediate insight into how every passive build performed yesterday and what it costs to maintain.
+- Reduce the click depth for quality upgrades and sell actions by embedding them into each instance row.
+- Provide an upbeat "New Asset Briefing" modal so players can review setup requirements and payout expectations before committing resources.
+
+## Player Impact
+- Faster comparisons: stat tiles on each card summarize launches, payouts, and upkeep so players can pick the next investment without cross-referencing logs.
+- Smoother upgrades: an "Upgrade Quality" shortcut expands the quality panel and auto-focuses on the selected instance when triggered from the instance list.
+- Confident launches: the briefing modal reuses live detail renderers, ensuring setup costs, maintenance, and quality roadmaps stay accurate as modifiers shift.
+
+## Implementation Notes
+- Asset cards keep the existing category structure but use a dedicated layout (`asset-card__*` classes) for stats, actions, and instance management.
+- Instance rows now expose both the previous day's payout and per-instance upgrade buttons that call `openQuality` from card extras.
+- The modal is populated via `populateAssetInfoModal` using current detail renderers so future balance changes automatically propagate.
+- Collapsed view hides the tagline, instances, and quality panel while keeping the stat summary visible for quick scanning.
+
+## Open Questions
+- Should the briefing modal include projected payback periods based on current quality levels?
+- Would a lightweight filter for "show only assets with payouts today" help players spot underperforming builds more quickly?

--- a/index.html
+++ b/index.html
@@ -160,6 +160,7 @@
                 <input type="checkbox" id="filter-assets-hide-locked" />
                 <span>Hide unavailable</span>
               </label>
+              <button id="asset-info-trigger" class="ghost-button" type="button">New Asset Briefing</button>
             </div>
           </header>
           <div class="asset-categories" id="asset-grid">
@@ -167,25 +168,25 @@
               <header>
                 <h3>Foundation</h3>
               </header>
-              <div class="card-grid" id="asset-grid-foundation"></div>
+              <div class="card-grid asset-card-grid" id="asset-grid-foundation"></div>
             </section>
             <section class="asset-category" data-category="creative">
               <header>
                 <h3>Creative</h3>
               </header>
-              <div class="card-grid" id="asset-grid-creative"></div>
+              <div class="card-grid asset-card-grid" id="asset-grid-creative"></div>
             </section>
             <section class="asset-category" data-category="commerce">
               <header>
                 <h3>Commerce</h3>
               </header>
-              <div class="card-grid" id="asset-grid-commerce"></div>
+              <div class="card-grid asset-card-grid" id="asset-grid-commerce"></div>
             </section>
             <section class="asset-category" data-category="advanced">
               <header>
                 <h3>Advanced</h3>
               </header>
-              <div class="card-grid" id="asset-grid-advanced"></div>
+              <div class="card-grid asset-card-grid" id="asset-grid-advanced"></div>
             </section>
           </div>
         </section>
@@ -232,6 +233,21 @@
         </section>
       </section>
     </main>
+
+    <div id="asset-info-modal" class="modal" aria-hidden="true">
+      <div class="modal__backdrop" data-modal-close></div>
+      <div class="modal__dialog" role="dialog" aria-modal="true" aria-labelledby="asset-info-title">
+        <button id="asset-info-close" class="modal__close" type="button" aria-label="Close asset briefing">×</button>
+        <div class="modal__content">
+          <header class="modal__header">
+            <p class="modal__eyebrow">New Asset Briefing</p>
+            <h3 id="asset-info-title"></h3>
+            <p id="asset-info-description" class="modal__description"></p>
+          </header>
+          <ul id="asset-info-details" class="modal__details"></ul>
+        </div>
+      </div>
+    </div>
 
     <section class="panel log" aria-label="Event log">
       <div class="panel-header">

--- a/src/ui/assetInstances.js
+++ b/src/ui/assetInstances.js
@@ -10,11 +10,19 @@ function describeInstance(definition, instance) {
     }
     return 'Setup • Launching soon';
   }
+  const level = Number(instance.quality?.level) || 0;
+  return `Active • Quality ${level}`;
+}
+
+function describeInstanceEarnings(instance) {
+  if (instance.status !== 'active') {
+    return '💤 No earnings until launch';
+  }
   const lastIncome = Math.max(0, Number(instance.lastIncome) || 0);
   if (lastIncome > 0) {
-    return `Active • Last payout $${formatMoney(lastIncome)}`;
+    return `💰 $${formatMoney(lastIncome)} yesterday`;
   }
-  return 'Active • No payout yesterday';
+  return '💤 No payout yesterday';
 }
 
 function renderInstanceList(definition, state, ui) {
@@ -39,6 +47,7 @@ function renderInstanceList(definition, state, ui) {
   instances.forEach((instance, index) => {
     const item = document.createElement('li');
     item.className = 'asset-instance-item';
+    item.dataset.instanceId = instance.id;
 
     const info = document.createElement('div');
     info.className = 'asset-instance-info';
@@ -51,10 +60,27 @@ function renderInstanceList(definition, state, ui) {
     status.className = 'asset-instance-status';
     status.textContent = describeInstance(definition, instance);
 
-    info.append(title, status);
+    const earnings = document.createElement('span');
+    earnings.className = 'asset-instance-earnings';
+    earnings.textContent = describeInstanceEarnings(instance);
+
+    info.append(title, status, earnings);
 
     const actions = document.createElement('div');
     actions.className = 'asset-instance-actions';
+
+    const upgradeButton = document.createElement('button');
+    upgradeButton.type = 'button';
+    upgradeButton.className = 'secondary outline';
+    upgradeButton.textContent = 'Upgrade';
+    upgradeButton.disabled = instance.status !== 'active' || typeof ui?.extra?.openQuality !== 'function';
+    upgradeButton.addEventListener('click', event => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (upgradeButton.disabled) return;
+      ui.extra.openQuality(instance.id);
+    });
+    actions.appendChild(upgradeButton);
 
     const price = calculateAssetSalePrice(instance);
     const sellButton = document.createElement('button');

--- a/src/ui/elements.js
+++ b/src/ui/elements.js
@@ -58,6 +58,12 @@ const elements = {
     collapsed: document.getElementById('filter-assets-collapsed'),
     hideLocked: document.getElementById('filter-assets-hide-locked')
   },
+  assetInfoTrigger: document.getElementById('asset-info-trigger'),
+  assetInfoModal: document.getElementById('asset-info-modal'),
+  assetInfoTitle: document.getElementById('asset-info-title'),
+  assetInfoDescription: document.getElementById('asset-info-description'),
+  assetInfoDetails: document.getElementById('asset-info-details'),
+  assetInfoClose: document.getElementById('asset-info-close'),
   upgradeSearch: document.getElementById('upgrade-search')
 };
 

--- a/src/ui/quality.js
+++ b/src/ui/quality.js
@@ -41,7 +41,7 @@ export function attachQualityPanel(card, definition) {
 
   card.appendChild(panel);
 
-  return { panel, list };
+  return { panel, list, instanceNodes: new Map() };
 }
 
 export function updateQualityPanel(definition, panelState) {
@@ -56,12 +56,14 @@ export function updateQualityPanel(definition, panelState) {
   }
 
   panelState.list.innerHTML = '';
+  panelState.instanceNodes = new Map();
   const tracks = getQualityTracks(definition);
   const actions = getQualityActions(definition);
 
   instances.forEach((instance, index) => {
     const item = document.createElement('div');
     item.className = 'quality-instance';
+    item.dataset.instanceId = instance.id;
 
     const header = document.createElement('div');
     header.className = 'quality-instance__header';
@@ -141,5 +143,20 @@ export function updateQualityPanel(definition, panelState) {
     }
 
     panelState.list.appendChild(item);
+    panelState.instanceNodes.set(instance.id, item);
   });
+}
+
+export function focusQualityInstance(panelState, instanceId) {
+  if (!panelState?.instanceNodes) return;
+  for (const node of panelState.instanceNodes.values()) {
+    node.classList.remove('is-highlighted');
+  }
+  const target = panelState.instanceNodes.get(instanceId);
+  if (!target) return;
+  target.classList.add('is-highlighted');
+  target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  setTimeout(() => {
+    target.classList.remove('is-highlighted');
+  }, 1600);
 }

--- a/styles.css
+++ b/styles.css
@@ -33,6 +33,10 @@ body {
   padding: 2rem 1rem 3rem;
 }
 
+body.modal-open {
+  overflow: hidden;
+}
+
 .app {
   width: min(1200px, 100%);
   display: flex;
@@ -213,6 +217,29 @@ body {
 .toggle-button:focus-visible {
   background: rgba(14, 165, 233, 0.18);
   color: var(--accent-strong);
+}
+
+.ghost-button {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: transparent;
+  color: var(--text);
+  border-radius: 999px;
+  padding: 0.5rem 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border 0.2s ease, color 0.2s ease;
+}
+
+.ghost-button:hover:not(:disabled),
+.ghost-button:focus-visible:not(:disabled) {
+  background: rgba(56, 189, 248, 0.16);
+  border-color: rgba(56, 189, 248, 0.45);
+  color: var(--text);
+}
+
+.ghost-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .stats-grid {
@@ -420,6 +447,129 @@ body {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
+.asset-card-grid {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.asset-card {
+  gap: 1.1rem;
+}
+
+.asset-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.asset-card__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.asset-card__heading .tag {
+  align-self: flex-start;
+}
+
+.asset-card__tagline {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.asset-card__briefing {
+  align-self: flex-start;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.8rem;
+}
+
+.asset-card__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+}
+
+.asset-stat {
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: 14px;
+  padding: 0.8rem 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.asset-stat__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.asset-stat__value {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.asset-stat__note {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.asset-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.asset-card__instances {
+  border-top: 1px solid rgba(148, 163, 184, 0.16);
+  padding-top: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.asset-card__instances-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.asset-card__instances-count {
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.8);
+  text-transform: none;
+}
+
+.asset-card__instances-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.asset-card__instances-body .asset-instance-section {
+  border: none;
+  padding: 0;
+  gap: 0.6rem;
+}
+
+.asset-card__quality {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.asset-card__quality[data-expanded='false'] {
+  display: none;
+}
+
 .card:hover {
   transform: translateY(-4px);
   box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.25);
@@ -468,8 +618,9 @@ body {
 .asset-instance-item {
   display: flex;
   justify-content: space-between;
-  align-items: center;
-  gap: 1rem;
+  align-items: flex-start;
+  gap: 0.75rem;
+  flex-wrap: wrap;
   padding: 0.6rem 0.75rem;
   border-radius: 12px;
   background: rgba(15, 23, 42, 0.35);
@@ -490,15 +641,32 @@ body {
   font-size: 0.9rem;
 }
 
+.asset-instance-earnings {
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
 .asset-instance-actions {
   display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  align-items: center;
 }
 
 .asset-instance-actions button[disabled] {
   opacity: 0.55;
   cursor: not-allowed;
+}
+
+.asset-instance-actions .outline {
+  background: transparent;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
+}
+
+.asset-instance-actions .outline:hover:not(:disabled),
+.asset-instance-actions .outline:focus-visible:not(:disabled) {
+  background: rgba(148, 163, 184, 0.12);
 }
 
 .card-header {
@@ -605,6 +773,10 @@ body {
   border: 1px solid rgba(56, 189, 248, 0.15);
 }
 
+.quality-instance.is-highlighted {
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.45);
+}
+
 .quality-instance__header {
   display: flex;
   align-items: baseline;
@@ -690,6 +862,12 @@ body {
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
+.card .ghost-button {
+  padding: 0.4rem 0.75rem;
+  background: transparent;
+  box-shadow: none;
+}
+
 .card button.primary {
   background: linear-gradient(90deg, var(--accent), var(--accent-strong));
   color: #0f172a;
@@ -721,17 +899,22 @@ body {
   margin-bottom: 0.6rem;
 }
 
-.assets-section.is-collapsed .card {
-  gap: 0.5rem;
+.assets-section.is-collapsed .asset-card {
+  gap: 0.75rem;
 }
 
-.assets-section.is-collapsed .card p,
-.assets-section.is-collapsed .details {
+.assets-section.is-collapsed .asset-card__tagline,
+.assets-section.is-collapsed .asset-card__instances,
+.assets-section.is-collapsed .asset-card__quality {
   display: none;
 }
 
-.assets-section.is-collapsed .card button {
-  margin-top: 0.5rem;
+.assets-section.is-collapsed .asset-card__stats {
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.assets-section.is-collapsed .details {
+  display: none;
 }
 
 .upgrade-group.is-empty {
@@ -742,6 +925,109 @@ body {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+  z-index: 100;
+}
+
+.modal.is-visible {
+  display: flex;
+}
+
+.modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(2, 6, 23, 0.7);
+  backdrop-filter: blur(12px);
+}
+
+.modal__dialog {
+  position: relative;
+  background: var(--panel-bg);
+  border-radius: 24px;
+  padding: 1.75rem 1.85rem 1.85rem;
+  width: min(560px, 100%);
+  box-shadow: var(--shadow);
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.modal__close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  border: none;
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text);
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.modal__close:hover,
+.modal__close:focus-visible {
+  background: rgba(56, 189, 248, 0.28);
+  transform: translateY(-1px);
+}
+
+.modal__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.modal__eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.modal__description {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.modal__details {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.modal__details li {
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  padding: 0.75rem 0.9rem;
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.modal__details-empty {
+  text-align: center;
+  color: var(--muted);
+  font-style: italic;
 }
 
 .log {


### PR DESCRIPTION
## Summary
- restyled passive asset cards with stat tiles, per-instance listings, and quality toggles
- added upgrade shortcuts, richer earnings details, and a reusable asset briefing modal
- updated styles and documentation to cover the refreshed passive asset dashboard

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d997a7daf0832cb73c50cb254baa29