### PR TITLE
Adjust dashboard action button sizing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -629,9 +629,10 @@ body {
 
 .quick-actions li button {
   flex: 0 0 auto;
-  inline-size: min(var(--dashboard-action-button-width, 140px), 100%);
-  min-height: 36px;
-  padding: 6px 12px;
+  inline-size: auto;
+  max-inline-size: min(100%, var(--dashboard-action-button-width, 140px));
+  min-height: 32px;
+  padding: 4px 10px;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- allow dashboard quick action buttons to size to their label content so they no longer overflow their cards
- trim button padding and minimum height so quick action and asset upgrade controls sit comfortably within each widget

## Testing
- npm test
- Manual: served index.html locally and confirmed quick actions and asset upgrade buttons fit within their cards


------
https://chatgpt.com/codex/tasks/task_e_68da9ccb2ad8832ca786d2ed982d8121