### PR TITLE
Add passive asset ROI insights and focused upgrade actions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Added a net-per-hour ROI column to passive asset rosters and refreshed the instance briefing modal with asset-specific quality progress and upgrade actions.
 - Added category-level asset rosters with upkeep, payout, and upgrade/sell shortcuts, plus an instance-aware briefing modal that surfaces owned and locked upgrades.
 - Shifted passive asset payouts to credit during the morning maintenance sweep so earnings persist in the new day’s snapshot.
 - Highlighted passive asset payouts in the Daily Snapshot caption and breakdown, including instance counts for each earning stream.

--- a/docs/features/passive-asset-dashboard.md
+++ b/docs/features/passive-asset-dashboard.md
@@ -1,10 +1,10 @@
 # Passive Asset Dashboard Refresh
 
 ## Summary
-The passive asset workspace now presents each asset as a management card that highlights ownership counts, yesterday's earnings, income potential, and upkeep at a glance. Cards surface quick actions to launch new builds, open quality upgrades, and sell individual instances without digging through secondary panels. Category toggles also roll up every launched instance into a single management list so upkeep, payouts, upgrades, and liquidation stay reachable even when the compact card view is enabled.
+The passive asset workspace now presents each asset as a management card that highlights ownership counts, yesterday's earnings, income potential, upkeep, and net return per upkeep hour at a glance. Cards surface quick actions to launch new builds, open quality upgrades, and sell individual instances without digging through secondary panels. Category toggles also roll up every launched instance into a single management list so upkeep, payouts, upgrades, and liquidation stay reachable even when the compact card view is enabled. The instance briefing modal now focuses on the selected build, showcasing its quality track progress, ROI, and relevant upgrade actions.
 
 ## Goals
-- Give players immediate insight into how every passive build performed yesterday and what it costs to maintain.
+- Give players immediate insight into how every passive build performed yesterday, what it costs to maintain, and whether upkeep hours are paying off.
 - Reduce the click depth for quality upgrades and sell actions by embedding them into each instance row.
 - Provide an upbeat "New Asset Briefing" modal so players can review setup requirements and payout expectations before committing resources.
 - Restore at-a-glance control of every active build via per-category asset rosters that remain available when cards are collapsed.
@@ -12,14 +12,16 @@ The passive asset workspace now presents each asset as a management card that hi
 ## Player Impact
 - Faster comparisons: stat tiles on each card summarize launches, payouts, and upkeep so players can pick the next investment without cross-referencing logs.
 - Smoother upgrades: an "Upgrade Quality" shortcut expands the quality panel and auto-focuses on the selected instance when triggered from the instance list.
-- Clearer oversight: category rosters list upkeep obligations, yesterday's payout, and one-click upgrade/sell controls for every active instance in a familiar table format.
+- Clearer oversight: category rosters list upkeep obligations, yesterday's payout, net gain per upkeep hour, and one-click upgrade/sell controls for every active instance in a familiar table format.
+- Sharper next steps: the instance modal highlights current quality level, progress toward the next milestone, and direct quality actions so players can immediately invest in the build they opened.
 - Confident launches: the briefing modal reuses live detail renderers, ensuring setup costs, maintenance, and quality roadmaps stay accurate as modifiers shift.
 
 ## Implementation Notes
 - Asset cards keep the existing category structure but use a dedicated layout (`asset-card__*` classes) for stats, actions, and instance management.
 - Instance rows now expose both the previous day's payout and per-instance upgrade buttons that call `openQuality` from card extras.
 - Category-level "View launched assets" toggles render aggregated tables populated by `assetCategoryView`, reusing the same upgrade and sell helpers so actions stay in sync with card state.
-- The briefing modal now switches between the legacy definition view and an instance-specific overview that highlights status, upkeep, yesterday's payout, and upgrade ownership/availability.
+- The briefing modal now switches between the legacy definition view and an instance-specific overview that highlights status, upkeep, yesterday's payout, net hourly return, and quality progress/upgrade actions tailored to that build.
+- ROI rows in the category roster use last income minus upkeep costs divided by upkeep hours to surface a quick dollars-per-hour snapshot for active builds.
 - The modal is populated via `populateAssetInfoModal` using current detail renderers so future balance changes automatically propagate.
 - Collapsed view hides the tagline, instances, and quality panel while keeping the stat summary visible for quick scanning.
 

--- a/index.html
+++ b/index.html
@@ -294,13 +294,19 @@
                   <dt>Last Payout</dt>
                   <dd id="asset-info-instance-payout"></dd>
                 </div>
+                <div class="asset-modal__stat">
+                  <dt>Net / Hour</dt>
+                  <dd id="asset-info-instance-roi"></dd>
+                </div>
               </dl>
             </div>
             <div class="asset-modal__upgrades">
-              <h4>Current Upgrades</h4>
-              <ul id="asset-info-upgrades-owned" class="modal__details modal__details--compact"></ul>
-              <h4>Available &amp; Locked Upgrades</h4>
-              <ul id="asset-info-upgrades-available" class="modal__details modal__details--compact"></ul>
+              <h4>Quality Progress</h4>
+              <ul id="asset-info-quality-progress" class="modal__details modal__details--compact"></ul>
+              <h4>Upgrade Actions</h4>
+              <div id="asset-info-quality-actions" class="asset-modal__actions"></div>
+              <h4>Supporting Upgrades</h4>
+              <ul id="asset-info-support-upgrades" class="modal__details modal__details--compact"></ul>
             </div>
           </div>
         </div>

--- a/src/ui/assetInstances.js
+++ b/src/ui/assetInstances.js
@@ -25,6 +25,35 @@ export function describeInstanceEarnings(instance) {
   return '💤 No payout yesterday';
 }
 
+export function calculateInstanceNetDaily(definition, instance) {
+  if (!definition || !instance) return null;
+  if (instance.status !== 'active') return null;
+  const income = Math.max(0, Number(instance.lastIncome) || 0);
+  const upkeepCost = Math.max(0, Number(definition.maintenance?.cost) || 0);
+  return income - upkeepCost;
+}
+
+export function calculateInstanceNetHourly(definition, instance) {
+  if (!definition || !instance) return null;
+  if (instance.status !== 'active') return null;
+  const upkeepHours = Math.max(0, Number(definition.maintenance?.hours) || 0);
+  if (upkeepHours <= 0) return null;
+  const netDaily = calculateInstanceNetDaily(definition, instance);
+  if (netDaily === null) return null;
+  return netDaily / upkeepHours;
+}
+
+export function describeInstanceNetHourly(definition, instance) {
+  const netHourly = calculateInstanceNetHourly(definition, instance);
+  if (netHourly === null) {
+    return instance.status === 'active' ? 'No upkeep hours' : 'Launch pending';
+  }
+  const absolute = Math.abs(netHourly);
+  const formatted = formatMoney(Math.round(absolute * 100) / 100);
+  const prefix = netHourly < 0 ? '-$' : '$';
+  return `${prefix}${formatted}/hr`;
+}
+
 function renderInstanceList(definition, state, ui) {
   const container = ui?.extra?.instanceList;
   if (!container) return;

--- a/src/ui/elements.js
+++ b/src/ui/elements.js
@@ -82,8 +82,10 @@ const elements = {
   assetInfoInstanceQuality: document.getElementById('asset-info-instance-quality'),
   assetInfoInstanceUpkeep: document.getElementById('asset-info-instance-upkeep'),
   assetInfoInstancePayout: document.getElementById('asset-info-instance-payout'),
-  assetInfoUpgradesOwned: document.getElementById('asset-info-upgrades-owned'),
-  assetInfoUpgradesAvailable: document.getElementById('asset-info-upgrades-available'),
+  assetInfoInstanceRoi: document.getElementById('asset-info-instance-roi'),
+  assetInfoQualityProgress: document.getElementById('asset-info-quality-progress'),
+  assetInfoQualityActions: document.getElementById('asset-info-quality-actions'),
+  assetInfoSupportUpgrades: document.getElementById('asset-info-support-upgrades'),
   assetInfoClose: document.getElementById('asset-info-close'),
   upgradeSearch: document.getElementById('upgrade-search')
 };

--- a/styles.css
+++ b/styles.css
@@ -1025,6 +1025,11 @@ body.modal-open {
   color: var(--success);
 }
 
+.asset-category__loss {
+  font-weight: 600;
+  color: var(--danger);
+}
+
 .assets-section.is-collapsed .asset-card {
   gap: 0.75rem;
 }
@@ -1198,6 +1203,14 @@ body.modal-open {
   color: var(--text);
 }
 
+.asset-modal__stat dd.is-positive {
+  color: var(--success);
+}
+
+.asset-modal__stat dd.is-negative {
+  color: var(--danger);
+}
+
 .asset-modal__upgrades h4 {
   font-size: 0.85rem;
   letter-spacing: 0.05em;
@@ -1208,6 +1221,16 @@ body.modal-open {
 
 .asset-modal__upgrades h4 + .modal__details {
   margin-bottom: 0.4rem;
+}
+
+.asset-modal__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.asset-modal__actions .quality-action {
+  align-self: flex-start;
 }
 
 .log {


### PR DESCRIPTION
## Summary
- add a net-per-hour ROI column to passive asset tables and highlight gains/losses
- refresh the asset instance modal with ROI stats, quality progress, upgrade actions, and requirement status
- update styling and documentation to reflect the new passive asset management details

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9a85033b4832c9a3502e289e7971a