### PR TITLE
Default upgrades view to unlocked filter

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Upgrade filters: the Upgrades panel now defaults to an "Unlocked now" view so only instant-install picks show until you opt to browse the full catalog.
 - Upgrade taxonomy: tech/house/infra tabs with family sub-sections and slot-aware tooltips make browsing gear lanes intuitive while the new effect engine drives unified payout, time, and quality multipliers.
 - Player screen: new overview tab spotlights character level, skills, education, gear, and hustle momentum in one place.
 - Asset liquidation rebalance: selling an instance now multiplies the 3× sale value by its quality tier for high-grade exits.

--- a/docs/features/upgrade-hub-revamp.md
+++ b/docs/features/upgrade-hub-revamp.md
@@ -10,7 +10,7 @@
 - Sectioned layouts cluster upgrades into unlocks, boosts, and support lanes with per-section availability notes.
 - Ready upgrades automatically populate the dock with their current label and price for one-click purchasing.
 - Each card now carries tag/status badges, refreshed copy, and rotating detail bullets that stay current with game state.
-- A friendly "Ready to install" toggle hides anything you can’t fire up yet—whether you’re short on cash or still chasing prerequisites.
+- A friendly "Unlocked now" toggle defaults to showing instant-install picks while a quick flip reveals the full future catalog.
 
 ## Structured taxonomy & stacking (Update)
 - Tech, House, Infra, and Support tabs organise the catalog into breezy, high-level lanes so players can zero in on the gear they crave.
@@ -26,7 +26,7 @@
 - The dock still anchors on the right, mirroring button states from cards, so the three-column layout keeps filters, catalog, and purchase-ready picks visible together.
 
 **Player Impact**
-- Players can filter by affordability, availability, or search simultaneously, drastically reducing scan time for priority upgrades.
+- Players land on a curated list of upgrades they can install immediately, with a single toggle to reveal future goals when they want to plan ahead.
 - The overview note reinforces short-term goals (buy now, meet requirements, or save up) so progression stalls are easier to diagnose.
 - Enhanced dock interactions mirror the card call-to-action, reinforcing confidence that the purchase will behave as expected.
 

--- a/index.html
+++ b/index.html
@@ -373,14 +373,9 @@
           </div>
           <div class="filter-bar" role="group" aria-label="Upgrade filters">
             <label class="filter-toggle">
-              <input id="upgrade-affordable-toggle" type="checkbox" />
-              <span>Affordable</span>
+              <input id="upgrade-unlocked-toggle" type="checkbox" checked />
+              <span>Unlocked now</span>
             </label>
-            <label class="filter-toggle">
-              <input id="upgrade-available-toggle" type="checkbox" />
-              <span>Ready to install</span>
-            </label>
-            <input id="upgrade-search" type="search" placeholder="Search upgrades" aria-label="Search upgrades" />
           </div>
         </header>
         <div class="upgrade-layout">
@@ -410,7 +405,7 @@
                 </div>
               </dl>
             </section>
-            <p id="upgrade-empty" class="upgrade-empty" hidden>No upgrades match these filters yet. Tweak the toggles or clear search.</p>
+            <p id="upgrade-empty" class="upgrade-empty" hidden>No upgrades match this view yet. Toggle "Unlocked now" to browse everything.</p>
             <div id="upgrade-list" class="upgrade-list" aria-live="polite"></div>
           </div>
           <aside class="upgrade-dock" aria-label="Upgrade dock">

--- a/src/ui/elements.js
+++ b/src/ui/elements.js
@@ -108,8 +108,7 @@ const elements = {
     content: document.getElementById('asset-launched-content')
   },
   upgradeFilters: {
-    affordable: document.getElementById('upgrade-affordable-toggle'),
-    available: document.getElementById('upgrade-available-toggle')
+    unlocked: document.getElementById('upgrade-unlocked-toggle')
   },
   upgradeOverview: {
     container: document.getElementById('upgrade-overview'),
@@ -119,7 +118,6 @@ const elements = {
   },
   upgradeEmpty: document.getElementById('upgrade-empty'),
   upgradeLaneList: document.getElementById('upgrade-lane-list'),
-  upgradeSearch: document.getElementById('upgrade-search'),
   upgradeList: document.getElementById('upgrade-list'),
   upgradeDockList: document.getElementById('upgrade-dock-list'),
   studyFilters: {

--- a/src/ui/layout.js
+++ b/src/ui/layout.js
@@ -145,9 +145,7 @@ function setupFilterHandlers() {
   elements.assetFilters.maintenance?.addEventListener('change', applyAssetFilters);
   elements.assetFilters.lowRisk?.addEventListener('change', applyAssetFilters);
 
-  elements.upgradeFilters.affordable?.addEventListener('change', applyUpgradeFilters);
-  elements.upgradeFilters.available?.addEventListener('change', applyUpgradeFilters);
-  elements.upgradeSearch?.addEventListener('input', debounce(applyUpgradeFilters, 150));
+  elements.upgradeFilters.unlocked?.addEventListener('change', applyUpgradeFilters);
 
   document.addEventListener('upgrades:state-updated', applyUpgradeFilters);
   document.addEventListener('hustles:availability-updated', applyHustleFilters);
@@ -214,15 +212,11 @@ function applyAssetFilters() {
 
 function applyUpgradeFilters() {
   const cards = Array.from(elements.upgradeList?.querySelectorAll('[data-upgrade]') || []);
-  const affordableOnly = Boolean(elements.upgradeFilters.affordable?.checked);
-  const availableOnly = Boolean(elements.upgradeFilters.available?.checked);
-  const query = (elements.upgradeSearch?.value || '').trim().toLowerCase();
+  const unlockedOnly = elements.upgradeFilters.unlocked?.checked !== false;
 
   cards.forEach(card => {
-    const matchesSearch = !query || card.dataset.search?.includes(query);
-    const matchesAffordable = !affordableOnly || card.dataset.affordable === 'true';
-    const matchesAvailability = !availableOnly || card.dataset.ready === 'true';
-    card.hidden = !(matchesSearch && matchesAffordable && matchesAvailability);
+    const matchesUnlocked = !unlockedOnly || card.dataset.ready === 'true';
+    card.hidden = !matchesUnlocked;
   });
 
   emitLayoutEvent('upgrades:filtered');

--- a/tests/helpers/setupDom.js
+++ b/tests/helpers/setupDom.js
@@ -103,8 +103,7 @@ export function ensureTestDom() {
             <button id="asset-batch-preset"></button>
           </section>
           <section id="panel-upgrades" class="panel" hidden>
-            <input id="upgrade-search" />
-            <input id="upgrade-affordable-toggle" type="checkbox" />
+            <input id="upgrade-unlocked-toggle" type="checkbox" checked />
             <div id="upgrade-category-chips"></div>
             <div id="upgrade-list"></div>
             <aside>


### PR DESCRIPTION
## Summary
- replace the upgrades search/affordability toggles with a single default-on "Unlocked now" filter that hides locked cards
- update layout wiring and test DOM helpers to honor the new toggle-only experience
- refresh feature notes and changelog to describe the streamlined upgrades view

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db16052f6c832c817fa7cf382c968c