### PR TITLE
Update study queue cap from state

### DIFF
--- a/src/ui/cards.js
+++ b/src/ui/cards.js
@@ -3,6 +3,7 @@ import { getAssetState, getState, getUpgradeState } from '../core/state.js';
 import { formatHours, formatMoney } from '../core/helpers.js';
 import { describeHustleRequirements } from '../game/hustles.js';
 import { KNOWLEDGE_TRACKS, getKnowledgeProgress } from '../game/requirements.js';
+import { getTimeCap } from '../game/time.js';
 import {
   describeInstance,
   describeInstanceNetHourly
@@ -1151,7 +1152,9 @@ function renderStudyQueue(definitions) {
     queue.appendChild(empty);
   }
   elements.studyQueueEta.textContent = `Total ETA: ${formatHours(totalHours)}`;
-  elements.studyQueueCap.textContent = 'Daily cap: 6h';
+  const state = getState();
+  const cap = state ? getTimeCap() : 0;
+  elements.studyQueueCap.textContent = `Daily cap: ${formatHours(cap)}`;
 }
 
 export function renderCardCollections({ hustles, education, assets, upgrades }) {


### PR DESCRIPTION
## Summary
- import the time cap helper into the study queue renderer
- calculate the current daily time cap from state and show it in the footer

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da5b5dd598832c8fc0fbf0e97ffac1