### PR TITLE
Add player overview screen with skills, education, and gear

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Player screen: new overview tab spotlights character level, skills, education, gear, and hustle momentum in one place.
 - Passive economy rebalance: smoother upkeep for blogs, stock photos, dropshipping, and SaaS so late tiers feel rewarding without micromanagement spikes.
 - Progression refresh: character skills, study scheduling, and celebratory UI now guide players through course-driven bonuses and countdowns.
 - Flow helpers: the "Next" action, Daily Stats card, and header pulse now keep priorities, earnings, and schedules visible at a glance.

--- a/docs/features/player-overview.md
+++ b/docs/features/player-overview.md
@@ -1,0 +1,23 @@
+# Player Overview Screen
+
+**Purpose**
+- Give players a dedicated home to review character growth, study plans, and purchased gear without hunting through other panels.
+- Highlight momentum stats that tie together cash flow, assistants, and study activity so the next decision feels obvious.
+
+**What players see**
+- A "Career snapshot" card summarizing level, XP progress, day count, cash on hand, and remaining focus hours.
+- A "Skill journey" list that ranks every discipline with tier badges, XP totals, and next-tier requirements.
+- Education rows for each workshop showing enrollment state, tuition paid, and whether today’s session is booked.
+- An equipment locker that only lists upgrades already purchased, with quick reminders of what each unlocks.
+- Momentum metrics covering assistants employed, passive earnings, upkeep spend, study queue status, and focus already booked.
+
+**Data plumbing**
+- Skills and character tiers reuse definitions from `src/game/skills/data.js`; XP formatting matches the dashboard widget.
+- Knowledge progress taps `getKnowledgeProgress` for enrollment, completion, and study scheduling state per track.
+- Equipment list reads `registry.upgrades` but filters to non-repeatable purchases via `getUpgradeState`.
+- Momentum stats combine registry asset counts, assistant state, and daily summary metrics computed in `computeDailySummary`.
+
+**Future hooks**
+- Add prestige, reputation, or perk systems as new cards without altering the navigation shell.
+- Surface historical trends (XP/day, cash delta) by extending the momentum metrics list to charts or sparklines.
+- Integrate customizable loadouts once multiple gear sets exist, reusing the equipment locker list structure.

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
 
     <nav class="shell__tabs" role="tablist" aria-label="Primary">
       <button id="tab-dashboard" class="shell__tab is-active" role="tab" aria-selected="true" aria-controls="panel-dashboard">Dashboard</button>
+      <button id="tab-player" class="shell__tab" role="tab" aria-selected="false" aria-controls="panel-player">Player</button>
       <button id="tab-hustles" class="shell__tab" role="tab" aria-selected="false" aria-controls="panel-hustles">Hustles</button>
       <button id="tab-assets" class="shell__tab" role="tab" aria-selected="false" aria-controls="panel-assets">Assets</button>
       <button id="tab-upgrades" class="shell__tab" role="tab" aria-selected="false" aria-controls="panel-upgrades">Upgrades</button>
@@ -198,6 +199,85 @@
               </article>
             </div>
           </section>
+        </div>
+      </section>
+
+      <section id="panel-player" class="panel" role="tabpanel" aria-labelledby="tab-player" hidden>
+        <header class="panel__header">
+          <div>
+            <h2>Player</h2>
+            <p>Track your personal growth, study streaks, and gear at a glance.</p>
+          </div>
+        </header>
+        <div class="player-overview">
+          <div class="player-overview__grid">
+            <article class="card player-card player-card--summary" aria-labelledby="player-summary-heading">
+              <header>
+                <h3 id="player-summary-heading">Career snapshot</h3>
+                <p>Celebrate today’s level, focus, and bankroll momentum.</p>
+              </header>
+              <div class="player-summary">
+                <div class="player-summary__level">
+                  <span id="player-summary-tier" class="player-summary__tier">Rising Creator · Level 1</span>
+                  <p id="player-summary-note" class="player-summary__note">0 XP logged so far.</p>
+                </div>
+                <dl class="player-summary__metrics">
+                  <div>
+                    <dt>Cash on hand</dt>
+                    <dd id="player-summary-money">$0</dd>
+                  </div>
+                  <div>
+                    <dt>Total earned</dt>
+                    <dd id="player-summary-earned">$0</dd>
+                  </div>
+                  <div>
+                    <dt>Total spent</dt>
+                    <dd id="player-summary-spent">$0</dd>
+                  </div>
+                  <div>
+                    <dt>Current day</dt>
+                    <dd id="player-summary-day">Day 1</dd>
+                  </div>
+                  <div>
+                    <dt>Focus left</dt>
+                    <dd id="player-summary-time">0h</dd>
+                  </div>
+                </dl>
+              </div>
+            </article>
+
+            <article class="card player-card" aria-labelledby="player-skills-heading">
+              <header>
+                <h3 id="player-skills-heading">Skill journey</h3>
+                <p id="player-skills-summary">Log XP to reveal your standout disciplines.</p>
+              </header>
+              <ol id="player-skills-list" class="player-skill-list" aria-live="polite"></ol>
+            </article>
+
+            <article class="card player-card" aria-labelledby="player-education-heading">
+              <header>
+                <h3 id="player-education-heading">Education</h3>
+                <p>Workshops and courses that power your next unlock.</p>
+              </header>
+              <ul id="player-education-list" class="player-education-list" aria-live="polite"></ul>
+            </article>
+
+            <article class="card player-card" aria-labelledby="player-equipment-heading">
+              <header>
+                <h3 id="player-equipment-heading">Equipment locker</h3>
+                <p>Your purchased gear and studio upgrades.</p>
+              </header>
+              <ul id="player-equipment-list" class="player-equipment-list" aria-live="polite"></ul>
+            </article>
+
+            <article class="card player-card" aria-labelledby="player-stats-heading">
+              <header>
+                <h3 id="player-stats-heading">Momentum metrics</h3>
+                <p>Extra stats that spotlight where the hustle is thriving.</p>
+              </header>
+              <ul id="player-stats-list" class="player-stats-list" aria-live="polite"></ul>
+            </article>
+          </div>
         </div>
       </section>
 

--- a/src/ui/elements.js
+++ b/src/ui/elements.js
@@ -133,7 +133,25 @@ const elements = {
   commandPaletteTrigger: document.getElementById('command-palette-trigger'),
   commandPaletteBackdrop: document.querySelector('#command-palette .command-palette__backdrop'),
   commandPaletteSearch: document.getElementById('command-palette-search'),
-  commandPaletteResults: document.getElementById('command-palette-results')
+  commandPaletteResults: document.getElementById('command-palette-results'),
+  player: {
+    summary: {
+      tier: document.getElementById('player-summary-tier'),
+      note: document.getElementById('player-summary-note'),
+      money: document.getElementById('player-summary-money'),
+      earned: document.getElementById('player-summary-earned'),
+      spent: document.getElementById('player-summary-spent'),
+      day: document.getElementById('player-summary-day'),
+      time: document.getElementById('player-summary-time')
+    },
+    skills: {
+      list: document.getElementById('player-skills-list'),
+      summary: document.getElementById('player-skills-summary')
+    },
+    educationList: document.getElementById('player-education-list'),
+    equipmentList: document.getElementById('player-equipment-list'),
+    statsList: document.getElementById('player-stats-list')
+  }
 };
 
 export default elements;

--- a/src/ui/player.js
+++ b/src/ui/player.js
@@ -1,0 +1,328 @@
+import elements from './elements.js';
+import { formatHours, formatList, formatMoney } from '../core/helpers.js';
+import { registry } from '../game/registry.js';
+import { getAssetState, getUpgradeState } from '../core/state.js';
+import {
+  SKILL_DEFINITIONS,
+  SKILL_LEVELS,
+  CHARACTER_LEVELS
+} from '../game/skills/data.js';
+import { KNOWLEDGE_TRACKS, getKnowledgeProgress } from '../game/requirements.js';
+
+const numberFormatter = new Intl.NumberFormat('en-US');
+
+function setText(element, value) {
+  if (!element) return;
+  element.textContent = value;
+}
+
+function formatXp(value) {
+  return numberFormatter.format(Math.max(0, Math.round(Number(value) || 0)));
+}
+
+function describeCharacter(character = {}) {
+  const xp = Math.max(0, Number(character.xp) || 0);
+  const level = Math.max(1, Number(character.level) || 1);
+  const tier = CHARACTER_LEVELS.find(entry => entry.level === level) || CHARACTER_LEVELS[0];
+  const nextTier = CHARACTER_LEVELS.find(entry => entry.level === level + 1) || null;
+  const remaining = nextTier ? Math.max(0, nextTier.xp - xp) : 0;
+  const note = nextTier
+    ? `${formatXp(xp)} XP logged • ${formatXp(remaining)} XP to ${nextTier.title}`
+    : `${formatXp(xp)} XP logged • Top tier achieved—legendary!`;
+  return {
+    label: `${tier.title} · Level ${level}`,
+    note
+  };
+}
+
+function findSkillTier(level) {
+  return SKILL_LEVELS.find(tier => tier.level === level) || SKILL_LEVELS[0];
+}
+
+function findNextSkillTier(level) {
+  return SKILL_LEVELS.find(tier => tier.level === level + 1) || null;
+}
+
+function describeSkill(definition, stateEntry = {}) {
+  const xp = Math.max(0, Number(stateEntry.xp) || 0);
+  const level = Math.max(0, Number(stateEntry.level) || 0);
+  const tier = findSkillTier(level);
+  const nextTier = findNextSkillTier(level);
+  const currentFloor = tier?.xp ?? 0;
+  const nextFloor = nextTier?.xp ?? currentFloor;
+  const range = Math.max(1, nextFloor - currentFloor);
+  const progress = nextTier ? Math.min(1, Math.max(0, (xp - currentFloor) / range)) : 1;
+  const remaining = nextTier ? Math.max(0, nextFloor - xp) : 0;
+
+  return {
+    id: definition.id,
+    name: definition.name,
+    xp,
+    level,
+    tierTitle: tier?.title || `Level ${level}`,
+    nextTier,
+    progressPercent: Math.round(progress * 100),
+    remainingXp: remaining
+  };
+}
+
+function renderSummary(state, summary) {
+  const target = elements.player?.summary;
+  if (!target) return;
+  const info = describeCharacter(state?.character);
+  setText(target.tier, info.label);
+  setText(target.note, info.note);
+  setText(target.money, `$${formatMoney(state?.money || 0)}`);
+  setText(target.earned, `$${formatMoney(state?.totals?.earned || 0)}`);
+  setText(target.spent, `$${formatMoney(state?.totals?.spent || 0)}`);
+  setText(target.day, `Day ${Math.max(1, Number(state?.day) || 1)}`);
+  setText(target.time, formatHours(Math.max(0, Number(state?.timeLeft) || 0)));
+}
+
+function renderSkillList(state) {
+  const target = elements.player?.skills;
+  if (!target?.list) return;
+
+  const skills = SKILL_DEFINITIONS.map(def => describeSkill(def, state?.skills?.[def.id]));
+  const topSkill = skills.reduce((best, skill) => {
+    if (!best) return skill;
+    if (skill.level > best.level) return skill;
+    if (skill.level === best.level && skill.progressPercent > best.progressPercent) {
+      return skill;
+    }
+    return best;
+  }, null);
+  const maxed = skills.filter(skill => !skill.nextTier).length;
+
+  if (target.summary) {
+    if (topSkill) {
+      const highlight = `${topSkill.name} is shining at Lv ${topSkill.level}`;
+      const completion = maxed > 0
+        ? `${maxed} skill${maxed === 1 ? '' : 's'} mastered`
+        : 'Keep stacking XP to master a discipline';
+      target.summary.textContent = `${highlight} • ${completion}.`;
+    } else {
+      target.summary.textContent = 'Log XP to reveal your standout disciplines.';
+    }
+  }
+
+  target.list.innerHTML = '';
+  skills.forEach(skill => {
+    const item = document.createElement('li');
+    item.className = 'player-skill';
+
+    const header = document.createElement('div');
+    header.className = 'player-skill__header';
+    const name = document.createElement('span');
+    name.className = 'player-skill__name';
+    name.textContent = skill.name;
+    const badge = document.createElement('span');
+    badge.className = 'player-skill__badge';
+    badge.textContent = `Lv ${skill.level}`;
+    header.append(name, badge);
+
+    const tier = document.createElement('p');
+    tier.className = 'player-skill__tier';
+    tier.textContent = `${skill.tierTitle}`;
+
+    const meter = document.createElement('div');
+    meter.className = 'player-skill__meter';
+    meter.setAttribute('role', 'progressbar');
+    meter.setAttribute('aria-valuemin', '0');
+    meter.setAttribute('aria-valuemax', '100');
+    meter.setAttribute('aria-valuenow', String(skill.progressPercent));
+    meter.setAttribute('aria-label', `${skill.name} progress toward the next tier`);
+    const fill = document.createElement('span');
+    fill.style.setProperty('--progress', `${skill.progressPercent}%`);
+    meter.appendChild(fill);
+
+    const meta = document.createElement('p');
+    meta.className = 'player-skill__meta';
+    meta.textContent = skill.nextTier
+      ? `${formatXp(skill.xp)} XP • ${formatXp(skill.remainingXp)} XP to ${skill.nextTier.title}`
+      : `${formatXp(skill.xp)} XP • Max tier achieved`;
+
+    item.append(header, tier, meter, meta);
+    target.list.appendChild(item);
+  });
+}
+
+const skillNameMap = new Map(SKILL_DEFINITIONS.map(def => [def.id, def.name]));
+
+function formatSkillFocus(skills) {
+  if (!Array.isArray(skills) || !skills.length) return null;
+  const names = skills
+    .map(entry => (typeof entry === 'string' ? entry : entry?.id))
+    .filter(Boolean)
+    .map(id => skillNameMap.get(id) || id);
+  if (!names.length) return null;
+  return formatList(names);
+}
+
+function renderEquipment(state) {
+  const list = elements.player?.equipmentList;
+  if (!list) return;
+  list.innerHTML = '';
+
+  const owned = registry.upgrades
+    .filter(upgrade => !upgrade.repeatable)
+    .filter(upgrade => getUpgradeState(upgrade.id, state)?.purchased);
+
+  if (!owned.length) {
+    const empty = document.createElement('li');
+    empty.className = 'player-equipment__empty';
+    empty.textContent = 'No gear purchased yet. Explore Upgrades to expand your toolkit.';
+    list.appendChild(empty);
+    return;
+  }
+
+  owned.forEach(upgrade => {
+    const item = document.createElement('li');
+    item.className = 'player-equipment__item';
+
+    const name = document.createElement('div');
+    name.className = 'player-equipment__name';
+    name.textContent = upgrade.name;
+
+    const summary = document.createElement('p');
+    summary.className = 'player-equipment__summary';
+    const summaryParts = [];
+    if (upgrade.unlocks) summaryParts.push(`Unlocks ${upgrade.unlocks}`);
+    if (upgrade.boosts) summaryParts.push(upgrade.boosts);
+    const summaryText = summaryParts.join(' • ') || upgrade.description;
+    summary.textContent = summaryText;
+
+    const skills = formatSkillFocus(upgrade.skills);
+    const note = document.createElement('p');
+    note.className = 'player-equipment__note';
+    note.textContent = skills ? `Skill focus: ${skills}` : 'Skill focus: Generalist boost';
+
+    item.append(name, summary, note);
+    list.appendChild(item);
+  });
+}
+
+function formatEducationStatus(progress) {
+  if (progress.completed) return 'Completed';
+  if (progress.enrolled) return progress.studiedToday ? 'Studied today' : 'In progress';
+  return 'Not enrolled';
+}
+
+function renderEducation(state) {
+  const list = elements.player?.educationList;
+  if (!list) return;
+  list.innerHTML = '';
+
+  const tracks = Object.values(KNOWLEDGE_TRACKS);
+  tracks.forEach(track => {
+    const progress = getKnowledgeProgress(track.id, state);
+    const status = formatEducationStatus(progress);
+    const item = document.createElement('li');
+    item.className = 'player-education__item';
+    item.dataset.status = progress.completed
+      ? 'completed'
+      : progress.enrolled
+      ? 'active'
+      : 'available';
+
+    const header = document.createElement('div');
+    header.className = 'player-education__header';
+    const name = document.createElement('span');
+    name.className = 'player-education__name';
+    name.textContent = track.name;
+    const badge = document.createElement('span');
+    badge.className = 'player-education__status';
+    badge.textContent = status;
+    header.append(name, badge);
+
+    const meta = document.createElement('p');
+    meta.className = 'player-education__meta';
+    const tuition = Number(track.tuition) > 0 ? `$${formatMoney(track.tuition)}` : 'Free';
+    meta.textContent = `${progress.daysCompleted}/${track.days} days • ${formatHours(track.hoursPerDay)} per day • Tuition ${tuition}`;
+
+    const note = document.createElement('p');
+    note.className = 'player-education__note';
+    if (progress.completed) {
+      note.textContent = 'Course complete—permanent bonuses unlocked!';
+    } else if (progress.enrolled) {
+      note.textContent = progress.studiedToday
+        ? 'Today’s session booked and underway.'
+        : 'Session still waiting for focus time today.';
+    } else {
+      note.textContent = 'Enroll when you’re ready for a new boost.';
+    }
+
+    item.append(header, meta, note);
+    list.appendChild(item);
+  });
+}
+
+function countActiveAssets(state) {
+  let count = 0;
+  for (const asset of registry.assets) {
+    const assetState = getAssetState(asset.id, state);
+    const instances = Array.isArray(assetState?.instances) ? assetState.instances : [];
+    count += instances.filter(instance => instance.status === 'active').length;
+  }
+  return count;
+}
+
+function renderStats(state, summary) {
+  const list = elements.player?.statsList;
+  if (!list) return;
+  list.innerHTML = '';
+
+  const assistantState = getUpgradeState('assistant', state);
+  const stats = [
+    {
+      label: 'Active assets',
+      value: String(countActiveAssets(state))
+    },
+    {
+      label: 'Assistants on payroll',
+      value: String(Math.max(0, Number(assistantState?.count) || 0))
+    },
+    {
+      label: 'Passive earnings today',
+      value: `$${formatMoney(summary?.passiveEarnings || 0)}`
+    },
+    {
+      label: 'Daily upkeep spend',
+      value: `$${formatMoney(summary?.upkeepSpend || 0)}`
+    },
+    {
+      label: 'Active study tracks',
+      value: summary?.knowledgeInProgress
+        ? `${summary.knowledgeInProgress} active (${summary.knowledgePendingToday} waiting today)`
+        : 'None scheduled'
+    },
+    {
+      label: 'Focus booked today',
+      value: formatHours(Math.max(0, Number(state?.baseTime || 0) + Number(state?.dailyBonusTime || 0) - Number(state?.timeLeft || 0)))
+    }
+  ];
+
+  stats.forEach(entry => {
+    const item = document.createElement('li');
+    item.className = 'player-stats__item';
+    const label = document.createElement('span');
+    label.className = 'player-stats__label';
+    label.textContent = entry.label;
+    const value = document.createElement('span');
+    value.className = 'player-stats__value';
+    value.textContent = entry.value;
+    item.append(label, value);
+    list.appendChild(item);
+  });
+}
+
+export function renderPlayerPanel(state, summary) {
+  if (!state) return;
+  renderSummary(state, summary);
+  renderSkillList(state);
+  renderEducation(state);
+  renderEquipment(state);
+  renderStats(state, summary);
+}
+
+export default { renderPlayerPanel };

--- a/src/ui/update.js
+++ b/src/ui/update.js
@@ -7,6 +7,7 @@ import { renderSkillWidgets } from './skillsWidget.js';
 import { updateHeaderAction } from './headerAction.js';
 import { applyCardFilters } from './layout.js';
 import { refreshActionCatalogDebug } from './debugCatalog.js';
+import { renderPlayerPanel } from './player.js';
 
 function buildCollections() {
   const hustles = registry.hustles.filter(hustle => hustle.tag?.type !== 'study');
@@ -32,6 +33,7 @@ export function updateUI() {
   const summary = computeDailySummary(state);
   renderDashboard(summary);
   renderSkillWidgets(state);
+  renderPlayerPanel(state, summary);
   updateHeaderAction(state);
 
   const collections = buildCollections();

--- a/styles.css
+++ b/styles.css
@@ -223,6 +223,259 @@ body {
   display: none;
 }
 
+.player-overview {
+  padding-inline: 8px;
+}
+
+.player-overview__grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.player-card {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 0;
+}
+
+.player-card header h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.player-card header p {
+  margin: 6px 0 0;
+  font-size: 14px;
+  color: var(--text-subtle);
+}
+
+.player-card--summary {
+  grid-column: 1 / -1;
+}
+
+.player-summary {
+  display: grid;
+  gap: 18px;
+}
+
+.player-summary__level {
+  display: grid;
+  gap: 6px;
+}
+
+.player-summary__tier {
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.player-summary__note {
+  margin: 0;
+  color: var(--text-subtle);
+  font-size: 14px;
+}
+
+.player-summary__metrics {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  margin: 0;
+}
+
+.player-summary__metrics div {
+  background: var(--surface-muted);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 12px 14px;
+  display: grid;
+  gap: 4px;
+}
+
+.player-summary__metrics dt {
+  margin: 0;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-subtle);
+}
+
+.player-summary__metrics dd {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.player-skill-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 14px;
+}
+
+.player-skill {
+  background: var(--surface-muted);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 14px 16px;
+  display: grid;
+  gap: 8px;
+}
+
+.player-skill__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.player-skill__name {
+  font-weight: 600;
+  font-size: 16px;
+}
+
+.player-skill__badge {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(94, 234, 212, 0.16);
+  color: #5eead4;
+  border-radius: 999px;
+  padding: 4px 10px;
+}
+
+.player-skill__tier {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-subtle);
+}
+
+.player-skill__meter {
+  position: relative;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.25);
+  overflow: hidden;
+}
+
+.player-skill__meter span {
+  position: absolute;
+  inset: 0;
+  width: var(--progress, 0%);
+  background: linear-gradient(120deg, rgba(129, 140, 248, 0.95), rgba(236, 72, 153, 0.9));
+}
+
+.player-skill__meta {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-subtle);
+}
+
+.player-education-list,
+.player-equipment-list,
+.player-stats-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.player-education__item,
+.player-equipment__item {
+  background: var(--surface-muted);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 14px 16px;
+  display: grid;
+  gap: 6px;
+}
+
+.player-education__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.player-education__name {
+  font-weight: 600;
+  font-size: 15px;
+}
+
+.player-education__status {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  border-radius: 999px;
+  padding: 4px 10px;
+  background: rgba(96, 165, 250, 0.16);
+  color: #93c5fd;
+}
+
+.player-education__item[data-status='completed'] .player-education__status {
+  background: rgba(74, 222, 128, 0.16);
+  color: #4ade80;
+}
+
+.player-education__item[data-status='active'] .player-education__status {
+  background: rgba(249, 115, 22, 0.16);
+  color: #fb923c;
+}
+
+.player-education__meta,
+.player-education__note,
+.player-equipment__summary,
+.player-equipment__note {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-subtle);
+}
+
+.player-equipment__name {
+  font-weight: 600;
+  font-size: 15px;
+}
+
+.player-equipment__note {
+  font-style: italic;
+}
+
+.player-equipment__empty {
+  background: rgba(15, 23, 42, 0.4);
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  padding: 16px;
+  font-size: 14px;
+  color: var(--text-subtle);
+}
+
+.player-stats__item {
+  background: var(--surface-muted);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 12px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.player-stats__label {
+  font-size: 13px;
+  color: var(--text-subtle);
+}
+
+.player-stats__value {
+  font-weight: 600;
+  font-size: 15px;
+}
+
 .dashboard__kpis {
   display: grid;
   grid-template-columns: repeat(6, minmax(0, 1fr));


### PR DESCRIPTION
## Summary
- add a dedicated Player tab that surfaces career snapshot metrics, skill journey, education status, equipment, and extra stats
- implement player panel renderer, DOM hooks, and styling to populate the new screen
- document the feature with a design note and changelog entry

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68daaaed49d8832c8b4e3b000fba8448