### PR TITLE
Align quick action controls and refine upgrade scrolling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -504,7 +504,7 @@ body {
 }
 
 .upgrade-actions {
-  max-height: 320px;
+  max-height: none;
   overflow-y: auto;
   padding-right: 4px;
   scrollbar-gutter: stable both-edges;
@@ -613,6 +613,12 @@ body {
 .quick-actions li button,
 .notifications li button {
   margin-left: 12px;
+}
+
+.quick-actions li button {
+  min-inline-size: var(--quick-action-button-width, 11.5rem);
+  text-align: center;
+  white-space: nowrap;
 }
 
 .event-preview {


### PR DESCRIPTION
## Summary
- keep quick action buttons (including revert) at a consistent width so labels with different counts no longer resize the control
- allow the asset upgrade recommendation list to expand with the card and only show a scrollbar when the content exceeds the space

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da94ba640c832cb579d3e67a446a87