### PR TITLE
Add schema-driven metric IDs and enrich summaries

### DIFF
--- a/src/core/state.js
+++ b/src/core/state.js
@@ -1,10 +1,12 @@
 import { DEFAULT_DAY_HOURS } from './constants.js';
 import { structuredClone } from './helpers.js';
+import { attachRegistryMetricIds, buildMetricIndex } from '../game/schema/metrics.js';
 
 let registry = { hustles: [], assets: [], upgrades: [] };
 let hustleMap = new Map();
 let assetMap = new Map();
 let upgradeMap = new Map();
+let metricIndex = new Map();
 
 export let state = null;
 
@@ -26,10 +28,12 @@ export function ensureDailyMetrics(target = state) {
 }
 
 export function configureRegistry({ hustles = [], assets = [], upgrades = [] }) {
-  registry = { hustles, assets, upgrades };
-  hustleMap = new Map(hustles.map(item => [item.id, item]));
-  assetMap = new Map(assets.map(item => [item.id, item]));
-  upgradeMap = new Map(upgrades.map(item => [item.id, item]));
+  const prepared = attachRegistryMetricIds({ hustles, assets, upgrades });
+  registry = prepared;
+  hustleMap = new Map(prepared.hustles.map(item => [item.id, item]));
+  assetMap = new Map(prepared.assets.map(item => [item.id, item]));
+  upgradeMap = new Map(prepared.upgrades.map(item => [item.id, item]));
+  metricIndex = buildMetricIndex(prepared);
 }
 
 export function getHustleDefinition(id) {
@@ -42,6 +46,10 @@ export function getAssetDefinition(id) {
 
 export function getUpgradeDefinition(id) {
   return upgradeMap.get(id);
+}
+
+export function getMetricDefinition(metricId) {
+  return metricIndex.get(metricId);
 }
 
 export function normalizeAssetInstance(definition, instance = {}) {

--- a/src/game/assets/helpers.js
+++ b/src/game/assets/helpers.js
@@ -23,6 +23,29 @@ import {
   getQualityTracks
 } from './quality.js';
 
+function fallbackAssetMetricId(definitionId, scope, type) {
+  if (!definitionId) return null;
+  if (scope === 'payout' && type === 'payout') {
+    return `asset:${definitionId}:payout`;
+  }
+  if (scope === 'sale' && type === 'payout') {
+    return `asset:${definitionId}:sale`;
+  }
+  const suffix = type === 'payout' ? 'payout' : type;
+  return `asset:${definitionId}:${scope}-${suffix}`;
+}
+
+function getAssetMetricId(definition, scope, type) {
+  if (!definition) return null;
+  const metricIds = definition.metricIds || {};
+  const scoped = metricIds[scope];
+  if (scoped && typeof scoped === 'object') {
+    const value = scoped[type];
+    if (value) return value;
+  }
+  return fallbackAssetMetricId(definition.id, scope, type);
+}
+
 export function buildAssetAction(definition, labels = {}) {
   return {
     label: () => assetActionLabel(definition, labels),
@@ -74,7 +97,7 @@ function startAsset(definition) {
     if (setupCost > 0) {
       spendMoney(setupCost);
       recordCostContribution({
-        key: `asset:${definition.id}:setup-cost`,
+        key: getAssetMetricId(definition, 'setup', 'cost'),
         label: `💵 ${definition.singular || definition.name} setup`,
         amount: setupCost,
         category: 'setup'
@@ -83,7 +106,7 @@ function startAsset(definition) {
     if (setupHours > 0) {
       spendTime(setupHours);
       recordTimeContribution({
-        key: `asset:${definition.id}:setup-time`,
+        key: getAssetMetricId(definition, 'setup', 'time'),
         label: `🚀 ${definition.singular || definition.name} prep`,
         hours: setupHours,
         category: 'setup'
@@ -198,7 +221,7 @@ export function sellAssetInstance(definition, instanceId) {
     if (price > 0) {
       addMoney(price, `${label} sold off for $${formatMoney(price)}. Fresh funds unlocked!`, 'passive');
       recordPayoutContribution({
-        key: `asset:${definition.id}:sale`,
+        key: getAssetMetricId(definition, 'sale', 'payout'),
         label: `🏷️ ${definition.singular || definition.name} sale`,
         amount: price,
         category: 'sale'
@@ -273,4 +296,4 @@ export function qualityProgressDetail(definition) {
   return `📈 Roadmap: ${lines}`;
 }
 
-export { assetActionLabel, isAssetPurchaseDisabled, startAsset };
+export { assetActionLabel, isAssetPurchaseDisabled, startAsset, getAssetMetricId };

--- a/src/game/assets/lifecycle.js
+++ b/src/game/assets/lifecycle.js
@@ -4,7 +4,7 @@ import { getAssetState, getState } from '../../core/state.js';
 import { addMoney, spendMoney } from '../currency.js';
 import { spendTime } from '../time.js';
 import { ASSETS } from './registry.js';
-import { instanceLabel, rollDailyIncome } from './helpers.js';
+import { getAssetMetricId, instanceLabel, rollDailyIncome } from './helpers.js';
 import {
   recordCostContribution,
   recordPayoutContribution,
@@ -39,7 +39,7 @@ export function allocateAssetMaintenance() {
           instance.setupFundedToday = true;
           setupFunded.push(instanceLabel(definition, index));
           recordTimeContribution({
-            key: `asset:${definition.id}:setup-time`,
+            key: getAssetMetricId(definition, 'setup', 'time'),
             label: `🚀 ${definition.singular || definition.name} prep`,
             hours: setupHours,
             category: 'setup'
@@ -53,17 +53,17 @@ export function allocateAssetMaintenance() {
       if (instance.status === 'active') {
         const label = instanceLabel(definition, index);
         const pendingIncome = Math.max(0, Number(instance.pendingIncome) || 0);
-        if (pendingIncome > 0) {
-          const incomeMessage = definition.messages?.income
-            ? definition.messages.income(pendingIncome, label, instance, assetState)
-            : `${definition.name} generated $${formatMoney(pendingIncome)} today.`;
-          addMoney(pendingIncome, incomeMessage, definition.income?.logType || 'passive');
-          recordPayoutContribution({
-            key: `asset:${definition.id}:payout`,
-            label: `💰 ${definition.singular || definition.name}`,
-            amount: pendingIncome,
-            category: 'passive'
-          });
+          if (pendingIncome > 0) {
+            const incomeMessage = definition.messages?.income
+              ? definition.messages.income(pendingIncome, label, instance, assetState)
+              : `${definition.name} generated $${formatMoney(pendingIncome)} today.`;
+            addMoney(pendingIncome, incomeMessage, definition.income?.logType || 'passive');
+            recordPayoutContribution({
+              key: getAssetMetricId(definition, 'payout', 'payout'),
+              label: `💰 ${definition.singular || definition.name}`,
+              amount: pendingIncome,
+              category: 'passive'
+            });
           instance.pendingIncome = 0;
         }
 
@@ -82,7 +82,7 @@ export function allocateAssetMaintenance() {
         if (maintenanceHours > 0) {
           spendTime(maintenanceHours);
           recordTimeContribution({
-            key: `asset:${definition.id}:maintenance-time`,
+            key: getAssetMetricId(definition, 'maintenance', 'time'),
             label: `🛠️ ${definition.singular || definition.name} upkeep`,
             hours: maintenanceHours,
             category: 'maintenance'
@@ -91,7 +91,7 @@ export function allocateAssetMaintenance() {
         if (maintenanceCost > 0) {
           spendMoney(maintenanceCost);
           recordCostContribution({
-            key: `asset:${definition.id}:maintenance-cost`,
+            key: getAssetMetricId(definition, 'maintenance', 'cost'),
             label: `🔧 ${definition.singular || definition.name} upkeep`,
             amount: maintenanceCost,
             category: 'maintenance'

--- a/src/game/hustles.js
+++ b/src/game/hustles.js
@@ -1,6 +1,12 @@
 import { createId, formatDays, formatHours, formatMoney } from '../core/helpers.js';
 import { addLog } from '../core/log.js';
-import { getAssetDefinition, getAssetState, getHustleState, getState } from '../core/state.js';
+import {
+  getAssetDefinition,
+  getAssetState,
+  getHustleDefinition,
+  getHustleState,
+  getState
+} from '../core/state.js';
 import { addMoney, spendMoney } from './currency.js';
 import { executeAction } from './actions.js';
 import { checkDayEnd } from './lifecycle.js';
@@ -40,6 +46,47 @@ function renderRequirementSummary(requirements = []) {
     .join(' • ');
 }
 
+function getHustleMetricIds(hustleId) {
+  const definition = getHustleDefinition(hustleId);
+  if (!definition) return {};
+  return definition.action?.metricIds || definition.metricIds || {};
+}
+
+function fallbackHustleMetricId(hustleId, type) {
+  const suffix = type === 'payout' ? 'payout' : type;
+  return `hustle:${hustleId}:${suffix}`;
+}
+
+function recordHustleTime(hustleId, { label, hours, category }) {
+  const metrics = getHustleMetricIds(hustleId);
+  recordTimeContribution({
+    key: metrics.time || fallbackHustleMetricId(hustleId, 'time'),
+    label,
+    hours,
+    category
+  });
+}
+
+function recordHustlePayout(hustleId, { label, amount, category }) {
+  const metrics = getHustleMetricIds(hustleId);
+  recordPayoutContribution({
+    key: metrics.payout || fallbackHustleMetricId(hustleId, 'payout'),
+    label,
+    amount,
+    category
+  });
+}
+
+function recordHustleCost(hustleId, { label, amount, category }) {
+  const metrics = getHustleMetricIds(hustleId);
+  recordCostContribution({
+    key: metrics.cost || fallbackHustleMetricId(hustleId, 'cost'),
+    label,
+    amount,
+    category
+  });
+}
+
 const AUDIENCE_CALL_REQUIREMENTS = [{ assetId: 'blog', count: 1 }];
 const BUNDLE_PUSH_REQUIREMENTS = [
   { assetId: 'blog', count: 2 },
@@ -63,15 +110,13 @@ export const HUSTLES = [
       onClick: () => {
         executeAction(() => {
           spendTime(2);
-          recordTimeContribution({
-            key: 'hustle:freelance:time',
+          recordHustleTime('freelance', {
             label: '⚡ Freelance writing time',
             hours: 2,
             category: 'hustle'
           });
           addMoney(18, 'You hustled an article for $18. Not Pulitzer material, but it pays the bills!');
-          recordPayoutContribution({
-            key: 'hustle:freelance:payout',
+          recordHustlePayout('freelance', {
             label: '💼 Freelance writing payout',
             amount: 18,
             category: 'hustle'
@@ -113,15 +158,13 @@ export const HUSTLES = [
             return;
           }
           spendTime(1);
-          recordTimeContribution({
-            key: 'hustle:audienceCall:time',
+          recordHustleTime('audienceCall', {
             label: '🎤 Audience Q&A prep',
             hours: 1,
             category: 'hustle'
           });
           addMoney(12, 'Your audience Q&A tipped $12 in template sales. Small wins add up!', 'hustle');
-          recordPayoutContribution({
-            key: 'hustle:audienceCall:payout',
+          recordHustlePayout('audienceCall', {
             label: '🎤 Audience Q&A payout',
             amount: 12,
             category: 'hustle'
@@ -163,15 +206,13 @@ export const HUSTLES = [
             return;
           }
           spendTime(2.5);
-          recordTimeContribution({
-            key: 'hustle:bundlePush:time',
+          recordHustleTime('bundlePush', {
             label: '🧺 Bundle promo planning',
             hours: 2.5,
             category: 'hustle'
           });
           addMoney(48, 'Your flash bundle moved $48 in upsells. Subscribers love the combo!', 'hustle');
-          recordPayoutContribution({
-            key: 'hustle:bundlePush:payout',
+          recordHustlePayout('bundlePush', {
             label: '🧺 Bundle promo payout',
             amount: 48,
             category: 'hustle'
@@ -204,15 +245,13 @@ export const HUSTLES = [
       onClick: () => {
         executeAction(() => {
           spendTime(4);
-          recordTimeContribution({
-            key: 'hustle:flips:time',
+          recordHustleTime('flips', {
             label: '📦 eBay flips prep',
             hours: 4,
             category: 'hustle'
           });
           spendMoney(20);
-          recordCostContribution({
-            key: 'hustle:flips:cost',
+          recordHustleCost('flips', {
             label: '💸 eBay flips sourcing',
             amount: 20,
             category: 'investment'
@@ -282,16 +321,14 @@ export function processFlipPayouts(now = Date.now(), offline = false) {
       if (offline) {
         state.money += flip.payout;
         offlineTotal += flip.payout;
-        recordPayoutContribution({
-          key: 'hustle:flips:payout',
+        recordHustlePayout('flips', {
           label: '💼 eBay flips payout',
           amount: flip.payout,
           category: offline ? 'offline' : 'delayed'
         });
       } else {
         addMoney(flip.payout, `Your eBay flip sold for $${formatMoney(flip.payout)}! Shipping label time.`, 'delayed');
-        recordPayoutContribution({
-          key: 'hustle:flips:payout',
+        recordHustlePayout('flips', {
           label: '💼 eBay flips payout',
           amount: flip.payout,
           category: 'delayed'

--- a/src/game/schema/metrics.js
+++ b/src/game/schema/metrics.js
@@ -1,0 +1,153 @@
+const METRIC_TYPES = ['time', 'payout', 'cost'];
+
+function ensureObject(target, key) {
+  if (!target[key]) {
+    target[key] = {};
+  }
+  return target[key];
+}
+
+function createAssetMetricId(definitionId, scope, type) {
+  if (scope === 'sale' && type === 'payout') {
+    return `asset:${definitionId}:sale`;
+  }
+  const suffix = type === 'payout' ? 'payout' : type;
+  return `asset:${definitionId}:${scope}-${suffix}`;
+}
+
+function createQualityMetricId(definitionId, actionId, type) {
+  const suffix = type === 'payout' ? 'payout' : type;
+  return `asset:${definitionId}:quality:${actionId}:${suffix}`;
+}
+
+function createHustleMetricId(definitionId, type) {
+  const suffix = type === 'payout' ? 'payout' : type;
+  return `hustle:${definitionId}:${suffix}`;
+}
+
+function registerMetric(index, metricId, definition, category, metricType) {
+  if (!metricId || index.has(metricId)) return;
+  const label = definition.singular || definition.name || definition.id;
+  index.set(metricId, {
+    id: definition.id,
+    type: definition.kind || 'asset',
+    name: definition.name || label,
+    label,
+    category,
+    metricType
+  });
+}
+
+export function attachHustleMetricIds(definition) {
+  if (!definition || !definition.id) return definition;
+  const metricIds = { ...(definition.metricIds || {}) };
+  for (const type of METRIC_TYPES) {
+    const key = createHustleMetricId(definition.id, type);
+    if (!metricIds[type]) {
+      metricIds[type] = key;
+    }
+  }
+  definition.metricIds = metricIds;
+  if (definition.action) {
+    definition.action.metricIds = { ...(definition.action.metricIds || {}), ...metricIds };
+  }
+  definition.kind = definition.kind || 'hustle';
+  return definition;
+}
+
+export function attachAssetMetricIds(definition) {
+  if (!definition || !definition.id) return definition;
+  const metricIds = { ...(definition.metricIds || {}) };
+  const setup = ensureObject(metricIds, 'setup');
+  setup.time = setup.time || createAssetMetricId(definition.id, 'setup', 'time');
+  setup.cost = setup.cost || createAssetMetricId(definition.id, 'setup', 'cost');
+
+  const maintenance = ensureObject(metricIds, 'maintenance');
+  maintenance.time = maintenance.time || createAssetMetricId(definition.id, 'maintenance', 'time');
+  maintenance.cost = maintenance.cost || createAssetMetricId(definition.id, 'maintenance', 'cost');
+
+  const payout = ensureObject(metricIds, 'payout');
+  payout.payout = payout.payout || `asset:${definition.id}:payout`;
+
+  const sale = ensureObject(metricIds, 'sale');
+  sale.payout = sale.payout || createAssetMetricId(definition.id, 'sale', 'payout');
+
+  if (definition.quality?.actions?.length) {
+    const quality = ensureObject(metricIds, 'quality');
+    for (const action of definition.quality.actions) {
+      if (!action?.id) continue;
+      const actionMetrics = quality[action.id] ? { ...quality[action.id] } : {};
+      if (!actionMetrics.time) {
+        actionMetrics.time = createQualityMetricId(definition.id, action.id, 'time');
+      }
+      if (!actionMetrics.cost) {
+        actionMetrics.cost = createQualityMetricId(definition.id, action.id, 'cost');
+      }
+      quality[action.id] = actionMetrics;
+      action.metricIds = { ...(action.metricIds || {}), ...actionMetrics };
+    }
+  }
+
+  definition.metricIds = metricIds;
+  definition.kind = definition.kind || 'asset';
+  return definition;
+}
+
+export function attachRegistryMetricIds({ hustles = [], assets = [], upgrades = [] }) {
+  hustles.forEach(attachHustleMetricIds);
+  assets.forEach(attachAssetMetricIds);
+  upgrades.forEach(definition => {
+    if (definition) {
+      definition.metricIds = definition.metricIds || {};
+      definition.kind = definition.kind || 'upgrade';
+    }
+  });
+  return { hustles, assets, upgrades };
+}
+
+export function buildMetricIndex({ hustles = [], assets = [], upgrades = [] }) {
+  const index = new Map();
+
+  for (const hustle of hustles) {
+    if (!hustle) continue;
+    const metricIds = hustle.metricIds || {};
+    registerMetric(index, metricIds.time, hustle, 'action', 'time');
+    registerMetric(index, metricIds.payout, hustle, 'action', 'payout');
+    registerMetric(index, metricIds.cost, hustle, 'action', 'cost');
+  }
+
+  for (const asset of assets) {
+    if (!asset) continue;
+    const metricIds = asset.metricIds || {};
+    const setup = metricIds.setup || {};
+    registerMetric(index, setup.time, asset, 'setup', 'time');
+    registerMetric(index, setup.cost, asset, 'setup', 'cost');
+
+    const maintenance = metricIds.maintenance || {};
+    registerMetric(index, maintenance.time, asset, 'maintenance', 'time');
+    registerMetric(index, maintenance.cost, asset, 'maintenance', 'cost');
+
+    const payout = metricIds.payout || {};
+    registerMetric(index, payout.payout, asset, 'payout', 'payout');
+
+    const sale = metricIds.sale || {};
+    registerMetric(index, sale.payout, asset, 'sale', 'payout');
+
+    const quality = metricIds.quality || {};
+    Object.entries(quality).forEach(([actionId, actionMetrics]) => {
+      if (!actionMetrics) return;
+      registerMetric(index, actionMetrics.time, asset, `quality:${actionId}`, 'time');
+      registerMetric(index, actionMetrics.cost, asset, `quality:${actionId}`, 'cost');
+    });
+  }
+
+  for (const upgrade of upgrades) {
+    if (!upgrade) continue;
+    const metricIds = upgrade.metricIds || {};
+    registerMetric(index, metricIds.time, upgrade, 'upgrade', 'time');
+    registerMetric(index, metricIds.payout, upgrade, 'upgrade', 'payout');
+    registerMetric(index, metricIds.cost, upgrade, 'upgrade', 'cost');
+  }
+
+  return index;
+}

--- a/src/game/summary.js
+++ b/src/game/summary.js
@@ -1,8 +1,16 @@
-import { getState, getAssetState } from '../core/state.js';
+import { getState, getAssetState, getMetricDefinition } from '../core/state.js';
 import { formatHours, formatMoney } from '../core/helpers.js';
 import { KNOWLEDGE_TRACKS, getKnowledgeProgress } from './requirements.js';
 import { getDailyMetrics } from './metrics.js';
 import { ASSETS } from './assets/registry.js';
+
+function resolveDefinitionReference(metricId) {
+  if (!metricId) return undefined;
+  const reference = getMetricDefinition(metricId);
+  if (!reference) return undefined;
+  const { id, name, category, type, label } = reference;
+  return { id, name, category, type, label };
+}
 
 export function computeDailySummary(state = getState()) {
   if (!state) {
@@ -52,10 +60,18 @@ export function computeDailySummary(state = getState()) {
   const formatTimeBreakdown = timeEntries
     .filter(entry => Number(entry?.hours) > 0)
     .sort((a, b) => Number(b.hours) - Number(a.hours))
-    .map(entry => ({
-      label: entry.label,
-      value: `${formatHours(Number(entry.hours))} today`
-    }));
+    .map(entry => {
+      const result = {
+        key: entry.key,
+        label: entry.label,
+        value: `${formatHours(Number(entry.hours))} today`
+      };
+      const definition = resolveDefinitionReference(entry.key);
+      if (definition) {
+        result.definition = definition;
+      }
+      return result;
+    });
 
   const totalEarnings = sumEntries(earningsEntries, 'amount');
   const passiveEarnings = sumEntries(passiveEntries, 'amount');
@@ -65,11 +81,18 @@ export function computeDailySummary(state = getState()) {
     entries
       .filter(entry => Number(entry?.amount) > 0)
       .sort((a, b) => Number(b.amount) - Number(a.amount))
-      .map(entry => ({
-        key: entry.key,
-        label: entry.label,
-        value: `$${formatMoney(Number(entry.amount))} today`
-      }));
+      .map(entry => {
+        const result = {
+          key: entry.key,
+          label: entry.label,
+          value: `$${formatMoney(Number(entry.amount))} today`
+        };
+        const definition = resolveDefinitionReference(entry.key);
+        if (definition) {
+          result.definition = definition;
+        }
+        return result;
+      });
 
   const passiveAssetSummaries = new Map();
 
@@ -114,10 +137,18 @@ export function computeDailySummary(state = getState()) {
   const spendBreakdown = spendEntries
     .filter(entry => Number(entry?.amount) > 0)
     .sort((a, b) => Number(b.amount) - Number(a.amount))
-    .map(entry => ({
-      label: entry.label,
-      value: `$${formatMoney(Number(entry.amount))} today`
-    }));
+    .map(entry => {
+      const result = {
+        key: entry.key,
+        label: entry.label,
+        value: `$${formatMoney(Number(entry.amount))} today`
+      };
+      const definition = resolveDefinitionReference(entry.key);
+      if (definition) {
+        result.definition = definition;
+      }
+      return result;
+    });
 
   let knowledgeInProgress = 0;
   let knowledgePendingToday = 0;

--- a/tests/schema.test.js
+++ b/tests/schema.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ensureTestDom } from './helpers/setupDom.js';
+
+ensureTestDom();
+
+const { configureRegistry, getAssetDefinition, getHustleDefinition } = await import('../src/core/state.js');
+const { registry } = await import('../src/game/registry.js');
+
+function ensureConfigured() {
+  configureRegistry(registry);
+}
+
+test('hustle definitions expose canonical metric identifiers', () => {
+  ensureConfigured();
+  const hustle = getHustleDefinition('freelance');
+  assert.ok(hustle?.action?.metricIds, 'hustle action should include metric ids');
+  assert.equal(hustle.action.metricIds.time, 'hustle:freelance:time');
+  assert.equal(hustle.action.metricIds.payout, 'hustle:freelance:payout');
+  assert.equal(hustle.action.metricIds.cost, 'hustle:freelance:cost');
+});
+
+test('asset definitions expose canonical metric identifiers for core flows', () => {
+  ensureConfigured();
+  const asset = getAssetDefinition('blog');
+  assert.ok(asset?.metricIds?.setup, 'asset should expose setup metric ids');
+  assert.equal(asset.metricIds.setup.time, 'asset:blog:setup-time');
+  assert.equal(asset.metricIds.setup.cost, 'asset:blog:setup-cost');
+  assert.ok(asset.metricIds.maintenance, 'asset should expose maintenance metric ids');
+  assert.equal(asset.metricIds.maintenance.time, 'asset:blog:maintenance-time');
+  assert.equal(asset.metricIds.maintenance.cost, 'asset:blog:maintenance-cost');
+  assert.ok(asset.metricIds.payout?.payout, 'asset should expose payout metric id');
+  assert.equal(asset.metricIds.payout.payout, 'asset:blog:payout');
+  const qualityAction = asset.quality?.actions?.find(action => action.id === 'seoSprint');
+  assert.ok(qualityAction?.metricIds, 'quality action should include metric ids');
+  assert.equal(qualityAction.metricIds.time, 'asset:blog:quality:seoSprint:time');
+  assert.equal(qualityAction.metricIds.cost, 'asset:blog:quality:seoSprint:cost');
+});

--- a/tests/summary.test.js
+++ b/tests/summary.test.js
@@ -71,3 +71,45 @@ test('daily summary aggregates metrics into category totals', () => {
   assert.equal(summary.earningsBreakdown.length, 1);
   assert.equal(summary.spendBreakdown.length, 2);
 });
+
+test('daily summary attaches definition references for canonical metrics', () => {
+  configureRegistry(registry);
+  const state = initializeState();
+  resetDailyMetrics(state);
+
+  recordTimeContribution({
+    key: 'asset:blog:setup-time',
+    label: '🚀 Blog setup',
+    hours: 3,
+    category: 'setup'
+  });
+  recordPayoutContribution({
+    key: 'hustle:freelance:payout',
+    label: '💼 Freelance payout',
+    amount: 20,
+    category: 'hustle'
+  });
+  recordCostContribution({
+    key: 'asset:blog:maintenance-cost',
+    label: '🔧 Blog upkeep',
+    amount: 5,
+    category: 'maintenance'
+  });
+
+  const summary = computeDailySummary(state);
+
+  const setupEntry = summary.timeBreakdown.find(entry => entry.key === 'asset:blog:setup-time');
+  assert.ok(setupEntry?.definition, 'setup entry should include definition metadata');
+  assert.equal(setupEntry.definition.name, 'Personal Blog Network');
+  assert.equal(setupEntry.definition.category, 'setup');
+
+  const hustleEntry = summary.earningsBreakdown.find(entry => entry.key === 'hustle:freelance:payout');
+  assert.ok(hustleEntry?.definition, 'earnings entry should include definition metadata');
+  assert.equal(hustleEntry.definition.category, 'action');
+
+  const maintenanceEntry = summary.spendBreakdown.find(
+    entry => entry.key === 'asset:blog:maintenance-cost'
+  );
+  assert.ok(maintenanceEntry?.definition, 'spend entry should include definition metadata');
+  assert.equal(maintenanceEntry.definition.category, 'maintenance');
+});


### PR DESCRIPTION
## Summary
- generate canonical metric identifiers through new schema helpers and expose them via the core registry
- update hustles, asset flows, and the daily summary to consume schema-provided metric IDs and surface definition metadata in breakdowns
- add regression tests covering schema metric IDs and summary definition references

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9b2589fd4832ca49f53ad1189b81f