### PR TITLE
feat: navigate upgrade lanes and tighten ready filter

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@
 - Commerce ladder: fulfillment automation, global supply mesh, and white-label alliances stack payouts for thriving dropshipping empires.
 - Education clarity: finished courses now show 100% progress and list the XP-rich skills they elevate.
 - Upgrade hub redesign: roadmap stats, lane map quick-read counts, and a "Ready to install" toggle make reinvestment planning faster and more celebratory.
+- Upgrade hub polish: lane map buttons now jump to their sections and the "Ready to install" filter hides anything you can’t buy yet.
 - Hustle pacing: retired the eBay flip queue and delayed payouts so every gig pays out the moment you wrap it.
 - Hustle caps: Audience Q&A now runs once per day and Micro Survey Dash allows four bursts, with UI cues showing remaining slots.
 - Creative upgrade ladder: editorial pipeline, syndication suite, and immersive story worlds stack payouts and progress boosts across blogs, e-books, and vlogs.

--- a/docs/features/upgrade-hub-revamp.md
+++ b/docs/features/upgrade-hub-revamp.md
@@ -10,7 +10,7 @@
 - Sectioned layouts cluster upgrades into unlocks, boosts, and support lanes with per-section availability notes.
 - Ready upgrades automatically populate the dock with their current label and price for one-click purchasing.
 - Each card now carries tag/status badges, refreshed copy, and rotating detail bullets that stay current with game state.
-- A friendly "Ready to install" toggle hides locked upgrades so players can zero in on what’s actionable.
+- A friendly "Ready to install" toggle hides anything you can’t fire up yet—whether you’re short on cash or still chasing prerequisites.
 
 ## Structured taxonomy & stacking (Update)
 - Tech, House, Infra, and Support tabs organise the catalog into breezy, high-level lanes so players can zero in on the gear they crave.
@@ -21,6 +21,7 @@
 ## Lane navigator & quick stats (Update)
 - A sticky rail on the left now spotlights the lane map, offering glanceable totals without extra toggles.
 - Each lane entry broadcasts total discoveries, owned counts, and ready-to-buy picks so players can triage sprawling catalogs without scanning every card.
+- Clicking a lane instantly scrolls the main list to that section, turning the map into a quick navigation companion.
 - Family groupings render inside bordered pods with local counts and notes, giving the new automation and infrastructure tiers breathing room as more upgrade options arrive.
 - The dock still anchors on the right, mirroring button states from cards, so the three-column layout keeps filters, catalog, and purchase-ready picks visible together.
 

--- a/src/ui/cards.js
+++ b/src/ui/cards.js
@@ -1763,6 +1763,32 @@ function buildUpgradeCategories(definitions) {
     });
 }
 
+function scrollUpgradeLaneIntoView(categoryId) {
+  if (!categoryId) return;
+
+  if (categoryId === 'all') {
+    const container = elements.upgradeList;
+    if (container) {
+      container.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      container.focus?.({ preventScroll: true });
+    }
+    return;
+  }
+
+  const entry = upgradeSections.get(categoryId);
+  if (entry?.section) {
+    entry.section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    entry.section.focus?.({ preventScroll: true });
+    return;
+  }
+
+  const fallback = Array.from(upgradeSections.values()).find(({ section }) => section?.dataset.category === categoryId);
+  if (fallback?.section) {
+    fallback.section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    fallback.section.focus?.({ preventScroll: true });
+  }
+}
+
 function renderUpgradeLaneMap(categories) {
   const list = elements.upgradeLaneList;
   if (!list) return;
@@ -1789,7 +1815,8 @@ function renderUpgradeLaneMap(categories) {
 
     const block = document.createElement('div');
     block.className = 'upgrade-rail__button';
-    block.setAttribute('role', 'presentation');
+    block.setAttribute('role', 'button');
+    block.tabIndex = 0;
 
     const heading = document.createElement('div');
     heading.className = 'upgrade-rail__heading';
@@ -1809,6 +1836,18 @@ function renderUpgradeLaneMap(categories) {
     owned.className = 'upgrade-rail__stat';
     stats.append(ready, owned);
     block.appendChild(stats);
+
+    const activateLane = event => {
+      event?.preventDefault?.();
+      scrollUpgradeLaneIntoView(lane.id);
+    };
+
+    block.addEventListener('click', activateLane);
+    block.addEventListener('keydown', event => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        activateLane(event);
+      }
+    });
 
     item.appendChild(block);
     list.appendChild(item);
@@ -2092,6 +2131,7 @@ function updateUpgradeCard(definition) {
 function renderUpgrades(definitions) {
   const list = elements.upgradeList;
   if (!list) return;
+  list.tabIndex = -1;
   currentUpgradeDefinitions = Array.isArray(definitions) ? [...definitions] : [];
   list.innerHTML = '';
   upgradeUi.clear();
@@ -2105,6 +2145,7 @@ function renderUpgrades(definitions) {
     const section = document.createElement('section');
     section.className = 'upgrade-section';
     section.dataset.category = category.id;
+    section.tabIndex = -1;
 
     const header = document.createElement('header');
     header.className = 'upgrade-section__header';

--- a/src/ui/layout.js
+++ b/src/ui/layout.js
@@ -221,7 +221,7 @@ function applyUpgradeFilters() {
   cards.forEach(card => {
     const matchesSearch = !query || card.dataset.search?.includes(query);
     const matchesAffordable = !affordableOnly || card.dataset.affordable === 'true';
-    const matchesAvailability = !availableOnly || card.dataset.available === 'true';
+    const matchesAvailability = !availableOnly || card.dataset.ready === 'true';
     card.hidden = !(matchesSearch && matchesAffordable && matchesAvailability);
   });
 


### PR DESCRIPTION
## Summary
- make lane map buttons scroll the upgrade list to their matching sections for faster navigation
- tighten the "Ready to install" filter so it only shows upgrades that can be purchased right now
- document the lane navigator behavior and filter update in the feature notes and changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db0e73ad64832cb9305d96528f8bc7