### PR TITLE
Prioritize available hustles in listings

### DIFF
--- a/src/ui/cards.js
+++ b/src/ui/cards.js
@@ -1075,7 +1075,12 @@ function updateHustleCard(definition) {
       ? definition.action.label(state)
       : definition.action?.label || 'Queue';
   }
-  ui.card.dataset.available = disabled ? 'false' : 'true';
+  const nextAvailability = disabled ? 'false' : 'true';
+  const availabilityChanged = ui.card.dataset.available !== nextAvailability;
+  ui.card.dataset.available = nextAvailability;
+  if (availabilityChanged) {
+    emitUIEvent('hustles:availability-updated');
+  }
 }
 
 function openHustleDetails(definition) {


### PR DESCRIPTION
## Summary
- ensure available hustles are surfaced first while preserving the chosen sort order and falling back to payout for locked entries
- re-run hustle filters when availability changes so the "available only" toggle reflects live state updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68dacd49b5f0832c879c2bdbb8540a98