### PR TITLE
Revamp education tracks with tuition and auto scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 Online Hustle Simulator is a browser-based incremental game about orchestrating your side-hustle empire one in-world day at a time. Each morning you receive a fresh stack of hours, decide how to divide them between quick gigs, study tracks, and asset upkeep, then close the day to trigger payouts. The loop rewards planning, lighthearted experimentation, and a healthy obsession with passive income spreadsheets.
 
 ## Gameplay Loop & Systems
-- **Daily Time Budget** – Every in-game day begins with 14 base hours (plus permanent bonuses). Hustles, knowledge study, asset setup, and upkeep all consume this pool. Assistants can be hired (up to four) for +2 hours each, but payroll hits every morning; you can always fire them if cash or time dips too low. Turbo coffee grants up to three one-hour boosts per day.
+- **Daily Time Budget** – Every in-game day begins with 14 base hours (plus permanent bonuses). Hustles, asset setup, upkeep, and any enrolled study tracks automatically reserve time from this pool. Assistants can be hired (up to four) for +2 hours each, but payroll hits every morning; you can always fire them if cash or time dips too low. Turbo coffee grants up to three one-hour boosts per day.
 - **Setup & Maintenance Allocation** – When a day ends, each asset checks whether you funded the required setup/maintenance hours **and** any daily cash cost. Funded instances progress (or earn income); unfunded ones pause. The next morning, the scheduler automatically earmarks required hours until you run out.
 - **Asset Quality Ladder** – Every passive asset launches at Quality 0 and can be upgraded by investing time (and sometimes cash) into bespoke quality actions. Quality milestones unlock higher payout ranges, steadier log messages, and whimsical celebrations when tiers are reached.
-- **Knowledge Tracks** – Study hustles (e.g., Outline Mastery, E-Commerce Playbook) require a fixed number of days at specific hour costs. Completing them unlocks advanced assets and generates celebratory log entries; skipping a day after you start produces gentle warnings.
+- **Knowledge Tracks** – Paying tuition enrolls you in longer-form courses that auto-schedule their daily study load until graduation. Completing them unlocks advanced assets and generates celebratory log entries; if the scheduler runs out of hours, you’ll receive gentle warnings and the course simply waits for tomorrow.
 - **Daily Recap Log** – Every launch, maintenance result, payout, and study milestone is written to the log so you can reconstruct exactly what happened during busy streaks.
 
 ### Interface Overview
@@ -19,10 +19,10 @@ Online Hustle Simulator is a browser-based incremental game about orchestrating 
 ### Hustles & Study Tracks
 - **Freelance Writing** – Spend 2h to earn $18 instantly.
 - **eBay Flips** – Spend 4h and $20; complete 30 seconds later for $48 (multiple flips queue).
-- **Outline Mastery Workshop** – Study 2h to mark daily progress toward e-book unlocks (3-day course).
-- **Photo Catalog Curation** – Study 1.5h/day for 2 days to unlock polished stock photo galleries.
-- **E-Commerce Playbook** – Study 2h/day for 5 days to prep dropshipping ventures.
-- **Automation Architecture Course** – Study 3h/day for 7 days to earn SaaS-ready engineering chops.
+- **Outline Mastery Workshop** – Pay $140 upfront; 2h/day for 5 days auto-reserve to unlock e-book production chops.
+- **Photo Catalog Curation** – Pay $95 upfront; 1.5h/day for 4 days auto-reserve to polish your stock gallery workflow.
+- **E-Commerce Playbook** – Pay $260 upfront; 2.5h/day for 7 days auto-reserve to prep dropshipping ventures.
+- **Automation Architecture Course** – Pay $540 upfront; 3h/day for 10 days auto-reserve to earn SaaS-ready engineering chops.
 
 ### Passive Assets (Daily Payouts)
 Each asset supports multiple instances, tracks setup progress, and rolls a daily income range once active. Quality actions unique to each asset increase payouts and stability, and you can liquidate any instance directly from the card—or from the category roster—for three times its previous day payout. The asset briefing modal doubles as an instance inspector, outlining status, upkeep, yesterday’s earnings, and which upgrades are owned or still locked.
@@ -49,7 +49,7 @@ Each asset supports multiple instances, tracks setup progress, and rolls a daily
 - Six passive asset types with multi-instance tracking, setup states, maintenance funding, and dynamic daily income rolls.
 - In-card asset management with instance-level breakdowns and a one-click sale option that converts yesterday’s earnings into cash at a 3× multiple.
 - Daily metrics ledger that captures hours, earnings, and spending, powering the refreshed snapshot breakdowns.
-- Knowledge study hustles that gate advanced assets and remember streak progress across days.
+- Knowledge study tracks with upfront tuition, automatic daily scheduling, and celebratory completion logs that gate advanced assets.
 - Equipment and experience requirements surfaced directly on asset cards with live progress indicators.
 - Responsive card grids with upbeat copy, tabbed navigation, filters, and search so players can focus on the work-in-progress that matters most.
 - Persistent save/load, offline hustle resolution, and flavourful log output to keep players oriented.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Revamped education tracks with upfront tuition costs, longer course lengths, and an automatic daily study scheduler that reserves hours until graduation.
 - Added category-level asset rosters with upkeep, payout, and upgrade/sell shortcuts, plus an instance-aware briefing modal that surfaces owned and locked upgrades.
 - Shifted passive asset payouts to credit during the morning maintenance sweep so earnings persist in the new day’s snapshot.
 - Highlighted passive asset payouts in the Daily Snapshot caption and breakdown, including instance counts for each earning stream.

--- a/docs/features/education-auto-scheduler.md
+++ b/docs/features/education-auto-scheduler.md
@@ -1,0 +1,19 @@
+# Auto-Scheduled Education Tracks
+
+## Goals
+- Make study commitments feel like real courses with upfront tuition and multi-day schedules.
+- Reduce repetitive clicks by auto-booking daily class time once a player enrolls.
+- Preserve clarity in the log and summary so players can confirm where their hours went.
+
+## Mechanics
+- Tuition is paid immediately on enrollment: Outline Mastery $140, Photo Catalog $95, E-Commerce Playbook $260, Automation Architecture $540.
+- Course lengths now stretch to 5/4/7/10 days respectively, holding their daily hour costs at 2h, 1.5h, 2.5h, and 3h.
+- `enrollInKnowledgeTrack` handles tuition payment, logging, and triggers a same-day scheduling sweep.
+- `allocateDailyStudy` runs each morning after assistant payroll, consuming hours for every active course until the daily budget runs out.
+- When time is insufficient, the scheduler logs the affected course and tries again the next day without penalising progress.
+- Completion marks the course finished, clears the enrollment flag, and surfaces a celebratory log entry.
+
+## Tuning Notes
+- Tuition prices align with mid-game savings (roughly 3–5 days of early hustles) so players plan purchases.
+- Automatic scheduling consumes hours before asset maintenance, ensuring study promises stay consistent.
+- Summary metrics count only enrolled courses, with "scheduled" status appearing once time is booked for the day.

--- a/src/game/hustles.js
+++ b/src/game/hustles.js
@@ -1,11 +1,15 @@
-import { createId, formatHours, formatMoney } from '../core/helpers.js';
+import { createId, formatDays, formatHours, formatMoney } from '../core/helpers.js';
 import { addLog } from '../core/log.js';
 import { getHustleState, getState } from '../core/state.js';
 import { addMoney, spendMoney } from './currency.js';
 import { executeAction } from './actions.js';
 import { checkDayEnd } from './lifecycle.js';
 import { spendTime } from './time.js';
-import { KNOWLEDGE_TRACKS, getKnowledgeProgress, markKnowledgeStudied } from './requirements.js';
+import {
+  KNOWLEDGE_TRACKS,
+  enrollInKnowledgeTrack,
+  getKnowledgeProgress
+} from './requirements.js';
 import {
   recordCostContribution,
   recordPayoutContribution,
@@ -191,45 +195,44 @@ function createKnowledgeHustles() {
     tag: { label: 'Study', type: 'study' },
     description: track.description,
     details: [
-      () => `⏳ Time: <strong>${formatHours(track.hoursPerDay)}</strong>`,
+      () => `🎓 Tuition: <strong>$${formatMoney(track.tuition)}</strong>`,
+      () => `⏳ Study Load: <strong>${formatHours(track.hoursPerDay)} / day for ${formatDays(track.days)}</strong>`,
       () => {
         const progress = getKnowledgeProgress(track.id);
-        const status = progress.completed ? 'Complete' : `${progress.daysCompleted}/${track.days} days`;
-        return `📚 Progress: <strong>${status}</strong>`;
+        if (progress.completed) {
+          return '✅ Status: <strong>Complete</strong>';
+        }
+        if (progress.enrolled) {
+          const remaining = Math.max(0, track.days - progress.daysCompleted);
+          return `📚 Status: <strong>${remaining} day${remaining === 1 ? '' : 's'} remaining</strong>`;
+        }
+        return '🚀 Status: <strong>Ready to enroll</strong>';
       }
     ],
     action: {
       label: () => {
         const progress = getKnowledgeProgress(track.id);
         if (progress.completed) return 'Course Complete';
-        if (progress.studiedToday) return 'Studied Today';
-        return 'Study Today';
+        if (progress.enrolled) {
+          const remaining = Math.max(0, track.days - progress.daysCompleted);
+          return remaining === 0 ? 'Graduation Pending' : `${remaining} day${remaining === 1 ? '' : 's'} remaining`;
+        }
+        const tuition = Number(track.tuition) || 0;
+        return tuition > 0 ? `Enroll for $${formatMoney(tuition)}` : 'Enroll Now';
       },
       className: 'secondary',
       disabled: () => {
         const state = getState();
         const progress = getKnowledgeProgress(track.id);
-        if (progress.completed || progress.studiedToday) return true;
-        return state.timeLeft < track.hoursPerDay;
+        if (progress.completed || progress.enrolled) return true;
+        const tuition = Number(track.tuition) || 0;
+        return tuition > 0 && state.money < tuition;
       },
       onClick: () => {
         executeAction(() => {
-          const state = getState();
           const progress = getKnowledgeProgress(track.id);
-          if (progress.completed || progress.studiedToday) return;
-          if (state.timeLeft < track.hoursPerDay) {
-            addLog('You need more free hours to study today.', 'warning');
-            return;
-          }
-          spendTime(track.hoursPerDay);
-          recordTimeContribution({
-            key: `study:${track.id}:time`,
-            label: `📘 ${track.name} study`,
-            hours: track.hoursPerDay,
-            category: 'study'
-          });
-          markKnowledgeStudied(track.id);
-          addLog(`You invested ${formatHours(track.hoursPerDay)} studying ${track.name}.`, 'info');
+          if (progress.completed || progress.enrolled) return;
+          enrollInKnowledgeTrack(track.id);
         });
         checkDayEnd();
       }
@@ -238,9 +241,10 @@ function createKnowledgeHustles() {
       if (!card) return;
       const progress = getKnowledgeProgress(track.id);
       card.classList.toggle('completed', progress.completed);
-      const inProgress = progress.daysCompleted > 0 || progress.studiedToday;
+      const inProgress = progress.enrolled && !progress.completed;
       card.dataset.inProgress = inProgress ? 'true' : 'false';
       card.dataset.studiedToday = progress.studiedToday ? 'true' : 'false';
+      card.dataset.enrolled = progress.enrolled ? 'true' : 'false';
     }
   }));
 }

--- a/src/game/lifecycle.js
+++ b/src/game/lifecycle.js
@@ -5,7 +5,7 @@ import { allocateAssetMaintenance, closeOutDay } from './assets/index.js';
 import { processAssistantPayroll } from './assistant.js';
 import { getTimeCap } from './time.js';
 import { updateUI } from '../ui/update.js';
-import { advanceKnowledgeTracks } from './requirements.js';
+import { advanceKnowledgeTracks, allocateDailyStudy } from './requirements.js';
 import { resetDailyMetrics } from './metrics.js';
 
 export function endDay(auto = false) {
@@ -25,6 +25,7 @@ export function endDay(auto = false) {
   state.timeLeft = getTimeCap();
   resetDailyMetrics(state);
   processAssistantPayroll();
+  allocateDailyStudy();
   allocateAssetMaintenance();
   updateUI();
   saveState();

--- a/src/game/summary.js
+++ b/src/game/summary.js
@@ -125,23 +125,18 @@ export function computeDailySummary(state = getState()) {
 
   for (const track of Object.values(KNOWLEDGE_TRACKS)) {
     const progress = getKnowledgeProgress(track.id, state);
-    if (progress.completed) continue;
-    const inProgress = progress.daysCompleted > 0 || progress.studiedToday;
-    if (inProgress) {
-      knowledgeInProgress += 1;
-    }
+    if (!progress.enrolled || progress.completed) continue;
+    knowledgeInProgress += 1;
     if (!progress.studiedToday) {
       knowledgePendingToday += 1;
     }
 
-    if (inProgress) {
-      const remainingDays = Math.max(0, track.days - progress.daysCompleted);
-      const status = progress.studiedToday ? 'studied' : 'waiting';
-      studyBreakdown.push({
-        label: `📘 ${track.name}`,
-        value: `${formatHours(track.hoursPerDay)} / day • ${remainingDays} day${remainingDays === 1 ? '' : 's'} left (${status})`
-      });
-    }
+    const remainingDays = Math.max(0, track.days - progress.daysCompleted);
+    const status = progress.studiedToday ? 'scheduled' : 'waiting';
+    studyBreakdown.push({
+      label: `📘 ${track.name}`,
+      value: `${formatHours(track.hoursPerDay)} / day • ${remainingDays} day${remainingDays === 1 ? '' : 's'} left (${status})`
+    });
   }
 
   return {


### PR DESCRIPTION
## Summary
- add upfront tuition, longer durations, and an automatic scheduler to knowledge tracks with enrollment/completion logging
- refresh education card copy, summary reporting, and documentation, including a new auto-study design note
- update automated tests to cover the new enrollment flow and ensure the daily lifecycle reserves study hours

## Testing
- npm test
- Manual: Verified the Education tab renders the new enrollment UI in a browser session


------
https://chatgpt.com/codex/tasks/task_e_68d9aa6e6dc8832c8c62fdaf64095174