### PR TITLE
Adjust dashboard quick action button sizing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -413,7 +413,7 @@ body {
 
 .quick-actions li {
   gap: var(--dashboard-action-gap, 12px);
-  align-items: stretch;
+  align-items: center;
   min-height: var(--dashboard-action-item-height, 64px);
 }
 
@@ -628,15 +628,17 @@ body {
 }
 
 .quick-actions li button {
-  flex: 0 0 var(--dashboard-action-button-width, 140px);
-  inline-size: var(--dashboard-action-button-width, 140px);
-  min-height: 44px;
+  flex: 0 0 auto;
+  inline-size: min(var(--dashboard-action-button-width, 140px), 100%);
+  min-height: 36px;
+  padding: 6px 12px;
   display: flex;
   align-items: center;
   justify-content: center;
   text-align: center;
   white-space: normal;
   line-height: 1.25;
+  align-self: center;
 }
 
 .event-preview {


### PR DESCRIPTION
## Summary
- reduce dashboard action button height while centering their alignment so they no longer stretch vertically
- allow quick action buttons to shrink with the widget width to prevent overflow in the quick actions and asset upgrade cards

## Testing
- manual: Viewed dashboard via local http server


------
https://chatgpt.com/codex/tasks/task_e_68da9b241e20832ca9b2cc5b6a024d3c