### PR TITLE
Add shared numeric normalization helper

### DIFF
--- a/src/core/helpers.js
+++ b/src/core/helpers.js
@@ -9,6 +9,11 @@ export function createId() {
   return Math.random().toString(36).slice(2);
 }
 
+export function toNumber(value, fallback = 0) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
 export function formatMoney(value) {
   return Number(value).toLocaleString(undefined, {
     minimumFractionDigits: value % 1 === 0 ? 0 : 2,

--- a/src/game/content/catalog.js
+++ b/src/game/content/catalog.js
@@ -1,5 +1,6 @@
 import { registry } from '../registry.js';
 import { getState, getAssetState, getUpgradeState, getUpgradeDefinition, getAssetDefinition } from '../../core/state.js';
+import { toNumber } from '../../core/helpers.js';
 import { assetRequirementsMet, listAssetRequirementDescriptors, KNOWLEDGE_TRACKS, getKnowledgeProgress } from '../requirements.js';
 import { getQualityActions, canPerformQualityAction } from '../assets/quality.js';
 import { describeHustleRequirements, areHustleRequirementsMet } from '../hustles.js';
@@ -8,11 +9,6 @@ import { COFFEE_LIMIT } from '../../core/constants.js';
 
 function createKey(sourceType, sourceId, actionId) {
   return `${sourceType}:${sourceId}:${actionId}`;
-}
-
-function asNumber(value) {
-  const numeric = Number(value);
-  return Number.isFinite(numeric) ? numeric : 0;
 }
 
 function resolveActionLabel(action, fallback) {
@@ -128,9 +124,9 @@ function buildAssetEntries() {
   return registry.assets.map(definition => {
     const action = definition.action || {};
     const actionId = action.id || 'launch';
-    const timeCost = Math.max(0, asNumber(definition.setup?.hoursPerDay));
-    const moneyCost = Math.max(0, asNumber(definition.setup?.cost));
-    const durationDays = Math.max(0, asNumber(definition.setup?.days));
+    const timeCost = Math.max(0, toNumber(definition.setup?.hoursPerDay, 0));
+    const moneyCost = Math.max(0, toNumber(definition.setup?.cost, 0));
+    const durationDays = Math.max(0, toNumber(definition.setup?.days, 0));
     return {
       key: createKey('asset', definition.id, actionId),
       sourceType: 'asset',
@@ -162,8 +158,8 @@ function buildQualityEntries() {
     const actions = getQualityActions(definition) || [];
     for (const action of actions) {
       const actionId = action.id || action.label;
-      const timeCost = Math.max(0, asNumber(action.time));
-      const moneyCost = Math.max(0, asNumber(action.cost));
+      const timeCost = Math.max(0, toNumber(action.time, 0));
+      const moneyCost = Math.max(0, toNumber(action.cost, 0));
       entries.push({
         key: createKey('quality', definition.id, actionId),
         sourceType: 'quality',
@@ -197,8 +193,8 @@ function buildHustleEntries() {
   return registry.hustles.map(definition => {
     const action = definition.action || {};
     const actionId = action.id || 'action';
-    const timeCost = Math.max(0, asNumber(action.timeCost));
-    const moneyCost = Math.max(0, asNumber(action.moneyCost));
+    const timeCost = Math.max(0, toNumber(action.timeCost, 0));
+    const moneyCost = Math.max(0, toNumber(action.moneyCost, 0));
     return {
       key: createKey('hustle', definition.id, actionId),
       sourceType: definition.tag?.type === 'study' ? 'study' : 'hustle',
@@ -208,7 +204,7 @@ function buildHustleEntries() {
       category: definition.tag?.type || 'instant',
       timeCost,
       moneyCost,
-      delaySeconds: asNumber(action.delaySeconds),
+      delaySeconds: toNumber(action.delaySeconds, 0),
       tags: {
         group: definition.tag?.type || null
       },
@@ -268,8 +264,8 @@ function buildUpgradeEntries() {
   return registry.upgrades.map(definition => {
     const action = definition.action || {};
     const actionId = action.id || 'activate';
-    const timeCost = Math.max(0, asNumber(action.timeCost));
-    const moneyCost = Math.max(0, asNumber(action.moneyCost));
+    const timeCost = Math.max(0, toNumber(action.timeCost, 0));
+    const moneyCost = Math.max(0, toNumber(action.moneyCost, 0));
     return {
       key: createKey('upgrade', definition.id, actionId),
       sourceType: 'upgrade',

--- a/src/game/content/schema.js
+++ b/src/game/content/schema.js
@@ -1,4 +1,4 @@
-import { formatHours, formatMoney } from '../../core/helpers.js';
+import { formatHours, formatMoney, toNumber } from '../../core/helpers.js';
 import { addLog } from '../../core/log.js';
 import { getAssetDefinition, getAssetState, getState, getUpgradeDefinition, getUpgradeState } from '../../core/state.js';
 import { executeAction } from '../actions.js';
@@ -24,11 +24,6 @@ import {
   describeInstantHustleEducationBonuses,
   formatEducationBonusSummary
 } from '../educationEffects.js';
-
-function asNumber(value, fallback = 0) {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : fallback;
-}
 
 function formatHourDetail(hours) {
   if (!hours) return '⏳ Time: <strong>Instant</strong>';
@@ -62,7 +57,7 @@ function renderRequirementSummary(requirements = []) {
     .map(req => {
       const definition = getAssetDefinition(req.assetId);
       const label = definition?.singular || definition?.name || req.assetId;
-      const need = asNumber(req.count, 1);
+      const need = toNumber(req.count, 1);
       const have = countActiveAssets(req.assetId);
       return `${label}: ${have}/${need} active`;
     })
@@ -71,7 +66,7 @@ function renderRequirementSummary(requirements = []) {
 
 function requirementsMet(requirements = []) {
   if (!requirements?.length) return true;
-  return requirements.every(req => countActiveAssets(req.assetId) >= asNumber(req.count, 1));
+  return requirements.every(req => countActiveAssets(req.assetId) >= toNumber(req.count, 1));
 }
 
 function buildMetricConfig(id, prefix, overrides = {}, defaults = {}) {
@@ -173,13 +168,13 @@ function applyMetric(recordFn, metric, payload) {
 export function createInstantHustle(config) {
   const metadata = {
     id: config.id,
-    time: asNumber(config.time, 0),
-    cost: asNumber(config.cost, 0),
+    time: toNumber(config.time, 0),
+    cost: toNumber(config.cost, 0),
     requirements: config.requirements || [],
     payout: config.payout
       ? {
-          amount: asNumber(config.payout.amount, 0),
-          delaySeconds: asNumber(config.payout.delaySeconds, 0) || undefined,
+          amount: toNumber(config.payout.amount, 0),
+          delaySeconds: toNumber(config.payout.delaySeconds, 0) || undefined,
           grantOnAction: config.payout.grantOnAction !== false,
           logType: config.payout.logType || 'hustle',
           message: config.payout.message
@@ -352,9 +347,9 @@ function upgradeRequirementMet(requirement) {
       const state = getAssetState(requirement.id);
       const instances = state?.instances || [];
       if (requirement.active) {
-        return instances.filter(instance => instance.status === 'active').length >= asNumber(requirement.count, 1);
+        return instances.filter(instance => instance.status === 'active').length >= toNumber(requirement.count, 1);
       }
-      return instances.length >= asNumber(requirement.count, 1);
+      return instances.length >= toNumber(requirement.count, 1);
     }
     case 'custom':
       return requirement.met ? requirement.met() : true;
@@ -374,7 +369,7 @@ function renderUpgradeRequirement(requirement) {
     case 'asset': {
       const asset = getAssetDefinition(requirement.id);
       const label = asset?.singular || asset?.name || requirement.id;
-      const count = asNumber(requirement.count, 1);
+      const count = toNumber(requirement.count, 1);
       const adjective = requirement.active ? 'active ' : '';
       return `Requires: <strong>${count} ${adjective}${label}${count === 1 ? '' : 's'}</strong>`;
     }

--- a/src/game/educationEffects.js
+++ b/src/game/educationEffects.js
@@ -1,14 +1,9 @@
-import { formatMoney } from '../core/helpers.js';
+import { formatMoney, toNumber } from '../core/helpers.js';
 import { getState } from '../core/state.js';
 import { KNOWLEDGE_TRACKS, getKnowledgeProgress } from './requirements.js';
 
-function asNumber(value, fallback = 0) {
-  const numeric = Number(value);
-  return Number.isFinite(numeric) ? numeric : fallback;
-}
-
 function formatPercent(value) {
-  const percent = asNumber(value) * 100;
+  const percent = toNumber(value) * 100;
   if (!Number.isFinite(percent)) return '0%';
   if (Math.abs(percent - Math.round(percent)) < 0.01) {
     return `${Math.round(percent)}%`;
@@ -18,7 +13,7 @@ function formatPercent(value) {
 
 function normalizeBoost(track, raw) {
   if (!raw || !raw.hustleId) return null;
-  const amount = asNumber(raw.amount ?? raw.value ?? raw.bonus, 0);
+  const amount = toNumber(raw.amount ?? raw.value ?? raw.bonus, 0);
   if (amount === 0) return null;
   const type = raw.type === 'flat' ? 'flat' : 'multiplier';
   return {
@@ -98,7 +93,7 @@ export function describeTrackEducationBonuses(trackId) {
 }
 
 export function applyInstantHustleEducationBonus({ hustleId, baseAmount, state = getState() }) {
-  const base = asNumber(baseAmount, 0);
+  const base = toNumber(baseAmount, 0);
   const boosts = getInstantHustleEducationBonuses(hustleId);
   if (!boosts.length) {
     return { amount: base, applied: [], boosts: [] };


### PR DESCRIPTION
## Summary
- add a reusable `toNumber` helper for consistent numeric fallback handling
- replace ad-hoc number parsing in education effects and content modules with the shared helper

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dac0550498832cbf07a305f0327f04