### PR TITLE
Fix completed course progress display and highlight skill rewards

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 - Flow helpers: the "Next" action, Daily Stats card, and header pulse now keep priorities, earnings, and schedules visible at a glance.
 - Asset stewardship: detail panels, sell controls, and recommendations highlight ROI, upkeep costs, and upgrade shortcuts for each build.
 - Automation & infrastructure: broader instant gigs, smarter assistant load balancing, and new studio/server tiers expand long-term play.
+- Education clarity: finished courses now show 100% progress and list the XP-rich skills they elevate.
 
 ## Recent Highlights
 - Passive assets gained Quality 4–5 milestones with higher payouts and refreshed modifiers.

--- a/docs/features/education-boosts.md
+++ b/docs/features/education-boosts.md
@@ -15,6 +15,14 @@
 - Brand Voice Lab: +$4 Audience Q&A Blast.
 - Guerrilla Buzz Workshop: +25% Street Team Promo, +$1.50 Micro Survey Dash.
 
+**Skill rewards**
+- Outline Mastery awards +120 XP with a signature focus on Writing & Storycraft.
+- Photo Catalog awards +120 XP split between Visual Production and Editing & Post-Production.
+- E-Commerce Playbook awards +120 XP balancing Market Research & Analytics and Commerce Operations & Fulfillment.
+- Automation Architecture awards +120 XP leaning toward Software Development & Automation with supporting Infrastructure & Reliability.
+- Brand Voice Lab awards +100 XP highlighting Audience Engagement & Teaching with Promotion & Funnel Strategy support.
+- Guerrilla Buzz Workshop awards +110 XP centered on Promotion & Funnel Strategy with Audience Engagement & Teaching backup.
+
 **Next steps**
 - Consider a compact daily tracker listing active boosts.
 - Leave room for future upgrades to append new modifiers to the same table.

--- a/src/game/requirements.js
+++ b/src/game/requirements.js
@@ -133,7 +133,7 @@ export const KNOWLEDGE_TRACKS = {
   }
 };
 
-const KNOWLEDGE_REWARDS = {
+export const KNOWLEDGE_REWARDS = {
   outlineMastery: { baseXp: 120, skills: ['writing'] },
   photoLibrary: {
     baseXp: 120,
@@ -154,6 +154,20 @@ const KNOWLEDGE_REWARDS = {
     skills: [
       { id: 'software', weight: 0.6 },
       { id: 'infrastructure', weight: 0.4 }
+    ]
+  },
+  brandVoiceLab: {
+    baseXp: 100,
+    skills: [
+      { id: 'audience', weight: 0.6 },
+      { id: 'promotion', weight: 0.4 }
+    ]
+  },
+  guerillaBuzzWorkshop: {
+    baseXp: 110,
+    skills: [
+      { id: 'promotion', weight: 0.6 },
+      { id: 'audience', weight: 0.4 }
     ]
   }
 };

--- a/styles.css
+++ b/styles.css
@@ -1105,6 +1105,54 @@ body {
   font-weight: 600;
 }
 
+.study-track__skills {
+  margin: 16px 0;
+  padding: 16px;
+  border-radius: var(--radius-md);
+  background: rgba(124, 92, 255, 0.08);
+  display: grid;
+  gap: 10px;
+}
+
+.study-track__skills-heading {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.study-track__skills-note {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-subtle);
+}
+
+.study-track__skills-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 8px;
+}
+
+.study-track__skills-item {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-subtle);
+}
+
+.study-track__skills-item strong {
+  font-size: 14px;
+  color: var(--text);
+}
+
+.study-track__skills-item span {
+  font-size: 13px;
+  color: var(--text-subtle);
+}
+
 .study-track__progress-wrap {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
## Summary
- correct education progress calculations so completed study tracks display 100% completion and clear status text
- surface skill reward summaries in the education tab and fill in reward data for every course
- update documentation and automated tests to cover the new education experience

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da8ff50074832c86f281d0af538951