### PR TITLE
Refactor skill helpers into shared module

### DIFF
--- a/src/ui/player.js
+++ b/src/ui/player.js
@@ -2,69 +2,19 @@ import elements from './elements.js';
 import { formatHours, formatList, formatMoney } from '../core/helpers.js';
 import { registry } from '../game/registry.js';
 import { getAssetState, getUpgradeState } from '../core/state.js';
-import {
-  SKILL_DEFINITIONS,
-  SKILL_LEVELS,
-  CHARACTER_LEVELS
-} from '../game/skills/data.js';
+import { SKILL_DEFINITIONS } from '../game/skills/data.js';
 import { KNOWLEDGE_TRACKS, getKnowledgeProgress } from '../game/requirements.js';
-
-const numberFormatter = new Intl.NumberFormat('en-US');
+import {
+  describeCharacter,
+  describeSkill,
+  formatXp
+} from './skills/helpers.js';
 
 function setText(element, value) {
   if (!element) return;
   element.textContent = value;
 }
 
-function formatXp(value) {
-  return numberFormatter.format(Math.max(0, Math.round(Number(value) || 0)));
-}
-
-function describeCharacter(character = {}) {
-  const xp = Math.max(0, Number(character.xp) || 0);
-  const level = Math.max(1, Number(character.level) || 1);
-  const tier = CHARACTER_LEVELS.find(entry => entry.level === level) || CHARACTER_LEVELS[0];
-  const nextTier = CHARACTER_LEVELS.find(entry => entry.level === level + 1) || null;
-  const remaining = nextTier ? Math.max(0, nextTier.xp - xp) : 0;
-  const note = nextTier
-    ? `${formatXp(xp)} XP logged • ${formatXp(remaining)} XP to ${nextTier.title}`
-    : `${formatXp(xp)} XP logged • Top tier achieved—legendary!`;
-  return {
-    label: `${tier.title} · Level ${level}`,
-    note
-  };
-}
-
-function findSkillTier(level) {
-  return SKILL_LEVELS.find(tier => tier.level === level) || SKILL_LEVELS[0];
-}
-
-function findNextSkillTier(level) {
-  return SKILL_LEVELS.find(tier => tier.level === level + 1) || null;
-}
-
-function describeSkill(definition, stateEntry = {}) {
-  const xp = Math.max(0, Number(stateEntry.xp) || 0);
-  const level = Math.max(0, Number(stateEntry.level) || 0);
-  const tier = findSkillTier(level);
-  const nextTier = findNextSkillTier(level);
-  const currentFloor = tier?.xp ?? 0;
-  const nextFloor = nextTier?.xp ?? currentFloor;
-  const range = Math.max(1, nextFloor - currentFloor);
-  const progress = nextTier ? Math.min(1, Math.max(0, (xp - currentFloor) / range)) : 1;
-  const remaining = nextTier ? Math.max(0, nextFloor - xp) : 0;
-
-  return {
-    id: definition.id,
-    name: definition.name,
-    xp,
-    level,
-    tierTitle: tier?.title || `Level ${level}`,
-    nextTier,
-    progressPercent: Math.round(progress * 100),
-    remainingXp: remaining
-  };
-}
 
 function renderSummary(state, summary) {
   const target = elements.player?.summary;

--- a/src/ui/skills/helpers.js
+++ b/src/ui/skills/helpers.js
@@ -1,0 +1,70 @@
+import {
+  SKILL_LEVELS,
+  CHARACTER_LEVELS
+} from '../../game/skills/data.js';
+
+export const numberFormatter = new Intl.NumberFormat('en-US');
+
+export function formatXp(value) {
+  return numberFormatter.format(Math.max(0, Math.round(Number(value) || 0)));
+}
+
+export function findSkillTier(level) {
+  return SKILL_LEVELS.find(tier => tier.level === level) || SKILL_LEVELS[0];
+}
+
+export function findNextSkillTier(level) {
+  return SKILL_LEVELS.find(tier => tier.level === level + 1) || null;
+}
+
+function findCharacterTier(level) {
+  return CHARACTER_LEVELS.find(tier => tier.level === level) || CHARACTER_LEVELS[0];
+}
+
+export function describeSkill(definition, stateEntry = {}) {
+  const xp = Math.max(0, Number(stateEntry.xp) || 0);
+  const level = Math.max(0, Number(stateEntry.level) || 0);
+  const tier = findSkillTier(level);
+  const nextTier = findNextSkillTier(level);
+  const currentFloor = tier?.xp ?? 0;
+  const nextFloor = nextTier?.xp ?? currentFloor;
+  const range = Math.max(1, nextFloor - currentFloor);
+  const progress = nextTier ? Math.min(1, Math.max(0, (xp - currentFloor) / range)) : 1;
+  const remaining = nextTier ? Math.max(0, nextFloor - xp) : 0;
+
+  return {
+    id: definition.id,
+    name: definition.name,
+    description: definition.description,
+    xp,
+    level,
+    tierTitle: tier?.title || `Level ${level}`,
+    nextTier,
+    progressPercent: Math.round(progress * 100),
+    remainingXp: remaining
+  };
+}
+
+export function describeCharacter(character = {}) {
+  const xp = Math.max(0, Number(character.xp) || 0);
+  const level = Math.max(1, Number(character.level) || 1);
+  const tier = findCharacterTier(level);
+  const nextTier = CHARACTER_LEVELS.find(entry => entry.level === level + 1) || null;
+  const remaining = nextTier ? Math.max(0, nextTier.xp - xp) : 0;
+  const note = nextTier
+    ? `${formatXp(xp)} XP logged • ${formatXp(remaining)} XP to ${nextTier.title}`
+    : `${formatXp(xp)} XP logged • Top tier achieved—legendary!`;
+  return {
+    label: `${tier.title} · Level ${level}`,
+    note
+  };
+}
+
+export default {
+  numberFormatter,
+  formatXp,
+  findSkillTier,
+  findNextSkillTier,
+  describeSkill,
+  describeCharacter
+};

--- a/src/ui/skillsWidget.js
+++ b/src/ui/skillsWidget.js
@@ -1,67 +1,11 @@
 import elements from './elements.js';
 import { getState } from '../core/state.js';
+import { SKILL_DEFINITIONS } from '../game/skills/data.js';
 import {
-  SKILL_DEFINITIONS,
-  SKILL_LEVELS,
-  CHARACTER_LEVELS
-} from '../game/skills/data.js';
-
-const numberFormatter = new Intl.NumberFormat('en-US');
-
-function formatXp(value) {
-  return numberFormatter.format(Math.max(0, Math.round(Number(value) || 0)));
-}
-
-function findSkillTier(level) {
-  return SKILL_LEVELS.find(tier => tier.level === level) || SKILL_LEVELS[0];
-}
-
-function findNextSkillTier(level) {
-  return SKILL_LEVELS.find(tier => tier.level === level + 1) || null;
-}
-
-function describeSkill(definition, stateEntry = {}) {
-  const xp = Math.max(0, Number(stateEntry.xp) || 0);
-  const level = Math.max(0, Number(stateEntry.level) || 0);
-  const tier = findSkillTier(level);
-  const nextTier = findNextSkillTier(level);
-  const currentFloor = tier?.xp ?? 0;
-  const nextFloor = nextTier?.xp ?? currentFloor;
-  const range = Math.max(1, nextFloor - currentFloor);
-  const progress = nextTier ? Math.min(1, Math.max(0, (xp - currentFloor) / range)) : 1;
-  const remaining = nextTier ? Math.max(0, nextFloor - xp) : 0;
-
-  return {
-    id: definition.id,
-    name: definition.name,
-    description: definition.description,
-    xp,
-    level,
-    tierTitle: tier?.title || `Level ${level}`,
-    nextTier,
-    progressPercent: Math.round(progress * 100),
-    remainingXp: remaining
-  };
-}
-
-function findCharacterTier(level) {
-  return CHARACTER_LEVELS.find(tier => tier.level === level) || CHARACTER_LEVELS[0];
-}
-
-function describeCharacter(character = {}) {
-  const xp = Math.max(0, Number(character.xp) || 0);
-  const level = Math.max(1, Number(character.level) || 1);
-  const tier = findCharacterTier(level);
-  const nextTier = CHARACTER_LEVELS.find(entry => entry.level === level + 1) || null;
-  const remaining = nextTier ? Math.max(0, nextTier.xp - xp) : 0;
-  const note = nextTier
-    ? `${formatXp(xp)} XP logged • ${formatXp(remaining)} XP to ${nextTier.title}`
-    : `${formatXp(xp)} XP logged • Top tier achieved—legendary!`;
-  return {
-    label: `${tier.title} · Level ${level}`,
-    note
-  };
-}
+  describeCharacter,
+  describeSkill,
+  formatXp
+} from './skills/helpers.js';
 
 function renderSkillItem(skill) {
   const item = document.createElement('li');


### PR DESCRIPTION
## Summary
- extract shared skill formatting helpers into `src/ui/skills/helpers.js`
- update the skill widget and player panel to consume the shared helpers

## Testing
- npm test
- Manual smoke-check of skill widget and player panel: not run (CLI-only environment)


------
https://chatgpt.com/codex/tasks/task_e_68dabbedd184832cbece2ea4662c699c