### PR TITLE
refactor: share asset requirement summary helper

### DIFF
--- a/src/game/content/schema.js
+++ b/src/game/content/schema.js
@@ -13,7 +13,11 @@ import { executeAction } from '../actions.js';
 import { addMoney, spendMoney } from '../currency.js';
 import { checkDayEnd } from '../lifecycle.js';
 import { recordCostContribution, recordPayoutContribution, recordTimeContribution } from '../metrics.js';
-import { renderAssetRequirementDetail, updateAssetCardLock } from '../requirements.js';
+import {
+  renderAssetRequirementDetail,
+  summarizeAssetRequirements,
+  updateAssetCardLock
+} from '../requirements.js';
 import { spendTime } from '../time.js';
 import { awardSkillProgress } from '../skills/index.js';
 import {
@@ -50,19 +54,6 @@ function formatPayoutDetail(payout) {
     return `${base} after ${payout.delaySeconds}s`;
   }
   return base;
-}
-
-function renderRequirementSummary(requirements = [], state = getState()) {
-  if (!requirements.length) return 'None';
-  return requirements
-    .map(req => {
-      const definition = getAssetDefinition(req.assetId);
-      const label = definition?.singular || definition?.name || req.assetId;
-      const need = toNumber(req.count, 1);
-      const have = countActiveAssetInstances(req.assetId, state);
-      return `${label}: ${have}/${need} active`;
-    })
-    .join(' • ');
 }
 
 function meetsAssetRequirements(requirements = [], state = getState()) {
@@ -265,7 +256,7 @@ export function createInstantHustle(config) {
     baseDetails.push(() => payoutDetail);
   }
   if (metadata.requirements.length) {
-    baseDetails.push(() => `Requires: <strong>${renderRequirementSummary(metadata.requirements)}</strong>`);
+    baseDetails.push(() => `Requires: <strong>${summarizeAssetRequirements(metadata.requirements)}</strong>`);
   }
 
   if (metadata.dailyLimit) {
@@ -303,7 +294,7 @@ export function createInstantHustle(config) {
       return `You need $${formatMoney(metadata.cost)} before funding ${definition.name}.`;
     }
     if (!meetsAssetRequirements(metadata.requirements, state)) {
-      return `You still need: ${renderRequirementSummary(metadata.requirements, state)}.`;
+      return `You still need: ${summarizeAssetRequirements(metadata.requirements, state)}.`;
     }
     return null;
   }
@@ -631,7 +622,7 @@ export function createUpgrade(config) {
 }
 
 export function renderHustleRequirementSummary(requirements) {
-  return renderRequirementSummary(requirements);
+  return summarizeAssetRequirements(requirements);
 }
 
 export function hustleRequirementsMet(requirements) {

--- a/src/game/hustles.js
+++ b/src/game/hustles.js
@@ -6,7 +6,8 @@ import { createInstantHustle } from './content/schema.js';
 import {
   KNOWLEDGE_TRACKS,
   enrollInKnowledgeTrack,
-  getKnowledgeProgress
+  getKnowledgeProgress,
+  summarizeAssetRequirements
 } from './requirements.js';
 import { recordPayoutContribution } from './metrics.js';
 import { describeTrackEducationBonuses } from './educationEffects.js';
@@ -58,16 +59,7 @@ function recordHustlePayout(hustleId, { label, amount, category }) {
 }
 
 function renderRequirementSummary(requirements = [], state = getState()) {
-  if (!requirements.length) return 'None';
-  return requirements
-    .map(req => {
-      const definition = getAssetDefinition(req.assetId);
-      const label = definition?.singular || definition?.name || req.assetId;
-      const need = Number(req.count) || 1;
-      const have = countActiveAssetInstances(req.assetId, state);
-      return `${label}: ${have}/${need} active`;
-    })
-    .join(' • ');
+  return summarizeAssetRequirements(requirements, state);
 }
 
 export function getHustleRequirements(definition) {

--- a/src/game/requirements.js
+++ b/src/game/requirements.js
@@ -1,4 +1,4 @@
-import { formatDays, formatHours, formatList, formatMoney } from '../core/helpers.js';
+import { formatDays, formatHours, formatList, formatMoney, toNumber } from '../core/helpers.js';
 import { addLog } from '../core/log.js';
 import {
   countActiveAssetInstances,
@@ -320,6 +320,19 @@ export function formatAssetRequirementLabel(assetId, state = getState()) {
   if (!missing.length) return 'Ready to Launch';
   const names = missing.map(req => describeRequirement(req, state).label);
   return `Requires ${names.join(' & ')}`;
+}
+
+export function summarizeAssetRequirements(requirements = [], state = getState()) {
+  if (!requirements?.length) return 'None';
+  return requirements
+    .map(req => {
+      const definition = getAssetDefinition(req.assetId);
+      const label = definition?.singular || definition?.name || req.assetId;
+      const need = toNumber(req.count, 1);
+      const have = countActiveAssetInstances(req.assetId, state);
+      return `${label}: ${have}/${need} active`;
+    })
+    .join(' • ');
 }
 
 export function renderAssetRequirementDetail(assetId, state = getState()) {


### PR DESCRIPTION
## Summary
- add a shared summarizeAssetRequirements helper for asset requirement copy
- update asset and hustle builders to rely on the shared formatter

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68dadb393fe8832cba81a62f5eb76fbb