### PR TITLE
Add assets builds tab and relocate active build summary

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Added a Builds tab to the Assets workspace with a "New builds" shortcut, relocating active build counts into category headers so the roster summary sits away from the Details controls.
 - Added an "Asset upgrade boosts" dashboard card that spotlights quality pushes for low-yield assets while trimming Daily Stats lists to the top three highlights for a tighter fit.
 - Streamlined the header pulse to spotlight daily flow and time stats in a single tidy row.
 - Centered the shell header around a "Daily pulse" band that highlights daily earnings and spend, lifetime cash flow, and the remaining versus committed hours for the current day.

--- a/docs/features/passive-asset-dashboard.md
+++ b/docs/features/passive-asset-dashboard.md
@@ -3,6 +3,8 @@
 ## Summary
 The passive asset workspace now presents each asset as a management card that highlights ownership counts, yesterday's earnings, income potential, upkeep, and net return per upkeep hour at a glance. Cards surface quick actions to launch new builds and sell individual instances without digging through secondary panels. Category toggles also roll up every launched instance into a single management list so upkeep, payouts, supporting upgrades, and liquidation stay reachable even when the compact card view is enabled. The instance briefing modal now focuses on the selected build, showcasing its quality track progress, ROI, and relevant upgrade actions, while quick-purchase upgrade buttons and a scrollable layout keep next steps visible without crowding the screen. Active builds are grouped at the top of the slide-over with stat tiles for last payout, net per hour, upkeep, and inline upgrade shortcuts so players can tune performance instantly. The briefing now opens with a "Launch blueprint" checklist that calls out setup time, upfront costs, upkeep, and income ranges before you commit, and every launched instance lists upgrade quick actions beside the sell shortcut.
 
+The Assets workspace also includes a Builds tab reachable from a "New builds" shortcut. Category headers now call out active and queued counts above the roster tables so players spot running crews without crowding the Details actions.
+
 ## Goals
 - Give players immediate insight into how every passive build performed yesterday, what it costs to maintain, and whether upkeep hours are paying off.
 - Reduce the click depth for upkeep decisions by embedding sell controls and upgrade guidance into each instance row.

--- a/index.html
+++ b/index.html
@@ -219,55 +219,71 @@
             <h2>Assets</h2>
             <p>Passive plays that need smart upkeep.</p>
           </div>
-          <div class="filter-bar" role="group" aria-label="Asset filters">
-            <label class="filter-toggle">
-              <input id="asset-active-toggle" type="checkbox" />
-              <span>Active only</span>
-            </label>
-            <label class="filter-toggle">
-              <input id="asset-maintenance-toggle" type="checkbox" />
-              <span>Needs maintenance</span>
-            </label>
-            <label class="filter-toggle">
-              <input id="asset-risk-toggle" type="checkbox" />
-              <span>Hide high risk</span>
-            </label>
+          <div class="panel__tools">
+            <div class="filter-bar" role="group" aria-label="Asset filters">
+              <label class="filter-toggle">
+                <input id="asset-active-toggle" type="checkbox" />
+                <span>Active only</span>
+              </label>
+              <label class="filter-toggle">
+                <input id="asset-maintenance-toggle" type="checkbox" />
+                <span>Needs maintenance</span>
+              </label>
+              <label class="filter-toggle">
+                <input id="asset-risk-toggle" type="checkbox" />
+                <span>Hide high risk</span>
+              </label>
+            </div>
+            <button id="asset-open-builds" class="ghost" type="button">New builds</button>
           </div>
         </header>
-        <div class="asset-table-wrapper">
-          <table class="asset-table" aria-describedby="asset-table-caption">
-            <caption id="asset-table-caption">Passive assets overview</caption>
-            <thead>
-              <tr>
-                <th scope="col">Name</th>
-                <th scope="col">State</th>
-                <th scope="col">Yield / day</th>
-                <th scope="col">Upkeep</th>
-                <th scope="col">Risk</th>
-                <th scope="col">Modifiers</th>
-                <th scope="col" class="actions-col">Actions</th>
-              </tr>
-            </thead>
-            <tbody id="asset-table-body"></tbody>
-          </table>
+        <div class="asset-panel">
+          <div class="asset-panel__tabs" role="tablist" aria-label="Asset views">
+            <button id="asset-tab-overview" class="asset-panel__tab is-active" role="tab" aria-selected="true" aria-controls="asset-panel-overview">Overview</button>
+            <button id="asset-tab-builds" class="asset-panel__tab" role="tab" aria-selected="false" aria-controls="asset-panel-builds">Builds</button>
+          </div>
+          <section id="asset-panel-overview" class="asset-panel__section is-active" role="tabpanel" aria-labelledby="asset-tab-overview">
+            <div class="asset-table-wrapper">
+              <table class="asset-table" aria-describedby="asset-table-caption">
+                <caption id="asset-table-caption">Passive assets overview</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Name</th>
+                    <th scope="col">State</th>
+                    <th scope="col">Yield / day</th>
+                    <th scope="col">Upkeep</th>
+                    <th scope="col">Risk</th>
+                    <th scope="col">Modifiers</th>
+                    <th scope="col" class="actions-col">Actions</th>
+                  </tr>
+                </thead>
+                <tbody id="asset-table-body"></tbody>
+              </table>
+            </div>
+            <footer class="asset-batch" aria-live="polite">
+              <div class="asset-batch__selection" id="asset-selection-note">No assets selected.</div>
+              <div class="asset-batch__actions">
+                <button id="asset-batch-maintain" class="ghost" type="button">Maintain</button>
+                <button id="asset-batch-pause" class="ghost" type="button">Pause</button>
+                <button id="asset-batch-preset" class="ghost" type="button">Apply preset</button>
+              </div>
+            </footer>
+            <section id="asset-launched" class="asset-launched" aria-live="polite">
+              <header class="asset-launched__header">
+                <h2 id="asset-launched-title">Launched builds</h2>
+                <p id="asset-launched-note">Select an asset to explore active and queued builds.</p>
+              </header>
+              <div id="asset-launched-content" class="asset-launched__content">
+                <p class="asset-launched__empty">No asset selected yet. Tap a row to review its build roster.</p>
+              </div>
+            </section>
+          </section>
+          <section id="asset-panel-builds" class="asset-panel__section" role="tabpanel" aria-labelledby="asset-tab-builds" hidden>
+            <div id="asset-builds-container" class="asset-builds" aria-live="polite">
+              <p class="asset-builds__empty" id="asset-builds-empty">No passive assets unlocked yet.</p>
+            </div>
+          </section>
         </div>
-        <footer class="asset-batch" aria-live="polite">
-          <div class="asset-batch__selection" id="asset-selection-note">No assets selected.</div>
-          <div class="asset-batch__actions">
-            <button id="asset-batch-maintain" class="ghost" type="button">Maintain</button>
-            <button id="asset-batch-pause" class="ghost" type="button">Pause</button>
-            <button id="asset-batch-preset" class="ghost" type="button">Apply preset</button>
-          </div>
-        </footer>
-        <section id="asset-launched" class="asset-launched" aria-live="polite">
-          <header class="asset-launched__header">
-            <h2 id="asset-launched-title">Launched builds</h2>
-            <p id="asset-launched-note">Select an asset to explore active and queued builds.</p>
-          </header>
-          <div id="asset-launched-content" class="asset-launched__content">
-            <p class="asset-launched__empty">No asset selected yet. Tap a row to review its build roster.</p>
-          </div>
-        </section>
       </section>
 
       <section id="panel-upgrades" class="panel" role="tabpanel" aria-labelledby="tab-upgrades" hidden>

--- a/src/ui/assetCategoryView.js
+++ b/src/ui/assetCategoryView.js
@@ -177,6 +177,7 @@ function renderCategoryList(key) {
 
     const detailsButton = document.createElement('button');
     detailsButton.type = 'button';
+    detailsButton.className = 'ghost';
     detailsButton.textContent = 'Details';
     detailsButton.addEventListener('click', event => {
       event.preventDefault();
@@ -188,6 +189,7 @@ function renderCategoryList(key) {
 
     const sellButton = document.createElement('button');
     sellButton.type = 'button';
+    sellButton.className = 'secondary';
     const price = calculateAssetSalePrice(row.instance);
     sellButton.textContent = price > 0 ? `Sell ($${formatMoney(price)})` : 'Sell (no buyer)';
     sellButton.disabled = price <= 0;

--- a/src/ui/elements.js
+++ b/src/ui/elements.js
@@ -80,6 +80,9 @@ const elements = {
     maintenance: document.getElementById('asset-maintenance-toggle'),
     lowRisk: document.getElementById('asset-risk-toggle')
   },
+  assetPanelTabs: Array.from(document.querySelectorAll('.asset-panel__tab')),
+  assetPanelSections: Array.from(document.querySelectorAll('.asset-panel__section')),
+  assetOpenBuilds: document.getElementById('asset-open-builds'),
   assetTableBody: document.getElementById('asset-table-body'),
   assetSelectionNote: document.getElementById('asset-selection-note'),
   assetBatchButtons: {
@@ -87,6 +90,11 @@ const elements = {
     pause: document.getElementById('asset-batch-pause'),
     preset: document.getElementById('asset-batch-preset')
   },
+  assetBuildsContainer: document.getElementById('asset-builds-container'),
+  assetBuildsEmpty: document.getElementById('asset-builds-empty'),
+  assetCategoryToggles: {},
+  assetCategoryLists: {},
+  assetCategorySummaries: {},
   assetLaunched: {
     container: document.getElementById('asset-launched'),
     title: document.getElementById('asset-launched-title'),

--- a/src/ui/layout.js
+++ b/src/ui/layout.js
@@ -2,6 +2,7 @@ import elements from './elements.js';
 
 export function initLayoutControls() {
   setupTabs();
+  setupAssetPanels();
   setupEventLog();
   setupSlideOver();
   setupCommandPalette();
@@ -38,6 +39,38 @@ function setupTabs() {
   });
 
   activate('panel-dashboard');
+}
+
+function setupAssetPanels() {
+  const { assetPanelTabs = [], assetPanelSections = [], assetOpenBuilds } = elements;
+  if (!assetPanelTabs.length || !assetPanelSections.length) return;
+
+  const activate = targetId => {
+    assetPanelTabs.forEach(tab => {
+      const controls = tab.getAttribute('aria-controls');
+      const isActive = controls === targetId;
+      tab.classList.toggle('is-active', isActive);
+      tab.setAttribute('aria-selected', String(isActive));
+      tab.tabIndex = isActive ? 0 : -1;
+    });
+    assetPanelSections.forEach(section => {
+      const match = section.id === targetId;
+      section.classList.toggle('is-active', match);
+      section.hidden = !match;
+    });
+  };
+
+  assetPanelTabs.forEach(tab => {
+    tab.addEventListener('click', () => activate(tab.getAttribute('aria-controls')));
+  });
+
+  assetOpenBuilds?.addEventListener('click', () => {
+    activate('asset-panel-builds');
+    elements.assetBuildsContainer?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  });
+
+  activate('asset-panel-overview');
+  elements.assetPanelActivate = activate;
 }
 
 function setupEventLog() {

--- a/styles.css
+++ b/styles.css
@@ -473,6 +473,22 @@ body {
   gap: 24px;
 }
 
+.panel__tools {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 16px;
+}
+
+.panel__tools .filter-bar {
+  flex: 1 1 auto;
+}
+
+.panel__tools button {
+  white-space: nowrap;
+}
+
 .panel__header h2 {
   margin: 0;
   font-size: 24px;
@@ -686,6 +702,210 @@ body {
 .asset-row-actions {
   display: inline-flex;
   gap: 8px;
+}
+
+.asset-panel {
+  display: grid;
+  gap: 20px;
+}
+
+.asset-panel__tabs {
+  display: inline-flex;
+  gap: 8px;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 8px;
+}
+
+.asset-panel__tab {
+  border: none;
+  background: transparent;
+  padding: 8px 14px;
+  border-radius: var(--radius-md);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-subtle);
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease;
+}
+
+.asset-panel__tab.is-active {
+  background: var(--surface-muted);
+  color: var(--text);
+}
+
+.asset-panel__tab:focus-visible {
+  box-shadow: 0 0 0 3px var(--focus);
+}
+
+.asset-panel__section {
+  display: grid;
+  gap: 20px;
+}
+
+.asset-builds {
+  display: grid;
+  gap: 16px;
+}
+
+.asset-builds__empty {
+  margin: 0;
+  padding: 16px 18px;
+  border-radius: var(--radius-md);
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--text-subtle);
+  font-size: 14px;
+}
+
+.asset-category {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 20px 24px;
+  display: grid;
+  gap: 16px;
+  box-shadow: var(--shadow-sm);
+}
+
+.asset-category__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.asset-category__info h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.asset-category__counts {
+  margin: 4px 0 0;
+  font-size: 14px;
+  color: var(--text-subtle);
+}
+
+.asset-category__toggle {
+  align-self: flex-start;
+}
+
+.asset-category__body {
+  display: grid;
+  gap: 16px;
+}
+
+.asset-category__empty {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-subtle);
+}
+
+.asset-category__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.asset-category__table th,
+.asset-category__table td {
+  padding: 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+
+.asset-category__name {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.asset-category__status {
+  color: var(--text-subtle);
+  font-size: 13px;
+}
+
+.asset-category__upkeep {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--text-subtle);
+}
+
+.asset-category__earnings {
+  color: var(--success);
+  font-weight: 600;
+}
+
+.asset-category__loss {
+  color: var(--danger);
+  font-weight: 600;
+}
+
+.asset-category__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-end;
+}
+
+.asset-category__upgrade-shortcuts {
+  display: grid;
+  gap: 6px;
+  align-self: stretch;
+}
+
+.asset-category__upgrade-title {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-subtle);
+}
+
+.asset-category__upgrade-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.asset-category__upgrade-button {
+  border: 1px solid var(--accent);
+  background: var(--accent-soft);
+  color: var(--text);
+  padding: 6px 10px;
+  border-radius: var(--radius-md);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.18s ease;
+}
+
+.asset-category__upgrade-button:disabled {
+  border-color: var(--border);
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--text-subtle);
+  cursor: not-allowed;
+}
+
+.asset-category__upgrade-button:not(:disabled):hover {
+  background: rgba(124, 92, 255, 0.28);
+}
+
+.asset-category__upgrade-more {
+  font-size: 12px;
+  color: var(--text-subtle);
+}
+
+.asset-category__upgrade-hints {
+  display: grid;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--text-subtle);
+}
+
+.asset-category__upgrade-entry.is-pending {
+  color: var(--text);
+  font-weight: 600;
 }
 
 .asset-batch {
@@ -1140,6 +1360,11 @@ body {
   gap: 12px;
 }
 
+.asset-detail__instance.is-highlighted {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(124, 92, 255, 0.25);
+}
+
 .asset-detail__instance-stats {
   display: grid;
   gap: 8px;
@@ -1393,5 +1618,10 @@ a:focus-visible {
   .panel__header {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .panel__tools {
+    width: 100%;
+    justify-content: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- add an assets sub-tab layout with a dedicated Builds view backed by the existing category roster renderer
- surface active and queued build counts in each category header so the details controls stay separate
- add a "New builds" shortcut button plus supporting styles for the new builds panel and highlighted instances

## Testing
- npm test
- Manual: Launched the local server, opened the Assets panel, and used the New builds shortcut to confirm the Builds tab renders


------
https://chatgpt.com/codex/tasks/task_e_68d9e9ec5b40832c8abf951b7f5461ee