### PR TITLE
Adjust header action button sizing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -50,7 +50,7 @@ body {
 
 .shell__header {
   display: grid;
-  grid-template-columns: minmax(0, 260px) minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 260px) minmax(0, 1fr) clamp(220px, 28%, 340px);
   align-items: stretch;
   gap: 24px;
 }
@@ -150,7 +150,8 @@ body {
   grid-template-columns: auto 1fr;
   align-items: stretch;
   gap: 12px;
-  width: clamp(220px, 28%, 340px);
+  justify-self: stretch;
+  width: 100%;
 }
 
 .shell__controls #command-palette-trigger {

--- a/styles.css
+++ b/styles.css
@@ -136,14 +136,39 @@ body {
   }
 
   .shell__controls {
-    justify-self: end;
+    justify-self: stretch;
+    width: 100%;
+  }
+
+  .shell__controls #end-day {
+    min-height: 54px;
   }
 }
 
 .shell__controls {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: stretch;
   gap: 12px;
-  align-items: center;
+  width: clamp(220px, 28%, 340px);
+}
+
+.shell__controls #command-palette-trigger {
+  align-self: center;
+}
+
+.shell__controls #end-day {
+  display: grid;
+  place-items: center;
+  padding: 16px 20px;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1.3;
+  min-height: 100%;
+  flex: 0 0 auto;
+  width: 100%;
+  white-space: normal;
+  text-align: center;
 }
 
 .shell__tabs {


### PR DESCRIPTION
## Summary
- lay out the header controls with a grid so the "Next day" action keeps a consistent footprint
- enlarge the end-day button styling and allow its caption to wrap instead of resizing the control

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da648fce00832cac68e88a984d11e8