### PR TITLE
Surface next recommended action in header button

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Replaced the static "End Day" button with a dynamic "Next" recommendation that fires the top asset upgrade or quick action, favouring longer time commitments before ending the day when no tasks remain.
 - Extended the "Asset upgrade" dashboard card with a scrollable list, up to eight recommendations, and percent-to-go callouts for each quality milestone.
 - Added an "Asset upgrade" dashboard card that spotlights quality pushes for low-yield assets while trimming Daily Stats lists to the top three highlights for a tighter fit.
 - Streamlined the header pulse to spotlight daily flow and time stats in a single tidy row.

--- a/docs/features/header-action-recommendations.md
+++ b/docs/features/header-action-recommendations.md
@@ -1,0 +1,15 @@
+# Header action recommendations
+
+## Goal
+Keep players focused on the most impactful next step without digging through cards or lists by turning the header's day control into a smart recommendation.
+
+## Player impact
+- Surfaces a single "do this next" suggestion drawn from the same logic that powers the Asset upgrade and Quick actions panels.
+- Prioritises longer time commitments so the button nudges players toward chunky investments before minor clean-up tasks.
+- Falls back to the traditional "End Day" control whenever no qualifying action is available, preserving a clear exit.
+
+## Mechanics
+- Pull the current recommendations from the Asset upgrade panel first; if none remain, evaluate the Quick actions pool.
+- Sort each candidate set by time cost (descending) to highlight the most time-intensive opportunity.
+- Update the header button copy with a "Next:" prefix plus the recommended action and its time commitment.
+- Clicking the button fires the recommended action immediately; only when no recommendation exists does it end the day.

--- a/src/main.js
+++ b/src/main.js
@@ -1,14 +1,13 @@
 import { addLog, renderLog } from './core/log.js';
 import { configureRegistry } from './core/state.js';
 import { loadState, saveState } from './core/storage.js';
-import elements from './ui/elements.js';
 import { renderCards, updateUI } from './ui/update.js';
 import { initLayoutControls } from './ui/layout.js';
 import { initActionCatalogDebug } from './ui/debugCatalog.js';
 import { registry } from './game/registry.js';
-import { endDay } from './game/lifecycle.js';
 import { resetTick, startGameLoop } from './game/loop.js';
 import { handleOfflineProgress } from './game/offline.js';
+import { initHeaderActionControls } from './ui/headerAction.js';
 
 configureRegistry(registry);
 const { returning, lastSaved } = loadState();
@@ -20,10 +19,9 @@ renderLog();
 renderCards();
 updateUI();
 initLayoutControls();
+initHeaderActionControls();
 initActionCatalogDebug();
 startGameLoop();
-
-elements.endDayButton.addEventListener('click', () => endDay(false));
 
 document.addEventListener('visibilitychange', () => {
   if (document.visibilityState === 'visible') {

--- a/src/ui/dashboard.js
+++ b/src/ui/dashboard.js
@@ -78,7 +78,7 @@ function describeQueue(summary) {
   }));
 }
 
-function buildQuickActions(state) {
+export function buildQuickActions(state) {
   const items = [];
   for (const hustle of registry.hustles) {
     if (!hustle?.action?.onClick) continue;
@@ -97,7 +97,8 @@ function buildQuickActions(state) {
         : hustle.action.label || 'Queue',
       description: `${formatMoney(payout)} payout • ${formatHours(time)}`,
       onClick: hustle.action.onClick,
-      roi
+      roi,
+      timeCost: time
     });
   }
 
@@ -105,7 +106,7 @@ function buildQuickActions(state) {
   return items.slice(0, 4);
 }
 
-function buildAssetUpgradeRecommendations(state) {
+export function buildAssetUpgradeRecommendations(state) {
   if (!state) return [];
 
   const suggestions = [];
@@ -178,7 +179,8 @@ function buildAssetUpgradeRecommendations(state) {
           performance,
           completion,
           remaining,
-          level
+          level,
+          timeCost
         });
       });
     });

--- a/src/ui/headerAction.js
+++ b/src/ui/headerAction.js
@@ -1,0 +1,104 @@
+import elements from './elements.js';
+import { endDay } from '../game/lifecycle.js';
+import { buildAssetUpgradeRecommendations, buildQuickActions } from './dashboard.js';
+import { formatHours } from '../core/helpers.js';
+
+let activeRecommendation = null;
+
+function formatActionLabel(base, timeCost) {
+  if (!base) return '';
+  const trimmed = base.trim();
+  if (!timeCost || timeCost <= 0) {
+    return `Next: ${trimmed}`;
+  }
+  return `Next: ${trimmed} • ${formatHours(timeCost)}`;
+}
+
+function normalizeAssetRecommendation(entry) {
+  if (!entry) return null;
+  const label = entry.buttonLabel || entry.title;
+  return {
+    id: entry.id,
+    mode: 'asset',
+    buttonText: formatActionLabel(label || entry.title, entry.timeCost),
+    description: entry.subtitle || entry.meta || entry.title,
+    onClick: entry.onClick,
+    timeCost: entry.timeCost || 0
+  };
+}
+
+function normalizeQuickAction(entry) {
+  if (!entry) return null;
+  const primary = entry.primaryLabel || 'Queue';
+  const fullLabel = `${primary} ${entry.label}`.trim();
+  return {
+    id: entry.id,
+    mode: 'hustle',
+    buttonText: formatActionLabel(fullLabel, entry.timeCost),
+    description: entry.description,
+    onClick: entry.onClick,
+    timeCost: entry.timeCost || 0
+  };
+}
+
+function selectRecommendation(state) {
+  const assetActions = buildAssetUpgradeRecommendations(state)
+    .map(normalizeAssetRecommendation)
+    .filter(Boolean)
+    .sort((a, b) => (b.timeCost || 0) - (a.timeCost || 0));
+  if (assetActions.length) {
+    return assetActions[0];
+  }
+
+  const quickActions = buildQuickActions(state)
+    .map(normalizeQuickAction)
+    .filter(Boolean)
+    .sort((a, b) => (b.timeCost || 0) - (a.timeCost || 0));
+  return quickActions[0] || null;
+}
+
+function applyButtonState(button, recommendation) {
+  if (!button) return;
+
+  if (!recommendation) {
+    activeRecommendation = null;
+    button.textContent = 'End Day';
+    button.dataset.actionMode = 'end';
+    delete button.dataset.actionId;
+    button.title = 'Wrap today when you are ready to reset the grind.';
+    button.classList.remove('is-recommendation');
+    return;
+  }
+
+  activeRecommendation = recommendation;
+  button.textContent = recommendation.buttonText || 'Next action';
+  button.dataset.actionMode = recommendation.mode;
+  button.dataset.actionId = recommendation.id || '';
+  if (recommendation.description) {
+    button.title = recommendation.description;
+  } else {
+    button.removeAttribute('title');
+  }
+  button.classList.add('is-recommendation');
+}
+
+export function initHeaderActionControls() {
+  const button = elements.endDayButton;
+  if (!button) return;
+
+  button.addEventListener('click', () => {
+    if (activeRecommendation?.onClick) {
+      activeRecommendation.onClick();
+      return;
+    }
+    endDay(false);
+  });
+}
+
+export function updateHeaderAction(state) {
+  const button = elements.endDayButton;
+  if (!button) return;
+
+  const recommendation = selectRecommendation(state);
+  applyButtonState(button, recommendation);
+}

--- a/src/ui/update.js
+++ b/src/ui/update.js
@@ -3,6 +3,7 @@ import { getState } from '../core/state.js';
 import { registry } from '../game/registry.js';
 import { computeDailySummary } from '../game/summary.js';
 import { renderDashboard } from './dashboard.js';
+import { updateHeaderAction } from './headerAction.js';
 import { applyCardFilters } from './layout.js';
 import { refreshActionCatalogDebug } from './debugCatalog.js';
 
@@ -29,6 +30,7 @@ export function updateUI() {
 
   const summary = computeDailySummary(state);
   renderDashboard(summary);
+  updateHeaderAction(state);
 
   const collections = buildCollections();
   updateAllCards(collections);


### PR DESCRIPTION
## Summary
- replace the static End Day control with a dynamic header recommendation that fires the top asset upgrade or quick action, prioritising longer commitments
- add a header action controller and reuse dashboard suggestion builders to keep the button in sync with dashboard panels
- document the feature in the design notes and changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da60aafa88832c9fee92196cdc0eeb