### PR TITLE
Align blog upkeep tuning with design spec

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Corrected the Personal Blog Network upkeep to its 0.75h/$3 tuning so maintenance consumes the intended time budget and queued payouts behave consistently.
 - Retuned Stock Photo Galleries, Dropshipping Labs, and Micro SaaS payouts with lighter upkeep and lower quality hurdles, and wired the Cinema Camera, Studio Expansion, and Edge Delivery upgrades into tangible income and progress boosts.
 - Introduced a character skill system with ten themed disciplines, action-driven XP awards, education bonuses, and overall creator levels that log celebratory progress.
 - Expanded the Micro SaaS quality ladder with an Edge-powered Quality 4 tier, fresh action gating, and UI messaging so late-game payouts highlight the Edge Delivery Network upgrade.

--- a/src/game/assets/definitions/blog.js
+++ b/src/game/assets/definitions/blog.js
@@ -9,7 +9,7 @@ const blogDefinition = createAssetDefinition({
   tag: { label: 'Foundation', type: 'passive' },
   description: 'Launch cozy blogs that drip ad revenue once the posts are polished.',
   setup: { days: 3, hoursPerDay: 3, cost: 180 },
-  maintenance: { hours: 1, cost: 5 },
+  maintenance: { hours: 0.75, cost: 3 },
   skills: {
     setup: [
       'writing',

--- a/tests/gameLifecycle.test.js
+++ b/tests/gameLifecycle.test.js
@@ -141,18 +141,18 @@ test('pending income stays queued when upkeep resources fall short', () => {
     daysRemaining: 0,
     daysCompleted: blogDefinition.setup.days,
     maintenanceFundedToday: false,
-    pendingIncome: 3
+    pendingIncome: 2
   })];
 
   const state = getState();
   state.timeLeft = 10;
-  state.money = 1;
+  state.money = 0;
 
   allocateAssetMaintenance();
 
   const updatedInstance = getAssetState('blog').instances[0];
-  assert.equal(state.money, 1, 'money should not change when upkeep fails');
-  assert.equal(updatedInstance.pendingIncome, 3, 'queued income should remain for future days');
+  assert.equal(state.money, 0, 'money should not change when upkeep fails');
+  assert.equal(updatedInstance.pendingIncome, 2, 'queued income should remain for future days');
   assert.equal(updatedInstance.maintenanceFundedToday, false, 'maintenance should remain unfunded');
 });
 


### PR DESCRIPTION
## Summary
- bring the Personal Blog Network maintenance configuration in line with the documented 0.75h/$3 tuning
- update lifecycle coverage to exercise the new upkeep thresholds when resources fall short
- record the upkeep correction in the changelog for visibility

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da73fc748c832ca12a811bb2c13fb8