### PR TITLE
Fix duplicated skill helper definitions in player UI

### DIFF
--- a/src/ui/player.js
+++ b/src/ui/player.js
@@ -11,61 +11,6 @@ import {
   formatXp
 } from './skills/helpers.js';
 
-function formatXp(value) {
-  return numberFormatter.format(Math.max(0, Math.round(Number(value) || 0)));
-}
-
-function describeCharacter(character = {}) {
-  const xp = Math.max(0, Number(character.xp) || 0);
-  const level = Math.max(1, Number(character.level) || 1);
-  const tier = CHARACTER_LEVELS.find(entry => entry.level === level) || CHARACTER_LEVELS[0];
-  const nextTier = CHARACTER_LEVELS.find(entry => entry.level === level + 1) || null;
-  const remaining = nextTier ? Math.max(0, nextTier.xp - xp) : 0;
-  const note = nextTier
-    ? `${formatXp(xp)} XP logged • ${formatXp(remaining)} XP to ${nextTier.title}`
-    : `${formatXp(xp)} XP logged • Top tier achieved—legendary!`;
-  return {
-    label: `${tier.title} · Level ${level}`,
-    note
-  };
-}
-
-function findSkillTier(level) {
-  return SKILL_LEVELS.find(tier => tier.level === level) || SKILL_LEVELS[0];
-}
-
-function findNextSkillTier(level) {
-  return SKILL_LEVELS.find(tier => tier.level === level + 1) || null;
-}
-
-function describeSkill(definition, stateEntry = {}) {
-  const xp = Math.max(0, Number(stateEntry.xp) || 0);
-  const level = Math.max(0, Number(stateEntry.level) || 0);
-  const tier = findSkillTier(level);
-  const nextTier = findNextSkillTier(level);
-  const currentFloor = tier?.xp ?? 0;
-  const nextFloor = nextTier?.xp ?? currentFloor;
-  const range = Math.max(1, nextFloor - currentFloor);
-  const progress = nextTier ? Math.min(1, Math.max(0, (xp - currentFloor) / range)) : 1;
-  const remaining = nextTier ? Math.max(0, nextFloor - xp) : 0;
-
-  return {
-    id: definition.id,
-    name: definition.name,
-    xp,
-    level,
-    tierTitle: tier?.title || `Level ${level}`,
-    nextTier,
-    progressPercent: Math.round(progress * 100),
-    remainingXp: remaining
-  };
-}
-
-function setText(element, value) {
-  if (!element) return;
-  element.textContent = value;
-}
-
 function renderSummary(state, summary) {
   const target = elements.player?.summary;
   if (!target) return;


### PR DESCRIPTION
## Summary
- remove duplicate skill helper implementations from the player panel module
- rely on the shared helper utilities for XP formatting and skill descriptions so the UI loads again

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dabf0f2a3c832c9c7ec9bb9f03e699