### PR TITLE
Increase asset upgrade card height on dashboard

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -320,6 +320,10 @@ body {
   scrollbar-gutter: stable both-edges;
 }
 
+.dashboard__top-row .upgrade-actions {
+  max-height: calc((var(--dashboard-action-item-height) * 6) + (var(--dashboard-action-gap) * 5));
+}
+
 .dashboard-card {
   background: var(--surface);
   border-radius: var(--radius-lg);


### PR DESCRIPTION
## Summary
- raise the max height for the asset upgrade list so the upgrade card fits all content without overflow

## Testing
- npm test
- Manual: Loaded dashboard in browser to confirm the asset upgrade list stays within the card

------
https://chatgpt.com/codex/tasks/task_e_68daa1b2830c832cba33c87dfa2980cb