### PR TITLE
Remove delayed hustle payouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Online Hustle Simulator is a browser-based incremental game about orchestrating 
 - **Freelance Writing** – Spend 2h to earn $18 instantly (Outline Mastery grads earn +25%).
 - **Audience Q&A Blast** – Spend 1h with at least one active blog to earn $12 from checklist upsells (+$4 after Brand Voice Lab).
 - **Bundle Promo Push** – Spend 2.5h once you have two active blogs plus an e-book to pocket $48 immediately (+$6 after E-Commerce Playbook).
-- **eBay Flips** – Spend 4h and $20; complete 30 seconds later for $48 (multiple flips queue).
 - **Outline Mastery Workshop** – Pay $140 upfront; 2h/day for 5 days auto-reserve to unlock e-book production chops and boost writing/narration gigs.
 - **Photo Catalog Curation** – Pay $95 upfront; 1.5h/day for 4 days auto-reserve to polish your stock gallery workflow and increase Event Photo Gig payouts by 20%.
 - **E-Commerce Playbook** – Pay $260 upfront; 2.5h/day for 7 days auto-reserve to prep dropshipping ventures (+$6 Bundle Promo Push, +20% Dropship Pack Party).
@@ -54,7 +53,7 @@ Each asset supports multiple instances, tracks setup progress, and rolls a daily
 
 ### Persistence & Offline Behaviour
 - **Autosave** – State saves every few seconds to `localStorage` (new key: `online-hustle-sim-v2`).
-- **Offline Resolution** – Delayed hustles (e.g., eBay flips) settle while you are away. Assets only progress when you advance days, keeping the economy deterministic.
+- **Offline Reminder** – The clock pauses while you are away; advance in-game days to keep assets earning.
 
 ## Current Feature Set
 - Day-driven scheduler with automatic setup/maintenance allocation and detailed end-of-day recaps.
@@ -64,7 +63,7 @@ Each asset supports multiple instances, tracks setup progress, and rolls a daily
 - Knowledge study tracks with upfront tuition, automatic daily scheduling, and celebratory completion logs that gate advanced assets.
 - Equipment and experience requirements surfaced directly on asset cards with live progress indicators.
 - Responsive card grids with upbeat copy, tabbed navigation, filters, and search so players can focus on the work-in-progress that matters most.
-- Persistent save/load, offline hustle resolution, and flavourful log output to keep players oriented.
+- Persistent save/load and flavourful log output to keep players oriented.
 
 ## Running the Project Locally
 1. Clone the repository or download the source.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@
 - Automation & infrastructure: broader instant gigs, smarter assistant load balancing, and new studio/server tiers expand long-term play.
 - Education clarity: finished courses now show 100% progress and list the XP-rich skills they elevate.
 - Upgrade hub redesign: roadmap stats, category chips, and a refreshed dock make reinvestment planning faster and more celebratory.
+- Hustle pacing: retired the eBay flip queue and delayed payouts so every gig pays out the moment you wrap it.
 
 ## Recent Highlights
 - Passive assets gained Quality 4–5 milestones with higher payouts and refreshed modifiers.

--- a/docs/content-authoring.md
+++ b/docs/content-authoring.md
@@ -5,7 +5,7 @@ Designers can configure new hustles, assets, and upgrades without writing impera
 ## Available Builders
 
 - `createAssetDefinition(config)` – Produces a full asset definition from declarative data. Standard details (owned count, setup, maintenance, quality, and yield summaries) are injected automatically. Provide `detailKeys` to reorder or extend the default stack and `actionLabels` to customize card CTA copy.
-- `createInstantHustle(config)` – Creates instant or delayed hustles. Supply `time`, `cost`, `payout`, and optional `requirements`. Metrics labels, payout copy, and requirement summaries are generated for you. Hook custom logic with `onExecute`/`onComplete` callbacks.
+- `createInstantHustle(config)` – Creates instant hustles. Supply `time`, `cost`, `payout`, and optional `requirements`. Metrics labels, payout copy, and requirement summaries are generated for you. Hook custom logic with `onExecute`/`onComplete` callbacks.
 - `createUpgrade(config)` – Generates purchase or repeatable upgrades. Costs, requirement details, and lock states are standardized. Use `labels` for dynamic button text, `metrics` for custom telemetry labels, and `onPurchase` to trigger special behavior.
 
 ## Adding New Content

--- a/docs/features/content-schema.md
+++ b/docs/features/content-schema.md
@@ -4,7 +4,7 @@
 - Designers define hustles, passive assets, and upgrades with plain objects so UI, requirements, and metrics stay consistent.
 
 **Builder cheatsheet**
-- `createInstantHustle`: set `time`, `cost`, `payout` (amount + delay), and `requirements` to shape quick or delayed gigs.
+- `createInstantHustle`: set `time`, `cost`, `payout`, and `requirements` to shape instant gigs.
 - `createAssetDefinition`: provide `setup`, `maintenance`, `income`, and `quality.levels` to map long-term arcs.
 - `createUpgrade`: configure `cost`, `requires`, optional `labels`, and `onPurchase` hooks for special effects.
 

--- a/docs/features/daily-breakdowns.md
+++ b/docs/features/daily-breakdowns.md
@@ -10,7 +10,7 @@
 
 **Data plumbing**
 - Time categories: `setup`, `maintenance`, `hustle`, `study`, `general`.
-- Earnings: `passive`, `offline`, `hustle`, `delayed`, `sale`.
+- Earnings: `passive`, `offline`, `hustle`, `sale`.
 - Spending: `maintenance`, `payroll`, `setup`, `investment`, `upgrade`, `consumable`.
 - Metrics reset inside `endDay` after the recap renders; helpers in `renderDailyList` cap each list at three rows.
 

--- a/docs/features/hustle-expansion-batch.md
+++ b/docs/features/hustle-expansion-batch.md
@@ -18,4 +18,4 @@
 - Requirement chips and ROI filters gain more meaning with this variety.
 
 **Next checks**
-- Monitor ROI ordering and consider delayed gig variants if players want longer arcs.
+- Monitor ROI ordering and explore new instant gig twists if players want longer arcs.

--- a/src/core/storage.js
+++ b/src/core/storage.js
@@ -5,7 +5,6 @@ import {
   ensureStateShape,
   getAssetDefinition,
   getAssetState,
-  getHustleState,
   getState,
   getUpgradeState,
   initializeState,
@@ -115,10 +114,6 @@ function migrateLegacyState(saved, defaultState) {
     } else {
       blogState.instances = [];
     }
-  }
-
-  if (Array.isArray(saved.pendingFlips)) {
-    getHustleState('flips', migrated).pending = saved.pendingFlips;
   }
 
   if (saved.assistantHired) {

--- a/src/game/content/catalog.js
+++ b/src/game/content/catalog.js
@@ -142,8 +142,7 @@ function buildAssetEntries() {
       moneyCost,
       durationDays,
       tags: {
-        group: definition.tag?.type || null,
-        delayed: durationDays > 0
+        group: definition.tag?.type || null
       },
       resolveLabel: state => resolveActionLabel(action, `Launch ${definition.singular || definition.name}`),
       describeRequirements: state => listAssetRequirementDescriptors(definition, state),
@@ -349,12 +348,6 @@ function applyFilters(entry, filters = {}) {
     return false;
   }
   if (filters.maxTime != null && entry.timeCost > filters.maxTime) {
-    return false;
-  }
-  if (filters.instantOnly && entry.tags?.delayed) {
-    return false;
-  }
-  if (filters.delayedOnly && !entry.tags?.delayed) {
     return false;
   }
   if (filters.groups && entry.tags?.group && !filters.groups.includes(entry.tags.group)) {

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -57,7 +57,6 @@ test('legacy saves migrate to new asset structure', () => {
         { active: false }
       ]
     },
-    pendingFlips: [{ id: 'legacy', readyAt: Date.now() + 1000, payout: 48 }],
     assistantHired: true,
     coffeesToday: 2,
     log: [{ id: 'legacy', message: 'Legacy entry', timestamp: Date.now(), type: 'info' }]


### PR DESCRIPTION
## Summary
- remove the eBay Flips hustle and the delayed payout queue it depended on
- drop delayed payout handling from storage, content catalog filters, and supporting docs
- update tests and offline reminders to reflect the all-instant hustle roster

## Testing
- npm test
- Manual testing: not run (no browser available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dabb207e38832ca72b77fefb44fe8c