### PR TITLE
Reorder dashboard cards to prioritize quick actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,15 +138,6 @@
               </div>
             </article>
 
-            <article class="card dashboard-card" aria-labelledby="queue-heading">
-              <header>
-                <h2 id="queue-heading">Action queue</h2>
-                <p>A snapshot of the work you’ve already teed up for today.</p>
-              </header>
-              <ol id="action-queue" class="queue" aria-live="polite"></ol>
-              <p class="queue__note">We’ll keep this rolling automatically—manual scheduling unlocks in a future update.</p>
-            </article>
-
             <article class="card dashboard-card" aria-labelledby="quick-actions-heading">
               <header>
                 <h2 id="quick-actions-heading">Quick actions</h2>
@@ -178,6 +169,15 @@
               </header>
               <div id="event-log-preview" class="event-preview" aria-live="polite"></div>
               <button id="open-event-log" class="ghost" type="button" aria-haspopup="dialog" aria-controls="event-log-panel">Open full log</button>
+            </article>
+
+            <article class="card dashboard-card" aria-labelledby="queue-heading">
+              <header>
+                <h2 id="queue-heading">Action queue</h2>
+                <p>A snapshot of the work you’ve already teed up for today.</p>
+              </header>
+              <ol id="action-queue" class="queue" aria-live="polite"></ol>
+              <p class="queue__note">We’ll keep this rolling automatically—manual scheduling unlocks in a future update.</p>
             </article>
           </section>
         </div>

--- a/src/ui/dashboard.js
+++ b/src/ui/dashboard.js
@@ -309,17 +309,6 @@ function renderAssetUpgradeActions(state) {
   container.innerHTML = '';
 
   const suggestions = buildAssetUpgradeRecommendations(state);
-  const assetCard = container.closest('.dashboard-card');
-  const queueCard = elements.actionQueue?.closest('.dashboard-card');
-  const parent = assetCard?.parentElement;
-  if (parent && queueCard && assetCard && parent.isSameNode(queueCard.parentElement)) {
-    if (suggestions.length) {
-      parent.insertBefore(assetCard, queueCard);
-    } else {
-      parent.insertBefore(queueCard, assetCard);
-    }
-  }
-
   if (!suggestions.length) {
     const empty = document.createElement('li');
     empty.textContent = 'Every asset is humming along. Check back after today’s upkeep.';


### PR DESCRIPTION
## Summary
- move the quick actions and asset upgrade cards directly after daily stats so they remain on the same row
- keep the action queue anchored at the bottom by removing the automatic reordering logic in the dashboard renderer

## Testing
- npm test
- Loaded dashboard via local HTTP server and confirmed layout

------
https://chatgpt.com/codex/tasks/task_e_68da5fdd225c832caf7c14a74262bb24