### PR TITLE
Streamline upgrade hub actions

### DIFF
--- a/docs/features/upgrade-hub-revamp.md
+++ b/docs/features/upgrade-hub-revamp.md
@@ -3,16 +3,16 @@
 **Purpose**
 - Give players a narrative snapshot of their reinvestment plan and surface ready-to-buy picks without hunting through a flat list.
 - Group upgrades into themed lanes so the growing catalog still feels intentional and approachable.
-- Celebrate momentum by highlighting owned, ready, and favorited upgrades in one glanceable dashboard.
+- Celebrate momentum by highlighting owned and ready upgrades in one glanceable dashboard.
 
 **Highlights**
-- New "Upgrade roadmap" panel tallies owned, ready-to-buy, and favorite upgrades while explaining the next suggested action.
+- New "Upgrade roadmap" panel tallies owned and ready-to-buy upgrades while explaining the next suggested action.
 - Category chips and sectioned layouts cluster upgrades into unlocks, boosts, and support lanes with per-section availability notes.
-- Ready or favorited upgrades automatically populate the dock with their current label and price for one-click purchasing.
+- Ready upgrades automatically populate the dock with their current label and price for one-click purchasing.
 - Each card now carries tag/status badges, refreshed copy, and rotating detail bullets that stay current with game state.
 
 **Player Impact**
-- Players can filter by affordability, favorites, search, or category simultaneously, drastically reducing scan time for priority upgrades.
+- Players can filter by affordability, search, or category simultaneously, drastically reducing scan time for priority upgrades.
 - The overview note reinforces short-term goals (buy now, meet requirements, or save up) so progression stalls are easier to diagnose.
 - Enhanced dock interactions mirror the card call-to-action, reinforcing confidence that the purchase will behave as expected.
 

--- a/index.html
+++ b/index.html
@@ -369,16 +369,12 @@
         <header class="panel__header upgrade-panel__header">
           <div>
             <h2>Upgrades</h2>
-            <p>Plot your reinvestments, queue favorites, and celebrate each new unlock.</p>
+            <p>Plot your reinvestments and celebrate each new unlock.</p>
           </div>
           <div class="filter-bar" role="group" aria-label="Upgrade filters">
             <label class="filter-toggle">
               <input id="upgrade-affordable-toggle" type="checkbox" />
               <span>Affordable</span>
-            </label>
-            <label class="filter-toggle">
-              <input id="upgrade-favorites-toggle" type="checkbox" />
-              <span>Favorites</span>
             </label>
             <div id="upgrade-category-chips" class="chips" role="listbox" aria-label="Categories"></div>
             <input id="upgrade-search" type="search" placeholder="Search upgrades" aria-label="Search upgrades" />
@@ -399,10 +395,6 @@
                 <div>
                   <dt>Ready to buy</dt>
                   <dd id="upgrade-overview-ready">0</dd>
-                </div>
-                <div>
-                  <dt>Favorites</dt>
-                  <dd id="upgrade-overview-favorites">0</dd>
                 </div>
               </dl>
             </section>

--- a/src/ui/cards.js
+++ b/src/ui/cards.js
@@ -1746,6 +1746,8 @@ function updateUpgradeCard(definition) {
   }
 
   ui.updateDetails?.();
+}
+
 function renderUpgrades(definitions) {
   const list = elements.upgradeList;
   if (!list) return;

--- a/src/ui/cards.js
+++ b/src/ui/cards.js
@@ -1,5 +1,5 @@
 import elements from './elements.js';
-import { getAssetState, getState, getUpgradeState } from '../core/state.js';
+import { getAssetState, getState } from '../core/state.js';
 import { formatDays, formatHours, formatMoney } from '../core/helpers.js';
 import { describeHustleRequirements } from '../game/hustles.js';
 import { KNOWLEDGE_TRACKS, KNOWLEDGE_REWARDS, getKnowledgeProgress } from '../game/requirements.js';
@@ -1418,13 +1418,11 @@ function getUpgradeSnapshot(definition, state = getState()) {
   const affordable = cost <= 0 || money >= cost;
   const disabled = isUpgradeDisabled(definition);
   const purchased = Boolean(upgradeState.purchased);
-  const favorite = Boolean(upgradeState.favorite);
   const ready = !purchased && affordable && !disabled;
   return {
     cost,
     affordable,
     disabled,
-    favorite,
     name: definition.name || definition.id,
     purchased,
     ready
@@ -1448,9 +1446,8 @@ function sortUpgradesForCategory(definitions, state = getState()) {
 
       const score = snapshot => {
         if (snapshot.ready) return 0;
-        if (snapshot.favorite && !snapshot.purchased) return 1;
-        if (!snapshot.purchased && snapshot.affordable) return 2;
-        if (snapshot.purchased) return 4;
+        if (!snapshot.purchased && snapshot.affordable) return 1;
+        if (!snapshot.purchased) return 2;
         return 3;
       };
 
@@ -1532,16 +1529,14 @@ function renderUpgradeOverview(definitions) {
       const snapshot = getUpgradeSnapshot(definition, state);
       if (snapshot.purchased) acc.purchased += 1;
       if (snapshot.ready) acc.ready += 1;
-      if (snapshot.favorite) acc.favorites += 1;
       acc.total += 1;
       return acc;
     },
-    { purchased: 0, ready: 0, favorites: 0, total: 0 }
+    { purchased: 0, ready: 0, total: 0 }
   );
 
   overview.purchased.textContent = `${stats.purchased}/${stats.total}`;
   overview.ready.textContent = String(stats.ready);
-  overview.favorites.textContent = String(stats.favorites);
   if (overview.note) {
     overview.note.textContent = describeOverviewNote(stats);
   }
@@ -1690,22 +1685,9 @@ function renderUpgradeCard(definition, container, categoryId) {
     actions.appendChild(buyButton);
   }
 
-  const favoriteButton = document.createElement('button');
-  favoriteButton.type = 'button';
-  favoriteButton.dataset.role = 'favorite-upgrade';
-  favoriteButton.className = 'ghost';
-  favoriteButton.textContent = 'Save';
-  favoriteButton.title = 'Toggle favorite to pin this upgrade in the dock.';
-  favoriteButton.addEventListener('click', () => toggleUpgradeFavorite(definition));
-  actions.appendChild(favoriteButton);
-
-  const detailsButton = document.createElement('button');
-  detailsButton.type = 'button';
-  detailsButton.className = 'ghost';
-  detailsButton.textContent = 'Details';
-  detailsButton.addEventListener('click', () => openUpgradeDetails(definition));
-  actions.appendChild(detailsButton);
-  card.appendChild(actions);
+  if (actions.childElementCount > 0) {
+    card.appendChild(actions);
+  }
 
   let extra = null;
   if (typeof definition.extraContent === 'function') {
@@ -1716,7 +1698,6 @@ function renderUpgradeCard(definition, container, categoryId) {
   upgradeUi.set(definition.id, {
     card,
     buyButton,
-    favoriteButton,
     status,
     price,
     updateDetails: details?.update,
@@ -1732,7 +1713,6 @@ function updateUpgradeCard(definition) {
   const snapshot = getUpgradeSnapshot(definition, state);
 
   ui.card.dataset.affordable = snapshot.affordable ? 'true' : 'false';
-  ui.card.dataset.favorite = snapshot.favorite ? 'true' : 'false';
   ui.card.dataset.purchased = snapshot.purchased ? 'true' : 'false';
   ui.card.dataset.ready = snapshot.ready ? 'true' : 'false';
 
@@ -1742,11 +1722,6 @@ function updateUpgradeCard(definition) {
     ui.buyButton.textContent = typeof definition.action?.label === 'function'
       ? definition.action.label(state)
       : definition.action?.label || 'Buy';
-  }
-
-  if (ui.favoriteButton) {
-    ui.favoriteButton.setAttribute('aria-pressed', snapshot.favorite ? 'true' : 'false');
-    ui.favoriteButton.textContent = snapshot.favorite ? 'Saved' : 'Save';
   }
 
   if (ui.status) {
@@ -1771,47 +1746,6 @@ function updateUpgradeCard(definition) {
   }
 
   ui.updateDetails?.();
-}
-
-function toggleUpgradeFavorite(definition) {
-  const state = getState();
-  if (!state) return;
-  state.upgrades = state.upgrades || {};
-  state.upgrades[definition.id] = state.upgrades[definition.id] || {};
-  const current = Boolean(state.upgrades[definition.id].favorite);
-  state.upgrades[definition.id].favorite = !current;
-  updateUpgradeCard(definition);
-  renderUpgradeDock();
-  if (!currentUpgradeDefinitions.length) {
-    currentUpgradeDefinitions = [definition];
-  }
-  renderUpgradeOverview(currentUpgradeDefinitions);
-  refreshUpgradeSections();
-  emitUIEvent('upgrades:state-updated');
-}
-
-function openUpgradeDetails(definition) {
-  const state = getState();
-  const body = document.createElement('div');
-  body.className = 'upgrade-detail';
-
-  if (definition.description) {
-    const intro = document.createElement('p');
-    intro.textContent = definition.description;
-    body.appendChild(intro);
-  }
-
-  const cost = Number(definition.cost) || 0;
-  body.appendChild(
-    createDefinitionSummary('Investment', [
-      { label: 'Price', value: cost > 0 ? `$${formatMoney(cost)}` : 'No cost' },
-      { label: 'Owned', value: getUpgradeState(definition.id, state)?.purchased ? 'Yes' : 'No' }
-    ])
-  );
-
-  showSlideOver({ eyebrow: 'Upgrade', title: definition.name, body });
-}
-
 function renderUpgrades(definitions) {
   const list = elements.upgradeList;
   if (!list) return;
@@ -1875,16 +1809,12 @@ function renderUpgradeDock() {
   dock.innerHTML = '';
 
   const cards = Array.from(upgradeUi.values()).map(ui => ui.card);
-  const readyCards = cards.filter(card => card.dataset.ready === 'true');
-  const favoriteCards = cards.filter(
-    card => card.dataset.favorite === 'true' && card.dataset.purchased !== 'true'
-  );
-  const pool = readyCards.length ? readyCards : favoriteCards;
+  const pool = cards.filter(card => card.dataset.ready === 'true');
 
   if (!pool.length) {
     const empty = document.createElement('li');
     empty.className = 'dock-item dock-item--empty';
-    empty.textContent = 'No standout upgrades yet. Favor a card or meet a prerequisite to populate this list.';
+    empty.textContent = 'No standout upgrades yet. Meet a prerequisite or stack more cash to populate this list.';
     dock.appendChild(empty);
     return;
   }

--- a/src/ui/elements.js
+++ b/src/ui/elements.js
@@ -108,14 +108,12 @@ const elements = {
     content: document.getElementById('asset-launched-content')
   },
   upgradeFilters: {
-    affordable: document.getElementById('upgrade-affordable-toggle'),
-    favorites: document.getElementById('upgrade-favorites-toggle')
+    affordable: document.getElementById('upgrade-affordable-toggle')
   },
   upgradeOverview: {
     container: document.getElementById('upgrade-overview'),
     purchased: document.getElementById('upgrade-overview-owned'),
     ready: document.getElementById('upgrade-overview-ready'),
-    favorites: document.getElementById('upgrade-overview-favorites'),
     note: document.getElementById('upgrade-overview-note')
   },
   upgradeEmpty: document.getElementById('upgrade-empty'),

--- a/src/ui/layout.js
+++ b/src/ui/layout.js
@@ -146,7 +146,6 @@ function setupFilterHandlers() {
   elements.assetFilters.lowRisk?.addEventListener('change', applyAssetFilters);
 
   elements.upgradeFilters.affordable?.addEventListener('change', applyUpgradeFilters);
-  elements.upgradeFilters.favorites?.addEventListener('change', applyUpgradeFilters);
   elements.upgradeSearch?.addEventListener('input', debounce(applyUpgradeFilters, 150));
 
   document.addEventListener('upgrades:category-changed', applyUpgradeFilters);
@@ -199,16 +198,14 @@ function applyAssetFilters() {
 function applyUpgradeFilters() {
   const cards = Array.from(elements.upgradeList?.querySelectorAll('[data-upgrade]') || []);
   const affordableOnly = Boolean(elements.upgradeFilters.affordable?.checked);
-  const favoritesOnly = Boolean(elements.upgradeFilters.favorites?.checked);
   const query = (elements.upgradeSearch?.value || '').trim().toLowerCase();
   const activeCategory = elements.upgradeCategoryChips?.dataset.active || 'all';
 
   cards.forEach(card => {
     const matchesSearch = !query || card.dataset.search?.includes(query);
     const matchesAffordable = !affordableOnly || card.dataset.affordable === 'true';
-    const matchesFavorites = !favoritesOnly || card.dataset.favorite === 'true';
     const matchesCategory = activeCategory === 'all' || card.dataset.category === activeCategory;
-    card.hidden = !(matchesSearch && matchesAffordable && matchesFavorites && matchesCategory);
+    card.hidden = !(matchesSearch && matchesAffordable && matchesCategory);
   });
 
   emitLayoutEvent('upgrades:filtered');

--- a/styles.css
+++ b/styles.css
@@ -1435,11 +1435,28 @@ body {
 }
 
 .upgrade-card__tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  color: var(--accent-strong);
   font-weight: 700;
+  color: var(--accent-strong);
+  padding: 4px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--surface-muted);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.upgrade-card__tag::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--accent-strong);
+  box-shadow: 0 0 0 2px rgba(159, 123, 255, 0.25);
 }
 
 .upgrade-card__status {
@@ -1508,18 +1525,20 @@ body {
 
 .upgrade-card__actions {
   display: flex;
-  justify-content: space-between;
   gap: 12px;
   flex-wrap: wrap;
+  align-items: stretch;
+  justify-content: flex-start;
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
+.upgrade-card__actions button {
+  flex: 1 1 160px;
+  display: inline-flex;
+  justify-content: center;
   align-items: center;
-}
-
-.upgrade-card__actions button[aria-pressed='true'] {
-  color: var(--accent-strong);
-}
-
-.upgrade-card__actions .ghost {
-  font-size: 13px;
 }
 
 .upgrade-dock {

--- a/tests/helpers/setupDom.js
+++ b/tests/helpers/setupDom.js
@@ -105,7 +105,6 @@ export function ensureTestDom() {
           <section id="panel-upgrades" class="panel" hidden>
             <input id="upgrade-search" />
             <input id="upgrade-affordable-toggle" type="checkbox" />
-            <input id="upgrade-favorites-toggle" type="checkbox" />
             <div id="upgrade-category-chips"></div>
             <div id="upgrade-list"></div>
             <aside>


### PR DESCRIPTION
## Summary
- remove the upgrade favorites toggle and legacy details button from the hub UI
- restyle upgrade tags and action areas so buy CTAs feel more prominent
- update fixtures and feature notes to reflect the new upgrade overview stats

## Testing
- npm test *(fails: SyntaxError: Unexpected token 'export' while importing src/ui/cards.js under node --test)*
- Manual: served index.html locally and opened the Upgrades tab

------
https://chatgpt.com/codex/tasks/task_e_68dab374da40832c8f02d2e6364a1859