### PR TITLE
Simplify dashboard action queue card

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,13 +141,10 @@
             <article class="card dashboard-card" aria-labelledby="queue-heading">
               <header>
                 <h2 id="queue-heading">Action queue</h2>
-                <p>Today’s commitments; drag to set priority.</p>
+                <p>A snapshot of the work you’ve already teed up for today.</p>
               </header>
               <ol id="action-queue" class="queue" aria-live="polite"></ol>
-              <footer class="queue__toolbar">
-                <button class="ghost" id="queue-pause" type="button">Pause selected</button>
-                <button class="ghost" id="queue-cancel" type="button">Cancel selected</button>
-              </footer>
+              <p class="queue__note">We’ll keep this rolling automatically—manual scheduling unlocks in a future update.</p>
             </article>
 
             <article class="card dashboard-card" aria-labelledby="quick-actions-heading">

--- a/src/ui/dashboard.js
+++ b/src/ui/dashboard.js
@@ -252,20 +252,21 @@ function renderQueue(summary) {
   for (const item of items) {
     const li = document.createElement('li');
     li.dataset.state = item.state;
-    const checkbox = document.createElement('input');
-    checkbox.type = 'checkbox';
-    checkbox.className = 'queue__select';
-    checkbox.disabled = true;
     const label = document.createElement('div');
     label.className = 'queue__meta';
     const title = document.createElement('strong');
     title.textContent = item.label;
-    const detail = document.createElement('span');
-    detail.textContent = item.detail;
-    label.append(title, detail);
+    label.appendChild(title);
+    if (item.detail) {
+      const detail = document.createElement('span');
+      detail.className = 'queue__detail';
+      detail.textContent = item.detail;
+      label.appendChild(detail);
+    }
     const hours = document.createElement('span');
+    hours.className = 'queue__hours';
     hours.textContent = formatHours(item.hours);
-    li.append(checkbox, label, hours);
+    li.append(label, hours);
     container.appendChild(li);
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -295,7 +295,7 @@ body {
   border-radius: var(--radius-md);
   padding: 12px 14px;
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: 1fr auto;
   gap: 12px;
   align-items: center;
   border: 1px solid transparent;
@@ -306,14 +306,25 @@ body {
   gap: 4px;
 }
 
+.queue__detail {
+  color: var(--text-subtle);
+  font-size: 14px;
+}
+
+.queue__hours {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--text);
+}
+
 .queue li[data-state='paused'] {
   border-color: rgba(248, 113, 113, 0.4);
 }
 
-.queue__toolbar {
-  display: flex;
-  justify-content: flex-end;
-  gap: 12px;
+.queue__note {
+  margin: -4px 0 0;
+  color: var(--text-subtle);
+  font-size: 13px;
 }
 
 .quick-actions,


### PR DESCRIPTION
## Summary
- show the dashboard action queue as a read-only recap instead of a disabled control list
- refresh the card copy and layout to explain that manual queueing is coming later
- update queue styling to match the simplified markup

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da5b5f246c832c98778d8f474d4e05