### PR TITLE
Fix timeline legend toggle collapse behavior

### DIFF
--- a/src/ui/layout.js
+++ b/src/ui/layout.js
@@ -95,11 +95,18 @@ function setupTimeLegendToggle() {
   const toggle = elements.timeLegendToggle;
   const legend = elements.timeLegend;
   if (!toggle || !legend) return;
+  const header = legend.closest('.dashboard-header') || toggle.closest('.dashboard-header');
+
+  const syncHeaderState = () => {
+    if (!header) return;
+    header.classList.toggle('legend-collapsed', legend.hidden);
+  };
 
   const setExpanded = expanded => {
     toggle.setAttribute('aria-expanded', String(expanded));
     toggle.textContent = expanded ? 'Hide timeline legend' : 'Show timeline legend';
     legend.hidden = !expanded;
+    syncHeaderState();
   };
 
   toggle.addEventListener('click', () => {

--- a/src/ui/update.js
+++ b/src/ui/update.js
@@ -127,6 +127,11 @@ function renderTimeLegend(playerSegments, assistantSegments = []) {
   } else {
     legend.hidden = !hasEntries;
   }
+
+  const header = legend.closest('.dashboard-header');
+  if (header) {
+    header.classList.toggle('legend-collapsed', legend.hidden);
+  }
 }
 
 function renderTimeProgress(summary) {

--- a/styles.css
+++ b/styles.css
@@ -271,6 +271,10 @@ body.modal-open {
   color: var(--muted);
 }
 
+.time-legend[hidden] {
+  display: none;
+}
+
 .time-legend li {
   display: inline-flex;
   align-items: center;
@@ -287,6 +291,10 @@ body.modal-open {
   border-radius: 50%;
   background: var(--legend-color, var(--muted));
   box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.35);
+}
+
+.dashboard-header.legend-collapsed .time-wrapper {
+  gap: 0.35rem;
 }
 
 .end-day {

--- a/tests/ui/legendToggle.test.js
+++ b/tests/ui/legendToggle.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ensureTestDom } from '../helpers/setupDom.js';
+
+test('timeline legend toggle hides legend and collapses the header', async () => {
+  ensureTestDom();
+
+  const { initLayoutControls } = await import('../../src/ui/layout.js');
+  initLayoutControls();
+
+  const toggle = document.getElementById('time-legend-toggle');
+  const legend = document.getElementById('time-legend');
+  const header = document.querySelector('.dashboard-header');
+
+  assert.equal(toggle.getAttribute('aria-expanded'), 'false');
+  assert.equal(legend.hidden, true);
+  assert.ok(header.classList.contains('legend-collapsed'));
+
+  toggle.click();
+
+  assert.equal(toggle.getAttribute('aria-expanded'), 'true');
+  assert.equal(legend.hidden, false);
+  assert.ok(!header.classList.contains('legend-collapsed'));
+
+  toggle.click();
+
+  assert.equal(toggle.getAttribute('aria-expanded'), 'false');
+  assert.equal(legend.hidden, true);
+  assert.ok(header.classList.contains('legend-collapsed'));
+});


### PR DESCRIPTION
## Summary
- ensure the timeline legend toggle updates the header state so the legend truly collapses
- add styling to respect the hidden attribute and tighten header spacing when the legend is folded
- cover the toggle behaviour with a UI-focused node test

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d9cd13f388832c9ef77a361bd87dba