### PR TITLE
Simplify header pulse metrics layout

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Streamlined the header pulse to spotlight daily flow and time stats in a single tidy row.
 - Centered the shell header around a "Daily pulse" band that highlights daily earnings and spend, lifetime cash flow, and the remaining versus committed hours for the current day.
 - Expanded the hustle catalog with eight new instant gigs ranging from 15-minute surveys to asset-specific pop-up events, adding more scheduling variety and requirement-driven payouts.
 - Grouped the asset detail slide-over into Active builds and Launch queue sections with scrollable stat strips, highlighting last payout, net hourly returns, upkeep, and inline upgrade shortcuts for every launched build.

--- a/index.html
+++ b/index.html
@@ -27,16 +27,6 @@
           <span class="shell-metric__value" id="header-daily-minus">$0</span>
           <span class="shell-metric__note" id="header-daily-minus-note">Upkeep + investments</span>
         </div>
-        <div class="shell-metric" data-tone="accent">
-          <span class="shell-metric__label">Total +</span>
-          <span class="shell-metric__value" id="header-total-plus">$0</span>
-          <span class="shell-metric__note" id="header-total-plus-note">Lifetime earnings</span>
-        </div>
-        <div class="shell-metric" data-tone="muted">
-          <span class="shell-metric__label">Total -</span>
-          <span class="shell-metric__value" id="header-total-minus">$0</span>
-          <span class="shell-metric__note" id="header-total-minus-note">Lifetime spend</span>
-        </div>
         <div class="shell-metric" data-tone="time">
           <span class="shell-metric__label">Time left</span>
           <span class="shell-metric__value" id="header-time-available">0h</span>

--- a/src/ui/dashboard.js
+++ b/src/ui/dashboard.js
@@ -377,9 +377,6 @@ export function renderDashboard(summary) {
   const dailySpend = Math.max(0, Number(summary.totalSpend) || 0);
   const upkeepSpend = Math.max(0, Number(summary.upkeepSpend) || 0);
   const investmentSpend = Math.max(0, Number(summary.investmentSpend) || 0);
-  const lifetimeEarned = Math.max(0, Number(state.totals?.earned) || 0);
-  const lifetimeSpent = Math.max(0, Number(state.totals?.spent) || 0);
-  const lifetimeNet = lifetimeEarned - lifetimeSpent;
   const timeCap = getTimeCap();
   const reservedHours = Math.max(0, timeCap - hoursLeft);
   const setupHours = Math.max(0, Number(summary.setupHours) || 0);
@@ -417,27 +414,6 @@ export function renderDashboard(summary) {
   setText(
     headerStats.dailyMinus?.note,
     spendSegments.length ? spendSegments.join(' • ') : 'No cash out yet'
-  );
-
-  setText(headerStats.totalPlus?.value, `$${formatMoney(lifetimeEarned)}`);
-  const lifetimeSegments = [];
-  if (lifetimeEarned > 0 || lifetimeSpent > 0) {
-    lifetimeSegments.push(
-      `${lifetimeNet >= 0 ? 'Net +' : 'Net -'}$${formatMoney(Math.abs(lifetimeNet))}`
-    );
-  }
-  setText(
-    headerStats.totalPlus?.note,
-    lifetimeSegments.length ? lifetimeSegments.join(' • ') : 'Fresh ledger'
-  );
-
-  setText(headerStats.totalMinus?.value, `$${formatMoney(lifetimeSpent)}`);
-  const spanDays = state.day || 1;
-  setText(
-    headerStats.totalMinus?.note,
-    lifetimeSpent > 0
-      ? `Across ${spanDays} day${spanDays === 1 ? '' : 's'}`
-      : 'No lifetime spend yet'
   );
 
   setText(headerStats.timeAvailable?.value, formatHours(hoursLeft));

--- a/src/ui/elements.js
+++ b/src/ui/elements.js
@@ -13,14 +13,6 @@ const elements = {
       value: document.getElementById('header-daily-minus'),
       note: document.getElementById('header-daily-minus-note')
     },
-    totalPlus: {
-      value: document.getElementById('header-total-plus'),
-      note: document.getElementById('header-total-plus-note')
-    },
-    totalMinus: {
-      value: document.getElementById('header-total-minus'),
-      note: document.getElementById('header-total-minus-note')
-    },
     timeAvailable: {
       value: document.getElementById('header-time-available'),
       note: document.getElementById('header-time-available-note')

--- a/styles.css
+++ b/styles.css
@@ -74,7 +74,7 @@ body {
 
 .shell__pulse {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 14px;
   padding: 18px 20px;
   border-radius: var(--radius-lg);


### PR DESCRIPTION
## Summary
- remove the lifetime total metrics from the shell header pulse so it focuses on daily flow and time
- lock the pulse layout to a single row of four stats and adjust copy to match
- update the changelog to capture the streamlined header presentation

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d9e23f33fc832c91af24a37ee95ae2