### PR TITLE
Adjust asset upgrade card ordering on dashboard

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [Unreleased]
-- Added an "Asset upgrade boosts" dashboard card that spotlights quality pushes for low-yield assets while trimming Daily Stats lists to the top three highlights for a tighter fit.
+- Added an "Asset upgrade" dashboard card that spotlights quality pushes for low-yield assets while trimming Daily Stats lists to the top three highlights for a tighter fit.
 - Streamlined the header pulse to spotlight daily flow and time stats in a single tidy row.
 - Centered the shell header around a "Daily pulse" band that highlights daily earnings and spend, lifetime cash flow, and the remaining versus committed hours for the current day.
 - Expanded the hustle catalog with eight new instant gigs ranging from 15-minute surveys to asset-specific pop-up events, adding more scheduling variety and requirement-driven payouts.

--- a/docs/features/passive-asset-dashboard.md
+++ b/docs/features/passive-asset-dashboard.md
@@ -18,7 +18,7 @@ The passive asset workspace now presents each asset as a management card that hi
 
 ## Implementation Notes
 - Asset cards keep the existing category structure but use a dedicated layout (`asset-card__*` classes) for stats, actions, and instance management.
-- The dashboard now includes an "Asset upgrade boosts" card that calls out the next quality actions for struggling builds, prioritising low-yield instances that still owe progress toward their upcoming quality tier.
+- The dashboard now includes an "Asset upgrade" card that calls out the next quality actions for struggling builds, prioritising low-yield instances that still owe progress toward their upcoming quality tier.
 - Instance rows now expose both the previous day's payout and inline sell buttons so liquidation is always one click away.
 - Each instance row can render up to two quick-purchase buttons for the next required equipment upgrades, deferring to existing upgrade action handlers for cost checks and logging. Quick actions now sit directly beside the sell button in the instance list so players can invest or liquidate without leaving the modal. Active builds in the slide-over now include a dedicated stat strip with payout, ROI, and upkeep details above the action row, plus inline shortcuts for pending equipment upgrades.
 - Category-level "View launched assets" toggles render aggregated tables populated by `assetCategoryView`, which now highlights the first couple of supporting upgrades directly under each instance's actions. Upgrade shortcut helpers live in `src/ui/assetUpgrades.js` so both the category roster and the slide-over reuse identical button logic.

--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
 
             <article class="card dashboard-card" aria-labelledby="asset-upgrades-heading">
               <header>
-                <h2 id="asset-upgrades-heading">Asset upgrade boosts</h2>
+                <h2 id="asset-upgrades-heading">Asset upgrade</h2>
                 <p>Cheer on underperformers with the next quality-friendly push.</p>
               </header>
               <ul id="asset-upgrade-actions" class="quick-actions upgrade-actions" aria-live="polite"></ul>

--- a/src/ui/dashboard.js
+++ b/src/ui/dashboard.js
@@ -308,6 +308,17 @@ function renderAssetUpgradeActions(state) {
   container.innerHTML = '';
 
   const suggestions = buildAssetUpgradeRecommendations(state);
+  const assetCard = container.closest('.dashboard-card');
+  const queueCard = elements.actionQueue?.closest('.dashboard-card');
+  const parent = assetCard?.parentElement;
+  if (parent && queueCard && assetCard && parent.isSameNode(queueCard.parentElement)) {
+    if (suggestions.length) {
+      parent.insertBefore(assetCard, queueCard);
+    } else {
+      parent.insertBefore(queueCard, assetCard);
+    }
+  }
+
   if (!suggestions.length) {
     const empty = document.createElement('li');
     empty.textContent = 'Every asset is humming along. Check back after today’s upkeep.';


### PR DESCRIPTION
## Summary
- rename the dashboard card headline to "Asset upgrade"
- move the asset upgrade card ahead of the action queue when recommendations exist while keeping the original order otherwise
- refresh documentation to match the new card name

## Testing
- npm test
- Manual: Served index.html with http-server and loaded the dashboard in a browser

------
https://chatgpt.com/codex/tasks/task_e_68d9ebe6f330832c8149b2c966da4a9b