### PR TITLE
Adjust dashboard grid to highlight asset upgrade boosts

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,15 @@
               </div>
             </article>
 
-            <article class="card dashboard-card" aria-labelledby="queue-heading">
+            <article class="card dashboard-card dashboard-card--asset-upgrades" aria-labelledby="asset-upgrades-heading">
+              <header>
+                <h2 id="asset-upgrades-heading">Asset upgrade boosts</h2>
+                <p>Cheer on underperformers with the next quality-friendly push.</p>
+              </header>
+              <ul id="asset-upgrade-actions" class="quick-actions upgrade-actions" aria-live="polite"></ul>
+            </article>
+
+            <article class="card dashboard-card dashboard-card--queue" aria-labelledby="queue-heading">
               <header>
                 <h2 id="queue-heading">Action queue</h2>
                 <p>Today’s commitments; drag to set priority.</p>
@@ -150,20 +158,12 @@
               </footer>
             </article>
 
-            <article class="card dashboard-card" aria-labelledby="quick-actions-heading">
+            <article class="card dashboard-card dashboard-card--quick-actions" aria-labelledby="quick-actions-heading">
               <header>
                 <h2 id="quick-actions-heading">Quick actions</h2>
                 <p>High-impact moves you can trigger now.</p>
               </header>
               <ul id="quick-actions" class="quick-actions" aria-live="polite"></ul>
-            </article>
-
-            <article class="card dashboard-card" aria-labelledby="asset-upgrades-heading">
-              <header>
-                <h2 id="asset-upgrades-heading">Asset upgrade boosts</h2>
-                <p>Cheer on underperformers with the next quality-friendly push.</p>
-              </header>
-              <ul id="asset-upgrade-actions" class="quick-actions upgrade-actions" aria-live="polite"></ul>
             </article>
 
             <article class="card dashboard-card" aria-labelledby="notifications-heading">

--- a/styles.css
+++ b/styles.css
@@ -251,9 +251,10 @@ body {
 
 .dashboard__grid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(220px, 1fr));
   grid-template-rows: auto auto;
   gap: 18px;
+  grid-auto-flow: dense;
 }
 
 .dashboard-card {
@@ -269,6 +270,22 @@ body {
 
 .dashboard-card--wide {
   grid-column: span 2;
+  grid-row: span 2;
+}
+
+.dashboard-card--asset-upgrades {
+  grid-column: 3;
+  grid-row: 1;
+}
+
+.dashboard-card--queue {
+  grid-column: 4;
+  grid-row: 1;
+}
+
+.dashboard-card--quick-actions {
+  grid-column: 3 / span 2;
+  grid-row: 2;
 }
 
 .dashboard-card header h2 {
@@ -1348,6 +1365,18 @@ a:focus-visible {
 
   .dashboard__grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-auto-flow: row;
+  }
+
+  .dashboard-card--wide {
+    grid-row: span 1;
+  }
+
+  .dashboard-card--asset-upgrades,
+  .dashboard-card--queue,
+  .dashboard-card--quick-actions {
+    grid-column: auto;
+    grid-row: auto;
   }
 }
 


### PR DESCRIPTION
## Summary
- move the asset upgrade boosts card alongside the daily stats and queue cards
- add layout hooks and grid rules so the dashboard shows four columns on wide screens and reflows cleanly when narrower

## Testing
- npm test
- manual: served index.html locally and verified dashboard layout

------
https://chatgpt.com/codex/tasks/task_e_68d9e9740490832ca95b6fe87db14bef