### PR TITLE
Revamp Education tab study track UI

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Revamped the Education tab with accurate countdowns, celebratory badges, and tuition/daily load summaries so enrolling in a course feels clear and motivating.
 - Extended the "Asset upgrade" dashboard card with a scrollable list, up to eight recommendations, and percent-to-go callouts for each quality milestone.
 - Added an "Asset upgrade" dashboard card that spotlights quality pushes for low-yield assets while trimming Daily Stats lists to the top three highlights for a tighter fit.
 - Streamlined the header pulse to spotlight daily flow and time stats in a single tidy row.

--- a/docs/features/education-auto-scheduler.md
+++ b/docs/features/education-auto-scheduler.md
@@ -13,6 +13,11 @@
 - When time is insufficient, the scheduler logs the affected course and tries again the next day without penalising progress.
 - Completion marks the course finished, clears the enrollment flag, and surfaces a celebratory log entry.
 
+## Interface Updates
+- The Education tab now pulls countdowns, tuition, and daily load straight from the canonical track definitions, so every card mirrors the in-game requirements exactly.
+- Each course card displays upbeat status badges (Ready to enroll, Enrolled, Logged today, Graduated) alongside a friendly reminder about today’s study momentum.
+- A refreshed progress strip pairs the percent bar with "days complete" and "days left" callouts, helping players see how close graduation is at a glance.
+
 ## Tuning Notes
 - Tuition prices align with mid-game savings (roughly 3–5 days of early hustles) so players plan purchases.
 - Automatic scheduling consumes hours before asset maintenance, ensuring study promises stay consistent.

--- a/src/ui/cards.js
+++ b/src/ui/cards.js
@@ -1,6 +1,6 @@
 import elements from './elements.js';
 import { getAssetState, getState, getUpgradeState } from '../core/state.js';
-import { formatHours, formatMoney } from '../core/helpers.js';
+import { formatDays, formatHours, formatMoney } from '../core/helpers.js';
 import { describeHustleRequirements } from '../game/hustles.js';
 import { KNOWLEDGE_TRACKS, getKnowledgeProgress } from '../game/requirements.js';
 import { getTimeCap } from '../game/time.js';
@@ -1165,18 +1165,135 @@ function renderUpgradeDock() {
 }
 
 function resolveTrack(definition) {
-  const info = KNOWLEDGE_TRACKS[definition.id];
-  if (info) {
-    return { ...info, action: definition.action };
+  if (!definition) {
+    return {
+      id: '',
+      name: '',
+      summary: '',
+      description: '',
+      days: 1,
+      hoursPerDay: 1,
+      tuition: 0,
+      action: null
+    };
   }
+
+  const canonicalId = definition.studyTrackId || definition.id;
+  const canonical = KNOWLEDGE_TRACKS[canonicalId];
+
+  const summary = definition.description || canonical?.description || '';
+  const description = canonical?.description || definition.description || '';
+  const days = Number(canonical?.days ?? definition.days ?? definition.action?.durationDays) || 1;
+  const hoursPerDay = Number(
+    canonical?.hoursPerDay ?? definition.hoursPerDay ?? definition.time ?? definition.action?.timeCost
+  ) || 1;
+  const tuition = Number(canonical?.tuition ?? definition.tuition ?? definition.action?.moneyCost) || 0;
+
   return {
-    id: definition.id,
-    name: definition.name,
-    summary: definition.description || '',
-    days: Number(definition.days) || 1,
-    hoursPerDay: Number(definition.time || definition.action?.timeCost) || 1,
+    id: canonical?.id || canonicalId,
+    name: canonical?.name || definition.name || canonicalId,
+    summary,
+    description,
+    days,
+    hoursPerDay,
+    tuition,
     action: definition.action
   };
+}
+
+function formatStudyCountdown(trackInfo, progress) {
+  if (progress.completed) {
+    return 'Diploma earned';
+  }
+
+  if (!progress.enrolled) {
+    return `${formatDays(trackInfo.days)}`;
+  }
+
+  const remainingDays = Math.max(0, trackInfo.days - progress.daysCompleted);
+  if (remainingDays === 0) {
+    return 'Graduation tomorrow';
+  }
+  if (remainingDays === 1) {
+    return '1 day remaining';
+  }
+  return `${remainingDays} days remaining`;
+}
+
+function describeStudyMomentum(trackInfo, progress) {
+  if (progress.completed) {
+    return 'Knowledge unlocked for every requirement. Toast your success!';
+  }
+  if (!progress.enrolled) {
+    const tuitionNote = trackInfo.tuition > 0 ? `Pay $${formatMoney(trackInfo.tuition)} upfront and` : 'Just';
+    return `${tuitionNote} we’ll reserve ${formatHours(trackInfo.hoursPerDay)} each day once you enroll.`;
+  }
+  if (progress.studiedToday) {
+    return '✅ Today’s session is logged. Keep the streak cozy until sundown.';
+  }
+  return `Reserve ${formatHours(trackInfo.hoursPerDay)} today to keep momentum humming.`;
+}
+
+function buildStudyBadges(progress) {
+  const badges = [];
+  if (progress.completed) {
+    badges.push(createBadge('Graduated'));
+  } else if (progress.enrolled) {
+    badges.push(createBadge('Enrolled'));
+    badges.push(createBadge(progress.studiedToday ? 'Logged today' : 'Study pending'));
+  } else {
+    badges.push(createBadge('Ready to enroll'));
+  }
+  return badges;
+}
+
+function applyStudyTrackState(track, trackInfo, progress) {
+  track.dataset.active = progress.enrolled ? 'true' : 'false';
+  track.dataset.complete = progress.completed ? 'true' : 'false';
+
+  const countdown = track.querySelector('.study-track__countdown');
+  if (countdown) {
+    countdown.textContent = formatStudyCountdown(trackInfo, progress);
+  }
+
+  const status = track.querySelector('.study-track__status');
+  if (status) {
+    status.innerHTML = '';
+    buildStudyBadges(progress).forEach(badge => status.appendChild(badge));
+  }
+
+  const note = track.querySelector('.study-track__note');
+  if (note) {
+    note.textContent = describeStudyMomentum(trackInfo, progress);
+  }
+
+  const remainingDays = Math.max(0, trackInfo.days - progress.daysCompleted);
+  const percent = Math.min(100, Math.round((progress.daysCompleted / Math.max(1, trackInfo.days)) * 100));
+  const fill = track.querySelector('.study-track__progress span');
+  if (fill) {
+    fill.style.width = `${percent}%`;
+    fill.setAttribute('aria-valuenow', String(percent));
+  }
+
+  const progressLabel = track.querySelector('.study-track__progress');
+  if (progressLabel) {
+    progressLabel.setAttribute('aria-label', `${trackInfo.name} progress: ${percent}%`);
+  }
+
+  const remaining = track.querySelector('.study-track__remaining');
+  if (remaining) {
+    const daysComplete = progress.completed ? trackInfo.days : progress.daysCompleted;
+    remaining.textContent = `${daysComplete}/${trackInfo.days} days complete`;
+  }
+
+  const countdownValue = track.querySelector('.study-track__remaining-days');
+  if (countdownValue) {
+    countdownValue.textContent = progress.completed
+      ? 'Course complete'
+      : remainingDays === 1
+        ? '1 day left'
+        : `${remainingDays} days left`;
+  }
 }
 
 function renderStudyTrack(definition) {
@@ -1186,31 +1303,75 @@ function renderStudyTrack(definition) {
   const track = document.createElement('article');
   track.className = 'study-track';
   track.dataset.track = trackInfo.id;
-  track.dataset.active = progress.enrolled ? 'true' : 'false';
-  track.dataset.complete = progress.completed ? 'true' : 'false';
+  track.setAttribute('aria-label', `${trackInfo.name} study track`);
 
-  const header = document.createElement('div');
+  const header = document.createElement('header');
   header.className = 'study-track__header';
+
+  const titleGroup = document.createElement('div');
+  titleGroup.className = 'study-track__title-group';
+
   const title = document.createElement('h3');
   title.textContent = trackInfo.name;
-  header.appendChild(title);
-  const eta = document.createElement('span');
-  const remainingDays = Math.max(0, trackInfo.days - progress.daysCompleted);
-  eta.textContent = `${remainingDays} day${remainingDays === 1 ? '' : 's'} remaining`;
-  header.appendChild(eta);
+  titleGroup.appendChild(title);
+
+  const status = document.createElement('div');
+  status.className = 'study-track__status badges';
+  titleGroup.appendChild(status);
+
+  header.appendChild(titleGroup);
+
+  const countdown = document.createElement('span');
+  countdown.className = 'study-track__countdown';
+  header.appendChild(countdown);
   track.appendChild(header);
 
   const summary = document.createElement('p');
+  summary.className = 'study-track__summary';
   summary.textContent = trackInfo.summary || '';
   track.appendChild(summary);
 
+  const meta = document.createElement('dl');
+  meta.className = 'study-track__meta';
+  const metaItems = [
+    { label: 'Daily load', value: `${formatHours(trackInfo.hoursPerDay)} / day` },
+    { label: 'Course length', value: formatDays(trackInfo.days) },
+    { label: 'Tuition', value: trackInfo.tuition > 0 ? `$${formatMoney(trackInfo.tuition)}` : 'Free' }
+  ];
+  metaItems.forEach(item => {
+    const dt = document.createElement('dt');
+    dt.textContent = item.label;
+    meta.appendChild(dt);
+    const dd = document.createElement('dd');
+    dd.textContent = item.value;
+    meta.appendChild(dd);
+  });
+  track.appendChild(meta);
+
+  const progressWrap = document.createElement('div');
+  progressWrap.className = 'study-track__progress-wrap';
+
+  const remaining = document.createElement('span');
+  remaining.className = 'study-track__remaining';
+  progressWrap.appendChild(remaining);
+
   const bar = document.createElement('div');
   bar.className = 'study-track__progress';
+  bar.setAttribute('role', 'progressbar');
+  bar.setAttribute('aria-valuemin', '0');
+  bar.setAttribute('aria-valuemax', '100');
   const fill = document.createElement('span');
-  const percent = Math.min(100, Math.round((progress.daysCompleted / Math.max(1, trackInfo.days)) * 100));
-  fill.style.width = `${percent}%`;
   bar.appendChild(fill);
-  track.appendChild(bar);
+  progressWrap.appendChild(bar);
+
+  const remainingDays = document.createElement('span');
+  remainingDays.className = 'study-track__remaining-days';
+  progressWrap.appendChild(remainingDays);
+  track.appendChild(progressWrap);
+
+  const note = document.createElement('p');
+  note.className = 'study-track__note';
+  track.appendChild(note);
 
   const actions = document.createElement('div');
   actions.className = 'hustle-card__actions';
@@ -1232,7 +1393,9 @@ function renderStudyTrack(definition) {
   actions.appendChild(details);
   track.appendChild(actions);
 
-  return { track, percent };
+  applyStudyTrackState(track, trackInfo, progress);
+
+  return { track };
 }
 
 function openStudyDetails(definition) {
@@ -1258,9 +1421,9 @@ function renderEducation(definitions) {
   list.innerHTML = '';
   studyUi.clear();
   definitions.forEach(def => {
-    const { track, percent } = renderStudyTrack(def);
+    const { track } = renderStudyTrack(def);
     list.appendChild(track);
-    studyUi.set(resolveTrack(def).id, { track, percent });
+    studyUi.set(resolveTrack(def).id, { track });
   });
   renderStudyQueue(definitions);
 }
@@ -1338,8 +1501,5 @@ function updateStudyTrack(definition) {
   if (!ui) return;
   const state = getState();
   const progress = getKnowledgeProgress(info.id, state);
-  ui.track.dataset.active = progress.enrolled ? 'true' : 'false';
-  ui.track.dataset.complete = progress.completed ? 'true' : 'false';
-  const percent = Math.min(100, Math.round((progress.daysCompleted / Math.max(1, info.days)) * 100));
-  ui.track.querySelector('.study-track__progress span').style.width = `${percent}%`;
+  applyStudyTrackState(ui.track, info, progress);
 }

--- a/styles.css
+++ b/styles.css
@@ -898,16 +898,66 @@ body {
   background: var(--surface);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border);
-  padding: 18px;
+  padding: 20px;
   display: grid;
-  gap: 12px;
+  gap: 14px;
 }
 
 .study-track__header {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 12px;
+  gap: 16px;
+}
+
+.study-track__title-group {
+  display: grid;
+  gap: 6px;
+}
+
+.study-track__title-group h3 {
+  margin: 0;
+}
+
+.study-track__countdown {
+  font-size: 14px;
+  color: var(--text-subtle);
+  font-weight: 600;
+}
+
+.study-track__summary {
+  margin: 0;
+  color: var(--text-subtle);
+}
+
+.study-track__meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 8px 16px;
+  margin: 0;
+}
+
+.study-track__meta dt {
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-subtle);
+}
+
+.study-track__meta dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.study-track__progress-wrap {
+  display: grid;
+  gap: 8px;
+  align-items: center;
+}
+
+.study-track__progress-wrap > span {
+  font-size: 14px;
+  color: var(--text-subtle);
 }
 
 .study-track__progress {
@@ -922,6 +972,12 @@ body {
   inset: 0;
   border-radius: inherit;
   background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+}
+
+.study-track__note {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-subtle);
 }
 
 .slide-over,

--- a/tests/education.test.js
+++ b/tests/education.test.js
@@ -1,0 +1,62 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM(`<!DOCTYPE html><body>
+  <div id="study-track-list"></div>
+  <ol id="study-queue-list"></ol>
+  <span id="study-queue-eta"></span>
+  <span id="study-queue-cap"></span>
+</body>`);
+
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+globalThis.Node = dom.window.Node;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.navigator = dom.window.navigator;
+globalThis.crypto ??= dom.window.crypto;
+
+test('education tracks reflect canonical study data', async () => {
+  const stateModule = await import('../src/core/state.js');
+  const { configureRegistry, initializeState, getState } = stateModule;
+
+  const { registry } = await import('../src/game/registry.js');
+  configureRegistry(registry);
+  initializeState();
+
+  const requirements = await import('../src/game/requirements.js');
+  const progress = requirements.getKnowledgeProgress('outlineMastery', getState());
+  progress.enrolled = true;
+  progress.daysCompleted = 2;
+  progress.studiedToday = false;
+
+  const { renderCardCollections } = await import('../src/ui/cards.js');
+  renderCardCollections({
+    hustles: [],
+    education: registry.hustles.filter(hustle => hustle.tag?.type === 'study'),
+    assets: [],
+    upgrades: []
+  });
+
+  const track = document.querySelector('.study-track');
+  assert.ok(track, 'study track should render');
+
+  const countdown = track.querySelector('.study-track__countdown');
+  assert.ok(countdown, 'countdown element should exist');
+  assert.equal(countdown.textContent, '3 days remaining');
+
+  const metaValues = Array.from(track.querySelectorAll('.study-track__meta dd')).map(node => node.textContent);
+  assert.deepEqual(metaValues, ['2h / day', '5 days', '$140']);
+
+  const badges = Array.from(track.querySelectorAll('.study-track__status .badge')).map(node => node.textContent);
+  assert.deepEqual(badges, ['Enrolled', 'Study pending']);
+
+  const remaining = track.querySelector('.study-track__remaining');
+  assert.equal(remaining?.textContent, '2/5 days complete');
+
+  const remainingDays = track.querySelector('.study-track__remaining-days');
+  assert.equal(remainingDays?.textContent, '3 days left');
+
+  const note = track.querySelector('.study-track__note');
+  assert.equal(note?.textContent, 'Reserve 2h today to keep momentum humming.');
+});


### PR DESCRIPTION
## Summary
- align Education study tracks with the canonical knowledge data so countdowns, tuition, and progress bars stay accurate
- restyle the Education panel with a meta grid, status badges, and upbeat copy that highlights daily load and remaining days
- add coverage for the Education cards and document the refreshed interface in the auto-scheduler design notes and changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da62c2eb4c832c84c6ddcce24510ae