### PR TITLE
Highlight passive income in daily snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Online Hustle Simulator is a browser-based incremental game about orchestrating 
 - **Daily Recap Log** – Every launch, maintenance result, payout, and study milestone is written to the log so you can reconstruct exactly what happened during busy streaks.
 
 ### Interface Overview
-- **Top Bar & Snapshot** – Money, time, and day stay pinned at the top. A collapsible Daily Snapshot panel now highlights per-stat breakdowns (time invested, cash earned, cash spent, study momentum) without overwhelming the main view.
+- **Top Bar & Snapshot** – Money, time, and day stay pinned at the top. A collapsible Daily Snapshot panel now highlights per-stat breakdowns (time invested, money earned, passive streams, cash spent, study momentum) without overwhelming the main view.
 - **Tabbed Workspace** – Hustles, Education, Passive Assets, and Upgrades each live in their own tab with dedicated copy and per-tab filters. Global toggles hide locked or completed cards, and you can spotlight only actionable options.
 - **Categorised Collections** – Passive assets surface in Foundation, Creative, Commerce, and Advanced groupings with a collapsed-card option for rapid scanning. Upgrades split into Equipment, Automation, Consumables, and a catch-all bucket with a quick search bar.
 - **Event Log Controls** – The log dock keeps its running commentary but now includes a summary/detailed toggle when you want a lighter feed during long sessions.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,6 @@
 - Reworked upgrades (camera, lighting kit, automation course) to align with the new asset ecosystem.
 - Expanded the virtual assistant upgrade into a four-person team with daily payroll, hire/fire controls, and log messaging.
 - Added cash-based maintenance costs for blogs ($2/day) and vlogs ($5/day) that block payouts when funds are unavailable.
-- Wired a daily metrics ledger into the snapshot so time invested, cash earned, and spending breakdowns reflect the current day’s actions.
+- Wired a daily metrics ledger into the snapshot so time invested, money earned (with passive streams called out), and spending breakdowns reflect the current day’s actions.
 - Introduced an asset quality ladder with bespoke actions, UI panels, and level-based payout scaling for every passive income stream.
 - Added instance-level asset lists with one-click liquidation; selling pays three times yesterday’s payout and logs the cash in the new daily ledger.

--- a/docs/features/daily-breakdowns.md
+++ b/docs/features/daily-breakdowns.md
@@ -6,7 +6,7 @@
 - Provide designers a single place to plug in additional categories (e.g., automation refunds, seasonal boosts) as the economy expands.
 
 ## Player Impact
-- The Daily Snapshot panel now celebrates progress with concrete figures: total time invested, cash earned, cash spent, and study momentum.
+- The Daily Snapshot panel now celebrates progress with concrete figures: total time invested, money earned, passive income streams, cash spent, and study momentum.
 - Hustle bursts, passive payouts, upkeep, and one-off investments appear in the breakdown lists as soon as they happen, helping players cross-check their plan against results.
 - Day transitions briefly surface the prior day’s totals before resetting, so players can review earnings before diving into the next loop.
 

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
         <details class="stat-card" id="summary-income-card">
           <summary>
             <div class="stat-heading">
-              <h3>Cash Earned</h3>
+              <h3>Money Earned</h3>
               <span id="summary-income" class="stat-value">$0</span>
             </div>
             <p id="summary-income-caption" class="stat-caption">No earnings logged yet today</p>

--- a/src/ui/dashboard.js
+++ b/src/ui/dashboard.js
@@ -50,6 +50,7 @@ export function renderSummary(summary) {
     timeBreakdown,
     earningsBreakdown,
     spendBreakdown,
+    passiveBreakdown = [],
     studyBreakdown
   } = summary;
 
@@ -72,7 +73,22 @@ export function renderSummary(summary) {
     elements.summaryIncomeCaption,
     earningsSegments.length ? earningsSegments.join(' • ') : 'No earnings logged yet today'
   );
-  renderBreakdown(elements.summaryIncomeBreakdown, earningsBreakdown);
+  const combinedIncomeBreakdown = [];
+  if (passiveBreakdown.length) {
+    combinedIncomeBreakdown.push({
+      label: 'Passive income',
+      value: `$${formatMoney(passiveEarnings)} today`
+    });
+    combinedIncomeBreakdown.push(...passiveBreakdown);
+  }
+  if (earningsBreakdown.length) {
+    combinedIncomeBreakdown.push({
+      label: 'Active wins',
+      value: `$${formatMoney(activeEarnings)} today`
+    });
+    combinedIncomeBreakdown.push(...earningsBreakdown);
+  }
+  renderBreakdown(elements.summaryIncomeBreakdown, combinedIncomeBreakdown);
 
   setText(elements.summaryCost, `$${formatMoney(totalSpend)} today`);
   const spendSegments = [];

--- a/tests/summary.test.js
+++ b/tests/summary.test.js
@@ -67,6 +67,7 @@ test('daily summary aggregates metrics into category totals', () => {
   assert.equal(summary.upkeepSpend, 8);
   assert.equal(summary.investmentSpend, 42);
   assert.equal(summary.timeBreakdown.length, 2);
-  assert.equal(summary.earningsBreakdown.length, 2);
+  assert.equal(summary.passiveBreakdown.length, 1);
+  assert.equal(summary.earningsBreakdown.length, 1);
   assert.equal(summary.spendBreakdown.length, 2);
 });


### PR DESCRIPTION
## Summary
- rename the Daily Snapshot income card to “Money Earned” and highlight passive versus active income totals
- extend the daily summary aggregation to expose passive income entries and surface them in the breakdown list
- update docs to describe the refreshed snapshot emphasis on money earned and passive streams

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d99a8b6898832c99572f946947e40f