### PR TITLE
Move launched builds listing to assets panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,6 +229,15 @@
             <button id="asset-batch-preset" class="ghost" type="button">Apply preset</button>
           </div>
         </footer>
+        <section id="asset-launched" class="asset-launched" aria-live="polite">
+          <header class="asset-launched__header">
+            <h2 id="asset-launched-title">Launched builds</h2>
+            <p id="asset-launched-note">Select an asset to explore active and queued builds.</p>
+          </header>
+          <div id="asset-launched-content" class="asset-launched__content">
+            <p class="asset-launched__empty">No asset selected yet. Tap a row to review its build roster.</p>
+          </div>
+        </section>
       </section>
 
       <section id="panel-upgrades" class="panel" role="tabpanel" aria-labelledby="tab-upgrades" hidden>

--- a/src/ui/cards.js
+++ b/src/ui/cards.js
@@ -806,9 +806,55 @@ function openAssetDetails(definition) {
   ];
   body.appendChild(createDefinitionSummary('Roster snapshot', summaryRows));
 
-  body.appendChild(createInstanceListSection(definition, state));
-
   showSlideOver({ eyebrow: 'Asset', title: definition.name, body });
+  renderLaunchedBuilds(definition, state);
+}
+
+function renderLaunchedBuilds(definition, state) {
+  const panel = elements.assetLaunched;
+  if (!panel?.content) return;
+
+  const { content, note, title } = panel;
+  content.innerHTML = '';
+
+  if (!definition) {
+    if (title) title.textContent = 'Launched builds';
+    if (note) note.textContent = 'Select an asset to explore active and queued builds.';
+    const empty = document.createElement('p');
+    empty.className = 'asset-launched__empty';
+    empty.textContent = 'No asset selected yet. Tap a row to review its build roster.';
+    content.appendChild(empty);
+    return;
+  }
+
+  const assetState = getAssetState(definition.id, state);
+  const instances = Array.isArray(assetState?.instances) ? assetState.instances : [];
+
+  if (title) {
+    title.textContent = `${definition.name} builds`;
+  }
+
+  if (note) {
+    const activeCount = instances.filter(instance => instance.status === 'active').length;
+    const queuedCount = instances.filter(instance => instance.status !== 'active').length;
+    if (!instances.length) {
+      note.textContent = 'Launch a build to start earning and it will show up right here.';
+    } else if (activeCount > 0) {
+      note.textContent = `${activeCount} active build${activeCount === 1 ? '' : 's'} humming along${queuedCount > 0 ? ` • ${queuedCount} queued` : ''}.`;
+    } else {
+      note.textContent = `Queue warming up • ${queuedCount} build${queuedCount === 1 ? '' : 's'} getting ready to launch.`;
+    }
+  }
+
+  const section = createInstanceListSection(definition, state);
+  const heading = section.querySelector('h3');
+  if (heading) {
+    section.removeChild(heading);
+  }
+
+  while (section.firstChild) {
+    content.appendChild(section.firstChild);
+  }
 }
 
 function renderAssets(definitions) {

--- a/src/ui/elements.js
+++ b/src/ui/elements.js
@@ -68,6 +68,12 @@ const elements = {
     pause: document.getElementById('asset-batch-pause'),
     preset: document.getElementById('asset-batch-preset')
   },
+  assetLaunched: {
+    container: document.getElementById('asset-launched'),
+    title: document.getElementById('asset-launched-title'),
+    note: document.getElementById('asset-launched-note'),
+    content: document.getElementById('asset-launched-content')
+  },
   upgradeFilters: {
     affordable: document.getElementById('upgrade-affordable-toggle'),
     favorites: document.getElementById('upgrade-favorites-toggle')

--- a/src/ui/layout.js
+++ b/src/ui/layout.js
@@ -80,6 +80,13 @@ function setupSlideOver() {
     if (event.key === 'Escape') hide();
   });
 
+  document.addEventListener('mousedown', event => {
+    if (slideOver.hidden) return;
+    const panel = slideOver.querySelector('.slide-over__panel');
+    if (panel?.contains(event.target)) return;
+    hide();
+  });
+
   slideOver.hidePanel = hide;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -620,6 +620,44 @@ body {
   gap: 12px;
 }
 
+.asset-launched {
+  margin-top: 28px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 20px 24px;
+  display: grid;
+  gap: 20px;
+  box-shadow: var(--shadow-sm);
+}
+
+.asset-launched__header {
+  display: grid;
+  gap: 4px;
+}
+
+.asset-launched__header h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.asset-launched__header p {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-subtle);
+}
+
+.asset-launched__content {
+  display: grid;
+  gap: 16px;
+}
+
+.asset-launched__empty {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-subtle);
+}
+
 .upgrade-layout {
   display: grid;
   grid-template-columns: 1fr 280px;


### PR DESCRIPTION
## Summary
- add a dedicated launched builds section directly inside the assets tab
- update slide-over handling so outside clicks close the panel and the new section mirrors instance details
- register new DOM references and styling to support the relocated build roster

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9e093c238832c808810f730495b10