### PR TITLE
Implement structured upgrade taxonomy and effects system

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Online Hustle Simulator is a browser-based incremental game about orchestrating 
 ### Interface Overview
 - **Top Bar & Snapshot** – Money, time, and day stay pinned at the top. A collapsible Daily Snapshot panel now highlights per-stat breakdowns (time invested, money earned, passive streams, cash spent, study momentum) without overwhelming the main view. Passive earnings even call out which assets (and how many instances) delivered today’s cash, so you can immediately see what worked.
 - **Tabbed Workspace** – Hustles, Education, Passive Assets, and Upgrades each live in their own tab with dedicated copy and per-tab filters. Global toggles hide locked or completed cards, and you can spotlight only actionable options.
-- **Categorised Collections** – Passive assets surface in Foundation, Creative, Commerce, and Advanced groupings with a collapsed-card option for rapid scanning. Each grouping now sports a "View launched assets" toggle that opens a management roster listing upkeep, yesterday’s payout, and upgrade/sell controls for every instance. Upgrades split into Equipment, Automation, Consumables, and a catch-all bucket with a quick search bar.
+- **Categorised Collections** – Passive assets surface in Foundation, Creative, Commerce, and Advanced groupings with a collapsed-card option for rapid scanning. Each grouping now sports a "View launched assets" toggle that opens a management roster listing upkeep, yesterday’s payout, and upgrade/sell controls for every instance. Upgrades now live inside Tech, House, Infra, and Support tabs, each with friendly family sub-sections (phones, workflow suites, automation chains, daily boosts) so progression lanes read clearly at a glance.
 - **Event Log Controls** – The log dock keeps its running commentary but now includes a summary/detailed toggle when you want a lighter feed during long sessions.
 
 ### Hustles & Study Tracks
@@ -45,19 +45,19 @@ Each asset supports multiple instances, tracks setup progress, and rolls a daily
 - **Hire Virtual Assistant** – $180 per hire, up to four assistants. Each adds +2h daily but costs $30/day in payroll; fire assistants anytime to cut wages (and hours).
 - **Turbo Coffee** – $40 per cup, up to three per day, each adding +1h for the current day.
 - **Camera** – $200, unlocks Vlog Channels and Stock Photo Galleries.
-- **Cinema Camera Upgrade** – $480, requires the base camera and promises richer vlog production value.
+- **Cinema Camera Upgrade** – $480, requires the base camera; trims setup/maintenance time, adds ~25% vlog payouts, and doubles quality progress for video/photo actions.
 - **Lighting Kit** – $220, unlocks Stock Photo Galleries after you buy the camera.
-- **Studio Expansion** – $540, requires the Lighting Kit and outfits your studio for rapid-fire shoots.
-- **Editorial Pipeline Suite** – $360, requires the Automation Course, an active blog, and Outline Mastery; adds +20% blog/e-book income plus +1 progress to posts, chapters, and vlog actions.
-- **Syndication Suite** – $720, requires Editorial Pipeline, an active blog and e-book, and Brand Voice Lab; layers another +25% blog/e-book boost, +20% vlog multipliers, and extra +1 progress for each creative action.
-- **Immersive Story Worlds** – $1,080, requires Syndication Suite alongside active blog/e-book/vlog combos and both knowledge tracks; adds +35% e-book income, +30% vlog hype, and +1 more progress to creative pushes.
-- **Server Rack - Starter** – $650, unlocks infrastructure foundations for advanced projects.
-- **Fulfillment Automation Suite** – $780, requires two active dropshipping shops plus the E-Commerce Playbook; adds a payout multiplier and +1 progress to dropshipping research/listing/ad actions.
-- **Cloud Cluster** – $1,150, requires the rack and unlocks SaaS deployments.
-- **Global Supply Mesh** – $1,150, requires the automation suite, three active shops, and Photo Catalog Curation to accelerate dropshipping payouts and marketing pushes.
-- **Edge Delivery Network** – $1,450, requires the cluster, keeps your micro-app snappy worldwide, and unlocks the Quality 4 edge deployment pushes for SaaS builds.
-- **White-Label Alliance** – $1,500, requires the global mesh, four active shops, and both commerce/photo studies; boosts dropshipping payouts again while empowering stock photo promos.
-- **Automation Course** – $260 once you have an active blog; permanently boosts blog daily payouts by +50%.
+- **Studio Expansion** – $540, requires the Lighting Kit; adds ~15% payouts to galleries, doubles related quality progress, and speeds photo/video setup work.
+- **Editorial Pipeline Suite** – $360, requires the Automation Course, an active blog, and Outline Mastery; grants ~20% more blog/e-book payouts, 1.5× quality progress for writing content, and snappier setup windows.
+- **Syndication Suite** – $720, requires Editorial Pipeline, an active blog and e-book, and Brand Voice Lab; adds ~25% payouts across blogs, e-books, and vlogs while multiplying creative quality progress by roughly 1.33×.
+- **Immersive Story Worlds** – $1,080, requires Syndication Suite alongside active blog/e-book/vlog combos and both knowledge tracks; adds ~12% extra payouts and doubles quality progress for every creative asset you target.
+- **Server Rack - Starter** – $650, unlocks infrastructure foundations for advanced projects and shaves ~5% off tech setup time.
+- **Fulfillment Automation Suite** – $780, requires two active dropshipping shops plus the E-Commerce Playbook; injects ~25% higher dropshipping payouts and doubles research/listing/ad quality progress.
+- **Cloud Cluster** – $1,150, requires the rack, unlocks SaaS deployments, and lifts micro-app payouts by ~20% while boosting feature/stability progress by 1.5×.
+- **Global Supply Mesh** – $1,150, requires the automation suite, three active shops, and Photo Catalog Curation; adds ~30% dropshipping income, 1.5× quality progress, and faster setup sprints for commerce actions.
+- **Edge Delivery Network** – $1,450, requires the cluster; multiplies SaaS payouts by ~35%, trims maintenance drag by ~15%, and doubles feature/stability/marketing progress.
+- **White-Label Alliance** – $1,500, requires the global mesh, four active shops, and both commerce/photo studies; layers ~35% more income across dropshipping and stock photos while adding a 1.33× quality progress multiplier for their actions.
+- **Automation Course** – $260 once you have an active blog; permanently boosts blog daily payouts by +50% and doubles post-quality progress.
 
 ### Persistence & Offline Behaviour
 - **Autosave** – State saves every few seconds to `localStorage` (new key: `online-hustle-sim-v2`).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Upgrade taxonomy: tech/house/infra tabs with family sub-sections and slot-aware tooltips make browsing gear lanes intuitive while the new effect engine drives unified payout, time, and quality multipliers.
 - Player screen: new overview tab spotlights character level, skills, education, gear, and hustle momentum in one place.
 - Asset liquidation rebalance: selling an instance now multiplies the 3× sale value by its quality tier for high-grade exits.
 - Passive economy rebalance: smoother upkeep for blogs, stock photos, dropshipping, and SaaS so late tiers feel rewarding without micromanagement spikes.

--- a/docs/features/upgrade-hub-revamp.md
+++ b/docs/features/upgrade-hub-revamp.md
@@ -11,6 +11,12 @@
 - Ready upgrades automatically populate the dock with their current label and price for one-click purchasing.
 - Each card now carries tag/status badges, refreshed copy, and rotating detail bullets that stay current with game state.
 
+## Structured taxonomy & stacking (Update)
+- Tech, House, Infra, and Support tabs organise the catalog into breezy, high-level lanes so players can zero in on the gear they crave.
+- Family groupings (phone rigs, workflow suites, automation, and more) now sit inside each category, clarifying upgrade progression at a glance.
+- The upgrade effect engine applies category/family filters for payout, time, and quality multipliers; bonuses stack multiplicatively with sensible floors to prevent runaway values.
+- Slot-aware upgrades (e.g., hubs providing monitor capacity) surface availability hints directly on cards, ensuring consumptive upgrades respect capacity before purchase.
+
 **Player Impact**
 - Players can filter by affordability, search, or category simultaneously, drastically reducing scan time for priority upgrades.
 - The overview note reinforces short-term goals (buy now, meet requirements, or save up) so progression stalls are easier to diagnose.

--- a/src/core/helpers.js
+++ b/src/core/helpers.js
@@ -43,3 +43,9 @@ export function formatDays(days) {
   }
   return `${days.toFixed(1)} days`;
 }
+
+export function ensureArray(value) {
+  if (Array.isArray(value)) return value;
+  if (value == null) return [];
+  return [value];
+}

--- a/src/game/assets/definitions/blog.js
+++ b/src/game/assets/definitions/blog.js
@@ -1,22 +1,12 @@
 import { formatMoney } from '../../../core/helpers.js';
-import { getUpgradeState } from '../../../core/state.js';
 import { createAssetDefinition } from '../../content/schema.js';
-
-function hasUpgrade(context, id) {
-  if (!id) return false;
-  if (context && typeof context.upgrade === 'function') {
-    const upgrade = context.upgrade(id);
-    if (upgrade) return Boolean(upgrade.purchased);
-  }
-  const state = getUpgradeState(id);
-  return Boolean(state?.purchased);
-}
 
 const blogDefinition = createAssetDefinition({
   id: 'blog',
   name: 'Personal Blog Network',
   singular: 'Blog',
   tag: { label: 'Foundation', type: 'passive' },
+  tags: ['writing', 'content', 'desktop_work'],
   description: 'Launch cozy blogs that drip ad revenue once the posts are polished.',
   setup: { days: 3, hoursPerDay: 3, cost: 180 },
   maintenance: { hours: 0.75, cost: 3 },
@@ -26,35 +16,7 @@ const blogDefinition = createAssetDefinition({
       { id: 'promotion', weight: 0.5 }
     ]
   },
-  income: {
-    base: 30,
-    variance: 0.2,
-    logType: 'passive',
-    modifier: (amount, context = {}) => {
-      const steps = [];
-      if (hasUpgrade(context, 'course')) {
-        steps.push({ id: 'course', label: 'Automation course boost', percent: 0.5 });
-      }
-      if (hasUpgrade(context, 'editorialPipeline')) {
-        steps.push({ id: 'editorialPipeline', label: 'Editorial pipeline boost', percent: 0.2 });
-      }
-      if (hasUpgrade(context, 'syndicationSuite')) {
-        steps.push({ id: 'syndicationSuite', label: 'Syndication suite boost', percent: 0.25 });
-      }
-      return steps.reduce((total, step) => {
-        const before = total;
-        const after = total * (1 + step.percent);
-        if (typeof context.recordModifier === 'function') {
-          context.recordModifier(step.label, after - before, {
-            id: step.id,
-            type: 'upgrade',
-            percent: step.percent
-          });
-        }
-        return after;
-      }, amount);
-    }
-  },
+  income: { base: 30, variance: 0.2, logType: 'passive' },
   quality: {
     summary: 'Draft posts, tune SEO, and rally backlinks to climb from skeleton sites to a thriving blog constellation.',
     tracks: {
@@ -113,13 +75,7 @@ const blogDefinition = createAssetDefinition({
         time: 3,
         dailyLimit: 1,
         progressKey: 'posts',
-        progressAmount: context => {
-          let progress = 1;
-          if (hasUpgrade(context, 'course')) progress += 1;
-          if (hasUpgrade(context, 'editorialPipeline')) progress += 1;
-          if (hasUpgrade(context, 'syndicationSuite')) progress += 1;
-          return progress;
-        },
+        progressAmount: () => 1,
         skills: ['writing'],
         log: ({ label }) => `${label} published a sparkling post. Subscribers sip the fresh ideas!`
       },

--- a/src/game/assets/definitions/dropshipping.js
+++ b/src/game/assets/definitions/dropshipping.js
@@ -1,55 +1,12 @@
 import { formatMoney } from '../../../core/helpers.js';
 import { createAssetDefinition } from '../../content/schema.js';
 
-const COMMERCE_UPGRADE_CHAIN = [
-  {
-    id: 'fulfillmentAutomation',
-    label: 'Fulfillment automation boost',
-    multiplier: 1.25
-  },
-  {
-    id: 'globalSupplyMesh',
-    label: 'Global supply mesh boost',
-    multiplier: 1.3
-  },
-  {
-    id: 'whiteLabelAlliance',
-    label: 'White-label alliance boost',
-    multiplier: 1.35
-  }
-];
-
-function getCommerceTierBonus(context) {
-  if (!context?.upgrade) return 0;
-  return COMMERCE_UPGRADE_CHAIN.reduce((bonus, tier) => {
-    return context.upgrade(tier.id)?.purchased ? bonus + 1 : bonus;
-  }, 0);
-}
-
-function applyCommerceMultipliers(amount, context) {
-  if (!context?.upgrade) return amount;
-  let total = amount;
-  COMMERCE_UPGRADE_CHAIN.forEach(tier => {
-    if (context.upgrade(tier.id)?.purchased) {
-      const before = total;
-      total *= tier.multiplier;
-      if (typeof context.recordModifier === 'function') {
-        context.recordModifier(tier.label, total - before, {
-          id: tier.id,
-          type: 'upgrade',
-          percent: tier.multiplier - 1
-        });
-      }
-    }
-  });
-  return total;
-}
-
 const dropshippingDefinition = createAssetDefinition({
   id: 'dropshipping',
   name: 'Dropshipping Product Lab',
   singular: 'Dropshipping Shop',
   tag: { label: 'Commerce', type: 'passive' },
+  tags: ['commerce', 'ecommerce', 'fulfillment'],
   description: 'Prototype products, source suppliers, and automate fulfillment funnels.',
   setup: { days: 6, hoursPerDay: 4, cost: 720 },
   maintenance: { hours: 1.5, cost: 12 },
@@ -60,12 +17,7 @@ const dropshippingDefinition = createAssetDefinition({
       { id: 'promotion', weight: 0.5 }
     ]
   },
-  income: {
-    base: 84,
-    variance: 0.35,
-    logType: 'passive',
-    modifier: (amount, context = {}) => applyCommerceMultipliers(amount, context)
-  },
+  income: { base: 84, variance: 0.35, logType: 'passive' },
   requirements: {
     knowledge: ['ecomPlaybook'],
     experience: [{ assetId: 'blog', count: 2 }]
@@ -128,7 +80,7 @@ const dropshippingDefinition = createAssetDefinition({
         time: 3,
         dailyLimit: 1,
         progressKey: 'research',
-        progressAmount: context => 1 + getCommerceTierBonus(context),
+        progressAmount: () => 1,
         skills: ['research'],
         log: ({ label }) => `${label} spotted a trending micro-niche. Suppliers start calling back!`
       },
@@ -139,7 +91,7 @@ const dropshippingDefinition = createAssetDefinition({
         cost: 28,
         dailyLimit: 1,
         progressKey: 'listing',
-        progressAmount: context => 1 + getCommerceTierBonus(context),
+        progressAmount: () => 1,
         skills: ['promotion', { id: 'commerce', weight: 0.6 }],
         log: ({ label }) => `${label} revamped copy and photos. Conversion rates begin to pop.`
       },
@@ -150,7 +102,7 @@ const dropshippingDefinition = createAssetDefinition({
         cost: 34,
         dailyLimit: 1,
         progressKey: 'ads',
-        progressAmount: context => 1 + getCommerceTierBonus(context),
+        progressAmount: () => 1,
         skills: ['promotion', { id: 'research', weight: 0.5 }],
         log: ({ label }) => `${label} tested lookalike audiences. Click-through rates jump!`
       }

--- a/src/game/assets/definitions/ebook.js
+++ b/src/game/assets/definitions/ebook.js
@@ -1,30 +1,12 @@
 import { formatMoney } from '../../../core/helpers.js';
-import { getUpgradeState } from '../../../core/state.js';
 import { createAssetDefinition } from '../../content/schema.js';
-
-function hasUpgrade(context, id) {
-  if (!id) return false;
-  if (context && typeof context.upgrade === 'function') {
-    const upgrade = context.upgrade(id);
-    if (upgrade) return Boolean(upgrade.purchased);
-  }
-  const state = getUpgradeState(id);
-  return Boolean(state?.purchased);
-}
-
-function applyCreativeProgress(base, context) {
-  let progress = base;
-  if (hasUpgrade(context, 'editorialPipeline')) progress += 1;
-  if (hasUpgrade(context, 'syndicationSuite')) progress += 1;
-  if (hasUpgrade(context, 'immersiveStoryWorlds')) progress += 1;
-  return progress;
-}
 
 const ebookDefinition = createAssetDefinition({
   id: 'ebook',
   name: 'Digital E-Book Series',
   singular: 'E-Book',
   tag: { label: 'Creative', type: 'passive' },
+  tags: ['writing', 'product', 'digital'],
   description: 'Package your expertise into downloadable page-turners that sell while you snooze.',
   setup: { days: 4, hoursPerDay: 3, cost: 260 },
   maintenance: { hours: 0.75, cost: 3 },
@@ -34,35 +16,7 @@ const ebookDefinition = createAssetDefinition({
       { id: 'editing', weight: 0.75 }
     ]
   },
-  income: {
-    base: 30,
-    variance: 0.2,
-    logType: 'passive',
-    modifier: (amount, context = {}) => {
-      const steps = [];
-      if (hasUpgrade(context, 'editorialPipeline')) {
-        steps.push({ id: 'editorialPipeline', label: 'Editorial pipeline royalties', percent: 0.2 });
-      }
-      if (hasUpgrade(context, 'syndicationSuite')) {
-        steps.push({ id: 'syndicationSuite', label: 'Syndication suite royalties', percent: 0.25 });
-      }
-      if (hasUpgrade(context, 'immersiveStoryWorlds')) {
-        steps.push({ id: 'immersiveStoryWorlds', label: 'Immersive story worlds royalties', percent: 0.35 });
-      }
-      return steps.reduce((total, step) => {
-        const before = total;
-        const after = total * (1 + step.percent);
-        if (typeof context.recordModifier === 'function') {
-          context.recordModifier(step.label, after - before, {
-            id: step.id,
-            type: 'upgrade',
-            percent: step.percent
-          });
-        }
-        return after;
-      }, amount);
-    }
-  },
+  income: { base: 30, variance: 0.2, logType: 'passive' },
   requirements: {
     knowledge: ['outlineMastery']
   },
@@ -124,7 +78,7 @@ const ebookDefinition = createAssetDefinition({
         time: 2.5,
         dailyLimit: 1,
         progressKey: 'chapters',
-        progressAmount: context => applyCreativeProgress(1, context),
+        progressAmount: () => 1,
         skills: ['writing'],
         log: ({ label }) => `${label} gained another gripping chapter. Cliffhangers everywhere!`
       },
@@ -135,7 +89,7 @@ const ebookDefinition = createAssetDefinition({
         cost: 60,
         dailyLimit: 1,
         progressKey: 'cover',
-        progressAmount: context => applyCreativeProgress(1, context),
+        progressAmount: () => 1,
         skills: ['visual', { id: 'editing', weight: 0.6 }],
         log: ({ label }) => `${label} unveiled a shiny cover mockup. Bookstores swoon.`
       },
@@ -146,7 +100,7 @@ const ebookDefinition = createAssetDefinition({
         cost: 10,
         dailyLimit: 1,
         progressKey: 'reviews',
-        progressAmount: context => applyCreativeProgress(1, context),
+        progressAmount: () => 1,
         skills: ['audience'],
         log: ({ label }) => `${label} nudged superfans for reviews. Star ratings climb skyward!`
       }

--- a/src/game/assets/definitions/saas.js
+++ b/src/game/assets/definitions/saas.js
@@ -1,5 +1,4 @@
 import { formatMoney } from '../../../core/helpers.js';
-import { getUpgradeState } from '../../../core/state.js';
 import { createAssetDefinition } from '../../content/schema.js';
 
 const saasDefinition = createAssetDefinition({
@@ -7,6 +6,7 @@ const saasDefinition = createAssetDefinition({
   name: 'Micro SaaS Platform',
   singular: 'Micro SaaS',
   tag: { label: 'Tech', type: 'passive' },
+  tags: ['software', 'tech', 'product'],
   description: 'Design lean software services, onboard early users, and ship updates that keep churn low.',
   setup: { days: 8, hoursPerDay: 4, cost: 960 },
   maintenance: { hours: 2.2, cost: 24 },
@@ -17,23 +17,7 @@ const saasDefinition = createAssetDefinition({
       { id: 'promotion', weight: 0.5 }
     ]
   },
-  income: {
-    base: 108,
-    variance: 0.4,
-    logType: 'passive',
-    modifier: (amount, context = {}) => {
-      const edge = getUpgradeState('serverEdge').purchased ? 1.35 : 1;
-      const total = amount * edge;
-      if (edge > 1 && typeof context.recordModifier === 'function') {
-        context.recordModifier('Edge delivery boost', total - amount, {
-          id: 'serverEdge',
-          type: 'upgrade',
-          percent: edge - 1
-        });
-      }
-      return total;
-    }
-  },
+  income: { base: 108, variance: 0.4, logType: 'passive' },
   requirements: {
     knowledge: ['automationCourse'],
     equipment: ['serverCluster'],
@@ -102,7 +86,7 @@ const saasDefinition = createAssetDefinition({
         cost: 32,
         dailyLimit: 1,
         progressKey: 'features',
-        progressAmount: context => (context.upgrade('serverEdge')?.purchased ? 2 : 1),
+        progressAmount: () => 1,
         skills: ['software'],
         log: ({ label }) => `${label} shipped a delightful feature. Beta users erupt in emoji reactions!`
       },
@@ -113,7 +97,7 @@ const saasDefinition = createAssetDefinition({
         cost: 36,
         dailyLimit: 1,
         progressKey: 'stability',
-        progressAmount: context => (context.upgrade('serverEdge')?.purchased ? 2 : 1),
+        progressAmount: () => 1,
         skills: ['infrastructure'],
         log: ({ label }) => `${label} patched outages and bolstered uptime. Pager alerts stay quiet.`
       },
@@ -124,7 +108,7 @@ const saasDefinition = createAssetDefinition({
         cost: 44,
         dailyLimit: 1,
         progressKey: 'marketing',
-        progressAmount: context => (context.upgrade('serverEdge')?.purchased ? 2 : 1),
+        progressAmount: () => 1,
         skills: ['promotion'],
         log: ({ label }) => `${label} launched a marketing sprint. Sign-ups trickle in all night.`
       },

--- a/src/game/assets/definitions/stockPhotos.js
+++ b/src/game/assets/definitions/stockPhotos.js
@@ -1,5 +1,4 @@
 import { formatMoney } from '../../../core/helpers.js';
-import { getUpgradeState } from '../../../core/state.js';
 import { createAssetDefinition } from '../../content/schema.js';
 
 const stockPhotosDefinition = createAssetDefinition({
@@ -7,6 +6,7 @@ const stockPhotosDefinition = createAssetDefinition({
   name: 'Stock Photo Galleries',
   singular: 'Gallery',
   tag: { label: 'Creative', type: 'passive' },
+  tags: ['photo', 'visual', 'content'],
   description: 'Stage props, shoot themed collections, and list them across marketplaces.',
   setup: { days: 5, hoursPerDay: 4, cost: 560 },
   maintenance: { hours: 1.2, cost: 10 },
@@ -17,38 +17,7 @@ const stockPhotosDefinition = createAssetDefinition({
       { id: 'promotion', weight: 0.4 }
     ]
   },
-  income: {
-    base: 58,
-    variance: 0.35,
-    logType: 'passive',
-    modifier: (amount, context = {}) => {
-      let total = amount;
-      const expansionOwned = getUpgradeState('studioExpansion').purchased;
-      if (expansionOwned) {
-        const before = total;
-        total *= 1.2;
-        if (typeof context.recordModifier === 'function') {
-          context.recordModifier('Studio expansion boost', total - before, {
-            id: 'studioExpansion',
-            type: 'upgrade',
-            percent: 0.2
-          });
-        }
-      }
-      if (context.upgrade?.('whiteLabelAlliance')?.purchased) {
-        const before = total;
-        total *= 1.3;
-        if (typeof context.recordModifier === 'function') {
-          context.recordModifier('White-label alliance boost', total - before, {
-            id: 'whiteLabelAlliance',
-            type: 'upgrade',
-            percent: 0.3
-          });
-        }
-      }
-      return total;
-    }
-  },
+  income: { base: 58, variance: 0.35, logType: 'passive' },
   requirements: {
     equipment: ['camera', 'studio'],
     knowledge: ['photoLibrary']
@@ -112,7 +81,7 @@ const stockPhotosDefinition = createAssetDefinition({
         cost: 22,
         dailyLimit: 1,
         progressKey: 'shoots',
-        progressAmount: context => (context.upgrade('studioExpansion')?.purchased ? 2 : 1),
+        progressAmount: () => 1,
         skills: ['visual'],
         log: ({ label }) => `${label} staged a dazzling shoot. Props now live rent-free in your studio.`
       },
@@ -123,7 +92,7 @@ const stockPhotosDefinition = createAssetDefinition({
         cost: 14,
         dailyLimit: 1,
         progressKey: 'editing',
-        progressAmount: context => (context.upgrade('studioExpansion')?.purchased ? 2 : 1),
+        progressAmount: () => 1,
         skills: ['editing'],
         log: ({ label }) => `${label} batch-edited a gallery. Clients cheer at the crisp exports!`
       },
@@ -134,13 +103,7 @@ const stockPhotosDefinition = createAssetDefinition({
         cost: 16,
         dailyLimit: 1,
         progressKey: 'marketing',
-        progressAmount: context => {
-          let amount = context.upgrade('studioExpansion')?.purchased ? 2 : 1;
-          if (context.upgrade('whiteLabelAlliance')?.purchased) {
-            amount += 1;
-          }
-          return amount;
-        },
+        progressAmount: () => 1,
         skills: ['promotion'],
         log: ({ label }) => `${label} ran a marketplace feature promo. Download counters spin faster!`
       }

--- a/src/game/assets/definitions/vlog.js
+++ b/src/game/assets/definitions/vlog.js
@@ -1,31 +1,12 @@
 import { formatMoney } from '../../../core/helpers.js';
-import { getUpgradeState } from '../../../core/state.js';
 import { createAssetDefinition } from '../../content/schema.js';
-
-function hasUpgrade(context, id) {
-  if (!id) return false;
-  if (context && typeof context.upgrade === 'function') {
-    const upgrade = context.upgrade(id);
-    if (upgrade) return Boolean(upgrade.purchased);
-  }
-  const state = getUpgradeState(id);
-  return Boolean(state?.purchased);
-}
-
-function vlogProgress(context) {
-  let progress = 1;
-  if (hasUpgrade(context, 'cameraPro')) progress += 1;
-  if (hasUpgrade(context, 'editorialPipeline')) progress += 1;
-  if (hasUpgrade(context, 'syndicationSuite')) progress += 1;
-  if (hasUpgrade(context, 'immersiveStoryWorlds')) progress += 1;
-  return progress;
-}
 
 const vlogDefinition = createAssetDefinition({
   id: 'vlog',
   name: 'Weekly Vlog Channel',
   singular: 'Vlog',
   tag: { label: 'Creative', type: 'passive' },
+  tags: ['video', 'visual', 'content', 'studio'],
   description: 'Film upbeat vlogs, edit late-night montages, and ride the algorithmic rollercoaster.',
   setup: { days: 4, hoursPerDay: 4, cost: 420 },
   maintenance: { hours: 1.5, cost: 9 },
@@ -41,29 +22,9 @@ const vlogDefinition = createAssetDefinition({
     logType: 'passive',
     modifier: (amount, context = {}) => {
       const instance = context.instance;
-      const hasCinemaGear = hasUpgrade(context, 'cameraPro');
-      const hasEditorial = hasUpgrade(context, 'editorialPipeline');
-      const hasSyndication = hasUpgrade(context, 'syndicationSuite');
-      const hasImmersive = hasUpgrade(context, 'immersiveStoryWorlds');
       const qualityLevel = instance?.quality?.level || 0;
       let viralChance = qualityLevel >= 4 ? 0.24 : 0.18;
       let viralMultiplier = qualityLevel >= 4 ? 3.5 : 3;
-      if (hasCinemaGear) {
-        viralChance += 0.06;
-        viralMultiplier += 0.5;
-      }
-      if (hasEditorial) {
-        viralChance += 0.03;
-        viralMultiplier += 0.25;
-      }
-      if (hasSyndication) {
-        viralChance += 0.04;
-        viralMultiplier += 0.5;
-      }
-      if (hasImmersive) {
-        viralChance += 0.05;
-        viralMultiplier += 0.75;
-      }
       let payout = amount;
       if (qualityLevel >= 3 && Math.random() < viralChance) {
         const before = payout;
@@ -79,31 +40,7 @@ const vlogDefinition = createAssetDefinition({
         }
         payout = after;
       }
-      const steps = [];
-      if (hasCinemaGear) {
-        steps.push({ id: 'cameraPro', label: 'Cinema rig bonus', percent: 0.25 });
-      }
-      if (hasEditorial) {
-        steps.push({ id: 'editorialPipeline', label: 'Editorial pipeline promo', percent: 0.15 });
-      }
-      if (hasSyndication) {
-        steps.push({ id: 'syndicationSuite', label: 'Syndication suite promo', percent: 0.2 });
-      }
-      if (hasImmersive) {
-        steps.push({ id: 'immersiveStoryWorlds', label: 'Immersive story worlds hype', percent: 0.3 });
-      }
-      return steps.reduce((total, step) => {
-        const before = total;
-        const after = total * (1 + step.percent);
-        if (typeof context.recordModifier === 'function') {
-          context.recordModifier(step.label, after - before, {
-            id: step.id,
-            type: 'upgrade',
-            percent: step.percent
-          });
-        }
-        return after;
-      }, payout);
+      return payout;
     }
   },
   requirements: {
@@ -167,7 +104,7 @@ const vlogDefinition = createAssetDefinition({
         time: 5,
         dailyLimit: 1,
         progressKey: 'videos',
-        progressAmount: context => vlogProgress(context),
+        progressAmount: () => 1,
         skills: ['visual'],
         log: ({ label }) => `${label} filmed an energetic episode. B-roll glitter everywhere!`
       },
@@ -178,7 +115,7 @@ const vlogDefinition = createAssetDefinition({
         cost: 16,
         dailyLimit: 1,
         progressKey: 'edits',
-        progressAmount: context => vlogProgress(context),
+        progressAmount: () => 1,
         skills: ['editing'],
         log: ({ label }) => `${label} tightened jump cuts and color graded every frame.`
       },
@@ -189,7 +126,7 @@ const vlogDefinition = createAssetDefinition({
         cost: 24,
         dailyLimit: 1,
         progressKey: 'promotion',
-        progressAmount: context => vlogProgress(context),
+        progressAmount: () => 1,
         skills: ['promotion'],
         log: ({ label }) => `${label} teased the drop on socials. Chat bubbles explode with hype!`
       }

--- a/src/game/assets/quality.js
+++ b/src/game/assets/quality.js
@@ -1,6 +1,7 @@
 import { formatHours, formatMoney } from '../../core/helpers.js';
 import { addLog } from '../../core/log.js';
 import { getAssetDefinition, getAssetState, getState, getUpgradeState } from '../../core/state.js';
+import { getAssetEffectMultiplier } from '../upgrades/effects.js';
 import { executeAction } from '../actions.js';
 import { spendMoney } from '../currency.js';
 import { checkDayEnd } from '../lifecycle.js';
@@ -272,8 +273,13 @@ function runQualityAction(definition, instanceId, actionId) {
   if (progressKey) {
     const amount = resolveProgressAmount(action, context);
     if (amount !== 0) {
+      const effect = getAssetEffectMultiplier(definition, 'quality_progress_mult', {
+        actionType: 'quality'
+      });
+      const multiplier = Number.isFinite(effect.multiplier) ? effect.multiplier : 1;
+      const adjusted = amount * multiplier;
       const current = Number(quality.progress[progressKey]) || 0;
-      quality.progress[progressKey] = Math.max(0, current + amount);
+      quality.progress[progressKey] = Math.max(0, current + adjusted);
     }
   }
 

--- a/src/game/content/schema.js
+++ b/src/game/content/schema.js
@@ -258,7 +258,7 @@ export function createInstantHustle(config) {
     if (!metadata.time) return metadata.time;
     const { multiplier } = getHustleEffectMultiplier(definition, 'setup_time_mult', {
       state,
-      actionType: 'run'
+      actionType: 'setup'
     });
     const adjusted = metadata.time * (Number.isFinite(multiplier) ? multiplier : 1);
     return Number.isFinite(adjusted) ? Math.max(0, adjusted) : metadata.time;

--- a/src/game/hustles.js
+++ b/src/game/hustles.js
@@ -155,6 +155,7 @@ const freelanceWriting = createInstantHustle({
   name: 'Freelance Writing',
   tag: { label: 'Instant', type: 'instant' },
   description: 'Crank out a quick article for a client. Not Pulitzer material, but it pays.',
+  tags: ['writing', 'desktop_work'],
   time: 2,
   payout: {
     amount: 18,
@@ -180,6 +181,7 @@ const audienceCall = createInstantHustle({
   name: 'Audience Q&A Blast',
   tag: { label: 'Instant', type: 'instant' },
   description: 'Host a 60-minute livestream for your blog readers and pitch a premium checklist.',
+  tags: ['community', 'live', 'video'],
   time: 1,
   requirements: AUDIENCE_CALL_REQUIREMENTS,
   dailyLimit: 1,
@@ -207,6 +209,7 @@ const bundlePush = createInstantHustle({
   name: 'Bundle Promo Push',
   tag: { label: 'Instant', type: 'instant' },
   description: 'Pair your top blogs with an e-book bonus bundle for a limited-time flash sale.',
+  tags: ['commerce', 'marketing'],
   time: 2.5,
   requirements: BUNDLE_PUSH_REQUIREMENTS,
   payout: {
@@ -233,6 +236,7 @@ const surveySprint = createInstantHustle({
   name: 'Micro Survey Dash',
   tag: { label: 'Instant', type: 'instant' },
   description: 'Knock out a 15-minute feedback survey while your coffee is still warm.',
+  tags: ['ops', 'desktop_work'],
   time: 0.25,
   dailyLimit: 4,
   payout: {
@@ -259,6 +263,7 @@ const eventPhotoGig = createInstantHustle({
   name: 'Event Photo Gig',
   tag: { label: 'Instant', type: 'instant' },
   description: 'Grab your gallery gear and capture candid magic at a pop-up showcase.',
+  tags: ['photo', 'shoot', 'studio'],
   time: 3.5,
   requirements: EVENT_PHOTO_REQUIREMENTS,
   payout: {
@@ -285,6 +290,7 @@ const popUpWorkshop = createInstantHustle({
   name: 'Pop-Up Workshop',
   tag: { label: 'Instant', type: 'instant' },
   description: 'Host a cozy crash course that blends your blog insights with e-book handouts.',
+  tags: ['education', 'in_person'],
   time: 2.5,
   requirements: WORKSHOP_REQUIREMENTS,
   payout: {
@@ -311,6 +317,7 @@ const vlogEditRush = createInstantHustle({
   name: 'Vlog Edit Rush',
   tag: { label: 'Instant', type: 'instant' },
   description: 'Slice, color, and caption a backlog vlog episode for a partner channel.',
+  tags: ['video', 'editing', 'desktop_work'],
   time: 1.5,
   requirements: EDIT_RUSH_REQUIREMENTS,
   payout: {
@@ -337,6 +344,7 @@ const dropshipPackParty = createInstantHustle({
   name: 'Dropship Pack Party',
   tag: { label: 'Instant', type: 'instant' },
   description: 'Bundle hot orders with branded tissue paper and a confetti of thank-you notes.',
+  tags: ['commerce', 'fulfillment'],
   time: 2,
   cost: 8,
   requirements: PACK_PARTY_REQUIREMENTS,
@@ -365,6 +373,7 @@ const saasBugSquash = createInstantHustle({
   name: 'SaaS Bug Squash',
   tag: { label: 'Instant', type: 'instant' },
   description: 'Dig through error logs and deploy a patch before support tickets pile up.',
+  tags: ['software', 'ops'],
   time: 1,
   requirements: BUG_SQUASH_REQUIREMENTS,
   payout: {
@@ -391,6 +400,7 @@ const audiobookNarration = createInstantHustle({
   name: 'Audiobook Narration',
   tag: { label: 'Instant', type: 'instant' },
   description: 'Record a silky-smooth sample chapter to hype your flagship e-book series.',
+  tags: ['audio', 'studio'],
   time: 2.75,
   requirements: NARRATION_REQUIREMENTS,
   payout: {
@@ -417,6 +427,7 @@ const streetPromoSprint = createInstantHustle({
   name: 'Street Team Promo',
   tag: { label: 'Instant', type: 'instant' },
   description: 'Hand out QR stickers at a pop-up market to funnel readers toward your latest drops.',
+  tags: ['marketing', 'field'],
   time: 0.75,
   cost: 5,
   requirements: STREET_PROMO_REQUIREMENTS,

--- a/src/game/upgrades.js
+++ b/src/game/upgrades.js
@@ -21,6 +21,8 @@ const assistantUpgrade = createUpgrade({
   name: 'Hire Virtual Assistant',
   tag: { label: 'Unlock', type: 'unlock' },
   description: 'Scale your admin squad. Each hire adds hours but expects daily wages.',
+  category: 'infra',
+  family: 'automation',
   defaultState: {
     count: 0
   },
@@ -71,14 +73,342 @@ const assistantUpgrade = createUpgrade({
   }
 });
 
+const creatorPhone = createUpgrade({
+  id: 'creatorPhone',
+  name: 'Creator Phone - Starter',
+  tag: { label: 'Gear', type: 'tech' },
+  description: 'A stabilised creator phone that shoots crisp 4K clips and behind-the-scenes snaps.',
+  category: 'tech',
+  family: 'phone',
+  exclusivityGroup: 'tech:phone',
+  cost: 140,
+  effects: { setup_time_mult: 0.95 },
+  affects: {
+    hustles: { tags: ['live', 'field'] },
+    assets: { tags: ['video'] },
+    actions: { types: ['setup'] }
+  },
+  metrics: {
+    cost: { label: '📱 Creator phone purchase', category: 'gear' }
+  },
+  logMessage: 'Pocket studio unlocked! IRL clips are now smoother and faster to capture.',
+  logType: 'upgrade'
+});
+
+const creatorPhonePro = createUpgrade({
+  id: 'creatorPhonePro',
+  name: 'Creator Phone - Pro',
+  tag: { label: 'Gear', type: 'tech' },
+  description: 'Upgraded camera array with on-device editing suites for instant field delivery.',
+  category: 'tech',
+  family: 'phone',
+  exclusivityGroup: 'tech:phone',
+  cost: 360,
+  requires: ['creatorPhone'],
+  effects: { setup_time_mult: 0.85, payout_mult: 1.05 },
+  affects: {
+    hustles: { tags: ['live', 'field'] },
+    assets: { tags: ['video'] },
+    actions: { types: ['setup', 'payout'] }
+  },
+  metrics: {
+    cost: { label: '📱 Creator phone pro upgrade', category: 'gear' }
+  },
+  onPurchase: () => {
+    const previous = getUpgradeState('creatorPhone');
+    if (previous) previous.purchased = false;
+  },
+  logMessage: 'Cinematic mobile shots now flow straight from pocket to platform.',
+  logType: 'upgrade'
+});
+
+const creatorPhoneUltra = createUpgrade({
+  id: 'creatorPhoneUltra',
+  name: 'Creator Phone - Ultra',
+  tag: { label: 'Gear', type: 'tech' },
+  description: 'AI framing, lidar depth, and broadcast-ready uplinks for live storytelling.',
+  category: 'tech',
+  family: 'phone',
+  exclusivityGroup: 'tech:phone',
+  cost: 720,
+  requires: ['creatorPhonePro'],
+  effects: { setup_time_mult: 0.8, payout_mult: 1.08 },
+  affects: {
+    hustles: { tags: ['live', 'field'] },
+    assets: { tags: ['video'] },
+    actions: { types: ['setup', 'payout'] }
+  },
+  metrics: {
+    cost: { label: '📱 Creator phone ultra upgrade', category: 'gear' }
+  },
+  onPurchase: () => {
+    const previous = getUpgradeState('creatorPhonePro');
+    if (previous) previous.purchased = false;
+  },
+  logMessage: 'Your mobile studio now beams polished stories from anywhere in seconds.',
+  logType: 'upgrade'
+});
+
+const studioLaptop = createUpgrade({
+  id: 'studioLaptop',
+  name: 'Studio Laptop',
+  tag: { label: 'Gear', type: 'tech' },
+  description: 'High-refresh laptop tuned for editing, streaming, and multitasking.',
+  category: 'tech',
+  family: 'pc',
+  exclusivityGroup: 'tech:pc',
+  cost: 280,
+  effects: { setup_time_mult: 0.92 },
+  affects: {
+    assets: { tags: ['desktop_work'] },
+    hustles: { tags: ['desktop_work'] },
+    actions: { types: ['setup'] }
+  },
+  metrics: {
+    cost: { label: '💻 Studio laptop purchase', category: 'gear' }
+  },
+  logMessage: 'Editing suites and dashboards glide on your new studio laptop.',
+  logType: 'upgrade'
+});
+
+const editingWorkstation = createUpgrade({
+  id: 'editingWorkstation',
+  name: 'Editing Workstation',
+  tag: { label: 'Gear', type: 'tech' },
+  description: 'Desktop workstation with GPU acceleration and silent cooling for marathon edits.',
+  category: 'tech',
+  family: 'pc',
+  exclusivityGroup: 'tech:pc',
+  cost: 640,
+  requires: ['studioLaptop'],
+  effects: { setup_time_mult: 0.85, maint_time_mult: 0.9 },
+  affects: {
+    assets: { tags: ['desktop_work', 'video'] },
+    actions: { types: ['setup', 'maintenance'] }
+  },
+  metrics: {
+    cost: { label: '🖥️ Editing workstation build', category: 'gear' }
+  },
+  onPurchase: () => {
+    const previous = getUpgradeState('studioLaptop');
+    if (previous) previous.purchased = false;
+  },
+  logMessage: 'Your workstation devours timelines and exports while you plan the next drop.',
+  logType: 'upgrade'
+});
+
+const quantumRig = createUpgrade({
+  id: 'quantumRig',
+  name: 'Quantum Creator Rig',
+  tag: { label: 'Gear', type: 'tech' },
+  description: 'Cutting-edge rig with neural encoders and instant renders for ambitious builds.',
+  category: 'tech',
+  family: 'pc',
+  exclusivityGroup: 'tech:pc',
+  cost: 1280,
+  requires: ['editingWorkstation'],
+  effects: { payout_mult: 1.12, maint_time_mult: 0.85 },
+  affects: {
+    assets: { tags: ['desktop_work', 'software', 'video'] },
+    actions: { types: ['maintenance', 'payout'] }
+  },
+  metrics: {
+    cost: { label: '🧠 Quantum rig investment', category: 'gear' }
+  },
+  onPurchase: () => {
+    const previous = getUpgradeState('editingWorkstation');
+    if (previous) previous.purchased = false;
+  },
+  logMessage: 'Rendering, compiling, and editing now feel instant—your rig hums with headroom.',
+  logType: 'upgrade'
+});
+
+const monitorHub = createUpgrade({
+  id: 'monitorHub',
+  name: 'Monitor Dock',
+  tag: { label: 'Gear', type: 'tech' },
+  description: 'USB-C dock that powers dual displays, capture cards, and creative peripherals.',
+  category: 'tech',
+  family: 'monitor_hub',
+  exclusivityGroup: 'tech:monitor_hub',
+  cost: 240,
+  provides: { monitor: 2 },
+  effects: { setup_time_mult: 0.95 },
+  affects: {
+    assets: { tags: ['desktop_work'] },
+    actions: { types: ['setup'] }
+  },
+  metrics: {
+    cost: { label: '🖥️ Monitor dock install', category: 'gear' }
+  },
+  logMessage: 'Your command center now has spare ports and screen real estate for days.',
+  logType: 'upgrade'
+});
+
+const dualMonitorArray = createUpgrade({
+  id: 'dualMonitorArray',
+  name: 'Dual Monitor Array',
+  tag: { label: 'Gear', type: 'tech' },
+  description: 'Pair of calibrated monitors for timeline scrubbing and asset management.',
+  category: 'tech',
+  family: 'monitor',
+  exclusivityGroup: 'tech:monitor',
+  cost: 260,
+  consumes: { monitor: 1 },
+  effects: { setup_time_mult: 0.9 },
+  affects: {
+    assets: { tags: ['desktop_work', 'video'] },
+    actions: { types: ['setup'] }
+  },
+  metrics: {
+    cost: { label: '🖥️ Dual monitor kit', category: 'gear' }
+  },
+  logMessage: 'Two displays keep editing, research, and dashboards aligned in view.',
+  logType: 'upgrade'
+});
+
+const colorGradingDisplay = createUpgrade({
+  id: 'colorGradingDisplay',
+  name: 'Color Grading Display',
+  tag: { label: 'Gear', type: 'tech' },
+  description: 'Reference-grade monitor that nails color accuracy for visual polish.',
+  category: 'tech',
+  family: 'monitor',
+  exclusivityGroup: 'tech:monitor',
+  cost: 420,
+  consumes: { monitor: 1 },
+  effects: { payout_mult: 1.05 },
+  affects: {
+    assets: { tags: ['video', 'photo'] },
+    actions: { types: ['payout'] }
+  },
+  metrics: {
+    cost: { label: '🎨 Color grading display', category: 'gear' }
+  },
+  logMessage: 'Visual work pops with accurate hues and clients notice the upgrade.',
+  logType: 'upgrade'
+});
+
+const scratchDriveArray = createUpgrade({
+  id: 'scratchDriveArray',
+  name: 'Scratch Drive Array',
+  tag: { label: 'Gear', type: 'tech' },
+  description: 'Blazing-fast SSD array for project files, proxies, and render caches.',
+  category: 'tech',
+  family: 'storage',
+  cost: 380,
+  effects: { maint_time_mult: 0.9 },
+  affects: {
+    assets: { tags: ['video', 'photo'] },
+    actions: { types: ['maintenance'] }
+  },
+  metrics: {
+    cost: { label: '💾 Scratch drive array', category: 'gear' }
+  },
+  logMessage: 'Media transfers and cache renders scream thanks to your scratch array.',
+  logType: 'upgrade'
+});
+
+const audioSuite = createUpgrade({
+  id: 'audioSuite',
+  name: 'Studio Audio Suite',
+  tag: { label: 'Home', type: 'boost' },
+  description: 'Acoustic treatment, premium mics, and mix-ready monitors for broadcast sound.',
+  category: 'house',
+  family: 'audio',
+  cost: 420,
+  effects: { payout_mult: 1.1, setup_time_mult: 0.9 },
+  affects: {
+    assets: { tags: ['audio', 'video'] },
+    hustles: { tags: ['audio'] },
+    actions: { types: ['setup', 'payout'] }
+  },
+  metrics: {
+    cost: { label: '🎙️ Audio suite build', category: 'home' }
+  },
+  logMessage: 'Voiceovers, podcasts, and narrations now sound buttery-smooth.',
+  logType: 'upgrade'
+});
+
+const fiberInternet = createUpgrade({
+  id: 'fiberInternet',
+  name: 'Fiber Internet Plan',
+  tag: { label: 'Home', type: 'boost' },
+  description: 'Symmetric gigabit fiber ensures uploads, streams, and syncs never choke.',
+  category: 'house',
+  family: 'internet',
+  exclusivityGroup: 'house:internet',
+  cost: 260,
+  effects: { setup_time_mult: 0.85 },
+  affects: {
+    hustles: { tags: ['live', 'upload'] },
+    assets: { tags: ['video', 'software'] },
+    actions: { types: ['setup'] }
+  },
+  metrics: {
+    cost: { label: '🌐 Fiber plan install', category: 'home' }
+  },
+  logMessage: 'Uploads and livestreams race through your new fiber connection.',
+  logType: 'upgrade'
+});
+
+const ergonomicRefit = createUpgrade({
+  id: 'ergonomicRefit',
+  name: 'Ergonomic Studio Refit',
+  tag: { label: 'Home', type: 'boost' },
+  description: 'Standing desk, adaptive chair, and lighting to keep marathon sessions comfy.',
+  category: 'house',
+  family: 'ergonomics',
+  cost: 320,
+  effects: { maint_time_mult: 0.88 },
+  affects: {
+    assets: { tags: ['desktop_work', 'software'] },
+    actions: { types: ['maintenance'] }
+  },
+  metrics: {
+    cost: { label: '🪑 Ergonomic refit', category: 'home' }
+  },
+  logMessage: 'Back-saving upgrades keep your output steady without burnout.',
+  logType: 'upgrade'
+});
+
+const backupPowerArray = createUpgrade({
+  id: 'backupPowerArray',
+  name: 'Backup Power Array',
+  tag: { label: 'Home', type: 'boost' },
+  description: 'Battery racks and surge conditioning protect launches from outages.',
+  category: 'house',
+  family: 'power_backup',
+  cost: 380,
+  effects: { maint_time_mult: 0.9 },
+  affects: {
+    assets: { tags: ['software', 'commerce'] },
+    actions: { types: ['maintenance'] }
+  },
+  metrics: {
+    cost: { label: '🔋 Backup power install', category: 'home' }
+  },
+  logMessage: 'Even surprise outages can’t derail your releases anymore.',
+  logType: 'upgrade'
+});
+
 const camera = createUpgrade({
   id: 'camera',
   name: 'Camera',
   tag: { label: 'Unlock', type: 'unlock' },
   description: 'Unlocks video production gear so you can start vlogs and shoot stock photos.',
+  category: 'tech',
+  family: 'camera',
+  exclusivityGroup: 'tech:camera',
   cost: 200,
   unlocks: 'Weekly Vlog Channel & Stock Photo Galleries',
   skills: ['visual'],
+  effects: { setup_time_mult: 0.9 },
+  affects: {
+    assets: { tags: ['video', 'photo'] },
+    hustles: { tags: ['video', 'photo'] },
+    actions: { types: ['setup'] }
+  },
   actionClassName: 'secondary',
   actionLabel: 'Purchase Camera',
   labels: {
@@ -96,9 +426,17 @@ const studio = createUpgrade({
   name: 'Lighting Kit',
   tag: { label: 'Unlock', type: 'unlock' },
   description: 'Soft boxes, reflectors, and editing presets for glossier stock photos.',
+  category: 'house',
+  family: 'lighting',
+  exclusivityGroup: 'house:lighting',
   cost: 220,
   unlocks: 'Stock Photo Galleries',
   skills: ['visual'],
+  effects: { maint_time_mult: 0.9 },
+  affects: {
+    assets: { tags: ['photo', 'video'] },
+    actions: { types: ['maintenance'] }
+  },
   actionClassName: 'secondary',
   actionLabel: 'Build Studio',
   labels: {
@@ -116,9 +454,22 @@ const cameraPro = createUpgrade({
   name: 'Cinema Camera Upgrade',
   tag: { label: 'Boost', type: 'boost' },
   description: 'Upgrade your rig with cinema glass and stabilized mounts for prestige productions.',
+  category: 'tech',
+  family: 'camera',
+  exclusivityGroup: 'tech:camera',
   cost: 480,
   requires: ['camera'],
   boosts: 'Boosts vlog payouts and doubles quality progress',
+  effects: {
+    setup_time_mult: 0.85,
+    maint_time_mult: 0.85,
+    payout_mult: 1.25,
+    quality_progress_mult: 2
+  },
+  affects: {
+    assets: { tags: ['video', 'photo'] },
+    actions: { types: ['setup', 'maintenance', 'payout', 'quality'] }
+  },
   details: [
     () => '🎞️ Vlog quality actions count double progress once the cinema rig is live.',
     () => '💰 Daily vlog income jumps by roughly +25% and viral bursts spike harder.'
@@ -142,9 +493,18 @@ const studioExpansion = createUpgrade({
   name: 'Studio Expansion',
   tag: { label: 'Boost', type: 'boost' },
   description: 'Add modular sets, color-controlled lighting, and prop storage for faster shoots.',
+  category: 'house',
+  family: 'studio',
+  exclusivityGroup: 'house:studio',
   cost: 540,
   requires: ['studio'],
   boosts: 'Stock photo payouts + faster shoot progress',
+  effects: { setup_time_mult: 0.85, payout_mult: 1.15, quality_progress_mult: 2 },
+  affects: {
+    assets: { tags: ['photo', 'video'] },
+    hustles: { tags: ['photo'] },
+    actions: { types: ['setup', 'payout', 'quality'] }
+  },
   details: [
     () => '📸 Stock photo quality actions earn double progress with the expanded studio.',
     () => '💵 Galleries pick up roughly +20% daily income thanks to premium staging.'
@@ -189,6 +549,8 @@ const editorialPipeline = createUpgrade({
   name: 'Editorial Pipeline Suite',
   tag: { label: 'Boost', type: 'boost' },
   description: 'Stand up pro-grade editorial calendars so every blog post ships polished and on schedule.',
+  category: 'tech',
+  family: 'workflow',
   cost: 360,
   requires: [
     'course',
@@ -200,6 +562,12 @@ const editorialPipeline = createUpgrade({
     }
   ],
   boosts: 'Stacks new blog and e-book bonuses across every publishing push',
+  effects: { setup_time_mult: 0.88, payout_mult: 1.2, quality_progress_mult: 1.5 },
+  affects: {
+    assets: { tags: ['writing', 'content'] },
+    hustles: { tags: ['writing'] },
+    actions: { types: ['setup', 'payout', 'quality'] }
+  },
   skills: ['writing', { id: 'promotion', weight: 0.5 }],
   actionClassName: 'secondary',
   actionLabel: 'Build Editorial Suite',
@@ -223,6 +591,8 @@ const syndicationSuite = createUpgrade({
   name: 'Syndication Suite',
   tag: { label: 'Boost', type: 'boost' },
   description: 'Spin up partner feeds, guest slots, and cross-promotions to syndicate your best work everywhere.',
+  category: 'tech',
+  family: 'workflow',
   cost: 720,
   requires: [
     'editorialPipeline',
@@ -235,6 +605,12 @@ const syndicationSuite = createUpgrade({
     }
   ],
   boosts: 'Energises blogs, e-books, and vlogs with syndicated promos and bigger payouts',
+  effects: { maint_time_mult: 0.9, payout_mult: 1.25, quality_progress_mult: 1.3333333333333333 },
+  affects: {
+    assets: { tags: ['writing', 'content', 'video'] },
+    hustles: { tags: ['writing', 'marketing'] },
+    actions: { types: ['maintenance', 'payout', 'quality'] }
+  },
   skills: ['audience', { id: 'promotion', weight: 0.5 }],
   actionClassName: 'secondary',
   actionLabel: 'Launch Syndication Suite',
@@ -260,6 +636,8 @@ const immersiveStoryWorlds = createUpgrade({
   name: 'Immersive Story Worlds',
   tag: { label: 'Boost', type: 'boost' },
   description: 'Blend blogs, books, and vlogs into one living universe with AR teasers and fan quests.',
+  category: 'tech',
+  family: 'workflow',
   cost: 1080,
   requires: [
     'syndicationSuite',
@@ -274,6 +652,11 @@ const immersiveStoryWorlds = createUpgrade({
     }
   ],
   boosts: 'Adds premium payouts and faster progress for every creative asset',
+  effects: { payout_mult: 1.12, setup_time_mult: 0.85, quality_progress_mult: 2 },
+  affects: {
+    assets: { tags: ['writing', 'video', 'photo'] },
+    actions: { types: ['setup', 'payout', 'quality'] }
+  },
   skills: ['visual', { id: 'writing', weight: 0.5 }],
   actionClassName: 'secondary',
   actionLabel: 'Launch Story Worlds',
@@ -300,8 +683,16 @@ const serverRack = createUpgrade({
   name: 'Server Rack - Starter',
   tag: { label: 'Unlock', type: 'unlock' },
   description: 'Spin up a reliable rack with monitoring so prototypes stay online.',
+  category: 'infra',
+  family: 'cloud_compute',
   cost: 650,
   unlocks: 'Stable environments for advanced products',
+  effects: { setup_time_mult: 0.95 },
+  affects: {
+    assets: { tags: ['software', 'tech'] },
+    hustles: { tags: ['software', 'automation'] },
+    actions: { types: ['setup'] }
+  },
   skills: ['infrastructure'],
   actionClassName: 'secondary',
   actionLabel: 'Install Rack',
@@ -320,6 +711,8 @@ const fulfillmentAutomation = createUpgrade({
   name: 'Fulfillment Automation Suite',
   tag: { label: 'Commerce', type: 'boost' },
   description: 'Tie together your winning storefronts with automated pick, pack, and ship magic.',
+  category: 'infra',
+  family: 'automation',
   cost: 780,
   requires: [
     {
@@ -335,6 +728,11 @@ const fulfillmentAutomation = createUpgrade({
     }
   ],
   boosts: 'Dropshipping payouts + faster research/listing/ads progress',
+  effects: { payout_mult: 1.25, quality_progress_mult: 2 },
+  affects: {
+    assets: { ids: ['dropshipping'] },
+    actions: { types: ['payout', 'quality'] }
+  },
   skills: ['commerce', { id: 'research', weight: 0.6 }],
   actionClassName: 'secondary',
   actionLabel: 'Automate Fulfillment',
@@ -353,9 +751,16 @@ const serverCluster = createUpgrade({
   name: 'Cloud Cluster',
   tag: { label: 'Unlock', type: 'unlock' },
   description: 'Deploy auto-scaling containers and CI pipelines so your SaaS survives launch day.',
+  category: 'infra',
+  family: 'cloud_compute',
   cost: 1150,
   requires: ['serverRack'],
   unlocks: 'SaaS deployments',
+  effects: { payout_mult: 1.2, quality_progress_mult: 1.5 },
+  affects: {
+    assets: { ids: ['saas'] },
+    actions: { types: ['payout', 'quality'] }
+  },
   skills: ['infrastructure'],
   actionClassName: 'secondary',
   actionLabel: 'Deploy Cluster',
@@ -375,6 +780,8 @@ const globalSupplyMesh = createUpgrade({
   name: 'Global Supply Mesh',
   tag: { label: 'Commerce', type: 'boost' },
   description: 'Forge data-sharing deals with worldwide 3PL partners so inventory never sleeps.',
+  category: 'infra',
+  family: 'automation',
   cost: 1150,
   requires: [
     'fulfillmentAutomation',
@@ -391,6 +798,12 @@ const globalSupplyMesh = createUpgrade({
     }
   ],
   boosts: 'Dropshipping payouts surge & marketing tests finish faster',
+  effects: { payout_mult: 1.3, quality_progress_mult: 1.5, setup_time_mult: 0.92 },
+  affects: {
+    assets: { ids: ['dropshipping'] },
+    hustles: { tags: ['commerce', 'ecommerce'] },
+    actions: { types: ['setup', 'payout', 'quality'] }
+  },
   skills: ['commerce', { id: 'promotion', weight: 0.5 }],
   actionClassName: 'secondary',
   actionLabel: 'Link Global Partners',
@@ -411,9 +824,16 @@ const serverEdge = createUpgrade({
   name: 'Edge Delivery Network',
   tag: { label: 'Boost', type: 'boost' },
   description: 'Distribute workloads across edge nodes for instant response times and uptime bragging rights.',
+  category: 'infra',
+  family: 'edge_network',
   cost: 1450,
   requires: ['serverCluster'],
   boosts: 'SaaS payouts + stability progress surges',
+  effects: { payout_mult: 1.35, quality_progress_mult: 2, maint_time_mult: 0.85 },
+  affects: {
+    assets: { ids: ['saas'] },
+    actions: { types: ['payout', 'quality', 'maintenance'] }
+  },
   details: [
     () => '⚙️ SaaS feature, stability, and marketing pushes count double progress once edge nodes hum.',
     () => '📈 Subscriptions pay roughly +35% more each day with the global edge footprint.'
@@ -437,6 +857,8 @@ const whiteLabelAlliance = createUpgrade({
   name: 'White-Label Alliance',
   tag: { label: 'Commerce', type: 'boost' },
   description: 'Partner with boutique studios to bundle your galleries with each storefront launch.',
+  category: 'infra',
+  family: 'commerce_network',
   cost: 1500,
   requires: [
     'globalSupplyMesh',
@@ -454,6 +876,12 @@ const whiteLabelAlliance = createUpgrade({
     }
   ],
   boosts: 'Dropshipping & stock photo income climb together with faster ad promos',
+  effects: { payout_mult: 1.35, quality_progress_mult: 1.3333333333333333 },
+  affects: {
+    assets: { ids: ['dropshipping', 'stockPhotos'] },
+    hustles: { tags: ['commerce', 'photo'] },
+    actions: { types: ['payout', 'quality'] }
+  },
   skills: ['commerce', { id: 'visual', weight: 0.4 }],
   actionClassName: 'secondary',
   actionLabel: 'Sign Alliance Charter',
@@ -474,6 +902,8 @@ const coffee = createUpgrade({
   name: 'Turbo Coffee',
   tag: { label: 'Boost', type: 'boost' },
   description: 'Instantly gain +1h of focus for today. Side effects include jittery success.',
+  category: 'support',
+  family: 'consumable',
   cost: 40,
   repeatable: true,
   defaultState: {
@@ -511,6 +941,8 @@ const course = createUpgrade({
   name: 'Automation Course',
   tag: { label: 'Boost', type: 'boost' },
   description: 'Unlocks smarter blogging tools, boosting blog income by +50%.',
+  category: 'tech',
+  family: 'workflow',
   cost: 260,
   requires: [
     {
@@ -519,6 +951,11 @@ const course = createUpgrade({
       detail: 'Requires: <strong>At least one active blog</strong>'
     }
   ],
+  effects: { payout_mult: 1.5, quality_progress_mult: 2 },
+  affects: {
+    assets: { ids: ['blog'] },
+    actions: { types: ['payout', 'quality'] }
+  },
   skills: ['software'],
   actionClassName: 'secondary',
   actionLabel: 'Study Up',
@@ -541,10 +978,24 @@ const course = createUpgrade({
 
 export const UPGRADES = [
   assistantUpgrade,
+  creatorPhone,
+  creatorPhonePro,
+  creatorPhoneUltra,
+  studioLaptop,
+  editingWorkstation,
+  quantumRig,
+  monitorHub,
+  dualMonitorArray,
+  colorGradingDisplay,
+  scratchDriveArray,
   camera,
   studio,
   cameraPro,
   studioExpansion,
+  audioSuite,
+  fiberInternet,
+  ergonomicRefit,
+  backupPowerArray,
   editorialPipeline,
   syndicationSuite,
   immersiveStoryWorlds,

--- a/src/game/upgrades/effects.js
+++ b/src/game/upgrades/effects.js
@@ -1,0 +1,264 @@
+import { ensureArray } from '../../core/helpers.js';
+import {
+  getAssetDefinition,
+  getHustleDefinition,
+  getState,
+  getUpgradeDefinition,
+  getUpgradeState
+} from '../../core/state.js';
+
+const MULTIPLIER_LIMITS = {
+  payout_mult: { min: 0.1, max: 10 },
+  setup_time_mult: { min: 0.5, max: 2 },
+  maint_time_mult: { min: 0.5, max: 2 },
+  quality_progress_mult: { min: 0.25, max: 5 }
+};
+
+function clampMultiplier(effect, value) {
+  const limits = MULTIPLIER_LIMITS[effect] || { min: 0.1, max: 10 };
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return 1;
+  return Math.min(limits.max, Math.max(limits.min, numeric));
+}
+
+function getUpgradeQuantity(definition, upgradeState = {}) {
+  if (!definition) return 0;
+  if (definition.repeatable) {
+    const count = Number(upgradeState.count);
+    if (Number.isFinite(count) && count > 0) {
+      return Math.max(0, count);
+    }
+    return upgradeState.purchased ? 1 : 0;
+  }
+  return upgradeState.purchased ? 1 : 0;
+}
+
+function collectActiveUpgrades(state = getState()) {
+  if (!state) return [];
+  const entries = [];
+  const upgradeStates = state.upgrades || {};
+  for (const [id, upgradeState] of Object.entries(upgradeStates)) {
+    const definition = getUpgradeDefinition(id);
+    if (!definition) continue;
+    const quantity = getUpgradeQuantity(definition, upgradeState);
+    if (quantity <= 0) continue;
+    entries.push({ definition, state: upgradeState, quantity });
+  }
+  return entries;
+}
+
+function normalizeTarget(target) {
+  if (!target) return {};
+  if (typeof target !== 'object') return {};
+  return {
+    ids: ensureArray(target.ids).filter(Boolean),
+    tags: ensureArray(target.tags).filter(Boolean),
+    families: ensureArray(target.families).filter(Boolean),
+    categories: ensureArray(target.categories).filter(Boolean)
+  };
+}
+
+function hasIntersection(a = [], b = []) {
+  if (!a.length || !b.length) return false;
+  const set = new Set(a);
+  return b.some(value => set.has(value));
+}
+
+function subjectMatches(target, subject) {
+  const normalized = normalizeTarget(target);
+  if (!normalized.ids.length && !normalized.tags.length && !normalized.families.length && !normalized.categories.length) {
+    return true;
+  }
+  if (normalized.ids.length && normalized.ids.includes(subject.id)) return true;
+  if (normalized.families.length && normalized.families.includes(subject.family)) return true;
+  if (normalized.categories.length && normalized.categories.includes(subject.category)) return true;
+  const subjectTags = ensureArray(subject.tags).filter(Boolean);
+  if (normalized.tags.length && hasIntersection(normalized.tags, subjectTags)) {
+    return true;
+  }
+  return false;
+}
+
+function actionMatches(affectsActions, actionType) {
+  if (!affectsActions) return true;
+  const normalized = normalizeTarget({ ids: affectsActions.types });
+  if (!normalized.ids.length) return true;
+  return normalized.ids.includes(actionType);
+}
+
+function prepareSubject(subjectType, subjectId) {
+  if (subjectType === 'asset') {
+    const definition = typeof subjectId === 'string' ? getAssetDefinition(subjectId) : subjectId;
+    if (!definition) return null;
+    return {
+      id: definition.id,
+      family: definition.family || null,
+      category: definition.category || null,
+      tags: ensureArray(definition.tags)
+    };
+  }
+  if (subjectType === 'hustle') {
+    const definition = typeof subjectId === 'string' ? getHustleDefinition(subjectId) : subjectId;
+    if (!definition) return null;
+    return {
+      id: definition.id,
+      family: definition.family || null,
+      category: definition.category || null,
+      tags: ensureArray(definition.tags)
+    };
+  }
+  return null;
+}
+
+function collectEffectSources({ subjectType, subject, effect, actionType, state }) {
+  const resolvedSubject = prepareSubject(subjectType, subject);
+  if (!resolvedSubject) {
+    return { multiplier: 1, sources: [] };
+  }
+
+  const upgrades = collectActiveUpgrades(state);
+  if (!upgrades.length) {
+    return { multiplier: 1, sources: [] };
+  }
+
+  const sources = [];
+  let multiplier = 1;
+
+  for (const { definition, quantity } of upgrades) {
+    const effects = definition.effects || {};
+    if (!effects || typeof effects !== 'object') continue;
+    let value = effects[effect];
+    if (!Number.isFinite(Number(value))) continue;
+
+    const affects = definition.affects || {};
+    const scope = subjectType === 'asset' ? affects.assets : affects.hustles;
+    if (!subjectMatches(scope, resolvedSubject)) continue;
+    if (!actionMatches(affects.actions, actionType)) continue;
+
+    const clamped = clampMultiplier(effect, value);
+
+    for (let index = 0; index < quantity; index += 1) {
+      multiplier *= clamped;
+      sources.push({
+        id: definition.id,
+        label: definition.name || definition.id,
+        multiplier: clamped
+      });
+    }
+  }
+
+  const clampedTotal = clampMultiplier(effect, multiplier);
+  return { multiplier: clampedTotal, sources };
+}
+
+export function getAssetEffectMultiplier(definition, effect, { actionType = null, state = getState() } = {}) {
+  return collectEffectSources({ subjectType: 'asset', subject: definition, effect, actionType, state });
+}
+
+export function getHustleEffectMultiplier(definition, effect, { actionType = null, state = getState() } = {}) {
+  return collectEffectSources({ subjectType: 'hustle', subject: definition, effect, actionType, state });
+}
+
+export function getExclusiveConflict(definition, { state = getState() } = {}) {
+  if (!definition?.exclusivityGroup) return null;
+  if (!state) return null;
+  const upgrades = state.upgrades || {};
+  const groupId = definition.exclusivityGroup;
+  const ignored = new Set(
+    Array.isArray(definition.requirements)
+      ? definition.requirements
+          .filter(requirement => requirement?.type === 'upgrade' && requirement.id)
+          .map(requirement => requirement.id)
+      : []
+  );
+  ignored.add(definition.id);
+  for (const [id, upgradeState] of Object.entries(upgrades)) {
+    if (ignored.has(id)) continue;
+    const otherDefinition = getUpgradeDefinition(id);
+    if (!otherDefinition) continue;
+    if (otherDefinition.exclusivityGroup !== groupId) continue;
+    const quantity = getUpgradeQuantity(otherDefinition, upgradeState);
+    if (quantity > 0) {
+      return otherDefinition;
+    }
+  }
+  return null;
+}
+
+function adjustLedgerEntry(target, provides = 0, consumes = 0) {
+  target.provided = (target.provided || 0) + provides;
+  target.consumed = (target.consumed || 0) + consumes;
+  return target;
+}
+
+function accumulateLedgerForUpgrade(ledger, definition, quantity = 1) {
+  const provides = definition.provides || {};
+  const consumes = definition.consumes || {};
+
+  for (const [slot, value] of Object.entries(provides)) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric) || numeric === 0) continue;
+    const entry = ledger.get(slot) || { provided: 0, consumed: 0 };
+    adjustLedgerEntry(entry, numeric * quantity, 0);
+    ledger.set(slot, entry);
+  }
+
+  for (const [slot, value] of Object.entries(consumes)) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric) || numeric === 0) continue;
+    const entry = ledger.get(slot) || { provided: 0, consumed: 0 };
+    adjustLedgerEntry(entry, 0, numeric * quantity);
+    ledger.set(slot, entry);
+  }
+}
+
+export function buildSlotLedger({ state = getState(), exclude } = {}) {
+  const ledger = new Map();
+  if (!state) return ledger;
+  const upgrades = state.upgrades || {};
+  for (const [id, upgradeState] of Object.entries(upgrades)) {
+    if (exclude && exclude.includes(id)) continue;
+    const definition = getUpgradeDefinition(id);
+    if (!definition) continue;
+    const quantity = getUpgradeQuantity(definition, upgradeState);
+    if (quantity <= 0) continue;
+    accumulateLedgerForUpgrade(ledger, definition, quantity);
+  }
+  return ledger;
+}
+
+function mergeLedgerAndUpgrade(ledger, definition) {
+  const result = new Map(ledger);
+  if (!definition) return result;
+  accumulateLedgerForUpgrade(result, definition, 1);
+  return result;
+}
+
+export function wouldExceedSlotCapacity(definition, { state = getState() } = {}) {
+  if (!definition?.consumes && !definition?.provides) return false;
+  const upgradeState = getUpgradeState(definition.id, state);
+  const quantity = getUpgradeQuantity(definition, upgradeState);
+  const exclude = definition.repeatable && quantity > 0 ? [] : [definition.id];
+  const baseLedger = buildSlotLedger({ state, exclude: exclude.length ? exclude : undefined });
+  const simulated = mergeLedgerAndUpgrade(baseLedger, definition);
+
+  for (const [slot, entry] of simulated.entries()) {
+    if ((entry.consumed || 0) > (entry.provided || 0)) {
+      return slot;
+    }
+  }
+  return false;
+}
+
+export function describeSlotLedger(slot, ledger) {
+  const entry = ledger.get(slot);
+  if (!entry) return null;
+  const available = Math.max(0, (entry.provided || 0) - (entry.consumed || 0));
+  return {
+    slot,
+    provided: entry.provided || 0,
+    consumed: entry.consumed || 0,
+    available
+  };
+}
+

--- a/src/ui/cards.js
+++ b/src/ui/cards.js
@@ -41,38 +41,112 @@ const studyUi = new Map();
 let activeUpgradeCategory = 'all';
 let currentUpgradeDefinitions = [];
 
-const UPGRADE_CATEGORY_ORDER = ['unlock', 'boost', 'automation', 'support', 'sustain', 'misc'];
+const UPGRADE_CATEGORY_ORDER = ['tech', 'house', 'infra', 'support', 'misc'];
 
 const UPGRADE_CATEGORY_COPY = {
-  unlock: {
-    label: 'Unlocks',
-    title: 'Unlock new ventures',
-    note: 'Open fresh money loops, actions, and production tiers.'
+  tech: {
+    label: 'Tech',
+    title: 'Tech gear & gadgets',
+    note: 'Outfit your digital arsenal with rigs, cameras, and clever workflows.'
   },
-  boost: {
-    label: 'Boosts',
-    title: 'Amplify payouts',
-    note: 'Tune quality, dial up income, and sharpen daily routines.'
+  house: {
+    label: 'House',
+    title: 'House & studio',
+    note: 'Shape the spaces that keep shoots smooth and edits comfy.'
   },
-  automation: {
-    label: 'Automation',
-    title: 'Delegate the busywork',
-    note: 'Hand repetitive tasks to bots, assistants, or scripts.'
+  infra: {
+    label: 'Infra',
+    title: 'Infrastructure',
+    note: 'Scale the back-end brains that keep products humming worldwide.'
   },
   support: {
     label: 'Support',
-    title: 'Sustain the squad',
-    note: 'Protect uptime, maintain rigs, and nourish your team.'
-  },
-  sustain: {
-    label: 'Sustain',
-    title: 'Keep momentum rolling',
-    note: 'Lightweight boosters that steady the daily grind.'
+    title: 'Support boosts',
+    note: 'Quick pick-me-ups and helpers that keep momentum rolling.'
   },
   misc: {
     label: 'Special',
-    title: 'Signature perks',
-    note: 'One-off upgrades with quirky, high-impact twists.'
+    title: 'Special upgrades',
+    note: 'One-off perks that refuse to stay in neat boxes.'
+  }
+};
+
+const UPGRADE_FAMILY_COPY = {
+  general: {
+    label: 'Highlights',
+    note: 'Curated upgrades that don’t mind sharing space.'
+  },
+  phone: {
+    label: 'Phone line',
+    note: 'Capture crisp mobile footage and stay responsive on the go.'
+  },
+  pc: {
+    label: 'PC rigs',
+    note: 'Crunch renders, spreadsheets, and creative suites without sweat.'
+  },
+  monitor_hub: {
+    label: 'Monitor hubs',
+    note: 'Dock displays and fan out fresh screen real estate.'
+  },
+  monitor: {
+    label: 'Monitors',
+    note: 'Stack extra displays for editing bays and dashboards.'
+  },
+  storage: {
+    label: 'Storage & scratch',
+    note: 'Keep footage safe and project files lightning fast.'
+  },
+  camera: {
+    label: 'Camera gear',
+    note: 'Level up lenses and rigs so every frame looks cinematic.'
+  },
+  lighting: {
+    label: 'Lighting rigs',
+    note: 'Bathe shoots in flattering glow and zero fuss shadows.'
+  },
+  audio: {
+    label: 'Audio gear',
+    note: 'Capture buttery vocals and clean ambient sound.'
+  },
+  internet: {
+    label: 'Internet plans',
+    note: 'Feed uploads and live drops with consistent bandwidth.'
+  },
+  ergonomics: {
+    label: 'Ergonomics',
+    note: 'Keep posture happy while the hustle runs long hours.'
+  },
+  power_backup: {
+    label: 'Power backup',
+    note: 'Ride through outages without missing a milestone.'
+  },
+  studio: {
+    label: 'Studio spaces',
+    note: 'Build sets and stages tailored to your next shoot.'
+  },
+  workflow: {
+    label: 'Workflow suites',
+    note: 'Coordinate publishing calendars and creative rituals.'
+  },
+  automation: {
+    label: 'Automation',
+    note: 'Let bots and partners handle the repetitive hustle.'
+  },
+  cloud_compute: {
+    label: 'Cloud compute',
+    note: 'Provision serious horsepower for software launches.'
+  },
+  edge_network: {
+    label: 'Edge network',
+    note: 'Beam snappy responses worldwide with low-latency magic.'
+  },
+  commerce_network: {
+    label: 'Commerce alliances',
+    note: 'Bundle storefronts, partners, and licensing deals into one push.'
+  },
+  consumable: {
+    label: 'Daily boosts',
+    note: 'Single-day treats that top up focus right when you need it.'
   }
 };
 let studyElementsDocument = null;
@@ -1501,23 +1575,48 @@ function renderAssets(definitions) {
   definitions.forEach(def => renderAssetRow(def, tbody));
 }
 
+function formatLabelFromKey(id, fallback = 'Special') {
+  if (!id) return fallback;
+  return (
+    id
+      .toString()
+      .replace(/[_-]+/g, ' ')
+      .replace(/([a-z])([A-Z])/g, '$1 $2')
+      .replace(/^./, match => match.toUpperCase())
+      .trim() || fallback
+  );
+}
+
 function getUpgradeCategory(definition) {
-  return definition?.tag?.type || 'misc';
+  return definition?.category || 'misc';
+}
+
+function getUpgradeFamily(definition) {
+  return definition?.family || 'general';
 }
 
 function getCategoryCopy(id) {
   if (UPGRADE_CATEGORY_COPY[id]) {
     return UPGRADE_CATEGORY_COPY[id];
   }
-  const label = (id || 'special')
-    .toString()
-    .replace(/([A-Z])/g, ' $1')
-    .replace(/^./, match => match.toUpperCase())
-    .trim() || 'Special';
+  const label = formatLabelFromKey(id, 'Special');
   return {
     label,
     title: `${label} upgrades`,
     note: 'Specialized boosters that defy tidy labels.'
+  };
+}
+
+function getFamilyCopy(id) {
+  if (!id) {
+    return UPGRADE_FAMILY_COPY.general;
+  }
+  if (UPGRADE_FAMILY_COPY[id]) {
+    return UPGRADE_FAMILY_COPY[id];
+  }
+  return {
+    label: formatLabelFromKey(id, 'Highlights'),
+    note: 'Specialized enhancements for this progression lane.'
   };
 }
 
@@ -1633,11 +1732,16 @@ function sortUpgradesForCategory(definitions, state = getState()) {
 function buildUpgradeCategories(definitions) {
   const grouped = new Map();
   definitions.forEach(definition => {
-    const category = getUpgradeCategory(definition);
-    if (!grouped.has(category)) {
-      grouped.set(category, []);
+    const categoryId = getUpgradeCategory(definition);
+    if (!grouped.has(categoryId)) {
+      grouped.set(categoryId, new Map());
     }
-    grouped.get(category).push(definition);
+    const families = grouped.get(categoryId);
+    const familyId = getUpgradeFamily(definition);
+    if (!families.has(familyId)) {
+      families.set(familyId, []);
+    }
+    families.get(familyId).push(definition);
   });
 
   const seen = new Set();
@@ -1652,11 +1756,21 @@ function buildUpgradeCategories(definitions) {
       seen.add(key);
       return true;
     })
-    .map(id => ({
-      id,
-      copy: getCategoryCopy(id),
-      definitions: grouped.get(id)
-    }));
+    .map(id => {
+      const families = Array.from(grouped.get(id)?.entries() || []).map(([familyId, defs]) => ({
+        id: familyId,
+        copy: getFamilyCopy(familyId),
+        definitions: defs
+      }));
+      families.sort((a, b) => a.copy.label.localeCompare(b.copy.label, undefined, { sensitivity: 'base' }));
+      const total = families.reduce((sum, family) => sum + family.definitions.length, 0);
+      return {
+        id,
+        copy: getCategoryCopy(id),
+        families,
+        total
+      };
+    });
 }
 
 function emitUIEvent(name) {
@@ -1741,8 +1855,8 @@ function renderUpgradeCategoryFilters(categories) {
 
   createChip('all', 'All upgrades', totals);
   categories.forEach(category => {
-    const { id, copy, definitions } = category;
-    createChip(id, copy.label, definitions.length);
+    const { id, copy, total } = category;
+    createChip(id, copy.label, total);
   });
 
   syncUpgradeCategoryChips();
@@ -1787,12 +1901,13 @@ document.addEventListener('upgrades:filtered', () => {
   refreshUpgradeSections();
 });
 
-function renderUpgradeCard(definition, container, categoryId) {
+function renderUpgradeCard(definition, container, categoryId, familyId = 'general') {
   const state = getState();
   const card = document.createElement('article');
   card.className = 'upgrade-card';
   card.dataset.upgrade = definition.id;
   card.dataset.category = categoryId;
+  card.dataset.family = familyId;
   const searchPieces = [definition.name, definition.description, definition.tag?.label]
     .filter(Boolean)
     .join(' ');
@@ -1951,11 +2066,52 @@ function renderUpgrades(definitions) {
     header.append(headingGroup, count);
     section.appendChild(header);
 
-    const categoryList = document.createElement('div');
-    categoryList.className = 'upgrade-section__list';
-    const sorted = sortUpgradesForCategory(category.definitions);
-    sorted.forEach(def => renderUpgradeCard(def, categoryList, category.id));
-    section.appendChild(categoryList);
+    const familiesContainer = document.createElement('div');
+    familiesContainer.className = 'upgrade-section__families';
+    const families = category.families.length ? category.families : [{ id: 'general', copy: getFamilyCopy('general'), definitions: [] }];
+    families.forEach(family => {
+      const familyArticle = document.createElement('article');
+      familyArticle.className = 'upgrade-family';
+      familyArticle.dataset.category = category.id;
+      familyArticle.dataset.family = family.id;
+
+      const familyHeader = document.createElement('header');
+      familyHeader.className = 'upgrade-family__header';
+      const familyTitle = document.createElement('h4');
+      familyTitle.textContent = family.copy.label;
+      const familyCount = document.createElement('span');
+      familyCount.className = 'upgrade-family__count';
+      familyHeader.append(familyTitle, familyCount);
+      familyArticle.appendChild(familyHeader);
+
+      if (family.copy.note) {
+        const familyNote = document.createElement('p');
+        familyNote.className = 'upgrade-family__note';
+        familyNote.textContent = family.copy.note;
+        familyArticle.appendChild(familyNote);
+      }
+
+      const familyList = document.createElement('div');
+      familyList.className = 'upgrade-family__list';
+      const sorted = sortUpgradesForCategory(family.definitions);
+      sorted.forEach(def => renderUpgradeCard(def, familyList, category.id, family.id));
+      familyArticle.appendChild(familyList);
+
+      const familyEmpty = document.createElement('p');
+      familyEmpty.className = 'upgrade-family__empty';
+      familyEmpty.textContent = 'No upgrades discovered yet in this family.';
+      familyEmpty.hidden = sorted.length > 0;
+      familyArticle.appendChild(familyEmpty);
+
+      familiesContainer.appendChild(familyArticle);
+      upgradeSections.set(`${category.id}:${family.id}`, {
+        section: familyArticle,
+        list: familyList,
+        count: familyCount,
+        emptyMessage: familyEmpty
+      });
+    });
+    section.appendChild(familiesContainer);
 
     const empty = document.createElement('p');
     empty.className = 'upgrade-section__empty';
@@ -1964,7 +2120,7 @@ function renderUpgrades(definitions) {
     section.appendChild(empty);
 
     fragment.appendChild(section);
-    upgradeSections.set(category.id, { section, list: categoryList, count, emptyMessage: empty });
+    upgradeSections.set(category.id, { section, list: familiesContainer, count, emptyMessage: empty });
   });
 
   list.appendChild(fragment);

--- a/src/ui/cards.js
+++ b/src/ui/cards.js
@@ -1828,7 +1828,7 @@ function renderUpgradeCategoryFilters(categories) {
   const container = elements.upgradeCategoryChips;
   if (!container) return;
 
-  const totals = categories.reduce((sum, category) => sum + category.definitions.length, 0);
+  const totals = categories.reduce((sum, category) => sum + (category?.total ?? 0), 0);
   const availableIds = categories.map(category => category.id);
   if (activeUpgradeCategory !== 'all' && !availableIds.includes(activeUpgradeCategory)) {
     activeUpgradeCategory = 'all';

--- a/tests/hustles.test.js
+++ b/tests/hustles.test.js
@@ -69,7 +69,7 @@ test('education multipliers boost freelance writing payout once mastered', () =>
   const boostedFreelance = HUSTLES.find(hustle => hustle.id === 'freelance');
   boostedFreelance.action.onClick();
 
-  assert.equal(boostedState.money, 22.5, 'outline mastery should add a 25% payout boost');
+  assert.equal(boostedState.money, 23, 'outline mastery should add a 25% payout boost (rounded)');
   assert.match(
     boostedState.log.at(-1).message,
     /Outline Mastery Workshop/,

--- a/tests/upgrades.effects.test.js
+++ b/tests/upgrades.effects.test.js
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  configureRegistry,
+  getUpgradeDefinition,
+  initializeState
+} from '../src/core/state.js';
+import {
+  buildSlotLedger,
+  describeSlotLedger,
+  getAssetEffectMultiplier,
+  getExclusiveConflict,
+  wouldExceedSlotCapacity
+} from '../src/game/upgrades/effects.js';
+
+function makeUpgrade(definition) {
+  return {
+    type: 'upgrade',
+    defaultState: { purchased: false },
+    requirements: [],
+    effects: {},
+    affects: {},
+    provides: {},
+    consumes: {},
+    exclusivityGroup: null,
+    ...definition
+  };
+}
+
+test('quality progress multipliers stack multiplicatively for matching assets', () => {
+  configureRegistry({
+    upgrades: [
+      makeUpgrade({
+        id: 'course',
+        effects: { quality_progress_mult: 2 },
+        affects: { assets: { ids: ['blog'] }, actions: { types: ['quality'] } }
+      }),
+      makeUpgrade({
+        id: 'pipeline',
+        effects: { quality_progress_mult: 1.5 },
+        affects: { assets: { ids: ['blog'] }, actions: { types: ['quality'] } }
+      })
+    ],
+    assets: [],
+    hustles: []
+  });
+
+  const state = initializeState();
+  state.upgrades.course = { purchased: true };
+  state.upgrades.pipeline = { purchased: true };
+
+  const subject = { id: 'blog', tags: ['writing'] };
+  const effect = getAssetEffectMultiplier(subject, 'quality_progress_mult', {
+    actionType: 'quality',
+    state
+  });
+
+  assert.equal(effect.multiplier, 3, 'quality progress should multiply');
+  assert.equal(effect.sources.length, 2);
+});
+
+test('exclusive conflicts ignore prerequisite upgrades but block peers', () => {
+  configureRegistry({
+    upgrades: [
+      makeUpgrade({
+        id: 'basicRig',
+        exclusivityGroup: 'tech:pc'
+      }),
+      makeUpgrade({
+        id: 'advancedRig',
+        exclusivityGroup: 'tech:pc',
+        requirements: [{ type: 'upgrade', id: 'basicRig' }]
+      }),
+      makeUpgrade({
+        id: 'sideRig',
+        exclusivityGroup: 'tech:pc'
+      })
+    ],
+    assets: [],
+    hustles: []
+  });
+
+  const state = initializeState();
+  state.upgrades.basicRig = { purchased: true };
+  state.upgrades.sideRig = { purchased: true };
+
+  const advanced = getUpgradeDefinition('advancedRig');
+  assert.equal(
+    getExclusiveConflict(advanced, { state }),
+    getUpgradeDefinition('sideRig'),
+    'should block conflicting sidegrade'
+  );
+
+  state.upgrades.sideRig = { purchased: false };
+  const noConflict = getExclusiveConflict(advanced, { state });
+  assert.equal(noConflict, null, 'prerequisite should not cause a conflict');
+});
+
+test('slot ledger tracks provided and consumed capacity for repeatables', () => {
+  configureRegistry({
+    upgrades: [
+      makeUpgrade({
+        id: 'monitorHub',
+        provides: { monitor: 2 }
+      }),
+      makeUpgrade({
+        id: 'colorMonitor',
+        repeatable: true,
+        consumes: { monitor: 1 }
+      })
+    ],
+    assets: [],
+    hustles: []
+  });
+
+  const state = initializeState();
+  state.upgrades.monitorHub = { purchased: true };
+  state.upgrades.colorMonitor = { purchased: true, count: 1 };
+
+  const ledger = buildSlotLedger({ state });
+  const summary = describeSlotLedger('monitor', ledger);
+  assert.deepEqual(summary, { slot: 'monitor', provided: 2, consumed: 1, available: 1 });
+
+  assert.equal(wouldExceedSlotCapacity(getUpgradeDefinition('colorMonitor'), { state }), false);
+
+  state.upgrades.colorMonitor = { purchased: true, count: 2 };
+  assert.equal(
+    wouldExceedSlotCapacity(getUpgradeDefinition('colorMonitor'), { state }),
+    'monitor',
+    'should flag when attempting to exceed slot capacity'
+  );
+});


### PR DESCRIPTION
## Summary
- add a data-driven upgrade effects engine with slot accounting, exclusivity helpers, and targeting filters
- migrate assets, hustles, and upgrades to the new taxonomy with categories, families, and multiplicative bonuses
- refresh upgrade UI groupings plus documentation and tests to cover effects and slot usage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dae205e550832ca5621cb9fe8ba31f