### PR TITLE
Revamp passive asset build cards with payout breakdown

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@
 - Progression refresh: character skills, study scheduling, and celebratory UI now guide players through course-driven bonuses and countdowns.
 - Flow helpers: the "Next" action, Daily Stats card, and header pulse now keep priorities, earnings, and schedules visible at a glance.
 - Asset stewardship: detail panels, sell controls, and recommendations highlight ROI, upkeep costs, and upgrade shortcuts for each build.
+- Active build cards surface quality tiers, remaining steps to the next milestone, and yesterday’s payout breakdown so upgrades feel tangible.
 - Automation & infrastructure: broader instant gigs, smarter assistant load balancing, and new studio/server tiers expand long-term play.
 
 ## Recent Highlights

--- a/docs/features/passive-asset-dashboard.md
+++ b/docs/features/passive-asset-dashboard.md
@@ -7,6 +7,7 @@
 - Category cards show launch counts, upkeep, and last income even when collapsed; toggles reveal instance rosters with ROI, sell, and quick-buy upgrade buttons.
 - The scrolling "Asset upgrade" card surfaces up to eight nudges with percent-to-go callouts.
 - Instance modals highlight current quality, next milestones, and pinned quality actions; the briefing variant reuses live setup data for confident launches.
+- Active build cards now surface the current quality tier, remaining steps for the next upgrade, and a breakdown of yesterday’s payout (base roll, upgrade boosts, bonuses).
 
 **Player benefit**
 - Faster comparisons and upgrades without digging through logs.

--- a/src/game/assets/definitions/blog.js
+++ b/src/game/assets/definitions/blog.js
@@ -20,9 +20,17 @@ const blogDefinition = createAssetDefinition({
     base: 30,
     variance: 0.2,
     logType: 'passive',
-    modifier: amount => {
+    modifier: (amount, context = {}) => {
       const automation = getUpgradeState('course').purchased ? 1.5 : 1;
-      return amount * automation;
+      const total = amount * automation;
+      if (automation > 1 && typeof context.recordModifier === 'function') {
+        context.recordModifier('Automation course boost', total - amount, {
+          id: 'course',
+          type: 'upgrade',
+          percent: automation - 1
+        });
+      }
+      return total;
     }
   },
   quality: {

--- a/src/game/assets/definitions/saas.js
+++ b/src/game/assets/definitions/saas.js
@@ -21,9 +21,17 @@ const saasDefinition = createAssetDefinition({
     base: 108,
     variance: 0.4,
     logType: 'passive',
-    modifier: amount => {
+    modifier: (amount, context = {}) => {
       const edge = getUpgradeState('serverEdge').purchased ? 1.35 : 1;
-      return Math.round(amount * edge);
+      const total = amount * edge;
+      if (edge > 1 && typeof context.recordModifier === 'function') {
+        context.recordModifier('Edge delivery boost', total - amount, {
+          id: 'serverEdge',
+          type: 'upgrade',
+          percent: edge - 1
+        });
+      }
+      return total;
     }
   },
   requirements: {

--- a/src/game/assets/definitions/stockPhotos.js
+++ b/src/game/assets/definitions/stockPhotos.js
@@ -21,9 +21,17 @@ const stockPhotosDefinition = createAssetDefinition({
     base: 58,
     variance: 0.35,
     logType: 'passive',
-    modifier: amount => {
+    modifier: (amount, context = {}) => {
       const expansion = getUpgradeState('studioExpansion').purchased ? 1.2 : 1;
-      return Math.round(amount * expansion);
+      const total = amount * expansion;
+      if (expansion > 1 && typeof context.recordModifier === 'function') {
+        context.recordModifier('Studio expansion boost', total - amount, {
+          id: 'studioExpansion',
+          type: 'upgrade',
+          percent: expansion - 1
+        });
+      }
+      return total;
     }
   },
   requirements: {

--- a/src/game/assets/lifecycle.js
+++ b/src/game/assets/lifecycle.js
@@ -199,6 +199,7 @@ export function closeOutDay() {
           instance.pendingIncome = (instance.pendingIncome || 0) + payout;
         } else {
           instance.lastIncome = 0;
+          instance.lastIncomeBreakdown = null;
           instance.pendingIncome = 0;
           const label = instanceLabel(definition, index);
           const message = definition.messages?.maintenanceSkipped

--- a/styles.css
+++ b/styles.css
@@ -1402,6 +1402,117 @@ body {
   gap: 12px;
 }
 
+.asset-detail__instance-overview {
+  display: grid;
+  gap: 12px;
+}
+
+@media (min-width: 720px) {
+  .asset-detail__instance-overview {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+}
+
+.asset-detail__insight {
+  background: rgba(148, 163, 184, 0.16);
+  border-radius: var(--radius-md);
+  padding: 12px;
+  display: grid;
+  gap: 6px;
+}
+
+.asset-detail__insight-title {
+  margin: 0;
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-subtle);
+  font-weight: 700;
+}
+
+.asset-detail__insight-body {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text);
+}
+
+.asset-detail__insight-note {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-subtle);
+}
+
+.asset-detail__requirement-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 4px;
+}
+
+.asset-detail__requirement-entry {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.asset-detail__requirement-label {
+  color: var(--text-subtle);
+  font-weight: 600;
+}
+
+.asset-detail__requirement-value {
+  font-weight: 700;
+}
+
+.asset-detail__payout-breakdown {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 4px;
+}
+
+.asset-detail__payout-entry {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.asset-detail__payout-label {
+  color: var(--text-subtle);
+  font-weight: 600;
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.asset-detail__payout-percent {
+  color: var(--text-subtle);
+  font-weight: 500;
+}
+
+.asset-detail__payout-value {
+  font-weight: 700;
+}
+
+.asset-detail__payout-entry.is-base .asset-detail__payout-label,
+.asset-detail__payout-entry.is-base .asset-detail__payout-value {
+  color: var(--text);
+}
+
+.asset-detail__payout-entry.is-positive .asset-detail__payout-value {
+  color: var(--success);
+}
+
+.asset-detail__payout-entry.is-negative .asset-detail__payout-value {
+  color: var(--danger);
+}
+
 .asset-detail__instance-stats {
   display: grid;
   gap: 8px;
@@ -1480,6 +1591,16 @@ body {
   gap: 8px 12px;
   font-size: 12px;
   color: var(--text-subtle);
+}
+
+.asset-detail__progress-entry.is-pending {
+  color: var(--warning);
+  font-weight: 600;
+}
+
+.asset-detail__progress-entry.is-complete {
+  color: var(--success);
+  font-weight: 600;
 }
 
 .asset-detail__actions {


### PR DESCRIPTION
## Summary
- track passive income breakdowns and persist them on asset instances for UI display
- redesign active build cards to show quality status, next milestone requirements, and payout breakdowns with refreshed styling
- document the dashboard change and add coverage for payout breakdown behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da8f9109fc832c94fc464c22e23fa5