### PR TITLE
Add skill constellation widget across dashboard and education

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 - Corrected the Personal Blog Network upkeep to its 0.75h/$3 tuning so maintenance consumes the intended time budget and queued payouts behave consistently.
 - Retuned Stock Photo Galleries, Dropshipping Labs, and Micro SaaS payouts with lighter upkeep and lower quality hurdles, and wired the Cinema Camera, Studio Expansion, and Edge Delivery upgrades into tangible income and progress boosts.
 - Introduced a character skill system with ten themed disciplines, action-driven XP awards, education bonuses, and overall creator levels that log celebratory progress.
+- Added a "Skill constellation" widget to the dashboard and education tab so current skill tiers and XP-to-next goals stay front and centre.
 - Expanded the Micro SaaS quality ladder with an Edge-powered Quality 4 tier, fresh action gating, and UI messaging so late-game payouts highlight the Edge Delivery Network upgrade.
 - Retuned Stock Photo Galleries, Dropshipping Labs, and Micro SaaS payouts with lighter upkeep and lower quality hurdles, and wired the Cinema Camera, Studio Expansion, and Edge Delivery upgrades into tangible income and progress boosts.
 - Rebalanced the Personal Blog Network and Digital E-Book Series so Quality 0–1 payouts cover their maintenance, trimmed early post/chapter requirements, and sped up support actions while keeping the Automation Course perk impactful.

--- a/docs/features/character-skills.md
+++ b/docs/features/character-skills.md
@@ -10,6 +10,7 @@
 - Each skill levels from **Novice** to **Master**, unlocking celebratory log lines that highlight specialisation progress.
 - Character XP aggregates all earned skill XP and promotes the player through five creative tiers, spotlighting momentum even when dabbling across disciplines.
 - Completing education tracks grants a lump-sum skill boost tied to the curriculum, making study days feel immediately valuable.
+- A "Skill constellation" widget on the dashboard and education screen makes current progress visible at a glance.
 
 ## Key Systems & Tuning
 - **Skill Taxonomy** – Ten skills cover the current content surface: Writing & Storycraft, Audience Engagement & Teaching, Promotion & Funnel Strategy, Market Research & Analytics, Visual Production, Editing & Post-Production, Commerce Operations & Fulfillment, Software Development & Automation, Infrastructure & Reliability, and Audio Production & Performance.
@@ -18,7 +19,10 @@
 - **Education Rewards** – Outline Mastery focuses on Writing, Photo Catalog splits between Visual and Editing, E-Commerce Playbook splits between Research and Commerce, and Automation Architecture leans on Software with a nod to Infrastructure.
 - **State & Persistence** – Skill progress and character level are stored on the save state, auto-initialised for existing saves, and surfaced to other systems for future UI hooks.
 
+## UI Surfacing
+- The dashboard hosts a dedicated "Skill constellation" card that lists every discipline, tier, and XP-to-next marker alongside the overall creator level.
+- The education tab mirrors the widget so study planning happens beside the skills it advances.
+
 ## Follow-Up Ideas
-- Surface skill summaries on the dashboard or a dedicated "Character Sheet" panel.
 - Gate upcoming perks or narrative beats behind specific skill tiers to give mid-game targets.
 - Explore assistants or upgrades that temporarily boost skill XP gain for themed playstyles.

--- a/index.html
+++ b/index.html
@@ -146,6 +146,20 @@
               <ul id="quick-actions" class="quick-actions" aria-live="polite"></ul>
             </article>
 
+            <article class="card dashboard-card" aria-labelledby="skills-heading">
+              <header>
+                <h2 id="skills-heading">Skill constellation</h2>
+                <p>Watch every discipline climb as you ship and study.</p>
+              </header>
+              <div id="dashboard-skills" class="skills-widget">
+                <div class="skills-widget__summary">
+                  <span id="dashboard-skills-tier" class="skills-widget__summary-tier">Rising Creator</span>
+                  <span id="dashboard-skills-progress" class="skills-widget__summary-note">0 XP logged so far.</span>
+                </div>
+                <ul id="dashboard-skills-list" class="skills-widget__list" aria-live="polite"></ul>
+              </div>
+            </article>
+
             <article class="card dashboard-card" aria-labelledby="asset-upgrades-heading">
               <header>
                 <h2 id="asset-upgrades-heading">Asset upgrade</h2>
@@ -324,6 +338,19 @@
           <div class="study-queue__meta">
             <span id="study-queue-eta">Total ETA: 0h</span>
             <span id="study-queue-cap">Daily cap: 0h</span>
+          </div>
+        </section>
+        <section class="education-skills" aria-labelledby="education-skills-heading">
+          <header>
+            <h3 id="education-skills-heading">Skill constellation</h3>
+            <p>Courses boost these creative disciplines.</p>
+          </header>
+          <div id="education-skills" class="skills-widget skills-widget--compact">
+            <div class="skills-widget__summary">
+              <span id="education-skills-tier" class="skills-widget__summary-tier">Rising Creator</span>
+              <span id="education-skills-progress" class="skills-widget__summary-note">Keep stacking XP to rank up.</span>
+            </div>
+            <ul id="education-skills-list" class="skills-widget__list" aria-live="polite"></ul>
           </div>
         </section>
         <div id="study-track-list" class="study-tracks" aria-live="polite"></div>

--- a/src/ui/elements.js
+++ b/src/ui/elements.js
@@ -56,6 +56,20 @@ const elements = {
     studySummary: document.getElementById('daily-study-summary'),
     studyList: document.getElementById('daily-study-list')
   },
+  skills: {
+    dashboard: {
+      container: document.getElementById('dashboard-skills'),
+      list: document.getElementById('dashboard-skills-list'),
+      tier: document.getElementById('dashboard-skills-tier'),
+      note: document.getElementById('dashboard-skills-progress')
+    },
+    education: {
+      container: document.getElementById('education-skills'),
+      list: document.getElementById('education-skills-list'),
+      tier: document.getElementById('education-skills-tier'),
+      note: document.getElementById('education-skills-progress')
+    }
+  },
   actionQueue: document.getElementById('action-queue'),
   queuePause: document.getElementById('queue-pause'),
   queueCancel: document.getElementById('queue-cancel'),

--- a/src/ui/skillsWidget.js
+++ b/src/ui/skillsWidget.js
@@ -1,0 +1,137 @@
+import elements from './elements.js';
+import { getState } from '../core/state.js';
+import {
+  SKILL_DEFINITIONS,
+  SKILL_LEVELS,
+  CHARACTER_LEVELS
+} from '../game/skills/data.js';
+
+const numberFormatter = new Intl.NumberFormat('en-US');
+
+function formatXp(value) {
+  return numberFormatter.format(Math.max(0, Math.round(Number(value) || 0)));
+}
+
+function findSkillTier(level) {
+  return SKILL_LEVELS.find(tier => tier.level === level) || SKILL_LEVELS[0];
+}
+
+function findNextSkillTier(level) {
+  return SKILL_LEVELS.find(tier => tier.level === level + 1) || null;
+}
+
+function describeSkill(definition, stateEntry = {}) {
+  const xp = Math.max(0, Number(stateEntry.xp) || 0);
+  const level = Math.max(0, Number(stateEntry.level) || 0);
+  const tier = findSkillTier(level);
+  const nextTier = findNextSkillTier(level);
+  const currentFloor = tier?.xp ?? 0;
+  const nextFloor = nextTier?.xp ?? currentFloor;
+  const range = Math.max(1, nextFloor - currentFloor);
+  const progress = nextTier ? Math.min(1, Math.max(0, (xp - currentFloor) / range)) : 1;
+  const remaining = nextTier ? Math.max(0, nextFloor - xp) : 0;
+
+  return {
+    id: definition.id,
+    name: definition.name,
+    description: definition.description,
+    xp,
+    level,
+    tierTitle: tier?.title || `Level ${level}`,
+    nextTier,
+    progressPercent: Math.round(progress * 100),
+    remainingXp: remaining
+  };
+}
+
+function findCharacterTier(level) {
+  return CHARACTER_LEVELS.find(tier => tier.level === level) || CHARACTER_LEVELS[0];
+}
+
+function describeCharacter(character = {}) {
+  const xp = Math.max(0, Number(character.xp) || 0);
+  const level = Math.max(1, Number(character.level) || 1);
+  const tier = findCharacterTier(level);
+  const nextTier = CHARACTER_LEVELS.find(entry => entry.level === level + 1) || null;
+  const remaining = nextTier ? Math.max(0, nextTier.xp - xp) : 0;
+  const note = nextTier
+    ? `${formatXp(xp)} XP logged • ${formatXp(remaining)} XP to ${nextTier.title}`
+    : `${formatXp(xp)} XP logged • Top tier achieved—legendary!`;
+  return {
+    label: `${tier.title} · Level ${level}`,
+    note
+  };
+}
+
+function renderSkillItem(skill) {
+  const item = document.createElement('li');
+  item.className = 'skills-widget__item';
+
+  const label = document.createElement('div');
+  label.className = 'skills-widget__label';
+  const name = document.createElement('span');
+  name.className = 'skills-widget__name';
+  name.textContent = skill.name;
+  const tier = document.createElement('span');
+  tier.className = 'skills-widget__tier';
+  tier.textContent = `${skill.tierTitle} · Lv ${skill.level}`;
+  label.append(name, tier);
+
+  const progress = document.createElement('div');
+  progress.className = 'skills-widget__progress';
+  progress.setAttribute('role', 'progressbar');
+  progress.setAttribute('aria-valuemin', '0');
+  progress.setAttribute('aria-valuemax', '100');
+  progress.setAttribute('aria-valuenow', String(skill.progressPercent));
+  progress.setAttribute('aria-label', `${skill.name} progress toward mastery`);
+  const bar = document.createElement('div');
+  bar.className = 'skills-widget__progress-bar';
+  bar.style.setProperty('--progress', `${skill.progressPercent}%`);
+  progress.appendChild(bar);
+
+  const meta = document.createElement('div');
+  meta.className = 'skills-widget__meta';
+  const xp = document.createElement('span');
+  xp.textContent = `${formatXp(skill.xp)} XP total`;
+  const next = document.createElement('span');
+  next.textContent = skill.nextTier
+    ? `${formatXp(skill.remainingXp)} XP to ${skill.nextTier.title}`
+    : 'Max tier achieved—shine on!';
+  meta.append(xp, next);
+
+  item.append(label, progress, meta);
+  return item;
+}
+
+function renderSkillList(target, skillState = {}) {
+  const list = target?.list;
+  if (!list) return;
+  list.innerHTML = '';
+
+  SKILL_DEFINITIONS.forEach(definition => {
+    const skill = describeSkill(definition, skillState[definition.id]);
+    const item = renderSkillItem(skill);
+    list.appendChild(item);
+  });
+}
+
+function renderSkillSummary(target, character) {
+  if (!target?.tier || !target?.note) return;
+  const summary = describeCharacter(character);
+  target.tier.textContent = summary.label;
+  target.note.textContent = summary.note;
+}
+
+function renderTarget(target, state) {
+  if (!target?.container) return;
+  renderSkillSummary(target, state.character);
+  renderSkillList(target, state.skills);
+}
+
+export function renderSkillWidgets(state = getState()) {
+  if (!state) return;
+  renderTarget(elements.skills?.dashboard, state);
+  renderTarget(elements.skills?.education, state);
+}
+
+export default { renderSkillWidgets };

--- a/src/ui/update.js
+++ b/src/ui/update.js
@@ -3,6 +3,7 @@ import { getState } from '../core/state.js';
 import { registry } from '../game/registry.js';
 import { computeDailySummary } from '../game/summary.js';
 import { renderDashboard } from './dashboard.js';
+import { renderSkillWidgets } from './skillsWidget.js';
 import { updateHeaderAction } from './headerAction.js';
 import { applyCardFilters } from './layout.js';
 import { refreshActionCatalogDebug } from './debugCatalog.js';
@@ -30,6 +31,7 @@ export function updateUI() {
 
   const summary = computeDailySummary(state);
   renderDashboard(summary);
+  renderSkillWidgets(state);
   updateHeaderAction(state);
 
   const collections = buildCollections();

--- a/styles.css
+++ b/styles.css
@@ -373,6 +373,103 @@ body {
   border: 1px solid transparent;
 }
 
+.skills-widget {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.skills-widget__summary {
+  display: grid;
+  gap: 4px;
+  padding: 14px 16px;
+  border-radius: var(--radius-md);
+  background: rgba(124, 92, 255, 0.08);
+  border: 1px solid rgba(124, 92, 255, 0.2);
+}
+
+.skills-widget__summary-tier {
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--accent-strong);
+}
+
+.skills-widget__summary-note {
+  font-size: 13px;
+  color: rgba(203, 213, 255, 0.85);
+}
+
+.skills-widget__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.skills-widget__item {
+  background: var(--surface-muted);
+  border-radius: var(--radius-md);
+  padding: 12px 14px;
+  display: grid;
+  gap: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.skills-widget__label {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: baseline;
+}
+
+.skills-widget__name {
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.skills-widget__tier {
+  font-size: 13px;
+  color: var(--text-subtle);
+}
+
+.skills-widget__progress {
+  position: relative;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  overflow: hidden;
+}
+
+.skills-widget__progress-bar {
+  position: absolute;
+  inset: 0;
+  width: var(--progress, 0%);
+  background: linear-gradient(90deg, var(--accent), var(--accent-strong));
+  border-radius: inherit;
+  transition: width 0.3s ease;
+}
+
+.skills-widget__meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+  color: rgba(203, 213, 255, 0.75);
+  gap: 12px;
+}
+
+.skills-widget__meta span {
+  white-space: nowrap;
+}
+
+.skills-widget--compact .skills-widget__list {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.skills-widget--compact .skills-widget__item {
+  height: 100%;
+}
+
 .upgrade-actions {
   max-height: 320px;
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- add a "Skill constellation" card to the dashboard and a mirrored panel on the education tab so every skill tier and XP target is visible
- implement a reusable skills widget renderer with progress bars, character tier summary, and supporting styles
- update the character skills design note and changelog to capture the new UI surface

## Testing
- npm test
- Manual testing: not performed (CI environment)


------
https://chatgpt.com/codex/tasks/task_e_68da75897a4c832cb4e20a086304062b