### PR TITLE
Refresh passive build cards

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1496,6 +1496,55 @@ body {
   gap: 6px;
 }
 
+.asset-detail__insight--milestone {
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(135deg, rgba(124, 92, 255, 0.28), var(--surface-highlight));
+  border: 1px solid rgba(124, 92, 255, 0.6);
+  box-shadow: 0 10px 28px rgba(124, 92, 255, 0.2);
+  gap: 12px;
+}
+
+.asset-detail__insight--milestone::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(159, 123, 255, 0.4), transparent 55%);
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+.asset-detail__insight--milestone > * {
+  position: relative;
+  z-index: 1;
+}
+
+.asset-detail__milestone-hero {
+  display: grid;
+  gap: 6px;
+}
+
+.asset-detail__milestone-label {
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: rgba(240, 237, 255, 0.85);
+}
+
+.asset-detail__milestone-target {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: #f5f1ff;
+}
+
+.asset-detail__milestone-message {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(240, 237, 255, 0.78);
+}
+
 .asset-detail__insight-title {
   margin: 0;
   font-size: 11px;
@@ -1525,6 +1574,10 @@ body {
   gap: 4px;
 }
 
+.asset-detail__requirement-list--milestone {
+  gap: 10px;
+}
+
 .asset-detail__requirement-entry {
   display: flex;
   justify-content: space-between;
@@ -1533,13 +1586,63 @@ body {
   font-size: 12px;
 }
 
+.asset-detail__requirement-entry--milestone {
+  display: grid;
+  gap: 8px;
+  align-items: stretch;
+  background: rgba(17, 27, 48, 0.35);
+  border-radius: var(--radius-md);
+  padding: 10px 12px;
+  backdrop-filter: blur(4px);
+}
+
 .asset-detail__requirement-label {
   color: var(--text-subtle);
   font-weight: 600;
 }
 
+.asset-detail__requirement-entry--milestone .asset-detail__requirement-label {
+  color: rgba(240, 237, 255, 0.82);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
 .asset-detail__requirement-value {
   font-weight: 700;
+}
+
+.asset-detail__requirement-value--milestone {
+  font-size: 15px;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.asset-detail__requirement-progress {
+  display: grid;
+  gap: 6px;
+}
+
+.asset-detail__requirement-remaining {
+  font-size: 12px;
+  color: rgba(240, 237, 255, 0.72);
+}
+
+.asset-detail__requirement-meter {
+  position: relative;
+  height: 6px;
+  background: rgba(240, 237, 255, 0.25);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.asset-detail__requirement-meter-fill {
+  position: absolute;
+  inset: 0;
+  width: 0;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--accent), var(--accent-strong));
+  transition: width 0.3s ease;
 }
 
 .asset-detail__payout-breakdown {
@@ -1658,24 +1761,6 @@ body {
 
 .asset-detail__instance-roi.is-negative {
   color: var(--danger);
-}
-
-.asset-detail__progress {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px 12px;
-  font-size: 12px;
-  color: var(--text-subtle);
-}
-
-.asset-detail__progress-entry.is-pending {
-  color: var(--warning);
-  font-weight: 600;
-}
-
-.asset-detail__progress-entry.is-complete {
-  color: var(--success);
-  font-weight: 600;
 }
 
 .asset-detail__actions {


### PR DESCRIPTION
## Summary
- restyle the next milestone section on passive build cards with an accent gradient and progress meters
- remove the duplicated track progress chips and add time estimates to the equipment upgrade shortcuts
- expand the supporting styles for the refreshed milestone presentation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da98294b60832cb3384a0f266fca65