### PR TITLE
Restore asset briefing launch blueprint

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Restored the asset briefing modal with a launch blueprint checklist plus per-instance upgrade quick actions paired with sell controls.
 - Reimagined the dashboard clock as a forward-moving 24h day tracker with colour-coded segments for sleep, upkeep, setup, and logged actions plus an at-a-glance legend.
 - Rebalanced assistant upkeep allocation so helper hours are consumed before tasks bounce to the player, with overflow now failing when both pools are spent.
 - Introduced schema-driven builders for hustles, assets, and upgrades so new content can be configured declaratively with shared UI details and metrics hooks.

--- a/docs/features/passive-asset-dashboard.md
+++ b/docs/features/passive-asset-dashboard.md
@@ -1,12 +1,12 @@
 # Passive Asset Dashboard Refresh
 
 ## Summary
-The passive asset workspace now presents each asset as a management card that highlights ownership counts, yesterday's earnings, income potential, upkeep, and net return per upkeep hour at a glance. Cards surface quick actions to launch new builds and sell individual instances without digging through secondary panels. Category toggles also roll up every launched instance into a single management list so upkeep, payouts, supporting upgrades, and liquidation stay reachable even when the compact card view is enabled. The instance briefing modal now focuses on the selected build, showcasing its quality track progress, ROI, and relevant upgrade actions, while quick-purchase upgrade buttons and a scrollable layout keep next steps visible without crowding the screen.
+The passive asset workspace now presents each asset as a management card that highlights ownership counts, yesterday's earnings, income potential, upkeep, and net return per upkeep hour at a glance. Cards surface quick actions to launch new builds and sell individual instances without digging through secondary panels. Category toggles also roll up every launched instance into a single management list so upkeep, payouts, supporting upgrades, and liquidation stay reachable even when the compact card view is enabled. The instance briefing modal now focuses on the selected build, showcasing its quality track progress, ROI, and relevant upgrade actions, while quick-purchase upgrade buttons and a scrollable layout keep next steps visible without crowding the screen. The briefing now opens with a "Launch blueprint" checklist that calls out setup time, upfront costs, upkeep, and income ranges before you commit, and every launched instance lists upgrade quick actions beside the sell shortcut.
 
 ## Goals
 - Give players immediate insight into how every passive build performed yesterday, what it costs to maintain, and whether upkeep hours are paying off.
 - Reduce the click depth for upkeep decisions by embedding sell controls and upgrade guidance into each instance row.
-- Provide an upbeat "New Asset Briefing" modal so players can review setup requirements and payout expectations before committing resources.
+- Provide an upbeat "New Asset Briefing" modal so players can review setup requirements and payout expectations before committing resources, including a live checklist of setup costs, upkeep, and income ranges.
 - Restore at-a-glance control of every active build via per-category asset rosters that remain available when cards are collapsed.
 
 ## Player Impact
@@ -19,9 +19,9 @@ The passive asset workspace now presents each asset as a management card that hi
 ## Implementation Notes
 - Asset cards keep the existing category structure but use a dedicated layout (`asset-card__*` classes) for stats, actions, and instance management.
 - Instance rows now expose both the previous day's payout and inline sell buttons so liquidation is always one click away.
-- Each instance row can render up to two quick-purchase buttons for the next required equipment upgrades, deferring to existing upgrade action handlers for cost checks and logging.
+- Each instance row can render up to two quick-purchase buttons for the next required equipment upgrades, deferring to existing upgrade action handlers for cost checks and logging. Quick actions now sit directly beside the sell button in the instance list so players can invest or liquidate without leaving the modal.
 - Category-level "View launched assets" toggles render aggregated tables populated by `assetCategoryView`, which now highlights the first couple of supporting upgrades directly under each instance's actions.
-- The briefing modal now switches between the legacy definition view and an instance-specific overview that highlights status, upkeep, yesterday's payout, net hourly return, and quality progress/upgrade actions tailored to that build, with the quality upgrades section pinned above the stat summary and the content area scrollable for long descriptions.
+- The briefing modal now switches between the legacy definition view and an instance-specific overview that highlights status, upkeep, yesterday's payout, net hourly return, and quality progress/upgrade actions tailored to that build, with the quality upgrades section pinned above the stat summary and the content area scrollable for long descriptions. The top of the modal reuses schema-driven detail renderers to keep setup and upkeep numbers accurate even before the first launch.
 - ROI rows in the category roster use last income minus upkeep costs divided by upkeep hours to surface a quick dollars-per-hour snapshot for active builds.
 - The modal is populated via `populateAssetInfoModal` using current detail renderers so future balance changes automatically propagate.
 - Collapsed view hides the tagline, instances, and quality panel while keeping the stat summary visible for quick scanning.

--- a/styles.css
+++ b/styles.css
@@ -854,6 +854,170 @@ body {
   font-weight: 600;
 }
 
+.asset-detail {
+  display: grid;
+  gap: 20px;
+  padding-bottom: 8px;
+}
+
+.asset-detail__intro {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--text-subtle);
+}
+
+.asset-detail__section {
+  display: grid;
+  gap: 12px;
+}
+
+.asset-detail__section h3 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.asset-detail__highlights {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.asset-detail__highlight {
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 12px 14px;
+  line-height: 1.5;
+}
+
+.asset-detail__instances {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.asset-detail__instance {
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.asset-detail__instance-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.asset-detail__instance-header strong {
+  font-size: 16px;
+}
+
+.asset-detail__instance-status {
+  color: var(--text-subtle);
+  font-size: 13px;
+}
+
+.asset-detail__instance-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+  font-size: 13px;
+  color: var(--text-subtle);
+}
+
+.asset-detail__instance-earnings {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.asset-detail__instance-roi {
+  color: var(--success);
+  font-weight: 600;
+}
+
+.asset-detail__instance-roi.is-negative {
+  color: var(--danger);
+}
+
+.asset-detail__progress {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  font-size: 12px;
+  color: var(--text-subtle);
+}
+
+.asset-detail__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.asset-detail__quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.asset-detail__action-button {
+  border: 1px solid var(--accent);
+  background: var(--accent-soft);
+  color: var(--text);
+  padding: 8px 12px;
+  border-radius: var(--radius-md);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.18s ease;
+}
+
+.asset-detail__action-button:disabled {
+  border-color: var(--border);
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--text-subtle);
+  cursor: not-allowed;
+}
+
+.asset-detail__action-button:not(:disabled):hover {
+  background: rgba(124, 92, 255, 0.28);
+}
+
+.asset-detail__action-note {
+  font-size: 13px;
+  color: var(--text-subtle);
+  align-self: center;
+}
+
+.asset-detail__sell {
+  margin-left: auto;
+}
+
+.asset-detail__sell[disabled] {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.asset-detail__empty {
+  margin: 0;
+  padding: 14px 16px;
+  border-radius: var(--radius-md);
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--text-subtle);
+  font-size: 14px;
+}
+
 button:focus-visible,
 a:focus-visible {
   outline: none;


### PR DESCRIPTION
## Summary
- add schema-driven launch blueprint details and per-instance quick actions to the asset briefing modal
- style the refreshed modal layout to highlight quick upgrades beside sell controls
- document the launch blueprint feature in the passive asset dashboard note and changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9d7fb3628832c9caca368a878ba44