### PR TITLE
Revamp upgrades hub layout

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@
 - Active build cards surface quality tiers, remaining steps to the next milestone, and yesterday’s payout breakdown so upgrades feel tangible.
 - Automation & infrastructure: broader instant gigs, smarter assistant load balancing, and new studio/server tiers expand long-term play.
 - Education clarity: finished courses now show 100% progress and list the XP-rich skills they elevate.
+- Upgrade hub redesign: roadmap stats, category chips, and a refreshed dock make reinvestment planning faster and more celebratory.
 
 ## Recent Highlights
 - Passive assets gained Quality 4–5 milestones with higher payouts and refreshed modifiers.

--- a/docs/features/upgrade-hub-revamp.md
+++ b/docs/features/upgrade-hub-revamp.md
@@ -1,0 +1,22 @@
+# Upgrade Hub Revamp
+
+**Purpose**
+- Give players a narrative snapshot of their reinvestment plan and surface ready-to-buy picks without hunting through a flat list.
+- Group upgrades into themed lanes so the growing catalog still feels intentional and approachable.
+- Celebrate momentum by highlighting owned, ready, and favorited upgrades in one glanceable dashboard.
+
+**Highlights**
+- New "Upgrade roadmap" panel tallies owned, ready-to-buy, and favorite upgrades while explaining the next suggested action.
+- Category chips and sectioned layouts cluster upgrades into unlocks, boosts, and support lanes with per-section availability notes.
+- Ready or favorited upgrades automatically populate the dock with their current label and price for one-click purchasing.
+- Each card now carries tag/status badges, refreshed copy, and rotating detail bullets that stay current with game state.
+
+**Player Impact**
+- Players can filter by affordability, favorites, search, or category simultaneously, drastically reducing scan time for priority upgrades.
+- The overview note reinforces short-term goals (buy now, meet requirements, or save up) so progression stalls are easier to diagnose.
+- Enhanced dock interactions mirror the card call-to-action, reinforcing confidence that the purchase will behave as expected.
+
+**Follow-ups**
+- Persist category/filter preferences per session.
+- Add inline tooltips for requirement blockers to reduce slide-over trips.
+- Explore mobile stacking patterns once responsive breakpoints are defined.

--- a/index.html
+++ b/index.html
@@ -286,10 +286,10 @@
       </section>
 
       <section id="panel-upgrades" class="panel" role="tabpanel" aria-labelledby="tab-upgrades" hidden>
-        <header class="panel__header">
+        <header class="panel__header upgrade-panel__header">
           <div>
             <h2>Upgrades</h2>
-            <p>Boost every hustle with focused reinvestment.</p>
+            <p>Plot your reinvestments, queue favorites, and celebrate each new unlock.</p>
           </div>
           <div class="filter-bar" role="group" aria-label="Upgrade filters">
             <label class="filter-toggle">
@@ -305,7 +305,30 @@
           </div>
         </header>
         <div class="upgrade-layout">
-          <div id="upgrade-list" class="upgrade-list" aria-live="polite"></div>
+          <div class="upgrade-main">
+            <section id="upgrade-overview" class="upgrade-overview" aria-labelledby="upgrade-overview-title" aria-live="polite">
+              <header>
+                <h3 id="upgrade-overview-title">Upgrade roadmap</h3>
+                <p id="upgrade-overview-note">Queue your next win and keep momentum humming.</p>
+              </header>
+              <dl class="upgrade-overview__stats">
+                <div>
+                  <dt>Owned</dt>
+                  <dd id="upgrade-overview-owned">0</dd>
+                </div>
+                <div>
+                  <dt>Ready to buy</dt>
+                  <dd id="upgrade-overview-ready">0</dd>
+                </div>
+                <div>
+                  <dt>Favorites</dt>
+                  <dd id="upgrade-overview-favorites">0</dd>
+                </div>
+              </dl>
+            </section>
+            <p id="upgrade-empty" class="upgrade-empty" hidden>No upgrades match these filters yet. Try another category or clear the toggles.</p>
+            <div id="upgrade-list" class="upgrade-list" aria-live="polite"></div>
+          </div>
           <aside class="upgrade-dock" aria-label="Upgrade dock">
             <header>
               <h3>Dock</h3>

--- a/src/ui/elements.js
+++ b/src/ui/elements.js
@@ -111,6 +111,14 @@ const elements = {
     affordable: document.getElementById('upgrade-affordable-toggle'),
     favorites: document.getElementById('upgrade-favorites-toggle')
   },
+  upgradeOverview: {
+    container: document.getElementById('upgrade-overview'),
+    purchased: document.getElementById('upgrade-overview-owned'),
+    ready: document.getElementById('upgrade-overview-ready'),
+    favorites: document.getElementById('upgrade-overview-favorites'),
+    note: document.getElementById('upgrade-overview-note')
+  },
+  upgradeEmpty: document.getElementById('upgrade-empty'),
   upgradeCategoryChips: document.getElementById('upgrade-category-chips'),
   upgradeSearch: document.getElementById('upgrade-search'),
   upgradeList: document.getElementById('upgrade-list'),

--- a/src/ui/layout.js
+++ b/src/ui/layout.js
@@ -1,5 +1,17 @@
 import elements from './elements.js';
 
+function emitLayoutEvent(name) {
+  if (typeof document?.createEvent === 'function') {
+    const event = document.createEvent('Event');
+    event.initEvent(name, true, true);
+    document.dispatchEvent(event);
+    return;
+  }
+  if (typeof Event === 'function') {
+    document.dispatchEvent(new Event(name));
+  }
+}
+
 export function initLayoutControls() {
   setupTabs();
   setupEventLog();
@@ -137,6 +149,9 @@ function setupFilterHandlers() {
   elements.upgradeFilters.favorites?.addEventListener('change', applyUpgradeFilters);
   elements.upgradeSearch?.addEventListener('input', debounce(applyUpgradeFilters, 150));
 
+  document.addEventListener('upgrades:category-changed', applyUpgradeFilters);
+  document.addEventListener('upgrades:state-updated', applyUpgradeFilters);
+
   elements.studyFilters.activeOnly?.addEventListener('change', applyStudyFilters);
   elements.studyFilters.hideComplete?.addEventListener('change', applyStudyFilters);
 }
@@ -186,13 +201,17 @@ function applyUpgradeFilters() {
   const affordableOnly = Boolean(elements.upgradeFilters.affordable?.checked);
   const favoritesOnly = Boolean(elements.upgradeFilters.favorites?.checked);
   const query = (elements.upgradeSearch?.value || '').trim().toLowerCase();
+  const activeCategory = elements.upgradeCategoryChips?.dataset.active || 'all';
 
   cards.forEach(card => {
     const matchesSearch = !query || card.dataset.search?.includes(query);
     const matchesAffordable = !affordableOnly || card.dataset.affordable === 'true';
     const matchesFavorites = !favoritesOnly || card.dataset.favorite === 'true';
-    card.hidden = !(matchesSearch && matchesAffordable && matchesFavorites);
+    const matchesCategory = activeCategory === 'all' || card.dataset.category === activeCategory;
+    card.hidden = !(matchesSearch && matchesAffordable && matchesFavorites && matchesCategory);
   });
+
+  emitLayoutEvent('upgrades:filtered');
 }
 
 function applyStudyFilters() {

--- a/styles.css
+++ b/styles.css
@@ -999,24 +999,205 @@ body {
   color: var(--text-subtle);
 }
 
+
+.upgrade-panel__header {
+  align-items: flex-start;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
 .upgrade-layout {
   display: grid;
-  grid-template-columns: 1fr 280px;
-  gap: 20px;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: 24px;
+  align-items: flex-start;
+}
+
+.upgrade-main {
+  display: grid;
+  gap: 24px;
+  align-content: start;
+}
+
+.upgrade-overview {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  padding: 20px;
+  display: grid;
+  gap: 16px;
+}
+
+.upgrade-overview header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.upgrade-overview header h3 {
+  margin: 0;
+}
+
+.upgrade-overview__stats {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.upgrade-overview__stats div {
+  background: var(--surface-muted);
+  border-radius: var(--radius-md);
+  padding: 12px;
+  display: grid;
+  gap: 4px;
+}
+
+.upgrade-overview__stats dt {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-subtle);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.upgrade-overview__stats dd {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.upgrade-empty {
+  background: var(--surface);
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius-lg);
+  padding: 16px 20px;
+  color: var(--text-subtle);
 }
 
 .upgrade-list {
   display: grid;
+  gap: 28px;
+}
+
+.upgrade-section {
+  display: grid;
+  gap: 18px;
+}
+
+.upgrade-section__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
   gap: 16px;
+  flex-wrap: wrap;
+}
+
+.upgrade-section__heading {
+  display: grid;
+  gap: 4px;
+}
+
+.upgrade-section__heading h3 {
+  margin: 0;
+}
+
+.upgrade-section__heading p {
+  margin: 0;
+  color: var(--text-subtle);
+  font-size: 14px;
+}
+
+.upgrade-section__eyebrow {
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent-strong);
+  font-weight: 600;
+}
+
+.upgrade-section__count {
+  font-size: 13px;
+  color: var(--text-subtle);
+}
+
+.upgrade-section[data-empty='true'] .upgrade-section__count {
+  color: rgba(148, 163, 184, 0.6);
+}
+
+.upgrade-section__list {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.upgrade-section__empty {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-subtle);
 }
 
 .upgrade-card {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  padding: 16px;
+  padding: 20px;
   display: grid;
+  gap: 14px;
+  position: relative;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.upgrade-card:focus-within,
+.upgrade-card:hover {
+  border-color: rgba(124, 92, 255, 0.35);
+  box-shadow: 0 12px 32px -24px rgba(124, 92, 255, 0.6);
+}
+
+.upgrade-card[data-ready='true'] {
+  border-color: rgba(124, 92, 255, 0.45);
+  box-shadow: 0 16px 36px -24px rgba(124, 92, 255, 0.7);
+}
+
+.upgrade-card[data-purchased='true'] {
+  opacity: 0.85;
+}
+
+.upgrade-card__eyebrow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   gap: 12px;
+}
+
+.upgrade-card__tag {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+
+.upgrade-card__status {
+  font-size: 13px;
+  color: var(--text-subtle);
+}
+
+.upgrade-card__status[data-state='ready'] {
+  color: var(--accent-strong);
+  font-weight: 600;
+}
+
+.upgrade-card__status[data-state='owned'] {
+  color: #2dd4bf;
+  font-weight: 600;
+}
+
+.upgrade-card__status[data-state='blocked'] {
+  color: #f97316;
 }
 
 .upgrade-card__header {
@@ -1028,24 +1209,56 @@ body {
 
 .upgrade-card__title {
   margin: 0;
-  font-size: 18px;
+  font-size: 20px;
 }
 
-.upgrade-card__meta {
-  display: flex;
-  justify-content: space-between;
+.upgrade-card__price {
+  font-weight: 600;
+  color: var(--accent-strong);
+}
+
+.upgrade-card__description {
+  margin: 0;
+  color: var(--text-subtle);
+}
+
+.upgrade-card__details {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
   font-size: 14px;
   color: var(--text-subtle);
 }
 
+.upgrade-card__detail {
+  position: relative;
+  padding-left: 18px;
+}
+
+.upgrade-card__detail::before {
+  content: '•';
+  position: absolute;
+  left: 0;
+  top: 0;
+  color: var(--accent-strong);
+}
+
 .upgrade-card__actions {
   display: flex;
-  justify-content: flex-end;
-  gap: 10px;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
 }
 
 .upgrade-card__actions button[aria-pressed='true'] {
   color: var(--accent-strong);
+}
+
+.upgrade-card__actions .ghost {
+  font-size: 13px;
 }
 
 .upgrade-dock {
@@ -1071,9 +1284,34 @@ body {
 .dock-item {
   background: var(--surface-muted);
   border-radius: var(--radius-md);
-  padding: 12px;
+  padding: 14px;
   display: grid;
   gap: 8px;
+  border: 1px solid transparent;
+}
+
+.dock-item__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: baseline;
+}
+
+.dock-item__price {
+  font-size: 14px;
+  color: var(--accent-strong);
+  font-weight: 600;
+}
+
+.dock-item__note {
+  color: var(--text-subtle);
+  font-size: 13px;
+}
+
+.dock-item--empty {
+  text-align: center;
+  color: var(--text-subtle);
+  border-style: dashed;
 }
 
 .study-queue {


### PR DESCRIPTION
## Summary
- redesign the upgrades panel with an overview, empty state, and category sections for clearer navigation
- refresh upgrade cards, dock suggestions, and filters to highlight ready, favorite, and affordable purchases
- document the hub revamp and capture the changelog entry for the new layout

## Testing
- npm test
- Manual: Loaded http://127.0.0.1:4173/ and reviewed the Upgrades tab

------
https://chatgpt.com/codex/tasks/task_e_68daab48d920832cb84bee65db13f417