### PR TITLE
Refactor requirement schema into shared utilities

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Unified asset and upgrade requirement schema so unlock conditions share consistent evaluation and UI messaging.
 - Revamped education tracks with upfront tuition costs, longer course lengths, and an automatic daily study scheduler that reserves hours until graduation.
 - Added cinema/studio upgrade tiers and a three-step server infrastructure ladder culminating in a Cloud Cluster requirement for SaaS launches.
 - Added instant hustles that reward active blogs/e-books, complete with live requirement summaries and one-hour payouts, plus per-instance cooldowns for high-impact passive quality actions.

--- a/src/game/assets/definitions/dropshipping.js
+++ b/src/game/assets/definitions/dropshipping.js
@@ -25,10 +25,10 @@ const dropshippingDefinition = {
     variance: 0.2,
     logType: 'passive'
   },
-  requirements: [
-    { type: 'knowledge', id: 'ecomPlaybook' },
-    { type: 'experience', assetId: 'blog', count: 2 }
-  ],
+  requirements: {
+    knowledge: ['ecomPlaybook'],
+    experience: [{ assetId: 'blog', count: 2 }]
+  },
   quality: {
     summary: 'Add listings, tune pages, and fund ad bursts to transform a fragile storefront into a conversion machine.',
     tracks: {

--- a/src/game/assets/definitions/ebook.js
+++ b/src/game/assets/definitions/ebook.js
@@ -25,7 +25,9 @@ const ebookDefinition = {
     variance: 0.2,
     logType: 'passive'
   },
-  requirements: [{ type: 'knowledge', id: 'outlineMastery' }],
+  requirements: {
+    knowledge: ['outlineMastery']
+  },
   quality: {
     summary: 'Draft chapters, commission covers, and gather reviews so royalties snowball as quality climbs.',
     tracks: {

--- a/src/game/assets/definitions/saas.js
+++ b/src/game/assets/definitions/saas.js
@@ -25,12 +25,14 @@ const saasDefinition = {
     variance: 0.2,
     logType: 'passive'
   },
-  requirements: [
-    { type: 'knowledge', id: 'automationCourse' },
-    { type: 'equipment', id: 'serverCluster' },
-    { type: 'experience', assetId: 'dropshipping', count: 1 },
-    { type: 'experience', assetId: 'ebook', count: 1 }
-  ],
+  requirements: {
+    knowledge: ['automationCourse'],
+    equipment: ['serverCluster'],
+    experience: [
+      { assetId: 'dropshipping', count: 1 },
+      { assetId: 'ebook', count: 1 }
+    ]
+  },
   quality: {
     summary: 'Squash bugs, ship features, and host support sprints so your app graduates into a churn-proof subscription machine.',
     tracks: {

--- a/src/game/assets/definitions/stockPhotos.js
+++ b/src/game/assets/definitions/stockPhotos.js
@@ -24,11 +24,10 @@ const stockPhotosDefinition = {
     variance: 0.2,
     logType: 'passive'
   },
-  requirements: [
-    { type: 'equipment', id: 'camera' },
-    { type: 'equipment', id: 'studio' },
-    { type: 'knowledge', id: 'photoLibrary' }
-  ],
+  requirements: {
+    equipment: ['camera', 'studio'],
+    knowledge: ['photoLibrary']
+  },
   quality: {
     summary: 'Shoot new packs, keyword diligently, and pitch marketplaces so galleries enjoy evergreen demand.',
     tracks: {

--- a/src/game/assets/definitions/vlog.js
+++ b/src/game/assets/definitions/vlog.js
@@ -32,7 +32,9 @@ const vlogDefinition = {
       return amount;
     }
   },
-  requirements: [{ type: 'equipment', id: 'camera' }],
+  requirements: {
+    equipment: ['camera']
+  },
   quality: {
     summary: 'Film episodes, polish edits, and promote premieres to unlock higher quality payouts and viral chances.',
     tracks: {

--- a/src/game/schema/requirements.js
+++ b/src/game/schema/requirements.js
@@ -1,0 +1,149 @@
+const SUPPORTED_TYPES = ['equipment', 'knowledge', 'experience'];
+
+function normalizeEquipment(value) {
+  if (!value) return null;
+  if (typeof value === 'string') {
+    return { type: 'equipment', id: value };
+  }
+  if (typeof value === 'object') {
+    const id = value.id ?? value.value ?? value.key;
+    if (!id) return null;
+    return { type: 'equipment', id };
+  }
+  return null;
+}
+
+function normalizeKnowledge(value) {
+  if (!value) return null;
+  if (typeof value === 'string') {
+    return { type: 'knowledge', id: value };
+  }
+  if (typeof value === 'object') {
+    const id = value.id ?? value.trackId ?? value.value;
+    if (!id) return null;
+    return { type: 'knowledge', id };
+  }
+  return null;
+}
+
+function normalizeExperience(value) {
+  if (!value) return null;
+  if (typeof value === 'string') {
+    return { type: 'experience', assetId: value, count: 1 };
+  }
+  if (typeof value === 'object') {
+    const assetId = value.assetId ?? value.id ?? value.asset;
+    if (!assetId) return null;
+    const count = Number(value.count ?? value.value ?? value.required ?? 0);
+    return { type: 'experience', assetId, count: Number.isFinite(count) ? Math.max(0, count) : 0 };
+  }
+  return null;
+}
+
+const NORMALIZERS = {
+  equipment: normalizeEquipment,
+  knowledge: normalizeKnowledge,
+  experience: normalizeExperience
+};
+
+function toArray(value) {
+  if (value == null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function finalizeBundle({ all, byType }) {
+  const bundle = {
+    all,
+    byType,
+    hasAny: all.length > 0,
+    every(predicate) {
+      if (typeof predicate !== 'function') return false;
+      return all.every(predicate);
+    },
+    some(predicate) {
+      if (typeof predicate !== 'function') return false;
+      return all.some(predicate);
+    },
+    map(mapper) {
+      if (typeof mapper !== 'function') return [];
+      return all.map(mapper);
+    },
+    filter(predicate) {
+      if (typeof predicate !== 'function') return [];
+      return all.filter(predicate);
+    },
+    missing(predicate) {
+      if (typeof predicate !== 'function') return [...all];
+      return all.filter(item => !predicate(item));
+    }
+  };
+  return bundle;
+}
+
+function normalizeRequirementEntry(entry) {
+  if (!entry) return null;
+  if (entry.type && NORMALIZERS[entry.type]) {
+    return NORMALIZERS[entry.type](entry);
+  }
+  return null;
+}
+
+export function normalizeRequirementConfig(config) {
+  const byType = {
+    equipment: [],
+    knowledge: [],
+    experience: []
+  };
+  const all = [];
+
+  if (!config) {
+    return finalizeBundle({ all, byType });
+  }
+
+  if (Array.isArray(config)) {
+    for (const item of config) {
+      const normalized = normalizeRequirementEntry(item);
+      if (normalized && SUPPORTED_TYPES.includes(normalized.type)) {
+        byType[normalized.type].push(normalized);
+        all.push(normalized);
+      }
+    }
+    return finalizeBundle({ all, byType });
+  }
+
+  if (typeof config === 'object') {
+    const entries = Object.entries(config);
+    for (const [type, value] of entries) {
+      if (!SUPPORTED_TYPES.includes(type)) continue;
+      const list = toArray(value);
+      for (const item of list) {
+        const normalized = NORMALIZERS[type](item);
+        if (normalized) {
+          byType[type].push(normalized);
+          all.push(normalized);
+        }
+      }
+    }
+    return finalizeBundle({ all, byType });
+  }
+
+  return finalizeBundle({ all, byType });
+}
+
+export function buildRequirementBundle(config) {
+  return normalizeRequirementConfig(config);
+}
+
+export function resolveRequirementConfig(definition) {
+  if (!definition) return null;
+  if (definition.requirements) {
+    return definition.requirements;
+  }
+  if (definition.requiresUpgrade) {
+    const upgrades = Array.isArray(definition.requiresUpgrade)
+      ? definition.requiresUpgrade
+      : [definition.requiresUpgrade];
+    return { equipment: upgrades };
+  }
+  return null;
+}

--- a/src/game/upgrades.js
+++ b/src/game/upgrades.js
@@ -16,6 +16,33 @@ import {
 import { checkDayEnd } from './lifecycle.js';
 import { spendMoney } from './currency.js';
 import { recordCostContribution } from './metrics.js';
+import { describeRequirement, isRequirementMet } from './requirements.js';
+import { buildRequirementBundle } from './schema/requirements.js';
+
+const CAMERA_PRO_REQUIREMENTS = { equipment: ['camera'] };
+const CAMERA_PRO_REQUIREMENT_BUNDLE = buildRequirementBundle(CAMERA_PRO_REQUIREMENTS);
+const STUDIO_EXPANSION_REQUIREMENTS = { equipment: ['studio'] };
+const STUDIO_EXPANSION_REQUIREMENT_BUNDLE = buildRequirementBundle(STUDIO_EXPANSION_REQUIREMENTS);
+const SERVER_CLUSTER_REQUIREMENTS = { equipment: ['serverRack'] };
+const SERVER_CLUSTER_REQUIREMENT_BUNDLE = buildRequirementBundle(SERVER_CLUSTER_REQUIREMENTS);
+const SERVER_EDGE_REQUIREMENTS = { equipment: ['serverCluster'] };
+const SERVER_EDGE_REQUIREMENT_BUNDLE = buildRequirementBundle(SERVER_EDGE_REQUIREMENTS);
+const COURSE_REQUIREMENTS = { experience: [{ assetId: 'blog', count: 1 }] };
+const COURSE_REQUIREMENT_BUNDLE = buildRequirementBundle(COURSE_REQUIREMENTS);
+
+function summarizeMissingRequirementLabels(bundle) {
+  if (!bundle?.hasAny) return '';
+  const missing = bundle.missing(isRequirementMet);
+  if (!missing.length) return '';
+  const labels = missing.map(req => describeRequirement(req).label);
+  return labels.join(' & ');
+}
+
+function formatRequirementHeadline(bundle) {
+  if (!bundle?.hasAny) return 'None';
+  const labels = bundle.map(req => describeRequirement(req).label);
+  return labels.join(' & ');
+}
 
 export const UPGRADES = [
   {
@@ -161,28 +188,30 @@ export const UPGRADES = [
     defaultState: {
       purchased: false
     },
+    requirements: CAMERA_PRO_REQUIREMENTS,
     details: [
       () => '💵 Cost: <strong>$480</strong>',
-      () => 'Requires: <strong>Camera</strong>',
+      () => `Requires: <strong>${formatRequirementHeadline(CAMERA_PRO_REQUIREMENT_BUNDLE)}</strong>`,
       () => 'Boosts: <strong>Higher vlog quality payouts</strong>'
     ],
     action: {
       label: () => {
         const upgrade = getUpgradeState('cameraPro');
         if (upgrade.purchased) return 'Cinema Ready';
-        if (!getUpgradeState('camera').purchased) return 'Requires Camera';
+        const missing = summarizeMissingRequirementLabels(CAMERA_PRO_REQUIREMENT_BUNDLE);
+        if (missing) return `Requires ${missing}`;
         return 'Install Cinema Gear';
       },
       className: 'secondary',
       disabled: () => {
         const upgrade = getUpgradeState('cameraPro');
         if (upgrade.purchased) return true;
-        if (!getUpgradeState('camera').purchased) return true;
+        if (summarizeMissingRequirementLabels(CAMERA_PRO_REQUIREMENT_BUNDLE)) return true;
         return getState().money < 480;
       },
       onClick: () => executeAction(() => {
         const upgrade = getUpgradeState('cameraPro');
-        if (upgrade.purchased || !getUpgradeState('camera').purchased) return;
+        if (upgrade.purchased || summarizeMissingRequirementLabels(CAMERA_PRO_REQUIREMENT_BUNDLE)) return;
         spendMoney(480);
         recordCostContribution({
           key: 'upgrade:cameraPro',
@@ -197,7 +226,8 @@ export const UPGRADES = [
     cardState: (_state, card) => {
       const upgrade = getUpgradeState('cameraPro');
       card.classList.toggle('locked', upgrade.purchased);
-      card.classList.toggle('requires-upgrade', !getUpgradeState('camera').purchased && !upgrade.purchased);
+      const missing = summarizeMissingRequirementLabels(CAMERA_PRO_REQUIREMENT_BUNDLE);
+      card.classList.toggle('requires-upgrade', Boolean(missing) && !upgrade.purchased);
     }
   },
   {
@@ -208,28 +238,30 @@ export const UPGRADES = [
     defaultState: {
       purchased: false
     },
+    requirements: STUDIO_EXPANSION_REQUIREMENTS,
     details: [
       () => '💵 Cost: <strong>$540</strong>',
-      () => 'Requires: <strong>Lighting Kit</strong>',
+      () => `Requires: <strong>${formatRequirementHeadline(STUDIO_EXPANSION_REQUIREMENT_BUNDLE)}</strong>`,
       () => 'Boosts: <strong>Stock photo session efficiency</strong>'
     ],
     action: {
       label: () => {
         const upgrade = getUpgradeState('studioExpansion');
         if (upgrade.purchased) return 'Studio Expanded';
-        if (!getUpgradeState('studio').purchased) return 'Requires Lighting Kit';
+        const missing = summarizeMissingRequirementLabels(STUDIO_EXPANSION_REQUIREMENT_BUNDLE);
+        if (missing) return `Requires ${missing}`;
         return 'Expand Studio';
       },
       className: 'secondary',
       disabled: () => {
         const upgrade = getUpgradeState('studioExpansion');
         if (upgrade.purchased) return true;
-        if (!getUpgradeState('studio').purchased) return true;
+        if (summarizeMissingRequirementLabels(STUDIO_EXPANSION_REQUIREMENT_BUNDLE)) return true;
         return getState().money < 540;
       },
       onClick: () => executeAction(() => {
         const upgrade = getUpgradeState('studioExpansion');
-        if (upgrade.purchased || !getUpgradeState('studio').purchased) return;
+        if (upgrade.purchased || summarizeMissingRequirementLabels(STUDIO_EXPANSION_REQUIREMENT_BUNDLE)) return;
         spendMoney(540);
         recordCostContribution({
           key: 'upgrade:studioExpansion',
@@ -244,7 +276,8 @@ export const UPGRADES = [
     cardState: (_state, card) => {
       const upgrade = getUpgradeState('studioExpansion');
       card.classList.toggle('locked', upgrade.purchased);
-      card.classList.toggle('requires-upgrade', !getUpgradeState('studio').purchased && !upgrade.purchased);
+      const missing = summarizeMissingRequirementLabels(STUDIO_EXPANSION_REQUIREMENT_BUNDLE);
+      card.classList.toggle('requires-upgrade', Boolean(missing) && !upgrade.purchased);
     }
   },
   {
@@ -294,28 +327,30 @@ export const UPGRADES = [
     defaultState: {
       purchased: false
     },
+    requirements: SERVER_CLUSTER_REQUIREMENTS,
     details: [
       () => '💵 Cost: <strong>$1,150</strong>',
-      () => 'Requires: <strong>Starter Server Rack</strong>',
+      () => `Requires: <strong>${formatRequirementHeadline(SERVER_CLUSTER_REQUIREMENT_BUNDLE)}</strong>`,
       () => 'Unlocks: <strong>SaaS deployments</strong>'
     ],
     action: {
       label: () => {
         const upgrade = getUpgradeState('serverCluster');
         if (upgrade.purchased) return 'Cluster Ready';
-        if (!getUpgradeState('serverRack').purchased) return 'Requires Rack';
+        const missing = summarizeMissingRequirementLabels(SERVER_CLUSTER_REQUIREMENT_BUNDLE);
+        if (missing) return `Requires ${missing}`;
         return 'Deploy Cluster';
       },
       className: 'secondary',
       disabled: () => {
         const upgrade = getUpgradeState('serverCluster');
         if (upgrade.purchased) return true;
-        if (!getUpgradeState('serverRack').purchased) return true;
+        if (summarizeMissingRequirementLabels(SERVER_CLUSTER_REQUIREMENT_BUNDLE)) return true;
         return getState().money < 1150;
       },
       onClick: () => executeAction(() => {
         const upgrade = getUpgradeState('serverCluster');
-        if (upgrade.purchased || !getUpgradeState('serverRack').purchased) return;
+        if (upgrade.purchased || summarizeMissingRequirementLabels(SERVER_CLUSTER_REQUIREMENT_BUNDLE)) return;
         spendMoney(1150);
         recordCostContribution({
           key: 'upgrade:serverCluster',
@@ -330,7 +365,8 @@ export const UPGRADES = [
     cardState: (_state, card) => {
       const upgrade = getUpgradeState('serverCluster');
       card.classList.toggle('locked', upgrade.purchased);
-      card.classList.toggle('requires-upgrade', !getUpgradeState('serverRack').purchased && !upgrade.purchased);
+      const missing = summarizeMissingRequirementLabels(SERVER_CLUSTER_REQUIREMENT_BUNDLE);
+      card.classList.toggle('requires-upgrade', Boolean(missing) && !upgrade.purchased);
     }
   },
   {
@@ -341,28 +377,30 @@ export const UPGRADES = [
     defaultState: {
       purchased: false
     },
+    requirements: SERVER_EDGE_REQUIREMENTS,
     details: [
       () => '💵 Cost: <strong>$1,450</strong>',
-      () => 'Requires: <strong>Cloud Cluster</strong>',
+      () => `Requires: <strong>${formatRequirementHeadline(SERVER_EDGE_REQUIREMENT_BUNDLE)}</strong>`,
       () => 'Boosts: <strong>SaaS subscriber trust</strong>'
     ],
     action: {
       label: () => {
         const upgrade = getUpgradeState('serverEdge');
         if (upgrade.purchased) return 'Edge Live';
-        if (!getUpgradeState('serverCluster').purchased) return 'Requires Cluster';
+        const missing = summarizeMissingRequirementLabels(SERVER_EDGE_REQUIREMENT_BUNDLE);
+        if (missing) return `Requires ${missing}`;
         return 'Activate Edge Network';
       },
       className: 'secondary',
       disabled: () => {
         const upgrade = getUpgradeState('serverEdge');
         if (upgrade.purchased) return true;
-        if (!getUpgradeState('serverCluster').purchased) return true;
+        if (summarizeMissingRequirementLabels(SERVER_EDGE_REQUIREMENT_BUNDLE)) return true;
         return getState().money < 1450;
       },
       onClick: () => executeAction(() => {
         const upgrade = getUpgradeState('serverEdge');
-        if (upgrade.purchased || !getUpgradeState('serverCluster').purchased) return;
+        if (upgrade.purchased || summarizeMissingRequirementLabels(SERVER_EDGE_REQUIREMENT_BUNDLE)) return;
         spendMoney(1450);
         recordCostContribution({
           key: 'upgrade:serverEdge',
@@ -377,7 +415,8 @@ export const UPGRADES = [
     cardState: (_state, card) => {
       const upgrade = getUpgradeState('serverEdge');
       card.classList.toggle('locked', upgrade.purchased);
-      card.classList.toggle('requires-upgrade', !getUpgradeState('serverCluster').purchased && !upgrade.purchased);
+      const missing = summarizeMissingRequirementLabels(SERVER_EDGE_REQUIREMENT_BUNDLE);
+      card.classList.toggle('requires-upgrade', Boolean(missing) && !upgrade.purchased);
     }
   },
   {
@@ -429,28 +468,29 @@ export const UPGRADES = [
     defaultState: {
       purchased: false
     },
+    requirements: COURSE_REQUIREMENTS,
     details: [
       () => '💵 Cost: <strong>$260</strong>',
-      () => 'Requires at least one active blog'
+      () => `Requires: <strong>${formatRequirementHeadline(COURSE_REQUIREMENT_BUNDLE)}</strong>`
     ],
     action: {
       label: () => {
         const upgrade = getUpgradeState('course');
         if (upgrade.purchased) return 'Automation Ready';
-        return getAssetState('blog').instances.length ? 'Study Up' : 'Requires Active Blog';
+        const missing = summarizeMissingRequirementLabels(COURSE_REQUIREMENT_BUNDLE);
+        if (missing) return `Requires ${missing}`;
+        return 'Study Up';
       },
       className: 'secondary',
       disabled: () => {
         const upgrade = getUpgradeState('course');
         if (upgrade.purchased) return true;
-        const blogActive = getAssetState('blog').instances.length > 0;
-        if (!blogActive) return true;
+        if (summarizeMissingRequirementLabels(COURSE_REQUIREMENT_BUNDLE)) return true;
         return getState().money < 260;
       },
       onClick: () => executeAction(() => {
         const upgrade = getUpgradeState('course');
-        const blog = getAssetState('blog');
-        if (upgrade.purchased || !blog.instances.length) return;
+        if (upgrade.purchased || summarizeMissingRequirementLabels(COURSE_REQUIREMENT_BUNDLE)) return;
         spendMoney(260);
         recordCostContribution({
           key: 'upgrade:course',
@@ -464,8 +504,8 @@ export const UPGRADES = [
     },
     cardState: (_state, card) => {
       const upgrade = getUpgradeState('course');
-      const blogActive = getAssetState('blog').instances.length > 0;
-      card.classList.toggle('locked', !blogActive && !upgrade.purchased);
+      const missing = summarizeMissingRequirementLabels(COURSE_REQUIREMENT_BUNDLE);
+      card.classList.toggle('locked', Boolean(missing) && !upgrade.purchased);
     }
   }
 ];


### PR DESCRIPTION
## Summary
- add a shared requirement schema helper that normalizes definitions and provides simple evaluators
- refactor requirements handling to reuse the shared bundle for assets while exposing describe/isRequirementMet helpers
- update asset and upgrade definitions to declare normalized requirements and consume the shared evaluators, refreshing the changelog entry

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9b259fc94832ca2475b6bc8a287a5