### PR TITLE
Rebuild workspace UI around command deck layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ Online Hustle Simulator is a browser-based incremental game about orchestrating 
 - **Daily Recap Log** – Every launch, maintenance result, payout, and study milestone is written to the log so you can reconstruct exactly what happened during busy streaks.
 
 ### Interface Overview
-- **Top Bar & Snapshot** – Money, time, and day stay pinned at the top. A collapsible Daily Snapshot panel now highlights per-stat breakdowns (time invested, money earned, passive streams, cash spent, study momentum) without overwhelming the main view. Passive earnings even call out which assets (and how many instances) delivered today’s cash, so you can immediately see what worked.
-- **Tabbed Workspace** – Hustles, Education, Passive Assets, and Upgrades each live in their own tab with dedicated copy and per-tab filters. Global toggles hide locked or completed cards, and you can spotlight only actionable options.
-- **Categorised Collections** – Passive assets surface in Foundation, Creative, Commerce, and Advanced groupings with a collapsed-card option for rapid scanning. Each grouping now sports a "View launched assets" toggle that opens a management roster listing upkeep, yesterday’s payout, and upgrade/sell controls for every instance. Upgrades split into Equipment, Automation, Consumables, and a catch-all bucket with a quick search bar.
-- **Event Log Controls** – The log dock keeps its running commentary but now includes a summary/detailed toggle when you want a lighter feed during long sessions.
+- **Command Deck** – Money and Day stats live beside a rebuilt day-progress timeline hub, all wrapped in a sticky header. A "Today’s brief" drawer sits next to the Wrap the Day button so you can jump straight to hustles, studies, or asset tuning with a single click.
+- **Mission Rails** – The left rail houses navigation links, the collapsible Daily Snapshot, and a stack of strategy shortcuts. The right rail carries the live event feed and a study/upgrade planner, letting you keep guidance visible without crowding the focus area.
+- **Global Control Drawer** – Hide locked or completed cards, highlight active work, and review filter tips inside a dedicated drawer above the main workspace. Quick-action buttons reopen this drawer and focus the upgrade search box automatically.
+- **Categorised Collections** – Passive assets remain grouped into Foundation, Creative, Commerce, and Advanced categories with roster toggles, while upgrades keep their Equipment, Automation, Consumables, and Other groupings.
+- **Event Log Controls** – The feed still supports summary/detailed modes, now tucked neatly inside the right rail so long-running sessions keep context at a glance.
 
 ### Hustles & Study Tracks
 - **Freelance Writing** – Spend 2h to earn $18 instantly.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Rebuilt the main interface into a command deck with navigation rails, drawer-based filters, and shortcut buttons that focus key inputs while preserving every existing hustle, study, asset, and upgrade panel.
 - Reimagined the dashboard clock as a forward-moving 24h day tracker with colour-coded segments for sleep, upkeep, setup, and logged actions plus an at-a-glance legend.
 - Introduced schema-driven builders for hustles, assets, and upgrades so new content can be configured declaratively with shared UI details and metrics hooks.
 - Added a centralized action catalog with selectors plus an optional debug panel that lists availability, costs, and requirement gaps across hustles, assets, upgrades, and quality actions.

--- a/docs/features/ui-redesign.md
+++ b/docs/features/ui-redesign.md
@@ -1,23 +1,22 @@
 # UI Redesign Notes
 
 ## Overview
-The workspace layout now mirrors the design brief: a clean dashboard that keeps vital stats visible while letting players dive into detail on demand. A sticky header holds the daily meters alongside a quick-jump navigation that smoothly scrolls to each activity pillar instead of swapping tabs.
+Mission Control has been rebuilt into a three-column experience: the Command Deck keeps core meters and marching orders within reach, the Mission Rail gathers navigation and shortcuts, and the Focus Stage in the centre gives each gameplay pillar generous breathing room. Everything noisy now lives inside collapsible drawers so new players see guidance first and summon depth only when they ask for it.
 
 ## Goals
-- Surface daily pacing information without overwhelming the player.
-- Separate instant hustles from longer-term study commitments.
-- Reduce passive asset clutter via categories and collapsed cards.
-- Provide global toggles so locked/completed content can stay out of the way.
-- Support growth of the upgrade catalog with grouping and search.
+- Keep the top-level day summary visible while moving secondary detail into drawers and popouts.
+- Provide obvious shortcuts for common flows (queue hustles, resume studies, browse upgrades) without duplicating entire panels.
+- Reduce cross-page scrolling by grouping navigation, filters, and planners into dedicated rails.
+- Preserve all existing mechanics and breakdowns so returning players still recognise their data.
 
 ## Key Elements
-- **Daily Snapshot Panel** – Collapsible wrapper with per-stat breakdown lists (time reserved, projected payouts, daily costs, study momentum).
-- **Scrolling Workspace Navigation** – Header links highlight as sections come into view, encouraging players to skim every pillar without losing the context of their meters.
-- **Filter Toolbars** – Global controls for hide locked/completed/show active, plus per-section filters (available hustles, active study tracks, collapsed asset view, upgrade search).
-- **Categorised Grids** – Passive assets appear under Foundation, Creative, Commerce, or Advanced headers; upgrades live inside Equipment, Automation, Consumables, and Other buckets.
-- **Event Log Toggle** – Summary/detailed switch keeps the recap readable during long play sessions.
+- **Command Deck** – Sticky three-column header with Money/Day stats, a dedicated timeline hub, and a "Today’s brief" drawer of quick-call buttons.
+- **Mission Rails** – Left rail wraps navigation, the daily snapshot, and strategy shortcuts inside `<details>` drawers; the right rail hosts the live event log plus planner prompts for upgrades and studies.
+- **Global Control Drawer** – Filters now sit inside a collapsible workspace drawer with reminder copy about how they affect the board.
+- **Shortcut Buttons** – Context-aware quick actions focus search inputs, open drawers, and smooth-scroll to their sections so players can move instantly.
+- **Preserved Pillars** – Hustles, Education, Assets, and Upgrades keep their grids, filters, and modal flows but inherit the new breathing room and scroll offsets.
 
 ## Future Considerations
-- Add persistent user preferences for filter states via saved settings.
-- Introduce iconography and progress bars to reinforce course duration and asset setup progress within collapsed cards.
-- Explore responsive tweaks for mobile-first layouts once card interactions are optimised for touch.
+- Animate drawer openings to reinforce the sense of panels sliding into view.
+- Persist drawer open states so veteran players can pin their favourite layout between sessions.
+- Introduce contextual callouts inside the Command Deck when time or cash dips below thresholds.

--- a/index.html
+++ b/index.html
@@ -11,277 +11,353 @@
 </head>
 <body>
   <div class="app">
-    <header class="dashboard-header">
-      <div class="top-bar">
-        <div class="stat">
+    <header class="command-bar">
+      <div class="command-bar__cluster command-bar__cluster--stats">
+        <div class="stat command-bar__stat">
           <span class="label">Money</span>
           <span id="money" class="value">$0</span>
         </div>
-        <div class="stat time">
-          <span class="label">Day Progress</span>
-          <div class="time-wrapper">
-            <div class="time-readout">
-              <span id="time" class="value">00h / 14h</span>
-              <span id="time-note" class="time-note">Sleep banked, hustle ready.</span>
+        <div class="stat command-bar__stat">
+          <span class="label">Day</span>
+          <span id="day" class="value">1</span>
+        </div>
+      </div>
+      <div class="command-bar__cluster command-bar__cluster--timeline">
+        <div class="timeline-hub">
+          <div class="timeline-hub__header">
+            <span class="label">Day Progress</span>
+            <span id="time" class="value">00h / 14h</span>
+          </div>
+          <p id="time-note" class="time-note">Sleep banked, hustle ready.</p>
+          <div class="timeline-hub__bars">
+            <div class="time-bar" aria-hidden="true">
+              <div id="time-progress" class="time-progress"></div>
             </div>
-            <div class="time-bars">
-              <div class="time-bar" aria-hidden="true">
-                <div id="time-progress" class="time-progress"></div>
+            <div id="assistant-support" class="time-support" hidden>
+              <div class="time-support__header">
+                <span class="time-support__label">Assistants</span>
+                <span id="assistant-note" class="time-support__note"></span>
               </div>
-              <div id="assistant-support" class="time-support" hidden>
-                <div class="time-support__header">
-                  <span class="time-support__label">Assistants</span>
-                  <span id="assistant-note" class="time-support__note"></span>
-                </div>
-                <div class="time-bar time-bar--assistants" aria-hidden="true">
-                  <div id="assistant-progress" class="time-progress"></div>
-                </div>
+              <div class="time-bar time-bar--assistants" aria-hidden="true">
+                <div id="assistant-progress" class="time-progress"></div>
               </div>
             </div>
+          </div>
+          <div class="timeline-hub__footer">
             <button
               id="time-legend-toggle"
               class="ghost-button time-legend-toggle"
               type="button"
               aria-expanded="false"
             >Show timeline legend</button>
-            <ul id="time-legend" class="time-legend" hidden aria-live="polite"></ul>
           </div>
+          <ul id="time-legend" class="time-legend" hidden aria-live="polite"></ul>
         </div>
-        <div class="stat">
-          <span class="label">Day</span>
-          <span id="day" class="value">1</span>
-        </div>
-        <button id="end-day" class="end-day">End Day</button>
       </div>
-      <nav class="section-nav" id="section-nav" aria-label="Workspace sections">
-        <a class="section-link is-active" href="#section-hustles">Daily Hustles</a>
-        <a class="section-link" href="#section-education">Education</a>
-        <a class="section-link" href="#section-assets">Passive Assets</a>
-        <a class="section-link" href="#section-upgrades">Upgrades &amp; Boosts</a>
-      </nav>
+      <div class="command-bar__cluster command-bar__cluster--actions">
+        <button id="end-day" class="end-day">Wrap the Day</button>
+        <details class="command-drawer" open>
+          <summary class="command-drawer__summary">Today’s brief</summary>
+          <div class="command-drawer__content">
+            <p>Keep your meters in the green, then jump into any pillar from the rails at your sides.</p>
+            <ul class="command-drawer__list">
+              <li><button type="button" class="link-button" data-quick-action data-scroll-target="#section-hustles">Plan a hustle</button></li>
+              <li><button type="button" class="link-button" data-quick-action data-scroll-target="#section-education">Check study queue</button></li>
+              <li><button type="button" class="link-button" data-quick-action data-scroll-target="#section-assets">Tune assets</button></li>
+            </ul>
+          </div>
+        </details>
+      </div>
     </header>
 
-    <section class="stats-panel" id="stats-panel" data-collapsed="true">
-      <div class="stats-toolbar">
-        <div>
-          <h2>Daily Snapshot</h2>
-          <p>Track today’s hustle at a glance, then pop open a stat to audit the fine print.</p>
-        </div>
-        <button id="stats-toggle" class="toggle-button" aria-expanded="false">Expand breakdowns</button>
-      </div>
-      <div class="stats-grid">
-        <details class="stat-card" id="summary-time-card">
-          <summary>
-            <div class="stat-heading">
-              <h3>Time Invested</h3>
-              <span id="summary-time" class="stat-value">0h</span>
-            </div>
-            <p id="summary-time-caption" class="stat-caption">No time logged yet today</p>
-          </summary>
-          <ul id="summary-time-breakdown" class="stat-breakdown" aria-live="polite"></ul>
+    <div class="dashboard-grid">
+      <aside class="dashboard-rail dashboard-rail--left">
+        <details class="rail-drawer" open>
+          <summary class="rail-drawer__summary">Workspace navigation</summary>
+          <nav class="section-nav" id="section-nav" aria-label="Workspace sections">
+            <a class="section-link is-active" href="#section-hustles">Daily Hustles</a>
+            <a class="section-link" href="#section-education">Education</a>
+            <a class="section-link" href="#section-assets">Passive Assets</a>
+            <a class="section-link" href="#section-upgrades">Upgrades &amp; Boosts</a>
+          </nav>
         </details>
-        <details class="stat-card" id="summary-income-card">
-          <summary>
-            <div class="stat-heading">
-              <h3>Money Earned</h3>
-              <span id="summary-income" class="stat-value">$0</span>
-            </div>
-            <p id="summary-income-caption" class="stat-caption">No earnings logged yet today</p>
-          </summary>
-          <ul id="summary-income-breakdown" class="stat-breakdown" aria-live="polite"></ul>
-        </details>
-        <details class="stat-card" id="summary-cost-card">
-          <summary>
-            <div class="stat-heading">
-              <h3>Cash Spent</h3>
-              <span id="summary-cost" class="stat-value">$0</span>
-            </div>
-            <p id="summary-cost-caption" class="stat-caption">No spending logged yet today</p>
-          </summary>
-          <ul id="summary-cost-breakdown" class="stat-breakdown" aria-live="polite"></ul>
-        </details>
-        <details class="stat-card" id="summary-study-card">
-          <summary>
-            <div class="stat-heading">
-              <h3>Study Momentum</h3>
-              <span id="summary-study" class="stat-value">0 tracks</span>
-            </div>
-            <p id="summary-study-caption" class="stat-caption">All study goals are on track</p>
-          </summary>
-          <ul id="summary-study-breakdown" class="stat-breakdown" aria-live="polite"></ul>
-        </details>
-      </div>
-    </section>
 
-    <main class="workspace">
-      <section class="global-filters" aria-label="Global filters">
-        <label class="filter-toggle">
-          <input type="checkbox" id="filter-hide-locked" />
-          <span>Hide locked</span>
-        </label>
-        <label class="filter-toggle">
-          <input type="checkbox" id="filter-hide-completed" />
-          <span>Hide completed</span>
-        </label>
-        <label class="filter-toggle">
-          <input type="checkbox" id="filter-show-active" />
-          <span>Show only active</span>
-        </label>
-      </section>
-
-      <section class="workspace-panels" id="workspace-panels">
-        <section class="workspace-section" id="section-hustles" aria-labelledby="heading-hustles">
-          <header class="section-header">
-            <div>
-              <h2 id="heading-hustles">Daily Hustles</h2>
-              <p>Quick-hit gigs for instant cash flow. Spend the hours, bank the wins.</p>
+        <details class="rail-drawer" open>
+          <summary class="rail-drawer__summary">Daily snapshot</summary>
+          <section class="stats-panel" id="stats-panel" data-collapsed="true">
+            <div class="stats-toolbar">
+              <div>
+                <h2>Daily Snapshot</h2>
+                <p>Flip open a tile to see where your time, cash, and focus went today.</p>
+              </div>
+              <button id="stats-toggle" class="toggle-button" aria-expanded="false">Expand breakdowns</button>
             </div>
-            <div class="section-controls">
+            <div class="stats-grid">
+              <details class="stat-card" id="summary-time-card">
+                <summary>
+                  <div class="stat-heading">
+                    <h3>Time Invested</h3>
+                    <span id="summary-time" class="stat-value">0h</span>
+                  </div>
+                  <p id="summary-time-caption" class="stat-caption">No time logged yet today</p>
+                </summary>
+                <ul id="summary-time-breakdown" class="stat-breakdown" aria-live="polite"></ul>
+              </details>
+              <details class="stat-card" id="summary-income-card">
+                <summary>
+                  <div class="stat-heading">
+                    <h3>Money Earned</h3>
+                    <span id="summary-income" class="stat-value">$0</span>
+                  </div>
+                  <p id="summary-income-caption" class="stat-caption">No earnings logged yet today</p>
+                </summary>
+                <ul id="summary-income-breakdown" class="stat-breakdown" aria-live="polite"></ul>
+              </details>
+              <details class="stat-card" id="summary-cost-card">
+                <summary>
+                  <div class="stat-heading">
+                    <h3>Cash Spent</h3>
+                    <span id="summary-cost" class="stat-value">$0</span>
+                  </div>
+                  <p id="summary-cost-caption" class="stat-caption">No spending logged yet today</p>
+                </summary>
+                <ul id="summary-cost-breakdown" class="stat-breakdown" aria-live="polite"></ul>
+              </details>
+              <details class="stat-card" id="summary-study-card">
+                <summary>
+                  <div class="stat-heading">
+                    <h3>Study Momentum</h3>
+                    <span id="summary-study" class="stat-value">0 tracks</span>
+                  </div>
+                  <p id="summary-study-caption" class="stat-caption">All study goals are on track</p>
+                </summary>
+                <ul id="summary-study-breakdown" class="stat-breakdown" aria-live="polite"></ul>
+              </details>
+            </div>
+          </section>
+        </details>
+
+        <details class="rail-drawer" open>
+          <summary class="rail-drawer__summary">Strategy shortcuts</summary>
+          <div class="rail-drawer__content">
+            <p>Hop straight to common moves as the day unfolds.</p>
+            <ul class="shortcut-list">
+              <li><button type="button" class="link-button" data-quick-action data-scroll-target="#section-hustles">Queue new gigs</button></li>
+              <li><button type="button" class="link-button" data-quick-action data-scroll-target="#section-education">Resume studies</button></li>
+              <li><button type="button" class="link-button" data-quick-action data-scroll-target="#section-assets">Review upkeep commitments</button></li>
+              <li><button type="button" class="link-button" data-quick-action data-focus-target="upgrade-search" data-scroll-target="#section-upgrades">Search upgrades</button></li>
+              <li><button type="button" class="link-button" data-quick-action data-open-details="drawer-global-controls">Tune global filters</button></li>
+            </ul>
+          </div>
+        </details>
+      </aside>
+
+      <main class="workspace">
+        <details class="workspace-drawer" id="drawer-global-controls">
+          <summary class="workspace-drawer__summary">Global controls &amp; filters</summary>
+          <div class="workspace-drawer__content">
+            <section class="global-filters" aria-label="Global filters">
               <label class="filter-toggle">
-                <input type="checkbox" id="filter-hustles-available" />
-                <span>Show only available gigs</span>
-              </label>
-            </div>
-          </header>
-          <div class="card-grid" id="hustle-grid"></div>
-        </section>
-
-        <section class="workspace-section" id="section-education" aria-labelledby="heading-education">
-          <header class="section-header">
-            <div>
-              <h2 id="heading-education">Education</h2>
-              <p>Courses, playbooks, and study tracks that unlock new mastery.</p>
-            </div>
-            <div class="section-controls">
-              <label class="filter-toggle">
-                <input type="checkbox" id="filter-education-active" />
-                <span>Show only active tracks</span>
+                <input type="checkbox" id="filter-hide-locked" />
+                <span>Hide locked</span>
               </label>
               <label class="filter-toggle">
-                <input type="checkbox" id="filter-education-hide-complete" />
+                <input type="checkbox" id="filter-hide-completed" />
                 <span>Hide completed</span>
               </label>
-            </div>
-          </header>
-          <div class="card-grid" id="education-grid"></div>
-        </section>
-
-        <section class="workspace-section assets-section" id="section-assets" aria-labelledby="heading-assets">
-          <header class="section-header">
-            <div>
-              <h2 id="heading-assets">Passive Assets</h2>
-              <p>Launch builds, manage upkeep, and keep payouts humming with lean cards.</p>
-            </div>
-            <div class="section-controls">
               <label class="filter-toggle">
-                <input type="checkbox" id="filter-assets-collapsed" checked />
-                <span>Collapsed card view</span>
+                <input type="checkbox" id="filter-show-active" />
+                <span>Show only active</span>
               </label>
-              <label class="filter-toggle">
-                <input type="checkbox" id="filter-assets-hide-locked" />
-                <span>Hide unavailable</span>
-              </label>
-              <button id="asset-info-trigger" class="ghost-button" type="button">New Asset Briefing</button>
+            </section>
+            <div class="workspace-drawer__notes">
+              <p>Filters apply across every pillar, so you can keep the decks focused on actionable work.</p>
             </div>
-          </header>
-          <div class="asset-categories" id="asset-grid">
-            <section class="asset-category" data-category="foundation">
-              <header>
-                <h3>Foundation</h3>
-                <button
-                  class="asset-category__toggle ghost-button"
-                  type="button"
-                  data-asset-category-toggle="foundation"
-                  aria-expanded="false"
-                >View launched assets</button>
-              </header>
-              <div class="asset-category__list" id="asset-list-foundation" hidden></div>
-              <div class="card-grid asset-card-grid" id="asset-grid-foundation"></div>
-            </section>
-            <section class="asset-category" data-category="creative">
-              <header>
-                <h3>Creative</h3>
-                <button
-                  class="asset-category__toggle ghost-button"
-                  type="button"
-                  data-asset-category-toggle="creative"
-                  aria-expanded="false"
-                >View launched assets</button>
-              </header>
-              <div class="asset-category__list" id="asset-list-creative" hidden></div>
-              <div class="card-grid asset-card-grid" id="asset-grid-creative"></div>
-            </section>
-            <section class="asset-category" data-category="commerce">
-              <header>
-                <h3>Commerce</h3>
-                <button
-                  class="asset-category__toggle ghost-button"
-                  type="button"
-                  data-asset-category-toggle="commerce"
-                  aria-expanded="false"
-                >View launched assets</button>
-              </header>
-              <div class="asset-category__list" id="asset-list-commerce" hidden></div>
-              <div class="card-grid asset-card-grid" id="asset-grid-commerce"></div>
-            </section>
-            <section class="asset-category" data-category="advanced">
-              <header>
-                <h3>Advanced</h3>
-                <button
-                  class="asset-category__toggle ghost-button"
-                  type="button"
-                  data-asset-category-toggle="advanced"
-                  aria-expanded="false"
-                >View launched assets</button>
-              </header>
-              <div class="asset-category__list" id="asset-list-advanced" hidden></div>
-              <div class="card-grid asset-card-grid" id="asset-grid-advanced"></div>
-            </section>
           </div>
-        </section>
+        </details>
 
-        <section class="workspace-section" id="section-upgrades" aria-labelledby="heading-upgrades">
-          <header class="section-header">
-            <div>
-              <h2 id="heading-upgrades">Upgrades &amp; Boosts</h2>
-              <p>Equipment, automation, and consumables. Stack them to scale.</p>
+        <section class="workspace-panels" id="workspace-panels">
+          <section class="workspace-section" id="section-hustles" aria-labelledby="heading-hustles">
+            <header class="section-header">
+              <div>
+                <h2 id="heading-hustles">Daily Hustles</h2>
+                <p>Quick-hit gigs for instant cash flow. Spend the hours, bank the wins.</p>
+              </div>
+              <div class="section-controls">
+                <label class="filter-toggle">
+                  <input type="checkbox" id="filter-hustles-available" />
+                  <span>Show only available gigs</span>
+                </label>
+              </div>
+            </header>
+            <div class="card-grid" id="hustle-grid"></div>
+          </section>
+
+          <section class="workspace-section" id="section-education" aria-labelledby="heading-education">
+            <header class="section-header">
+              <div>
+                <h2 id="heading-education">Education</h2>
+                <p>Courses, playbooks, and study tracks that unlock new mastery.</p>
+              </div>
+              <div class="section-controls">
+                <label class="filter-toggle">
+                  <input type="checkbox" id="filter-education-active" />
+                  <span>Show only active tracks</span>
+                </label>
+                <label class="filter-toggle">
+                  <input type="checkbox" id="filter-education-hide-complete" />
+                  <span>Hide completed</span>
+                </label>
+              </div>
+            </header>
+            <div class="card-grid" id="education-grid"></div>
+          </section>
+
+          <section class="workspace-section assets-section" id="section-assets" aria-labelledby="heading-assets">
+            <header class="section-header">
+              <div>
+                <h2 id="heading-assets">Passive Assets</h2>
+                <p>Launch builds, manage upkeep, and keep payouts humming with lean cards.</p>
+              </div>
+              <div class="section-controls">
+                <label class="filter-toggle">
+                  <input type="checkbox" id="filter-assets-collapsed" checked />
+                  <span>Collapsed card view</span>
+                </label>
+                <label class="filter-toggle">
+                  <input type="checkbox" id="filter-assets-hide-locked" />
+                  <span>Hide unavailable</span>
+                </label>
+                <button id="asset-info-trigger" class="ghost-button" type="button">New Asset Briefing</button>
+              </div>
+            </header>
+            <div class="asset-categories" id="asset-grid">
+              <section class="asset-category" data-category="foundation">
+                <header>
+                  <h3>Foundation</h3>
+                  <button
+                    class="asset-category__toggle ghost-button"
+                    type="button"
+                    data-asset-category-toggle="foundation"
+                    aria-expanded="false"
+                  >View launched assets</button>
+                </header>
+                <div class="asset-category__list" id="asset-list-foundation" hidden></div>
+                <div class="card-grid asset-card-grid" id="asset-grid-foundation"></div>
+              </section>
+              <section class="asset-category" data-category="creative">
+                <header>
+                  <h3>Creative</h3>
+                  <button
+                    class="asset-category__toggle ghost-button"
+                    type="button"
+                    data-asset-category-toggle="creative"
+                    aria-expanded="false"
+                  >View launched assets</button>
+                </header>
+                <div class="asset-category__list" id="asset-list-creative" hidden></div>
+                <div class="card-grid asset-card-grid" id="asset-grid-creative"></div>
+              </section>
+              <section class="asset-category" data-category="commerce">
+                <header>
+                  <h3>Commerce</h3>
+                  <button
+                    class="asset-category__toggle ghost-button"
+                    type="button"
+                    data-asset-category-toggle="commerce"
+                    aria-expanded="false"
+                  >View launched assets</button>
+                </header>
+                <div class="asset-category__list" id="asset-list-commerce" hidden></div>
+                <div class="card-grid asset-card-grid" id="asset-grid-commerce"></div>
+              </section>
+              <section class="asset-category" data-category="advanced">
+                <header>
+                  <h3>Advanced</h3>
+                  <button
+                    class="asset-category__toggle ghost-button"
+                    type="button"
+                    data-asset-category-toggle="advanced"
+                    aria-expanded="false"
+                  >View launched assets</button>
+                </header>
+                <div class="asset-category__list" id="asset-list-advanced" hidden></div>
+                <div class="card-grid asset-card-grid" id="asset-grid-advanced"></div>
+              </section>
             </div>
-            <div class="section-controls">
-              <label class="filter-toggle search">
-                <span class="sr-only" id="upgrade-search-label">Search upgrades</span>
-                <input type="search" id="upgrade-search" placeholder="Search upgrades" aria-labelledby="upgrade-search-label" />
-              </label>
+          </section>
+
+          <section class="workspace-section" id="section-upgrades" aria-labelledby="heading-upgrades">
+            <header class="section-header">
+              <div>
+                <h2 id="heading-upgrades">Upgrades &amp; Boosts</h2>
+                <p>Equipment, automation, and consumables. Stack them to scale.</p>
+              </div>
+              <div class="section-controls">
+                <label class="filter-toggle search">
+                  <span class="sr-only" id="upgrade-search-label">Search upgrades</span>
+                  <input type="search" id="upgrade-search" placeholder="Search upgrades" aria-labelledby="upgrade-search-label" />
+                </label>
+              </div>
+            </header>
+            <div class="upgrade-groups">
+              <section class="upgrade-group" data-upgrade-group="equipment">
+                <header>
+                  <h3>Equipment</h3>
+                </header>
+                <div class="card-grid" id="upgrade-grid-equipment"></div>
+              </section>
+              <section class="upgrade-group" data-upgrade-group="automation">
+                <header>
+                  <h3>Automation</h3>
+                </header>
+                <div class="card-grid" id="upgrade-grid-automation"></div>
+              </section>
+              <section class="upgrade-group" data-upgrade-group="consumables">
+                <header>
+                  <h3>Consumables</h3>
+                </header>
+                <div class="card-grid" id="upgrade-grid-consumables"></div>
+              </section>
+              <section class="upgrade-group" data-upgrade-group="misc">
+                <header>
+                  <h3>Other Boosts</h3>
+                </header>
+                <div class="card-grid" id="upgrade-grid"></div>
+              </section>
             </div>
-          </header>
-          <div class="upgrade-groups">
-            <section class="upgrade-group" data-upgrade-group="equipment">
-              <header>
-                <h3>Equipment</h3>
-              </header>
-              <div class="card-grid" id="upgrade-grid-equipment"></div>
-            </section>
-            <section class="upgrade-group" data-upgrade-group="automation">
-              <header>
-                <h3>Automation</h3>
-              </header>
-              <div class="card-grid" id="upgrade-grid-automation"></div>
-            </section>
-            <section class="upgrade-group" data-upgrade-group="consumables">
-              <header>
-                <h3>Consumables</h3>
-              </header>
-              <div class="card-grid" id="upgrade-grid-consumables"></div>
-            </section>
-            <section class="upgrade-group" data-upgrade-group="misc">
-              <header>
-                <h3>Other Boosts</h3>
-              </header>
-              <div class="card-grid" id="upgrade-grid"></div>
-            </section>
-          </div>
+          </section>
         </section>
-      </section>
-    </main>
+      </main>
+
+      <aside class="dashboard-rail dashboard-rail--right">
+        <details class="rail-drawer" open id="drawer-log">
+          <summary class="rail-drawer__summary">Live event feed</summary>
+          <section class="panel log" aria-label="Event log">
+            <div class="panel-header">
+              <div>
+                <h2>Event Log</h2>
+                <p id="log-tip">Welcome! Invest time to queue builds and watch the recap at daybreak.</p>
+              </div>
+              <button id="log-toggle" class="toggle-button" aria-expanded="false">Detailed view</button>
+            </div>
+            <div id="log-feed" class="log-feed"></div>
+          </section>
+        </details>
+
+        <details class="rail-drawer" open>
+          <summary class="rail-drawer__summary">Upgrade &amp; study planner</summary>
+          <div class="rail-drawer__content">
+            <p>Keep your long bets thriving with quick pivots.</p>
+            <ul class="shortcut-list">
+              <li><button type="button" class="link-button" data-quick-action data-scroll-target="#section-upgrades" data-focus-target="upgrade-search">Browse the catalog</button></li>
+              <li><button type="button" class="link-button" data-quick-action data-scroll-target="#section-education">Check tuition commitments</button></li>
+              <li><button type="button" class="link-button" data-quick-action data-scroll-target="#section-assets">Review launched assets</button></li>
+            </ul>
+          </div>
+        </details>
+      </aside>
+    </div>
 
     <section class="debug-panel" id="debug-action-catalog" hidden aria-hidden="true">
       <header>
@@ -344,17 +420,6 @@
         </div>
       </div>
     </div>
-
-    <section class="panel log" aria-label="Event log">
-      <div class="panel-header">
-        <div>
-          <h2>Event Log</h2>
-          <p id="log-tip">Welcome! Invest time to queue builds and watch the recap at daybreak.</p>
-        </div>
-        <button id="log-toggle" class="toggle-button" aria-expanded="false">Detailed view</button>
-      </div>
-      <div id="log-feed" class="log-feed"></div>
-    </section>
   </div>
 
   <template id="log-template">

--- a/src/ui/layout.js
+++ b/src/ui/layout.js
@@ -10,6 +10,7 @@ export function initLayoutControls() {
   setupEducationFilters();
   setupAssetFilters();
   setupUpgradeSearch();
+  setupQuickActions();
   applyCardFilters();
 }
 
@@ -245,5 +246,45 @@ function applyUpgradeSearchFilter() {
     if (group) {
       group.classList.toggle('is-empty', visibleCount === 0);
     }
+  });
+}
+
+function setupQuickActions() {
+  const triggers = Array.from(document.querySelectorAll('[data-quick-action]'));
+  if (!triggers.length) return;
+
+  triggers.forEach(trigger => {
+    trigger.addEventListener('click', () => {
+      const { openDetails, focusTarget, scrollTarget } = trigger.dataset;
+
+      if (openDetails) {
+        const details = document.getElementById(openDetails);
+        if (details && typeof details.open === 'boolean') {
+          details.open = true;
+          const summary = details.querySelector('summary');
+          if (summary && typeof summary.focus === 'function') {
+            try {
+              summary.focus({ preventScroll: true });
+            } catch (error) {
+              summary.focus();
+            }
+          }
+        }
+      }
+
+      if (scrollTarget) {
+        const target = document.querySelector(scrollTarget);
+        if (target) {
+          target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+      }
+
+      if (focusTarget) {
+        const focusEl = document.getElementById(focusTarget);
+        if (focusEl && typeof focusEl.focus === 'function') {
+          requestAnimationFrame(() => focusEl.focus());
+        }
+      }
+    });
   });
 }

--- a/styles.css
+++ b/styles.css
@@ -47,68 +47,258 @@ body.modal-open {
 }
 
 .app {
-  width: min(1200px, 100%);
-  display: flex;
-  flex-direction: column;
+  width: min(1280px, 100%);
+  display: grid;
+  grid-template-rows: auto 1fr;
   gap: 1.5rem;
 }
 
-.dashboard-header {
+.command-bar {
   position: sticky;
   top: 1.5rem;
-  z-index: 20;
+  z-index: 30;
+  display: grid;
+  grid-template-columns: minmax(200px, 0.9fr) minmax(320px, 1.2fr) minmax(220px, 0.9fr);
+  gap: 1rem;
+  padding: 1.25rem 1.5rem;
+  background: var(--panel-bg);
+  border-radius: 28px;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(22px);
+}
+
+.command-bar__cluster {
   display: flex;
   flex-direction: column;
   gap: 0.9rem;
 }
 
-.top-bar {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 1rem;
-  background: var(--panel-bg);
-  backdrop-filter: blur(20px);
-  padding: 1rem 1.25rem;
+.command-bar__cluster--stats {
+  justify-content: space-between;
+}
+
+.command-bar__cluster--actions {
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.command-bar__cluster--actions .end-day {
+  width: 100%;
+}
+
+.command-bar__stat {
+  padding: 0.85rem 1rem;
   border-radius: 18px;
+  background: rgba(15, 23, 42, 0.65);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.16);
+}
+
+.command-bar__stat .label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.command-bar__stat .value {
+  font-size: 1.75rem;
+}
+
+.timeline-hub {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  padding: 1rem 1.1rem;
+  border-radius: 20px;
+  background: rgba(15, 23, 42, 0.6);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12);
+}
+
+.timeline-hub__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.timeline-hub__bars {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.timeline-hub__footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.command-drawer {
+  width: 100%;
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 18px;
+  padding: 0.65rem 0.9rem 0.85rem;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.16);
+}
+
+.command-drawer__summary {
+  list-style: none;
+  font-weight: 700;
+  font-size: 0.9rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.9);
+  cursor: pointer;
+}
+
+.command-drawer__summary::-webkit-details-marker {
+  display: none;
+}
+
+.command-drawer[open] .command-drawer__summary {
+  color: var(--accent);
+}
+
+.command-drawer__content {
+  margin-top: 0.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.command-drawer__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  list-style: none;
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: minmax(240px, 0.9fr) minmax(0, 1.7fr) minmax(220px, 0.85fr);
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.dashboard-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.rail-drawer,
+.workspace-drawer {
+  background: var(--panel-bg);
+  border-radius: 24px;
   box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+  padding: 1.2rem 1.4rem;
+}
+
+.rail-drawer__summary,
+.workspace-drawer__summary {
+  list-style: none;
+  display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-weight: 700;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.85);
+  cursor: pointer;
+}
+
+.rail-drawer__summary::-webkit-details-marker,
+.workspace-drawer__summary::-webkit-details-marker {
+  display: none;
+}
+
+.rail-drawer[open] > .rail-drawer__summary,
+.workspace-drawer[open] > .workspace-drawer__summary {
+  color: var(--accent);
+}
+
+.rail-drawer__content,
+.workspace-drawer__content {
+  margin-top: 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.workspace-drawer__notes {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.shortcut-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.link-button {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--accent);
+  cursor: pointer;
+  text-align: left;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.link-button::after {
+  content: '→';
+  font-size: 0.8rem;
+  opacity: 0.8;
+}
+
+.link-button:hover,
+.link-button:focus-visible {
+  color: var(--accent-strong);
+  text-decoration: underline;
 }
 
 .section-nav {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
+  display: grid;
   gap: 0.6rem;
-  background: rgba(15, 23, 42, 0.78);
-  border-radius: 999px;
-  padding: 0.55rem 0.75rem;
-  box-shadow: var(--shadow);
-  backdrop-filter: blur(18px);
 }
 
 .section-link {
-  border: 1px solid transparent;
-  border-radius: 999px;
-  padding: 0.55rem 0.95rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  border-radius: 14px;
+  padding: 0.65rem 0.85rem;
   font-weight: 600;
   font-size: 0.9rem;
   letter-spacing: 0.01em;
   text-decoration: none;
-  color: var(--muted);
-  transition: background 0.2s ease, color 0.2s ease, border 0.2s ease;
+  color: rgba(226, 232, 240, 0.78);
+  background: rgba(15, 23, 42, 0.55);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.16);
+  transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease;
 }
 
 .section-link:hover,
 .section-link:focus-visible {
+  transform: translateX(4px);
+  background: rgba(56, 189, 248, 0.16);
   color: var(--text);
-  background: rgba(56, 189, 248, 0.18);
 }
 
 .section-link.is-active,
 .section-link[aria-current='true'] {
+  background: rgba(56, 189, 248, 0.22);
   color: var(--text);
-  border-color: rgba(56, 189, 248, 0.4);
-  background: rgba(56, 189, 248, 0.16);
+  box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.45);
 }
 
 .stat {
@@ -1588,5 +1778,37 @@ body.modal-open {
 
   .filter-toggle.search input[type='search'] {
     width: 160px;
+  }
+}
+@media (max-width: 1200px) {
+  .command-bar {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .dashboard-grid {
+    grid-template-columns: minmax(220px, 0.95fr) minmax(0, 1.4fr);
+  }
+}
+
+@media (max-width: 960px) {
+  body {
+    padding: 1.5rem 1rem 2.5rem;
+  }
+
+  .command-bar {
+    position: static;
+    grid-template-columns: 1fr;
+  }
+
+  .command-bar__cluster--actions {
+    align-items: stretch;
+  }
+
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard-rail {
+    order: unset;
   }
 }


### PR DESCRIPTION
## Summary
- restructure the dashboard into a three-column command deck with navigation rails and drawer-based filters
- add quick-action helpers that open drawers, focus the upgrade search, and smooth-scroll to core sections
- refresh UI documentation, changelog, and README to describe the new navigation model

## Testing
- npm test
- Manual QA: python -m http.server 4173 and verified navigation drawers and shortcuts

------
https://chatgpt.com/codex/tasks/task_e_68d9c93b1584832cb071a59813ff0854