### PR TITLE
Redesign asset detail slide-over layout

### DIFF
--- a/src/ui/cards.js
+++ b/src/ui/cards.js
@@ -2,7 +2,7 @@ import elements from './elements.js';
 import { getAssetState, getState, getUpgradeState } from '../core/state.js';
 import { formatDays, formatHours, formatMoney } from '../core/helpers.js';
 import { describeHustleRequirements } from '../game/hustles.js';
-import { KNOWLEDGE_TRACKS, KNOWLEDGE_REWARDS, getKnowledgeProgress } from '../game/requirements.js';
+import { describeRequirement, getDefinitionRequirements, KNOWLEDGE_TRACKS, KNOWLEDGE_REWARDS, getKnowledgeProgress } from '../game/requirements.js';
 import { getTimeCap } from '../game/time.js';
 import {
   describeInstance,
@@ -23,6 +23,7 @@ import {
   getQualityActionCooldown,
   getQualityActions,
   getQualityLevel,
+  getQualityLevelSummary,
   getQualityNextRequirements,
   getQualityTracks,
   getNextQualityLevel,
@@ -122,48 +123,182 @@ function describeSkillWeight(weight = 0) {
 }
 
 function createAssetDetailHighlights(definition) {
-  const detailBuilders = Array.isArray(definition.details) ? definition.details : [];
-  const details = detailBuilders
-    .map(builder => {
-      if (typeof builder === 'function') {
-        try {
-          return builder();
-        } catch (error) {
-          console.error('Failed to render asset detail', error);
-          return null;
+  const entries = Array.isArray(definition.detailEntries)
+    ? definition.detailEntries
+    : Array.isArray(definition.details)
+      ? definition.details.map((render, index) => ({ key: `detail-${index}`, render }))
+      : [];
+
+  const renderedDetails = entries
+    .map((entry, index) => {
+      const render = typeof entry.render === 'function' ? entry.render : entry;
+      if (typeof render !== 'function') return null;
+      try {
+        const value = render();
+        if (!value) return null;
+        if (typeof value === 'string') {
+          const trimmed = value.trim();
+          if (!trimmed) return null;
+          return { key: entry.key || `detail-${index}`, value: trimmed };
         }
+        if (value instanceof Node) {
+          return { key: entry.key || `detail-${index}`, value };
+        }
+        return null;
+      } catch (error) {
+        console.error('Failed to render asset detail', error);
+        return null;
       }
-      return builder;
     })
-    .filter(detail => {
-      if (!detail) return false;
-      if (typeof detail === 'string') {
-        return detail.trim().length > 0;
-      }
-      return detail instanceof Node;
-    });
+    .filter(Boolean);
 
-  if (!details.length) return null;
+  const detailByKey = new Map();
+  renderedDetails.forEach(detail => {
+    if (!detailByKey.has(detail.key)) {
+      detailByKey.set(detail.key, []);
+    }
+    detailByKey.get(detail.key).push(detail.value);
+  });
 
+  const requirements = getDefinitionRequirements(definition);
   const section = document.createElement('section');
-  section.className = 'asset-detail__section';
+  section.className = 'asset-detail__section asset-detail__section--blueprint';
   const heading = document.createElement('h3');
   heading.textContent = 'Launch blueprint';
   section.appendChild(heading);
 
-  const list = document.createElement('ul');
-  list.className = 'asset-detail__highlights';
-  details.forEach(detail => {
+  const grid = document.createElement('div');
+  grid.className = 'asset-detail__summary-grid';
+  section.appendChild(grid);
+
+  // Requirements column
+  const requirementsCard = document.createElement('article');
+  requirementsCard.className = 'asset-detail__summary-card asset-detail__summary-card--requirements';
+  const requirementsTitle = document.createElement('h4');
+  requirementsTitle.textContent = 'Requirements';
+  requirementsCard.appendChild(requirementsTitle);
+  const requirementsList = document.createElement('ul');
+  requirementsList.className = 'asset-detail__summary-list';
+  if (requirements?.hasAny) {
+    requirements.all.forEach(req => {
+      const descriptor = describeRequirement(req);
+      const item = document.createElement('li');
+      item.className = 'asset-detail__summary-item';
+      item.innerHTML = descriptor?.detail || '❔ <strong>Requirement</strong>';
+      requirementsList.appendChild(item);
+    });
+  } else {
+    const fallbackItem = document.createElement('li');
+    fallbackItem.className = 'asset-detail__summary-item';
+    const fallbackDetail = detailByKey.get('requirements')?.[0] || '🔓 Requirements: <strong>None</strong>';
+    if (typeof fallbackDetail === 'string') {
+      fallbackItem.innerHTML = fallbackDetail;
+    } else if (fallbackDetail instanceof Node) {
+      fallbackItem.appendChild(fallbackDetail);
+    }
+    requirementsList.appendChild(fallbackItem);
+  }
+  requirementsCard.appendChild(requirementsList);
+  grid.appendChild(requirementsCard);
+
+  // Quality column
+  const qualityCard = document.createElement('article');
+  qualityCard.className = 'asset-detail__summary-card asset-detail__summary-card--quality';
+  const qualityTitle = document.createElement('h4');
+  qualityTitle.textContent = 'Quality journey';
+  qualityCard.appendChild(qualityTitle);
+
+  const qualitySummary = detailByKey.get('qualitySummary')?.[0];
+  const summaryCopy = document.createElement('p');
+  summaryCopy.className = 'asset-detail__summary-copy';
+  if (typeof qualitySummary === 'string') {
+    summaryCopy.innerHTML = qualitySummary;
+  } else if (qualitySummary instanceof Node) {
+    summaryCopy.appendChild(qualitySummary);
+  } else {
+    summaryCopy.textContent = '✨ Quality boosts unlock as you invest in specialty tracks.';
+  }
+  qualityCard.appendChild(summaryCopy);
+
+  const qualityList = document.createElement('ul');
+  qualityList.className = 'asset-detail__summary-list asset-detail__summary-list--quality';
+  const tracks = getQualityTracks(definition);
+  const levels = getQualityLevelSummary(definition);
+  levels.forEach(level => {
     const item = document.createElement('li');
-    item.className = 'asset-detail__highlight';
-    if (typeof detail === 'string') {
-      item.innerHTML = detail;
-    } else if (detail instanceof Node) {
+    item.className = 'asset-detail__summary-item';
+    const title = document.createElement('div');
+    title.className = 'asset-detail__summary-line';
+    title.innerHTML = `<strong>Quality ${level.level}:</strong> ${level.name}`;
+    item.appendChild(title);
+    const requirementEntries = Object.entries(level.requirements || {});
+    if (requirementEntries.length) {
+      const detail = document.createElement('div');
+      detail.className = 'asset-detail__summary-subtext';
+      const parts = requirementEntries.map(([key, value]) => {
+        const label = tracks[key]?.shortLabel || tracks[key]?.label || key;
+        return `${value} ${label}`;
+      });
+      detail.textContent = parts.join(' • ');
+      item.appendChild(detail);
+    } else {
+      const detail = document.createElement('div');
+      detail.className = 'asset-detail__summary-subtext';
+      detail.textContent = 'Entry tier — no prep required.';
       item.appendChild(detail);
     }
-    list.appendChild(item);
+    qualityList.appendChild(item);
   });
-  section.appendChild(list);
+  qualityCard.appendChild(qualityList);
+  grid.appendChild(qualityCard);
+
+  // Roadmap / stats column
+  const roadmapCard = document.createElement('article');
+  roadmapCard.className = 'asset-detail__summary-card asset-detail__summary-card--roadmap';
+  const roadmapTitle = document.createElement('h4');
+  roadmapTitle.textContent = 'Roadmap & stats';
+  roadmapCard.appendChild(roadmapTitle);
+
+  const roadmapList = document.createElement('ul');
+  roadmapList.className = 'asset-detail__summary-list';
+  const roadmapKeys = ['owned', 'setup', 'setupCost', 'maintenance', 'income', 'latestYield'];
+  roadmapKeys.forEach(key => {
+    const values = detailByKey.get(key) || [];
+    values.forEach(value => {
+      const item = document.createElement('li');
+      item.className = 'asset-detail__summary-item';
+      if (typeof value === 'string') {
+        item.innerHTML = value;
+      } else if (value instanceof Node) {
+        item.appendChild(value);
+      }
+      roadmapList.appendChild(item);
+    });
+  });
+
+  const consumedKeys = new Set(['requirements', 'qualitySummary', 'qualityProgress', ...roadmapKeys]);
+  const extraDetails = renderedDetails.filter(detail => !consumedKeys.has(detail.key));
+  extraDetails.forEach(detail => {
+    const item = document.createElement('li');
+    item.className = 'asset-detail__summary-item';
+    if (typeof detail.value === 'string') {
+      item.innerHTML = detail.value;
+    } else if (detail.value instanceof Node) {
+      item.appendChild(detail.value);
+    }
+    roadmapList.appendChild(item);
+  });
+
+  if (!roadmapList.children.length) {
+    const empty = document.createElement('li');
+    empty.className = 'asset-detail__summary-item';
+    empty.textContent = 'No roadmap details available yet.';
+    roadmapList.appendChild(empty);
+  }
+
+  roadmapCard.appendChild(roadmapList);
+  grid.appendChild(roadmapCard);
+
   return section;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1694,6 +1694,82 @@ body {
   gap: 12px;
 }
 
+.asset-detail__section--blueprint {
+  gap: 16px;
+}
+
+.asset-detail__summary-grid {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 720px) {
+  .asset-detail__summary-grid {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  }
+}
+
+.asset-detail__summary-card {
+  display: grid;
+  gap: 12px;
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.08), rgba(17, 27, 48, 0.6));
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: var(--radius-lg);
+  padding: 18px;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.4);
+}
+
+.asset-detail__summary-card h4 {
+  margin: 0;
+  font-size: 15px;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: rgba(203, 213, 255, 0.85);
+}
+
+.asset-detail__summary-copy {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.6;
+  color: rgba(226, 232, 255, 0.85);
+}
+
+.asset-detail__summary-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.asset-detail__summary-list--quality {
+  gap: 12px;
+}
+
+.asset-detail__summary-item {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: var(--radius-md);
+  padding: 12px 14px;
+  line-height: 1.5;
+  font-size: 13px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.asset-detail__summary-item strong {
+  color: var(--text);
+}
+
+.asset-detail__summary-line {
+  font-size: 13.5px;
+}
+
+.asset-detail__summary-subtext {
+  margin-top: 6px;
+  font-size: 12px;
+  color: rgba(203, 213, 255, 0.75);
+}
+
 .asset-detail__section h3 {
   margin: 0;
   font-size: 16px;


### PR DESCRIPTION
## Summary
- group asset detail content into requirements, quality, and roadmap cards for better readability
- preserve detail metadata when building asset definitions so the slider knows which data to display
- add styling for the new summary grid and supporting copy

## Testing
- npm test
- manual: viewed asset detail slide-over in browser

------
https://chatgpt.com/codex/tasks/task_e_68dab12984b0832ca20b7efe14505880