### PR TITLE
Reorder dashboard widgets and scroll behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,110 +89,114 @@
           </section>
 
           <section class="dashboard__grid">
-            <article class="card dashboard-card dashboard-card--wide" aria-labelledby="daily-stats-heading">
-              <header>
-                <h2 id="daily-stats-heading">Daily stats</h2>
-                <p>Celebrate where today’s hustle hours and dollars landed.</p>
-              </header>
-              <div class="daily-stats">
-                <section class="daily-stats__section" aria-labelledby="daily-time-heading">
-                  <div class="daily-stats__header">
-                    <h3 id="daily-time-heading">Time allocation</h3>
-                    <p id="daily-time-summary" class="daily-stats__summary">No hours logged yet. Queue a hustle to get moving.</p>
-                  </div>
-                  <ul id="daily-time-list" class="daily-stats__list" aria-live="polite"></ul>
-                </section>
-
-                <section class="daily-stats__section" aria-labelledby="daily-earnings-heading">
-                  <div class="daily-stats__header">
-                    <h3 id="daily-earnings-heading">Cash earned</h3>
-                    <p id="daily-earnings-summary" class="daily-stats__summary">Payouts will appear once you start closing deals.</p>
-                  </div>
-                  <div class="daily-stats__columns">
-                    <div class="daily-stats__column">
-                      <h4 id="daily-earnings-active-heading">Active bursts</h4>
-                      <ul id="daily-earnings-active" class="daily-stats__list" aria-labelledby="daily-earnings-active-heading" aria-live="polite"></ul>
+            <div class="dashboard__top-row">
+              <article class="card dashboard-card dashboard-card--wide" aria-labelledby="daily-stats-heading">
+                <header>
+                  <h2 id="daily-stats-heading">Daily stats</h2>
+                  <p>Celebrate where today’s hustle hours and dollars landed.</p>
+                </header>
+                <div class="daily-stats">
+                  <section class="daily-stats__section" aria-labelledby="daily-time-heading">
+                    <div class="daily-stats__header">
+                      <h3 id="daily-time-heading">Time allocation</h3>
+                      <p id="daily-time-summary" class="daily-stats__summary">No hours logged yet. Queue a hustle to get moving.</p>
                     </div>
-                    <div class="daily-stats__column">
-                      <h4 id="daily-earnings-passive-heading">Passive streams</h4>
-                      <ul id="daily-earnings-passive" class="daily-stats__list" aria-labelledby="daily-earnings-passive-heading" aria-live="polite"></ul>
+                    <ul id="daily-time-list" class="daily-stats__list" aria-live="polite"></ul>
+                  </section>
+
+                  <section class="daily-stats__section" aria-labelledby="daily-earnings-heading">
+                    <div class="daily-stats__header">
+                      <h3 id="daily-earnings-heading">Cash earned</h3>
+                      <p id="daily-earnings-summary" class="daily-stats__summary">Payouts will appear once you start closing deals.</p>
                     </div>
-                  </div>
-                </section>
+                    <div class="daily-stats__columns">
+                      <div class="daily-stats__column">
+                        <h4 id="daily-earnings-active-heading">Active bursts</h4>
+                        <ul id="daily-earnings-active" class="daily-stats__list" aria-labelledby="daily-earnings-active-heading" aria-live="polite"></ul>
+                      </div>
+                      <div class="daily-stats__column">
+                        <h4 id="daily-earnings-passive-heading">Passive streams</h4>
+                        <ul id="daily-earnings-passive" class="daily-stats__list" aria-labelledby="daily-earnings-passive-heading" aria-live="polite"></ul>
+                      </div>
+                    </div>
+                  </section>
 
-                <section class="daily-stats__section" aria-labelledby="daily-spend-heading">
-                  <div class="daily-stats__header">
-                    <h3 id="daily-spend-heading">Cash spent</h3>
-                    <p id="daily-spend-summary" class="daily-stats__summary">Outflows land here when upkeep and investments fire.</p>
-                  </div>
-                  <ul id="daily-spend-list" class="daily-stats__list" aria-live="polite"></ul>
-                </section>
+                  <section class="daily-stats__section" aria-labelledby="daily-spend-heading">
+                    <div class="daily-stats__header">
+                      <h3 id="daily-spend-heading">Cash spent</h3>
+                      <p id="daily-spend-summary" class="daily-stats__summary">Outflows land here when upkeep and investments fire.</p>
+                    </div>
+                    <ul id="daily-spend-list" class="daily-stats__list" aria-live="polite"></ul>
+                  </section>
 
-                <section class="daily-stats__section" aria-labelledby="daily-study-heading">
-                  <div class="daily-stats__header">
-                    <h3 id="daily-study-heading">Study momentum</h3>
-                    <p id="daily-study-summary" class="daily-stats__summary">Enroll in a track to kickstart your learning streak.</p>
-                  </div>
-                  <ul id="daily-study-list" class="daily-stats__list" aria-live="polite"></ul>
-                </section>
-              </div>
-            </article>
-
-            <article class="card dashboard-card" aria-labelledby="quick-actions-heading">
-              <header>
-                <h2 id="quick-actions-heading">Quick actions</h2>
-                <p>High-impact moves you can trigger now.</p>
-              </header>
-              <ul id="quick-actions" class="quick-actions" aria-live="polite"></ul>
-            </article>
-
-            <article class="card dashboard-card" aria-labelledby="skills-heading">
-              <header>
-                <h2 id="skills-heading">Skill constellation</h2>
-                <p>Watch every discipline climb as you ship and study.</p>
-              </header>
-              <div id="dashboard-skills" class="skills-widget">
-                <div class="skills-widget__summary">
-                  <span id="dashboard-skills-tier" class="skills-widget__summary-tier">Rising Creator</span>
-                  <span id="dashboard-skills-progress" class="skills-widget__summary-note">0 XP logged so far.</span>
+                  <section class="daily-stats__section" aria-labelledby="daily-study-heading">
+                    <div class="daily-stats__header">
+                      <h3 id="daily-study-heading">Study momentum</h3>
+                      <p id="daily-study-summary" class="daily-stats__summary">Enroll in a track to kickstart your learning streak.</p>
+                    </div>
+                    <ul id="daily-study-list" class="daily-stats__list" aria-live="polite"></ul>
+                  </section>
                 </div>
-                <ul id="dashboard-skills-list" class="skills-widget__list" aria-live="polite"></ul>
-              </div>
-            </article>
+              </article>
 
-            <article class="card dashboard-card" aria-labelledby="asset-upgrades-heading">
-              <header>
-                <h2 id="asset-upgrades-heading">Asset upgrade</h2>
-                <p>Cheer on underperformers with the next quality-friendly push.</p>
-              </header>
-              <ul id="asset-upgrade-actions" class="quick-actions upgrade-actions" aria-live="polite"></ul>
-            </article>
+              <article class="card dashboard-card" aria-labelledby="quick-actions-heading">
+                <header>
+                  <h2 id="quick-actions-heading">Quick actions</h2>
+                  <p>High-impact moves you can trigger now.</p>
+                </header>
+                <ul id="quick-actions" class="quick-actions" aria-live="polite"></ul>
+              </article>
 
-            <article class="card dashboard-card" aria-labelledby="notifications-heading">
-              <header>
-                <h2 id="notifications-heading">Notifications</h2>
-                <p>Alerts for upkeep, upgrades, and opportunities.</p>
-              </header>
-              <ul id="notification-list" class="notifications" aria-live="polite"></ul>
-            </article>
+              <article class="card dashboard-card" aria-labelledby="asset-upgrades-heading">
+                <header>
+                  <h2 id="asset-upgrades-heading">Asset upgrade</h2>
+                  <p>Cheer on underperformers with the next quality-friendly push.</p>
+                </header>
+                <ul id="asset-upgrade-actions" class="quick-actions upgrade-actions" aria-live="polite"></ul>
+              </article>
+            </div>
 
-            <article class="card dashboard-card" aria-labelledby="event-log-heading">
-              <header>
-                <h2 id="event-log-heading">Event log</h2>
-                <p>Recent highlights from the grind.</p>
-              </header>
-              <div id="event-log-preview" class="event-preview" aria-live="polite"></div>
-              <button id="open-event-log" class="ghost" type="button" aria-haspopup="dialog" aria-controls="event-log-panel">Open full log</button>
-            </article>
+            <div class="dashboard__scroll">
+              <article class="card dashboard-card" aria-labelledby="skills-heading">
+                <header>
+                  <h2 id="skills-heading">Skill constellation</h2>
+                  <p>Watch every discipline climb as you ship and study.</p>
+                </header>
+                <div id="dashboard-skills" class="skills-widget">
+                  <div class="skills-widget__summary">
+                    <span id="dashboard-skills-tier" class="skills-widget__summary-tier">Rising Creator</span>
+                    <span id="dashboard-skills-progress" class="skills-widget__summary-note">0 XP logged so far.</span>
+                  </div>
+                  <ul id="dashboard-skills-list" class="skills-widget__list" aria-live="polite"></ul>
+                </div>
+              </article>
 
-            <article class="card dashboard-card" aria-labelledby="queue-heading">
-              <header>
-                <h2 id="queue-heading">Action queue</h2>
-                <p>A snapshot of the work you’ve already teed up for today.</p>
-              </header>
-              <ol id="action-queue" class="queue" aria-live="polite"></ol>
-              <p class="queue__note">We’ll keep this rolling automatically—manual scheduling unlocks in a future update.</p>
-            </article>
+              <article class="card dashboard-card" aria-labelledby="notifications-heading">
+                <header>
+                  <h2 id="notifications-heading">Notifications</h2>
+                  <p>Alerts for upkeep, upgrades, and opportunities.</p>
+                </header>
+                <ul id="notification-list" class="notifications" aria-live="polite"></ul>
+              </article>
+
+              <article class="card dashboard-card" aria-labelledby="event-log-heading">
+                <header>
+                  <h2 id="event-log-heading">Event log</h2>
+                  <p>Recent highlights from the grind.</p>
+                </header>
+                <div id="event-log-preview" class="event-preview" aria-live="polite"></div>
+                <button id="open-event-log" class="ghost" type="button" aria-haspopup="dialog" aria-controls="event-log-panel">Open full log</button>
+              </article>
+
+              <article class="card dashboard-card" aria-labelledby="queue-heading">
+                <header>
+                  <h2 id="queue-heading">Action queue</h2>
+                  <p>A snapshot of the work you’ve already teed up for today.</p>
+                </header>
+                <ol id="action-queue" class="queue" aria-live="polite"></ol>
+                <p class="queue__note">We’ll keep this rolling automatically—manual scheduling unlocks in a future update.</p>
+              </article>
+            </div>
           </section>
         </div>
       </section>

--- a/styles.css
+++ b/styles.css
@@ -215,6 +215,8 @@ body {
 .panel {
   display: grid;
   gap: 24px;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: 0;
 }
 
 .panel[hidden] {
@@ -277,9 +279,40 @@ body {
 
 .dashboard__grid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  grid-template-rows: auto auto;
+  grid-template-rows: auto minmax(0, 1fr);
   gap: 18px;
+  min-height: 0;
+}
+
+.dashboard__top-row,
+.dashboard__scroll {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.dashboard__top-row {
+  align-items: stretch;
+}
+
+.dashboard__scroll {
+  overflow-y: auto;
+  padding-right: 4px;
+  min-height: 0;
+  align-content: start;
+}
+
+.dashboard__top-row .dashboard-card {
+  height: 100%;
+  min-height: 0;
+}
+
+.dashboard__top-row .quick-actions,
+.dashboard__top-row .upgrade-actions {
+  flex: 1 1 auto;
+  height: 100%;
+  overflow-y: auto;
+  padding-right: 4px;
 }
 
 .dashboard-card {
@@ -1575,7 +1608,8 @@ a:focus-visible {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
-  .dashboard__grid {
+  .dashboard__top-row,
+  .dashboard__scroll {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
@@ -1589,8 +1623,13 @@ a:focus-visible {
     flex-wrap: wrap;
   }
 
-  .dashboard__grid {
+  .dashboard__top-row,
+  .dashboard__scroll {
     grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+
+  .dashboard__scroll {
+    padding-right: 0;
   }
 
   .dashboard-card--wide {

--- a/tests/helpers/setupDom.js
+++ b/tests/helpers/setupDom.js
@@ -62,18 +62,24 @@ export function ensureTestDom() {
               <button id="kpi-study"><span id="kpi-study-value"></span><span id="kpi-study-note"></span></button>
             </section>
             <section class="dashboard__grid">
-              <article>
-                <ol id="action-queue"></ol>
-                <button id="queue-pause"></button>
-                <button id="queue-cancel"></button>
-              </article>
-              <article><ul id="quick-actions"></ul></article>
-              <article><ul id="asset-upgrade-actions"></ul></article>
-              <article><ul id="notification-list"></ul></article>
-              <article>
-                <div id="event-log-preview"></div>
-                <button id="open-event-log"></button>
-              </article>
+              <div class="dashboard__top-row">
+                <article><div id="daily-time-summary"></div></article>
+                <article><ul id="quick-actions"></ul></article>
+                <article><ul id="asset-upgrade-actions"></ul></article>
+              </div>
+              <div class="dashboard__scroll">
+                <article><div id="dashboard-skills"></div></article>
+                <article><ul id="notification-list"></ul></article>
+                <article>
+                  <div id="event-log-preview"></div>
+                  <button id="open-event-log"></button>
+                </article>
+                <article>
+                  <ol id="action-queue"></ol>
+                  <button id="queue-pause"></button>
+                  <button id="queue-cancel"></button>
+                </article>
+              </div>
             </section>
           </section>
           <section id="panel-hustles" class="panel" hidden>


### PR DESCRIPTION
## Summary
- group daily stats, quick actions, and asset upgrade widgets in a dedicated top row
- add scrollable layout styling so lower dashboard cards stay accessible while capping top row height
- update the DOM test harness to reflect the new dashboard structure

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da81bbee38832c9203b3c4e7f7e788