### PR TITLE
Retune advanced asset payouts and upgrade boosts

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Retuned Stock Photo Galleries, Dropshipping Labs, and Micro SaaS payouts with lighter upkeep and lower quality hurdles, and wired the Cinema Camera, Studio Expansion, and Edge Delivery upgrades into tangible income and progress boosts.
 - Revamped the Education tab with accurate countdowns, celebratory badges, and tuition/daily load summaries so enrolling in a course feels clear and motivating.
 - Replaced the static "End Day" button with a dynamic "Next" recommendation that fires the top asset upgrade or quick action, favouring longer time commitments before ending the day when no tasks remain.
 - Extended the "Asset upgrade" dashboard card with a scrollable list, up to eight recommendations, and percent-to-go callouts for each quality milestone.

--- a/docs/features/equipment-tiers.md
+++ b/docs/features/equipment-tiers.md
@@ -14,7 +14,10 @@
 - Cinema Camera Upgrade costs $480 and requires the base camera before purchase. Studio Expansion costs $540 and requires the Lighting Kit.
 - Server Rack - Starter costs $650 and unlocks foundational infrastructure. Cloud Cluster costs $1,150, requires the rack, and is the new SaaS prerequisite. Edge Delivery Network costs $1,450 and requires the cluster.
 - All upgrades log celebratory flavour text and contribute spending data to the daily metrics ledger.
+- Cinema Camera now doubles vlog quality progress, bumps daily payouts by roughly 25%, and adds a juicier viral spike chance at Quality 3.
+- Studio Expansion doubles stock photo quality action progress and lifts gallery payouts by about 20% to offset the larger marketing pushes.
+- Edge Delivery Network doubles SaaS quality action progress across all tracks and increases subscription payouts by roughly 35%.
 
 ## Follow-Up Ideas
-- Wire the new boosts into asset payout calculations so higher-tier equipment improves actual revenue rather than flavour only.
+- Explore prestige-tier upgrades that convert the doubled progress into passive automation for late-game scaling.
 - Introduce maintenance costs or downtime events that encourage balancing infrastructure investments against daily upkeep budgets.

--- a/src/game/assets/definitions/dropshipping.js
+++ b/src/game/assets/definitions/dropshipping.js
@@ -8,10 +8,10 @@ const dropshippingDefinition = createAssetDefinition({
   tag: { label: 'Commerce', type: 'passive' },
   description: 'Prototype products, source suppliers, and automate fulfillment funnels.',
   setup: { days: 6, hoursPerDay: 4, cost: 720 },
-  maintenance: { hours: 2, cost: 14 },
+  maintenance: { hours: 1.5, cost: 12 },
   income: {
-    base: 52,
-    variance: 0.3,
+    base: 84,
+    variance: 0.35,
     logType: 'passive'
   },
   requirements: {
@@ -30,52 +30,52 @@ const dropshippingDefinition = createAssetDefinition({
         level: 0,
         name: 'Prototype Pile',
         description: 'Inconsistent suppliers mean sporadic payouts.',
-        income: { min: 3, max: 6 },
+        income: { min: 5, max: 9 },
         requirements: {}
       },
       {
         level: 1,
         name: 'Optimized Listings',
         description: 'Top products have polished listings and reviews.',
-        income: { min: 16, max: 26 },
-        requirements: { research: 5 }
+        income: { min: 24, max: 38 },
+        requirements: { research: 4 }
       },
       {
         level: 2,
         name: 'Automation Groove',
         description: 'Fulfillment and ad funnels make sales steady.',
-        income: { min: 28, max: 40 },
-        requirements: { research: 12, listing: 4 }
+        income: { min: 44, max: 62 },
+        requirements: { research: 11, listing: 5 }
       },
       {
         level: 3,
         name: 'Scaled Flywheel',
         description: 'Paid campaigns bring consistent high-ticket orders.',
-        income: { min: 42, max: 58 },
-        requirements: { research: 18, listing: 7, ads: 6 }
+        income: { min: 68, max: 92 },
+        requirements: { research: 18, listing: 8, ads: 7 }
       }
     ],
     actions: [
       {
         id: 'researchProduct',
         label: 'Research Product',
-        time: 3.5,
+        time: 3,
         progressKey: 'research',
         log: ({ label }) => `${label} spotted a trending micro-niche. Suppliers start calling back!`
       },
       {
         id: 'optimizeListing',
         label: 'Optimize Listing',
-        time: 2,
-        cost: 32,
+        time: 1.8,
+        cost: 28,
         progressKey: 'listing',
         log: ({ label }) => `${label} revamped copy and photos. Conversion rates begin to pop.`
       },
       {
         id: 'experimentAds',
         label: 'Experiment With Ads',
-        time: 2.5,
-        cost: 38,
+        time: 2.2,
+        cost: 34,
         progressKey: 'ads',
         log: ({ label }) => `${label} tested lookalike audiences. Click-through rates jump!`
       }

--- a/src/game/assets/definitions/saas.js
+++ b/src/game/assets/definitions/saas.js
@@ -1,4 +1,5 @@
 import { formatMoney } from '../../../core/helpers.js';
+import { getUpgradeState } from '../../../core/state.js';
 import { createAssetDefinition } from '../../content/schema.js';
 
 const saasDefinition = createAssetDefinition({
@@ -8,11 +9,15 @@ const saasDefinition = createAssetDefinition({
   tag: { label: 'Tech', type: 'passive' },
   description: 'Design lean software services, onboard early users, and ship updates that keep churn low.',
   setup: { days: 8, hoursPerDay: 4, cost: 960 },
-  maintenance: { hours: 2.5, cost: 28 },
+  maintenance: { hours: 2.2, cost: 24 },
   income: {
-    base: 68,
-    variance: 0.35,
-    logType: 'passive'
+    base: 108,
+    variance: 0.4,
+    logType: 'passive',
+    modifier: amount => {
+      const edge = getUpgradeState('serverEdge').purchased ? 1.35 : 1;
+      return Math.round(amount * edge);
+    }
   },
   requirements: {
     knowledge: ['automationCourse'],
@@ -34,54 +39,57 @@ const saasDefinition = createAssetDefinition({
         level: 0,
         name: 'Beta Sandbox',
         description: 'Tiny user base and messy bugs limit revenue.',
-        income: { min: 4, max: 8 },
+        income: { min: 6, max: 12 },
         requirements: {}
       },
       {
         level: 1,
         name: 'Early Traction',
         description: 'Feature roadmap clicks with early adopters.',
-        income: { min: 22, max: 34 },
-        requirements: { features: 6 }
+        income: { min: 32, max: 48 },
+        requirements: { features: 5 }
       },
       {
         level: 2,
         name: 'Reliable Service',
         description: 'Reliability boosts and updates reduce churn.',
-        income: { min: 36, max: 50 },
-        requirements: { features: 14, stability: 4 }
+        income: { min: 54, max: 74 },
+        requirements: { features: 12, stability: 5 }
       },
       {
         level: 3,
         name: 'Scaling Flywheel',
         description: 'Marketing pushes and infrastructure unlock bigger accounts.',
-        income: { min: 54, max: 74 },
-        requirements: { features: 24, stability: 8, marketing: 6 }
+        income: { min: 82, max: 110 },
+        requirements: { features: 20, stability: 9, marketing: 7 }
       }
     ],
     actions: [
       {
         id: 'shipFeature',
         label: 'Ship Feature',
-        time: 4,
-        cost: 34,
+        time: 3.5,
+        cost: 32,
         progressKey: 'features',
+        progressAmount: context => (context.upgrade('serverEdge')?.purchased ? 2 : 1),
         log: ({ label }) => `${label} shipped a delightful feature. Beta users erupt in emoji reactions!`
       },
       {
         id: 'improveStability',
         label: 'Improve Stability',
-        time: 3,
-        cost: 40,
+        time: 2.5,
+        cost: 36,
         progressKey: 'stability',
+        progressAmount: context => (context.upgrade('serverEdge')?.purchased ? 2 : 1),
         log: ({ label }) => `${label} patched outages and bolstered uptime. Pager alerts stay quiet.`
       },
       {
         id: 'launchCampaign',
         label: 'Launch Campaign',
         time: 2.5,
-        cost: 48,
+        cost: 44,
         progressKey: 'marketing',
+        progressAmount: context => (context.upgrade('serverEdge')?.purchased ? 2 : 1),
         log: ({ label }) => `${label} launched a marketing sprint. Sign-ups trickle in all night.`
       }
     ],

--- a/src/game/assets/definitions/stockPhotos.js
+++ b/src/game/assets/definitions/stockPhotos.js
@@ -1,4 +1,5 @@
 import { formatMoney } from '../../../core/helpers.js';
+import { getUpgradeState } from '../../../core/state.js';
 import { createAssetDefinition } from '../../content/schema.js';
 
 const stockPhotosDefinition = createAssetDefinition({
@@ -8,11 +9,15 @@ const stockPhotosDefinition = createAssetDefinition({
   tag: { label: 'Creative', type: 'passive' },
   description: 'Stage props, shoot themed collections, and list them across marketplaces.',
   setup: { days: 5, hoursPerDay: 4, cost: 560 },
-  maintenance: { hours: 1.5, cost: 12 },
+  maintenance: { hours: 1.2, cost: 10 },
   income: {
-    base: 42,
-    variance: 0.25,
-    logType: 'passive'
+    base: 58,
+    variance: 0.35,
+    logType: 'passive',
+    modifier: amount => {
+      const expansion = getUpgradeState('studioExpansion').purchased ? 1.2 : 1;
+      return Math.round(amount * expansion);
+    }
   },
   requirements: {
     equipment: ['camera', 'studio'],
@@ -30,54 +35,57 @@ const stockPhotosDefinition = createAssetDefinition({
         level: 0,
         name: 'Camera Roll Chaos',
         description: 'Unsorted shoots drip pennies.',
-        income: { min: 2, max: 5 },
+        income: { min: 4, max: 9 },
         requirements: {}
       },
       {
         level: 1,
         name: 'Curated Collections',
-        description: 'Five themed shoots win daily sales.',
-        income: { min: 12, max: 20 },
-        requirements: { shoots: 5 }
+        description: 'Four themed shoots unlock daily bundles.',
+        income: { min: 18, max: 30 },
+        requirements: { shoots: 4 }
       },
       {
         level: 2,
         name: 'Marketplace Darling',
         description: 'Batch edits make downloads soar.',
-        income: { min: 22, max: 32 },
-        requirements: { shoots: 12, editing: 4 }
+        income: { min: 34, max: 52 },
+        requirements: { shoots: 10, editing: 4 }
       },
       {
         level: 3,
         name: 'Brand Staple',
         description: 'Marketing funnels keep cash flowing.',
-        income: { min: 30, max: 44 },
-        requirements: { shoots: 18, editing: 7, marketing: 5 }
+        income: { min: 54, max: 78 },
+        requirements: { shoots: 16, editing: 7, marketing: 5 }
       }
     ],
     actions: [
       {
         id: 'planShoot',
         label: 'Plan Shoot',
-        time: 4,
-        cost: 24,
+        time: 3.5,
+        cost: 22,
         progressKey: 'shoots',
+        progressAmount: context => (context.upgrade('studioExpansion')?.purchased ? 2 : 1),
         log: ({ label }) => `${label} staged a dazzling shoot. Props now live rent-free in your studio.`
       },
       {
         id: 'batchEdit',
         label: 'Batch Edit',
-        time: 2.5,
-        cost: 16,
+        time: 2,
+        cost: 14,
         progressKey: 'editing',
+        progressAmount: context => (context.upgrade('studioExpansion')?.purchased ? 2 : 1),
         log: ({ label }) => `${label} batch-edited a gallery. Clients cheer at the crisp exports!`
       },
       {
         id: 'runPromo',
         label: 'Run Promo',
         time: 2,
-        cost: 18,
+        cost: 16,
         progressKey: 'marketing',
+        progressAmount: context => (context.upgrade('studioExpansion')?.purchased ? 2 : 1),
         log: ({ label }) => `${label} ran a marketplace feature promo. Download counters spin faster!`
       }
     ],

--- a/src/game/assets/definitions/vlog.js
+++ b/src/game/assets/definitions/vlog.js
@@ -1,4 +1,5 @@
 import { formatMoney } from '../../../core/helpers.js';
+import { getUpgradeState } from '../../../core/state.js';
 import { createAssetDefinition } from '../../content/schema.js';
 
 const vlogDefinition = createAssetDefinition({
@@ -14,11 +15,16 @@ const vlogDefinition = createAssetDefinition({
     variance: 0.2,
     logType: 'passive',
     modifier: (amount, { instance }) => {
+      const hasCinemaGear = getUpgradeState('cameraPro').purchased;
       const qualityLevel = instance?.quality?.level || 0;
-      if (qualityLevel >= 3 && Math.random() < 0.18) {
-        return Math.round(amount * 3);
+      const viralChance = hasCinemaGear ? 0.24 : 0.18;
+      const viralMultiplier = hasCinemaGear ? 3.5 : 3;
+      let payout = amount;
+      if (qualityLevel >= 3 && Math.random() < viralChance) {
+        payout = Math.round(payout * viralMultiplier);
       }
-      return amount;
+      const baseMultiplier = hasCinemaGear ? 1.25 : 1;
+      return Math.round(payout * baseMultiplier);
     }
   },
   requirements: {
@@ -67,6 +73,7 @@ const vlogDefinition = createAssetDefinition({
         label: 'Film Episode',
         time: 5,
         progressKey: 'videos',
+        progressAmount: context => (context.upgrade('cameraPro')?.purchased ? 2 : 1),
         log: ({ label }) => `${label} filmed an energetic episode. B-roll glitter everywhere!`
       },
       {
@@ -75,6 +82,7 @@ const vlogDefinition = createAssetDefinition({
         time: 2.5,
         cost: 16,
         progressKey: 'edits',
+        progressAmount: context => (context.upgrade('cameraPro')?.purchased ? 2 : 1),
         log: ({ label }) => `${label} tightened jump cuts and color graded every frame.`
       },
       {
@@ -83,6 +91,7 @@ const vlogDefinition = createAssetDefinition({
         time: 2,
         cost: 24,
         progressKey: 'promotion',
+        progressAmount: context => (context.upgrade('cameraPro')?.purchased ? 2 : 1),
         log: ({ label }) => `${label} teased the drop on socials. Chat bubbles explode with hype!`
       }
     ],

--- a/src/game/upgrades.js
+++ b/src/game/upgrades.js
@@ -115,7 +115,11 @@ const cameraPro = createUpgrade({
   description: 'Upgrade your rig with cinema glass and stabilized mounts for prestige productions.',
   cost: 480,
   requires: ['camera'],
-  boosts: 'Higher vlog quality payouts',
+  boosts: 'Boosts vlog payouts and doubles quality progress',
+  details: [
+    () => '🎞️ Vlog quality actions count double progress once the cinema rig is live.',
+    () => '💰 Daily vlog income jumps by roughly +25% and viral bursts spike harder.'
+  ],
   actionClassName: 'secondary',
   actionLabel: 'Install Cinema Gear',
   labels: {
@@ -136,7 +140,11 @@ const studioExpansion = createUpgrade({
   description: 'Add modular sets, color-controlled lighting, and prop storage for faster shoots.',
   cost: 540,
   requires: ['studio'],
-  boosts: 'Stock photo session efficiency',
+  boosts: 'Stock photo payouts + faster shoot progress',
+  details: [
+    () => '📸 Stock photo quality actions earn double progress with the expanded studio.',
+    () => '💵 Galleries pick up roughly +20% daily income thanks to premium staging.'
+  ],
   actionClassName: 'secondary',
   actionLabel: 'Expand Studio',
   labels: {
@@ -197,7 +205,11 @@ const serverEdge = createUpgrade({
   description: 'Distribute workloads across edge nodes for instant response times and uptime bragging rights.',
   cost: 1450,
   requires: ['serverCluster'],
-  boosts: 'SaaS subscriber trust',
+  boosts: 'SaaS payouts + stability progress surges',
+  details: [
+    () => '⚙️ SaaS feature, stability, and marketing pushes count double progress once edge nodes hum.',
+    () => '📈 Subscriptions pay roughly +35% more each day with the global edge footprint.'
+  ],
   actionClassName: 'secondary',
   actionLabel: 'Activate Edge Network',
   labels: {


### PR DESCRIPTION
## Summary
- rebalance Stock Photo Galleries, Dropshipping Labs, and Micro SaaS earnings, maintenance, and quality hurdles to reward late tiers with higher net income
- wire Cinema Camera, Studio Expansion, and Edge Delivery upgrades into asset income multipliers and double-progress quality actions, and surface the boost details in upgrade cards
- document the tuning in the equipment feature notes and changelog for future balancing passes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da6b373664832c8afd67686d4785ed