### PR TITLE
Add action catalog selectors and debug panel

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Added a centralized action catalog with selectors plus an optional debug panel that lists availability, costs, and requirement gaps across hustles, assets, upgrades, and quality actions.
 - Revamped education tracks with upfront tuition costs, longer course lengths, and an automatic daily study scheduler that reserves hours until graduation.
 - Added cinema/studio upgrade tiers and a three-step server infrastructure ladder culminating in a Cloud Cluster requirement for SaaS launches.
 - Added instant hustles that reward active blogs/e-books, complete with live requirement summaries and one-hour payouts, plus per-instance cooldowns for high-impact passive quality actions.

--- a/docs/features/action-catalog.md
+++ b/docs/features/action-catalog.md
@@ -1,0 +1,15 @@
+# Action Catalog & Debug Panel
+
+## Goals
+- Provide a single source of truth for actionable content (hustles, asset launches, quality pushes, upgrades) so future systems can reuse shared data.
+- Surface requirement, time, and money availability in a developer-facing panel for quicker tuning and balancing.
+- Prepare groundwork for player-facing features such as action search, category filters, or smart recommendations.
+
+## Player / Developer Impact
+- Players do not see the debug panel, but they will benefit from more consistent requirement handling across cards as the catalog powers upcoming UI.
+- Developers gain a live dashboard (toggle via `?debugActions=1` or `#debug-actions`) listing every action, its availability, and unmet gates for faster iteration.
+
+## Tuning Notes
+- Catalog entries compute availability using shared selectors that respect time, money, prerequisites, cooldowns, and daily limits.
+- Debug rows highlight missing resources (time, cash, requirements) in orange to spotlight balancing issues.
+- The catalog API (`listCatalog`, `listAvailableActions`) accepts filters for future panels that may target specific categories (e.g., instant-only hustles or long-form quality work).

--- a/index.html
+++ b/index.html
@@ -262,6 +262,17 @@
       </section>
     </main>
 
+    <section class="debug-panel" id="debug-action-catalog" hidden aria-hidden="true">
+      <header>
+        <h2>Action Catalog (Debug)</h2>
+        <p>Developer overview of every action, its costs, and requirement status.</p>
+      </header>
+      <p id="debug-action-catalog-summary" class="debug-panel__summary"></p>
+      <div class="debug-panel__body">
+        <table id="debug-action-catalog-list" class="debug-table"></table>
+      </div>
+    </section>
+
     <div id="asset-info-modal" class="modal" aria-hidden="true">
       <div class="modal__backdrop" data-modal-close></div>
       <div class="modal__dialog" role="dialog" aria-modal="true" aria-labelledby="asset-info-title">

--- a/src/game/assets/helpers.js
+++ b/src/game/assets/helpers.js
@@ -25,6 +25,7 @@ import {
 
 export function buildAssetAction(definition, labels = {}) {
   return {
+    id: 'launch',
     label: () => assetActionLabel(definition, labels),
     className: 'primary',
     disabled: () => isAssetPurchaseDisabled(definition),

--- a/src/game/content/catalog.js
+++ b/src/game/content/catalog.js
@@ -1,0 +1,404 @@
+import { registry } from '../registry.js';
+import { getState, getAssetState, getUpgradeState, getUpgradeDefinition, getAssetDefinition } from '../../core/state.js';
+import { assetRequirementsMet, listAssetRequirementDescriptors, KNOWLEDGE_TRACKS, getKnowledgeProgress } from '../requirements.js';
+import { getQualityActions, canPerformQualityAction } from '../assets/quality.js';
+import { describeHustleRequirements, areHustleRequirementsMet } from '../hustles.js';
+import { canHireAssistant, getAssistantCount, ASSISTANT_CONFIG } from '../assistant.js';
+import { COFFEE_LIMIT } from '../../core/constants.js';
+
+function createKey(sourceType, sourceId, actionId) {
+  return `${sourceType}:${sourceId}:${actionId}`;
+}
+
+function asNumber(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : 0;
+}
+
+function resolveActionLabel(action, fallback) {
+  if (!action) return fallback;
+  if (typeof action.label === 'function') {
+    try {
+      return action.label();
+    } catch (error) {
+      return fallback;
+    }
+  }
+  if (typeof action.label === 'string' && action.label.length) {
+    return action.label;
+  }
+  return fallback;
+}
+
+function describeQualityRequirements(definition, action, state) {
+  const assetState = getAssetState(definition.id, state);
+  const totalInstances = assetState.instances?.length || 0;
+  const activeInstances = (assetState.instances || []).filter(instance => instance.status === 'active');
+  const availableInstances = activeInstances.filter(instance => canPerformQualityAction(definition, instance, action, state));
+  const descriptors = [
+    {
+      type: 'assetInstance',
+      assetId: definition.id,
+      label: `${definition.singular || definition.name} active`,
+      met: activeInstances.length > 0,
+      progress: { active: activeInstances.length, total: totalInstances }
+    }
+  ];
+  if (activeInstances.length > 0) {
+    descriptors.push({
+      type: 'cooldown',
+      label: 'Cooldown ready',
+      met: availableInstances.length > 0,
+      progress: { available: availableInstances.length, total: activeInstances.length }
+    });
+  }
+  return descriptors;
+}
+
+function describeStudyStatus(hustle, state) {
+  if (!hustle.studyTrackId) return [];
+  const track = KNOWLEDGE_TRACKS[hustle.studyTrackId];
+  const progress = getKnowledgeProgress(hustle.studyTrackId, state);
+  if (!track || !progress) return [];
+  return [
+    {
+      type: 'study',
+      id: hustle.studyTrackId,
+      label: track.name,
+      met: !progress.enrolled && !progress.completed,
+      progress: {
+        enrolled: progress.enrolled,
+        completed: progress.completed,
+        daysCompleted: progress.daysCompleted,
+        totalDays: track.days
+      }
+    }
+  ];
+}
+
+function describeUpgradeRequirements(definition, state) {
+  const requirements = Array.isArray(definition.requirements) ? definition.requirements : [];
+  if (!requirements.length) return [];
+  return requirements.map(req => {
+    switch (req.type) {
+      case 'upgrade': {
+        const upgradeDef = getUpgradeDefinition(req.id);
+        const upgradeState = getUpgradeState(req.id, state);
+        return {
+          type: 'upgrade',
+          id: req.id,
+          label: upgradeDef?.name || req.id,
+          met: Boolean(upgradeState?.purchased)
+        };
+      }
+      case 'experience': {
+        const assetDef = getAssetDefinition(req.assetId);
+        const need = Math.max(0, Number(req.count) || 0);
+        const assetState = getAssetState(req.assetId, state);
+        const have = (assetState.instances || []).filter(instance => instance.status === 'active').length;
+        return {
+          type: 'experience',
+          assetId: req.assetId,
+          label: `${need} ${(assetDef?.singular || assetDef?.name || req.assetId)}${need === 1 ? '' : 's'}`,
+          met: have >= need,
+          progress: { have, need }
+        };
+      }
+      case 'knowledge': {
+        const track = KNOWLEDGE_TRACKS[req.id];
+        const progress = getKnowledgeProgress(req.id, state);
+        return {
+          type: 'knowledge',
+          id: req.id,
+          label: track?.name || req.id,
+          met: progress.completed,
+          progress: {
+            daysCompleted: progress.daysCompleted,
+            totalDays: track?.days ?? 0
+          }
+        };
+      }
+      default:
+        return { type: req.type || 'unknown', met: false };
+    }
+  });
+}
+
+function buildAssetEntries() {
+  return registry.assets.map(definition => {
+    const action = definition.action || {};
+    const actionId = action.id || 'launch';
+    const timeCost = Math.max(0, asNumber(definition.setup?.hoursPerDay));
+    const moneyCost = Math.max(0, asNumber(definition.setup?.cost));
+    const durationDays = Math.max(0, asNumber(definition.setup?.days));
+    return {
+      key: createKey('asset', definition.id, actionId),
+      sourceType: 'asset',
+      sourceId: definition.id,
+      sourceName: definition.name,
+      actionId,
+      category: 'setup',
+      timeCost,
+      moneyCost,
+      durationDays,
+      tags: {
+        group: definition.tag?.type || null,
+        delayed: durationDays > 0
+      },
+      resolveLabel: state => resolveActionLabel(action, `Launch ${definition.singular || definition.name}`),
+      describeRequirements: state => listAssetRequirementDescriptors(definition, state),
+      isAvailable: state => {
+        if (!state) return false;
+        if (timeCost > 0 && state.timeLeft < timeCost) return false;
+        if (moneyCost > 0 && state.money < moneyCost) return false;
+        return assetRequirementsMet(definition, state);
+      }
+    };
+  });
+}
+
+function buildQualityEntries() {
+  const entries = [];
+  for (const definition of registry.assets) {
+    const actions = getQualityActions(definition) || [];
+    for (const action of actions) {
+      const actionId = action.id || action.label;
+      const timeCost = Math.max(0, asNumber(action.time));
+      const moneyCost = Math.max(0, asNumber(action.cost));
+      entries.push({
+        key: createKey('quality', definition.id, actionId),
+        sourceType: 'quality',
+        sourceId: definition.id,
+        sourceName: definition.name,
+        actionId,
+        category: 'quality',
+        timeCost,
+        moneyCost,
+        tags: {
+          group: definition.tag?.type || null
+        },
+        resolveLabel: () => action.label,
+        describeRequirements: state => describeQualityRequirements(definition, action, state),
+        isAvailable: state => {
+          if (!state) return false;
+          if (timeCost > 0 && state.timeLeft < timeCost) return false;
+          if (moneyCost > 0 && state.money < moneyCost) return false;
+          const assetState = getAssetState(definition.id, state);
+          const activeInstances = (assetState.instances || []).filter(instance => instance.status === 'active');
+          if (!activeInstances.length) return false;
+          return activeInstances.some(instance => canPerformQualityAction(definition, instance, action, state));
+        }
+      });
+    }
+  }
+  return entries;
+}
+
+function buildHustleEntries() {
+  return registry.hustles.map(definition => {
+    const action = definition.action || {};
+    const actionId = action.id || 'action';
+    const timeCost = Math.max(0, asNumber(action.timeCost));
+    const moneyCost = Math.max(0, asNumber(action.moneyCost));
+    return {
+      key: createKey('hustle', definition.id, actionId),
+      sourceType: definition.tag?.type === 'study' ? 'study' : 'hustle',
+      sourceId: definition.id,
+      sourceName: definition.name,
+      actionId,
+      category: definition.tag?.type || 'instant',
+      timeCost,
+      moneyCost,
+      delaySeconds: asNumber(action.delaySeconds),
+      tags: {
+        group: definition.tag?.type || null
+      },
+      resolveLabel: () => resolveActionLabel(action, definition.action?.label || definition.name),
+      describeRequirements: state => {
+        const base = describeHustleRequirements(definition, state);
+        if (definition.tag?.type === 'study') {
+          return [...base, ...describeStudyStatus(definition, state)];
+        }
+        return base;
+      },
+      isAvailable: state => {
+        if (!state) return false;
+        if (definition.tag?.type === 'study') {
+          const trackId = definition.studyTrackId;
+          if (!trackId) return false;
+          const progress = getKnowledgeProgress(trackId, state);
+          if (progress.completed || progress.enrolled) return false;
+          if (moneyCost > 0 && state.money < moneyCost) return false;
+          return true;
+        }
+        if (timeCost > 0 && state.timeLeft < timeCost) return false;
+        if (moneyCost > 0 && state.money < moneyCost) return false;
+        return areHustleRequirementsMet(definition, state);
+      }
+    };
+  });
+}
+
+function upgradeDailyLimitDescriptor(definition, state) {
+  if (definition.id !== 'coffee') return [];
+  const upgrade = getUpgradeState('coffee', state);
+  const used = Number(upgrade.usedToday) || 0;
+  return [
+    {
+      type: 'limit',
+      label: `Daily limit (${COFFEE_LIMIT})`,
+      met: used < COFFEE_LIMIT,
+      progress: { used, limit: COFFEE_LIMIT }
+    }
+  ];
+}
+
+function describeAssistantRequirement(state) {
+  const count = getAssistantCount(state);
+  return [
+    {
+      type: 'limit',
+      label: `Team size < ${ASSISTANT_CONFIG.maxAssistants}`,
+      met: count < ASSISTANT_CONFIG.maxAssistants,
+      progress: { have: count, limit: ASSISTANT_CONFIG.maxAssistants }
+    }
+  ];
+}
+
+function buildUpgradeEntries() {
+  return registry.upgrades.map(definition => {
+    const action = definition.action || {};
+    const actionId = action.id || 'activate';
+    const timeCost = Math.max(0, asNumber(action.timeCost));
+    const moneyCost = Math.max(0, asNumber(action.moneyCost));
+    return {
+      key: createKey('upgrade', definition.id, actionId),
+      sourceType: 'upgrade',
+      sourceId: definition.id,
+      sourceName: definition.name,
+      actionId,
+      category: 'upgrade',
+      timeCost,
+      moneyCost,
+      tags: {
+        group: definition.tag?.type || null
+      },
+      resolveLabel: () => resolveActionLabel(action, definition.name),
+      describeRequirements: state => {
+        const descriptors = describeUpgradeRequirements(definition, state);
+        if (definition.id === 'assistant') {
+          return [...descriptors, ...describeAssistantRequirement(state)];
+        }
+        if (definition.id === 'coffee') {
+          return [...descriptors, ...upgradeDailyLimitDescriptor(definition, state)];
+        }
+        return descriptors;
+      },
+      isAvailable: state => {
+        if (!state) return false;
+        if (definition.id === 'assistant') {
+          if (!canHireAssistant(state)) return false;
+          if (moneyCost > 0 && state.money < moneyCost) return false;
+          return true;
+        }
+        if (definition.id === 'coffee') {
+          const coffeeState = getUpgradeState('coffee', state);
+          if (moneyCost > 0 && state.money < moneyCost) return false;
+          if (state.timeLeft <= 0) return false;
+          return (Number(coffeeState.usedToday) || 0) < COFFEE_LIMIT;
+        }
+        const upgradeState = getUpgradeState(definition.id, state);
+        if (upgradeState?.purchased) return false;
+        if (moneyCost > 0 && state.money < moneyCost) return false;
+        const requirements = describeUpgradeRequirements(definition, state);
+        if (requirements.some(req => req.met === false)) {
+          return false;
+        }
+        return true;
+      }
+    };
+  });
+}
+
+let catalogCache = null;
+
+function getCatalogCache() {
+  if (!catalogCache) {
+    catalogCache = [
+      ...buildAssetEntries(),
+      ...buildQualityEntries(),
+      ...buildHustleEntries(),
+      ...buildUpgradeEntries()
+    ];
+  }
+  return catalogCache;
+}
+
+function applyFilters(entry, filters = {}) {
+  if (!filters) return true;
+  if (filters.sourceTypes && !filters.sourceTypes.includes(entry.sourceType)) {
+    return false;
+  }
+  if (filters.sourceId && entry.sourceId !== filters.sourceId) {
+    return false;
+  }
+  if (filters.actionId && entry.actionId !== filters.actionId) {
+    return false;
+  }
+  if (filters.category && entry.category !== filters.category) {
+    return false;
+  }
+  if (filters.maxTime != null && entry.timeCost > filters.maxTime) {
+    return false;
+  }
+  if (filters.instantOnly && entry.tags?.delayed) {
+    return false;
+  }
+  if (filters.delayedOnly && !entry.tags?.delayed) {
+    return false;
+  }
+  if (filters.groups && entry.tags?.group && !filters.groups.includes(entry.tags.group)) {
+    return false;
+  }
+  return true;
+}
+
+export function getActionCatalog() {
+  return getCatalogCache().slice();
+}
+
+export function evaluateCatalogEntry(entry, state = getState()) {
+  const label = entry.resolveLabel(state);
+  const requirements = entry.describeRequirements ? entry.describeRequirements(state) : [];
+  const timeSatisfied = !entry.timeCost || (state ? state.timeLeft >= entry.timeCost : false);
+  const moneySatisfied = !entry.moneyCost || (state ? state.money >= entry.moneyCost : false);
+  const requirementSatisfied = requirements.every(req => req.met !== false);
+  const available = Boolean(entry.isAvailable ? entry.isAvailable(state) : (timeSatisfied && moneySatisfied && requirementSatisfied));
+  return {
+    ...entry,
+    label,
+    requirements,
+    available,
+    timeSatisfied,
+    moneySatisfied,
+    requirementSatisfied
+  };
+}
+
+export function listCatalog(state = getState(), filters = {}) {
+  return getCatalogCache()
+    .filter(entry => applyFilters(entry, filters))
+    .map(entry => evaluateCatalogEntry(entry, state));
+}
+
+export function listAvailableActions(state = getState(), filters = {}) {
+  return listCatalog(state, filters).filter(entry => entry.available);
+}
+
+export function findCatalogEntry(sourceType, sourceId, actionId) {
+  return getCatalogCache().find(entry =>
+    entry.sourceType === sourceType &&
+    entry.sourceId === sourceId &&
+    entry.actionId === actionId
+  ) || null;
+}

--- a/src/game/hustles.js
+++ b/src/game/hustles.js
@@ -16,25 +16,25 @@ import {
   recordTimeContribution
 } from './metrics.js';
 
-function countActiveAssets(assetId) {
-  const assetState = getAssetState(assetId);
+function countActiveAssets(assetId, state = getState()) {
+  const assetState = getAssetState(assetId, state);
   if (!assetState?.instances) return 0;
   return assetState.instances.filter(instance => instance.status === 'active').length;
 }
 
-function requirementsMet(requirements = []) {
+function requirementsMet(requirements = [], state = getState()) {
   if (!requirements?.length) return true;
-  return requirements.every(req => countActiveAssets(req.assetId) >= (Number(req.count) || 1));
+  return requirements.every(req => countActiveAssets(req.assetId, state) >= (Number(req.count) || 1));
 }
 
-function renderRequirementSummary(requirements = []) {
+function renderRequirementSummary(requirements = [], state = getState()) {
   if (!requirements.length) return 'None';
   return requirements
     .map(req => {
       const definition = getAssetDefinition(req.assetId);
       const label = definition?.singular || definition?.name || req.assetId;
       const need = Number(req.count) || 1;
-      const have = countActiveAssets(req.assetId);
+      const have = countActiveAssets(req.assetId, state);
       return `${label}: ${have}/${need} active`;
     })
     .join(' • ');
@@ -45,6 +45,33 @@ const BUNDLE_PUSH_REQUIREMENTS = [
   { assetId: 'blog', count: 2 },
   { assetId: 'ebook', count: 1 }
 ];
+
+export function getHustleRequirements(definition) {
+  if (!definition) return [];
+  return Array.isArray(definition.requirements) ? definition.requirements : [];
+}
+
+export function describeHustleRequirements(definition, state = getState()) {
+  const requirements = getHustleRequirements(definition);
+  if (!requirements.length) return [];
+  return requirements.map(req => {
+    const assetDefinition = getAssetDefinition(req.assetId);
+    const label = assetDefinition?.singular || assetDefinition?.name || req.assetId;
+    const need = Number(req.count) || 1;
+    const have = countActiveAssets(req.assetId, state);
+    return {
+      type: 'asset',
+      assetId: req.assetId,
+      label: `${need} ${label}${need === 1 ? '' : 's'}`,
+      met: have >= need,
+      progress: { have, need }
+    };
+  });
+}
+
+export function areHustleRequirementsMet(definition, state = getState()) {
+  return requirementsMet(getHustleRequirements(definition), state);
+}
 
 export const HUSTLES = [
   {
@@ -57,6 +84,9 @@ export const HUSTLES = [
       () => '💵 Payout: <strong>$18</strong>'
     ],
     action: {
+      id: 'writeArticle',
+      timeCost: 2,
+      moneyCost: 0,
       label: 'Write Now',
       className: 'primary',
       disabled: () => getState().timeLeft < 2,
@@ -86,19 +116,23 @@ export const HUSTLES = [
     name: 'Audience Q&A Blast',
     tag: { label: 'Instant', type: 'instant' },
     description: 'Host a 60-minute livestream for your blog readers and pitch a premium checklist.',
+    requirements: AUDIENCE_CALL_REQUIREMENTS,
     details: [
       () => '⏳ Time: <strong>1h</strong>',
       () => '💵 Payout: <strong>$12</strong>',
       () => `Requires: <strong>${renderRequirementSummary(AUDIENCE_CALL_REQUIREMENTS)}</strong>`
     ],
     action: {
+      id: 'goLive',
+      timeCost: 1,
+      moneyCost: 0,
       label: 'Go Live',
       className: 'primary',
       disabled: () => {
         const state = getState();
         if (!state) return true;
         if (state.timeLeft < 1) return true;
-        return !requirementsMet(AUDIENCE_CALL_REQUIREMENTS);
+        return !requirementsMet(AUDIENCE_CALL_REQUIREMENTS, state);
       },
       onClick: () => {
         executeAction(() => {
@@ -108,7 +142,7 @@ export const HUSTLES = [
             addLog('You need a full free hour before going live with your readers.', 'warning');
             return;
           }
-          if (!requirementsMet(AUDIENCE_CALL_REQUIREMENTS)) {
+          if (!requirementsMet(AUDIENCE_CALL_REQUIREMENTS, state)) {
             addLog('You need an active blog to invite readers to that Q&A.', 'warning');
             return;
           }
@@ -136,19 +170,23 @@ export const HUSTLES = [
     name: 'Bundle Promo Push',
     tag: { label: 'Instant', type: 'instant' },
     description: 'Pair your top blogs with an e-book bonus bundle for a limited-time flash sale.',
+    requirements: BUNDLE_PUSH_REQUIREMENTS,
     details: [
       () => '⏳ Time: <strong>2.5h</strong>',
       () => '💵 Payout: <strong>$48</strong>',
       () => `Requires: <strong>${renderRequirementSummary(BUNDLE_PUSH_REQUIREMENTS)}</strong>`
     ],
     action: {
+      id: 'launchBundle',
+      timeCost: 2.5,
+      moneyCost: 0,
       label: 'Launch Bundle',
       className: 'primary',
       disabled: () => {
         const state = getState();
         if (!state) return true;
         if (state.timeLeft < 2.5) return true;
-        return !requirementsMet(BUNDLE_PUSH_REQUIREMENTS);
+        return !requirementsMet(BUNDLE_PUSH_REQUIREMENTS, state);
       },
       onClick: () => {
         executeAction(() => {
@@ -158,7 +196,7 @@ export const HUSTLES = [
             addLog('You need 2.5 free hours to build that promo bundle.', 'warning');
             return;
           }
-          if (!requirementsMet(BUNDLE_PUSH_REQUIREMENTS)) {
+          if (!requirementsMet(BUNDLE_PUSH_REQUIREMENTS, state)) {
             addLog('You need two active blogs and an e-book live before that bundle will sell.', 'warning');
             return;
           }
@@ -195,6 +233,10 @@ export const HUSTLES = [
       pending: []
     },
     action: {
+      id: 'startFlip',
+      timeCost: 4,
+      moneyCost: 20,
+      delaySeconds: 30,
       label: 'Start Flip',
       className: 'primary',
       disabled: () => {
@@ -321,6 +363,7 @@ export function processFlipPayouts(now = Date.now(), offline = false) {
 function createKnowledgeHustles() {
   return Object.values(KNOWLEDGE_TRACKS).map(track => ({
     id: `study-${track.id}`,
+    studyTrackId: track.id,
     name: track.name,
     tag: { label: 'Study', type: 'study' },
     description: track.description,
@@ -340,6 +383,9 @@ function createKnowledgeHustles() {
       }
     ],
     action: {
+      id: `enroll-${track.id}`,
+      timeCost: 0,
+      moneyCost: Number(track.tuition) || 0,
       label: () => {
         const progress = getKnowledgeProgress(track.id);
         if (progress.completed) return 'Course Complete';

--- a/src/game/upgrades.js
+++ b/src/game/upgrades.js
@@ -37,6 +37,9 @@ export const UPGRADES = [
       () => `📅 Current Payroll: <strong>$${formatMoney(getAssistantDailyCost())} / day</strong>`
     ],
     action: {
+      id: 'hireAssistant',
+      timeCost: 0,
+      moneyCost: ASSISTANT_CONFIG.hiringCost,
       label: () => {
         const count = getAssistantCount();
         if (count >= ASSISTANT_CONFIG.maxAssistants) return 'Assistant Team Full';
@@ -88,6 +91,9 @@ export const UPGRADES = [
       () => 'Unlocks: <strong>Weekly Vlog Channel & Stock Photo Galleries</strong>'
     ],
     action: {
+      id: 'purchaseCamera',
+      timeCost: 0,
+      moneyCost: 200,
       label: () => getUpgradeState('camera').purchased ? 'Camera Ready' : 'Purchase Camera',
       className: 'secondary',
       disabled: () => {
@@ -127,6 +133,9 @@ export const UPGRADES = [
       () => 'Unlocks: <strong>Stock Photo Galleries</strong>'
     ],
     action: {
+      id: 'buildStudio',
+      timeCost: 0,
+      moneyCost: 220,
       label: () => getUpgradeState('studio').purchased ? 'Studio Ready' : 'Build Studio',
       className: 'secondary',
       disabled: () => {
@@ -166,7 +175,11 @@ export const UPGRADES = [
       () => 'Requires: <strong>Camera</strong>',
       () => 'Boosts: <strong>Higher vlog quality payouts</strong>'
     ],
+    requirements: [{ type: 'upgrade', id: 'camera' }],
     action: {
+      id: 'installCinemaGear',
+      timeCost: 0,
+      moneyCost: 480,
       label: () => {
         const upgrade = getUpgradeState('cameraPro');
         if (upgrade.purchased) return 'Cinema Ready';
@@ -213,7 +226,11 @@ export const UPGRADES = [
       () => 'Requires: <strong>Lighting Kit</strong>',
       () => 'Boosts: <strong>Stock photo session efficiency</strong>'
     ],
+    requirements: [{ type: 'upgrade', id: 'studio' }],
     action: {
+      id: 'expandStudio',
+      timeCost: 0,
+      moneyCost: 540,
       label: () => {
         const upgrade = getUpgradeState('studioExpansion');
         if (upgrade.purchased) return 'Studio Expanded';
@@ -260,6 +277,9 @@ export const UPGRADES = [
       () => 'Unlocks: <strong>Stable environments for advanced products</strong>'
     ],
     action: {
+      id: 'installServerRack',
+      timeCost: 0,
+      moneyCost: 650,
       label: () => (getUpgradeState('serverRack').purchased ? 'Rack Online' : 'Install Rack'),
       className: 'secondary',
       disabled: () => {
@@ -299,7 +319,11 @@ export const UPGRADES = [
       () => 'Requires: <strong>Starter Server Rack</strong>',
       () => 'Unlocks: <strong>SaaS deployments</strong>'
     ],
+    requirements: [{ type: 'upgrade', id: 'serverRack' }],
     action: {
+      id: 'deployCloudCluster',
+      timeCost: 0,
+      moneyCost: 1150,
       label: () => {
         const upgrade = getUpgradeState('serverCluster');
         if (upgrade.purchased) return 'Cluster Ready';
@@ -346,7 +370,11 @@ export const UPGRADES = [
       () => 'Requires: <strong>Cloud Cluster</strong>',
       () => 'Boosts: <strong>SaaS subscriber trust</strong>'
     ],
+    requirements: [{ type: 'upgrade', id: 'serverCluster' }],
     action: {
+      id: 'activateEdgeNetwork',
+      timeCost: 0,
+      moneyCost: 1450,
       label: () => {
         const upgrade = getUpgradeState('serverEdge');
         if (upgrade.purchased) return 'Edge Live';
@@ -393,6 +421,9 @@ export const UPGRADES = [
       () => `Daily limit: <strong>${COFFEE_LIMIT}</strong>`
     ],
     action: {
+      id: 'brewTurboCoffee',
+      timeCost: 0,
+      moneyCost: 40,
       label: () => {
         const upgrade = getUpgradeState('coffee');
         return upgrade.usedToday >= COFFEE_LIMIT ? 'Too Much Caffeine' : 'Brew Boost';
@@ -433,7 +464,11 @@ export const UPGRADES = [
       () => '💵 Cost: <strong>$260</strong>',
       () => 'Requires at least one active blog'
     ],
+    requirements: [{ type: 'experience', assetId: 'blog', count: 1 }],
     action: {
+      id: 'enrollAutomationCourse',
+      timeCost: 0,
+      moneyCost: 260,
       label: () => {
         const upgrade = getUpgradeState('course');
         if (upgrade.purchased) return 'Automation Ready';

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import { loadState, saveState } from './core/storage.js';
 import elements from './ui/elements.js';
 import { renderCards, updateUI } from './ui/update.js';
 import { initLayoutControls } from './ui/layout.js';
+import { initActionCatalogDebug } from './ui/debugCatalog.js';
 import { registry } from './game/registry.js';
 import { endDay } from './game/lifecycle.js';
 import { resetTick, startGameLoop } from './game/loop.js';
@@ -19,6 +20,7 @@ renderLog();
 renderCards();
 updateUI();
 initLayoutControls();
+initActionCatalogDebug();
 startGameLoop();
 
 elements.endDayButton.addEventListener('click', () => endDay(false));

--- a/src/ui/debugCatalog.js
+++ b/src/ui/debugCatalog.js
@@ -1,0 +1,179 @@
+import { formatHours, formatMoney } from '../core/helpers.js';
+import { getState } from '../core/state.js';
+import { listCatalog } from '../game/content/catalog.js';
+import elements from './elements.js';
+
+let debugEnabled = false;
+
+function shouldEnableDebugPanel() {
+  if (typeof window === 'undefined') return false;
+  try {
+    const url = new URL(window.location.href);
+    if (url.searchParams.get('debugActions') === '1') {
+      window.localStorage.setItem('debugActions', 'true');
+      return true;
+    }
+    if (url.hash.includes('debug-actions')) {
+      return true;
+    }
+    return window.localStorage.getItem('debugActions') === 'true';
+  } catch (error) {
+    return false;
+  }
+}
+
+function persistDebugFlag(value) {
+  if (typeof window === 'undefined') return;
+  try {
+    if (value) {
+      window.localStorage.setItem('debugActions', 'true');
+    } else {
+      window.localStorage.removeItem('debugActions');
+    }
+  } catch (error) {
+    // ignore storage errors
+  }
+}
+
+function renderRequirementSummary(requirements = []) {
+  if (!requirements.length) return 'None';
+  return requirements
+    .map(req => {
+      const status = req.met === false ? '⚠️' : '✅';
+      const label = req.label || req.type || 'Requirement';
+      return `${status} ${label}`;
+    })
+    .join(' • ');
+}
+
+function renderActionRows(table, entries) {
+  const header = document.createElement('thead');
+  const headerRow = document.createElement('tr');
+  ['Source', 'Action', 'Category', 'Time', 'Cost', 'Available', 'Requirements'].forEach(text => {
+    const th = document.createElement('th');
+    th.scope = 'col';
+    th.textContent = text;
+    headerRow.appendChild(th);
+  });
+  header.appendChild(headerRow);
+
+  const body = document.createElement('tbody');
+  entries.forEach(entry => {
+    const row = document.createElement('tr');
+    row.dataset.available = entry.available ? 'true' : 'false';
+    row.classList.toggle('is-available', entry.available);
+
+    const sourceCell = document.createElement('td');
+    sourceCell.textContent = `${entry.sourceName}`;
+    sourceCell.title = `${entry.sourceType}:${entry.sourceId}`;
+
+    const actionCell = document.createElement('td');
+    actionCell.textContent = entry.label;
+    actionCell.title = entry.actionId;
+
+    const categoryCell = document.createElement('td');
+    categoryCell.textContent = entry.category;
+
+    const timeCell = document.createElement('td');
+    timeCell.textContent = entry.timeCost ? formatHours(entry.timeCost) : '—';
+    timeCell.className = entry.timeSatisfied ? '' : 'is-missing';
+
+    const costCell = document.createElement('td');
+    costCell.textContent = entry.moneyCost ? `$${formatMoney(entry.moneyCost)}` : '—';
+    costCell.className = entry.moneySatisfied ? '' : 'is-missing';
+
+    const availableCell = document.createElement('td');
+    availableCell.textContent = entry.available ? 'Yes' : 'No';
+
+    const requirementCell = document.createElement('td');
+    requirementCell.textContent = renderRequirementSummary(entry.requirements);
+    if (entry.requirements.some(req => req.met === false)) {
+      requirementCell.classList.add('is-missing');
+    }
+
+    [
+      sourceCell,
+      actionCell,
+      categoryCell,
+      timeCell,
+      costCell,
+      availableCell,
+      requirementCell
+    ].forEach(cell => row.appendChild(cell));
+
+    body.appendChild(row);
+  });
+
+  table.appendChild(header);
+  table.appendChild(body);
+}
+
+function renderDebugCatalog() {
+  const table = elements.debugActionCatalogList;
+  if (!table) return;
+  table.textContent = '';
+  const state = getState();
+  const entries = listCatalog(state).sort((a, b) => {
+    if (a.sourceType === b.sourceType) {
+      if (a.sourceName === b.sourceName) {
+        return a.label.localeCompare(b.label);
+      }
+      return a.sourceName.localeCompare(b.sourceName);
+    }
+    return a.sourceType.localeCompare(b.sourceType);
+  });
+
+  const summary = elements.debugActionCatalogSummary;
+  if (summary) {
+    const availableCount = entries.filter(entry => entry.available).length;
+    summary.textContent = `${availableCount} of ${entries.length} actions currently available`;
+  }
+
+  renderActionRows(table, entries);
+}
+
+function enableDebugPanel() {
+  const panel = elements.debugActionCatalog;
+  if (!panel) return;
+  debugEnabled = true;
+  persistDebugFlag(true);
+  panel.hidden = false;
+  panel.setAttribute('aria-hidden', 'false');
+  renderDebugCatalog();
+}
+
+function disableDebugPanel() {
+  const panel = elements.debugActionCatalog;
+  if (!panel) return;
+  debugEnabled = false;
+  persistDebugFlag(false);
+  panel.hidden = true;
+  panel.setAttribute('aria-hidden', 'true');
+  const table = elements.debugActionCatalogList;
+  if (table) {
+    table.textContent = '';
+  }
+  const summary = elements.debugActionCatalogSummary;
+  if (summary) {
+    summary.textContent = '';
+  }
+}
+
+export function initActionCatalogDebug() {
+  if (typeof window !== 'undefined') {
+    window.debugActions = {
+      enable: enableDebugPanel,
+      disable: disableDebugPanel,
+      refresh: renderDebugCatalog
+    };
+  }
+
+  if (shouldEnableDebugPanel()) {
+    enableDebugPanel();
+  }
+}
+
+export function refreshActionCatalogDebug() {
+  if (!debugEnabled) return;
+  renderDebugCatalog();
+}

--- a/src/ui/elements.js
+++ b/src/ui/elements.js
@@ -87,7 +87,10 @@ const elements = {
   assetInfoQualityActions: document.getElementById('asset-info-quality-actions'),
   assetInfoSupportUpgrades: document.getElementById('asset-info-support-upgrades'),
   assetInfoClose: document.getElementById('asset-info-close'),
-  upgradeSearch: document.getElementById('upgrade-search')
+  upgradeSearch: document.getElementById('upgrade-search'),
+  debugActionCatalog: document.getElementById('debug-action-catalog'),
+  debugActionCatalogSummary: document.getElementById('debug-action-catalog-summary'),
+  debugActionCatalogList: document.getElementById('debug-action-catalog-list')
 };
 
 export default elements;

--- a/src/ui/update.js
+++ b/src/ui/update.js
@@ -7,6 +7,7 @@ import { registry } from '../game/registry.js';
 import { computeDailySummary } from '../game/summary.js';
 import { renderSummary } from './dashboard.js';
 import { applyCardFilters } from './layout.js';
+import { refreshActionCatalogDebug } from './debugCatalog.js';
 
 function buildCollections() {
   const hustles = registry.hustles.filter(hustle => hustle.tag?.type !== 'study');
@@ -43,4 +44,5 @@ export function updateUI() {
   const summary = computeDailySummary(state);
   renderSummary(summary);
   applyCardFilters();
+  refreshActionCatalogDebug();
 }

--- a/styles.css
+++ b/styles.css
@@ -1275,6 +1275,65 @@ body.modal-open {
   color: rgba(148, 163, 184, 0.7);
 }
 
+.debug-panel {
+  background: rgba(15, 23, 42, 0.78);
+  border-radius: 16px;
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  box-shadow: var(--shadow);
+  padding: 1.5rem;
+  margin: 2rem auto;
+  max-width: 960px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.debug-panel header h2 {
+  font-size: 1.2rem;
+  margin-bottom: 0.25rem;
+}
+
+.debug-panel header p {
+  color: var(--muted);
+}
+
+.debug-panel__summary {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.debug-panel__body {
+  overflow-x: auto;
+}
+
+.debug-table {
+  width: 100%;
+  min-width: 560px;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.debug-table th,
+.debug-table td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  text-align: left;
+}
+
+.debug-table th {
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.debug-table tr.is-available {
+  background: rgba(74, 222, 128, 0.08);
+}
+
+.debug-table td.is-missing {
+  color: var(--warning);
+  font-weight: 600;
+}
+
 .log.summary .log-entry .message {
   display: inline-block;
   white-space: nowrap;


### PR DESCRIPTION
## Summary
- add a centralized game action catalog with selectors for availability and filtering
- annotate hustle, upgrade, and asset metadata so catalog entries include costs, cooldown readiness, and requirement descriptors
- wire a hidden developer debug panel, styling, and docs updates for the new catalog tooling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9b2582634832cad04cb97bc6c4fde