### PR TITLE
Use shared createId helper in state module

### DIFF
--- a/src/core/state.js
+++ b/src/core/state.js
@@ -1,5 +1,5 @@
 import { DEFAULT_DAY_HOURS } from './constants.js';
-import { structuredClone } from './helpers.js';
+import { createId, structuredClone } from './helpers.js';
 import { attachRegistryMetricIds, buildMetricIndex } from '../game/schema/metrics.js';
 import {
   createEmptyCharacterState,
@@ -61,7 +61,7 @@ export function getMetricDefinition(metricId) {
 export function normalizeAssetInstance(definition, instance = {}) {
   const normalized = { ...instance };
   if (!normalized.id) {
-    normalized.id = cryptoId();
+    normalized.id = createId();
   }
 
   const setupDays = Math.max(0, Number(definition?.setup?.days) || 0);
@@ -334,9 +334,3 @@ export function getUpgradeState(id, target = state) {
   return target.upgrades[id];
 }
 
-function cryptoId() {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID();
-  }
-  return Math.random().toString(36).slice(2);
-}


### PR DESCRIPTION
## Summary
- import the shared `createId` helper into the core state module
- replace the local `cryptoId` usage in asset normalization and drop the redundant helper

## Testing
- npm test
- Manual testing: not run (not feasible in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dac0559754832cb448fab2d7f3bc0a