### PR TITLE
Refactor UI modules to use shared DOM text helper

### DIFF
--- a/src/ui/dashboard.js
+++ b/src/ui/dashboard.js
@@ -1,4 +1,5 @@
 import elements from './elements.js';
+import setText from './dom.js';
 import { formatHours, formatMoney } from '../core/helpers.js';
 import { getAssetState, getState } from '../core/state.js';
 import { registry } from '../game/registry.js';
@@ -12,11 +13,6 @@ import {
 import { instanceLabel } from '../game/assets/helpers.js';
 import { KNOWLEDGE_TRACKS, getKnowledgeProgress } from '../game/requirements.js';
 import { getTimeCap } from '../game/time.js';
-
-function setText(element, value) {
-  if (!element) return;
-  element.textContent = value;
-}
 
 function createDailyListItem(entry) {
   const li = document.createElement('li');

--- a/src/ui/dom.js
+++ b/src/ui/dom.js
@@ -1,0 +1,4 @@
+export default function setText(element, value) {
+  if (!element) return;
+  element.textContent = value;
+}

--- a/src/ui/player.js
+++ b/src/ui/player.js
@@ -1,4 +1,5 @@
 import elements from './elements.js';
+import setText from './dom.js';
 import { formatHours, formatList, formatMoney } from '../core/helpers.js';
 import { registry } from '../game/registry.js';
 import { getAssetState, getUpgradeState } from '../core/state.js';
@@ -10,11 +11,6 @@ import {
 import { KNOWLEDGE_TRACKS, getKnowledgeProgress } from '../game/requirements.js';
 
 const numberFormatter = new Intl.NumberFormat('en-US');
-
-function setText(element, value) {
-  if (!element) return;
-  element.textContent = value;
-}
 
 function formatXp(value) {
   return numberFormatter.format(Math.max(0, Math.round(Number(value) || 0)));


### PR DESCRIPTION
## Summary
- add a shared `setText` DOM helper for UI modules
- update the dashboard and player views to import the new helper instead of duplicating it

## Testing
- npm test *(fails: npm is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dabbef2aec832c9382879e8934ff47