### PR TITLE
Handle queued income when asset upkeep can't run

### DIFF
--- a/tests/education.test.js
+++ b/tests/education.test.js
@@ -1,22 +1,24 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { JSDOM } from 'jsdom';
+import { ensureTestDom } from './helpers/setupDom.js';
 
-const dom = new JSDOM(`<!DOCTYPE html><body>
-  <div id="study-track-list"></div>
-  <ol id="study-queue-list"></ol>
-  <span id="study-queue-eta"></span>
-  <span id="study-queue-cap"></span>
-</body>`);
-
-globalThis.window = dom.window;
-globalThis.document = dom.window.document;
-globalThis.Node = dom.window.Node;
-globalThis.HTMLElement = dom.window.HTMLElement;
-globalThis.navigator = dom.window.navigator;
-globalThis.crypto ??= dom.window.crypto;
+const dom = ensureTestDom();
+const { document } = dom.window;
 
 test('education tracks reflect canonical study data', async () => {
+  const trackList = document.getElementById('study-track-list');
+  const queueList = document.getElementById('study-queue-list');
+  const queueEta = document.getElementById('study-queue-eta');
+  const queueCap = document.getElementById('study-queue-cap');
+  assert.ok(trackList, 'study track list should exist in test DOM');
+  assert.ok(queueList, 'study queue list should exist in test DOM');
+  assert.ok(queueEta, 'study queue ETA should exist in test DOM');
+  assert.ok(queueCap, 'study queue cap should exist in test DOM');
+  trackList.innerHTML = '';
+  queueList.innerHTML = '';
+  queueEta.textContent = '';
+  queueCap.textContent = '';
+
   const stateModule = await import('../src/core/state.js');
   const { configureRegistry, initializeState, getState } = stateModule;
 

--- a/tests/gameLifecycle.test.js
+++ b/tests/gameLifecycle.test.js
@@ -127,6 +127,29 @@ test('maintenance stalls when upkeep cash is unavailable', () => {
   assert.equal(state.money, 4, 'money should not be deducted when upkeep fails');
 });
 
+test('pending income stays queued when upkeep resources fall short', () => {
+  const blogDefinition = getAssetDefinition('blog');
+  const blogState = getAssetState('blog');
+  blogState.instances = [createAssetInstance(blogDefinition, {
+    status: 'active',
+    daysRemaining: 0,
+    daysCompleted: blogDefinition.setup.days,
+    maintenanceFundedToday: false,
+    pendingIncome: 3
+  })];
+
+  const state = getState();
+  state.timeLeft = 10;
+  state.money = 1;
+
+  allocateAssetMaintenance();
+
+  const updatedInstance = getAssetState('blog').instances[0];
+  assert.equal(state.money, 1, 'money should not change when upkeep fails');
+  assert.equal(updatedInstance.pendingIncome, 3, 'queued income should remain for future days');
+  assert.equal(updatedInstance.maintenanceFundedToday, false, 'maintenance should remain unfunded');
+});
+
 test('knowledge tracks auto-advance after enrollment when time is available', () => {
   const trackDef = KNOWLEDGE_TRACKS.outlineMastery;
   const progress = getKnowledgeProgress('outlineMastery');


### PR DESCRIPTION
## Summary
- prevent allocateAssetMaintenance from cashing out queued income when upkeep lacks time or funds
- adjust asset lifecycle tests and add coverage to ensure pending income persists until maintenance succeeds

## Testing
- npm test
- Manual testing: not run (logic-only change; headless CI environment)


------
https://chatgpt.com/codex/tasks/task_e_68da6e114138832c99a8b3c4c8971a48