### PR TITLE
Remove min-width constraint from milestone requirement cards

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2264,7 +2264,6 @@ body {
   border-radius: var(--radius-md);
   padding: 10px 12px;
   backdrop-filter: blur(4px);
-  min-width: 220px;
   flex: 0 0 auto;
   scroll-snap-align: start;
 }


### PR DESCRIPTION
## Summary
- remove the fixed min-width from milestone requirement entries so they can shrink on smaller viewports

## Testing
- not run (css-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dabaae1644832c866cd5b0df5156d2