### PR TITLE
Enhance asset upgrade dashboard guidance

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Extended the "Asset upgrade" dashboard card with a scrollable list, up to eight recommendations, and percent-to-go callouts for each quality milestone.
 - Added an "Asset upgrade" dashboard card that spotlights quality pushes for low-yield assets while trimming Daily Stats lists to the top three highlights for a tighter fit.
 - Streamlined the header pulse to spotlight daily flow and time stats in a single tidy row.
 - Centered the shell header around a "Daily pulse" band that highlights daily earnings and spend, lifetime cash flow, and the remaining versus committed hours for the current day.

--- a/docs/features/passive-asset-dashboard.md
+++ b/docs/features/passive-asset-dashboard.md
@@ -11,14 +11,14 @@ The passive asset workspace now presents each asset as a management card that hi
 
 ## Player Impact
 - Faster comparisons: stat tiles on each card summarize launches, payouts, and upkeep so players can pick the next investment without cross-referencing logs.
-- Smoother upgrades: inline "Support boosts" hints highlight pending equipment and study paths so players know which upgrades will unlock the next payout bump, and dedicated quick-buy buttons sit beside each instance to trigger the next one or two upgrades immediately.
+- Smoother upgrades: inline "Support boosts" hints highlight pending equipment and study paths so players know which upgrades will unlock the next payout bump, and dedicated quick-buy buttons sit beside each instance to trigger the next one or two upgrades immediately. The dashboard card now lists a scrollable queue of upgrade nudges and calls out the percentage still needed for each quality milestone so players can celebrate progress at a glance.
 - Clearer oversight: category rosters list upkeep obligations, yesterday's payout, net gain per upkeep hour, and one-click sell controls for every active instance in a familiar table format.
 - Sharper next steps: the instance modal highlights current quality level, progress toward the next milestone, and direct quality actions so players can immediately invest in the build they opened, with quality upgrades now pinned to the top of the scrollable modal.
 - Confident launches: the briefing modal reuses live detail renderers, ensuring setup costs, maintenance, and quality roadmaps stay accurate as modifiers shift.
 
 ## Implementation Notes
 - Asset cards keep the existing category structure but use a dedicated layout (`asset-card__*` classes) for stats, actions, and instance management.
-- The dashboard now includes an "Asset upgrade" card that calls out the next quality actions for struggling builds, prioritising low-yield instances that still owe progress toward their upcoming quality tier.
+- The dashboard now includes an "Asset upgrade" card that calls out the next quality actions for struggling builds, prioritising low-yield instances that still owe progress toward their upcoming quality tier. The list now scrolls to surface up to eight recommendations at once and each entry highlights the percentage remaining alongside the existing effort notes.
 - Instance rows now expose both the previous day's payout and inline sell buttons so liquidation is always one click away.
 - Each instance row can render up to two quick-purchase buttons for the next required equipment upgrades, deferring to existing upgrade action handlers for cost checks and logging. Quick actions now sit directly beside the sell button in the instance list so players can invest or liquidate without leaving the modal. Active builds in the slide-over now include a dedicated stat strip with payout, ROI, and upkeep details above the action row, plus inline shortcuts for pending equipment upgrades.
 - Category-level "View launched assets" toggles render aggregated tables populated by `assetCategoryView`, which now highlights the first couple of supporting upgrades directly under each instance's actions. Upgrade shortcut helpers live in `src/ui/assetUpgrades.js` so both the category roster and the slide-over reuse identical button logic.

--- a/src/ui/dashboard.js
+++ b/src/ui/dashboard.js
@@ -105,8 +105,6 @@ function buildQuickActions(state) {
   return items.slice(0, 4);
 }
 
-const MAX_UPGRADE_RECOMMENDATIONS = 3;
-
 function buildAssetUpgradeRecommendations(state) {
   if (!state) return [];
 
@@ -150,6 +148,8 @@ function buildAssetUpgradeRecommendations(state) {
         if (!canPerformQualityAction(asset, instance, action, state)) return;
 
         const completion = target > 0 ? Math.min(1, current / target) : 1;
+        const percentComplete = Math.max(0, Math.min(100, Math.round(completion * 100)));
+        const percentRemaining = Math.max(0, 100 - percentComplete);
         const track = tracks?.[key] || {};
         const requirementLabel = track.shortLabel || track.label || key;
         const timeCost = Math.max(0, Number(action.time) || 0);
@@ -161,7 +161,7 @@ function buildAssetUpgradeRecommendations(state) {
         if (moneyCost > 0) {
           effortParts.push(`$${formatMoney(moneyCost)}`);
         }
-        const progressNote = `${Math.min(current, target)}/${target} logged`;
+        const progressNote = `${Math.min(current, target)}/${target} logged (${percentComplete}% complete)`;
         const meta = effortParts.length ? `${progressNote} • ${effortParts.join(' • ')}` : progressNote;
         const actionLabel = typeof action.label === 'function'
           ? action.label({ definition: asset, instance, state })
@@ -171,7 +171,7 @@ function buildAssetUpgradeRecommendations(state) {
         suggestions.push({
           id: `asset-upgrade:${asset.id}:${instance.id}:${action.id}:${key}`,
           title: `${label} · ${buttonLabel}`,
-          subtitle: `${remaining} ${requirementLabel} to go for Quality ${nextLevel.level}.`,
+          subtitle: `${remaining} ${requirementLabel} to go for Quality ${nextLevel.level} (${percentRemaining}% to go).`,
           meta,
           buttonLabel,
           onClick: () => performQualityAction(asset.id, instance.id, action.id),
@@ -200,7 +200,7 @@ function buildAssetUpgradeRecommendations(state) {
     return a.title.localeCompare(b.title);
   });
 
-  return suggestions.slice(0, MAX_UPGRADE_RECOMMENDATIONS);
+  return suggestions;
 }
 
 function buildNotifications(state) {

--- a/styles.css
+++ b/styles.css
@@ -336,6 +336,13 @@ body {
   border: 1px solid transparent;
 }
 
+.upgrade-actions {
+  max-height: 320px;
+  overflow-y: auto;
+  padding-right: 4px;
+  scrollbar-gutter: stable both-edges;
+}
+
 .upgrade-actions li {
   border-color: rgba(129, 140, 248, 0.35);
 }


### PR DESCRIPTION
## Summary
- allow the Asset upgrade dashboard card to surface all quality suggestions and add percent-to-go messaging alongside progress notes
- give the widget a scrollable layout so more than three upgrades remain accessible without crowding the dashboard
- document the refreshed behavior in the passive asset dashboard feature note and changelog

## Testing
- npm test
- Manual: Served the build locally and confirmed the Asset upgrade card scrolls with more than three entries and shows percent-to-go messaging for each suggestion.

------
https://chatgpt.com/codex/tasks/task_e_68da5bd96560832cbc16fab11c016bb0