### PR TITLE
Fix education study button state updates

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Education study buttons now reflect affordability and progress, updating their labels and disabled state after enrollment.
 - Added an "Asset upgrade boosts" dashboard card that spotlights quality pushes for low-yield assets while trimming Daily Stats lists to the top three highlights for a tighter fit.
 - Streamlined the header pulse to spotlight daily flow and time stats in a single tidy row.
 - Centered the shell header around a "Daily pulse" band that highlights daily earnings and spend, lifetime cash flow, and the remaining versus committed hours for the current day.

--- a/tests/ui/educationTab.test.js
+++ b/tests/ui/educationTab.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ensureTestDom } from '../helpers/setupDom.js';
+
+const EDUCATION_TRACK_ID = 'outlineMastery';
+
+function getStudyActionButton() {
+  const button = document.querySelector('#panel-education .study-track .hustle-card__actions button:not(.ghost)');
+  assert.ok(button, 'expected study action button');
+  return button;
+}
+
+test('education track button reflects affordability and progress', async () => {
+  ensureTestDom();
+
+  const { configureRegistry, initializeState, getState } = await import('../../src/core/state.js');
+  const { registry } = await import('../../src/game/registry.js');
+  configureRegistry(registry);
+  initializeState();
+
+  const { renderCards, updateUI } = await import('../../src/ui/update.js');
+  renderCards();
+  updateUI();
+
+  const actionButton = getStudyActionButton();
+  assert.equal(actionButton.disabled, true);
+
+  const state = getState();
+  state.money = 500;
+  updateUI();
+  assert.equal(actionButton.disabled, false);
+
+  const { enrollInKnowledgeTrack } = await import('../../src/game/requirements.js');
+  enrollInKnowledgeTrack(EDUCATION_TRACK_ID);
+  updateUI();
+
+  assert.equal(actionButton.disabled, true);
+  assert.match(actionButton.textContent, /remaining/i);
+});


### PR DESCRIPTION
## Summary
- ensure education study track buttons mirror their disabled/label state from the underlying action and guard clicks when unavailable
- update the changelog entry to note the education tab fix and add a regression test covering the button state

## Testing
- npm test

## Manual Testing
- Launched the app via `npx --yes http-server -p 4173` and used a browser to switch to the Education tab, confirming the enroll button starts disabled without funds and updates after enrolling

------
https://chatgpt.com/codex/tasks/task_e_68d9ea4d45a8832caaf372c39a235a9e