### PR TITLE
Update niche roster to real-world market segments

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Niche realism: swapped in ten real-world audience niches so daily trend chasing mirrors recognizable markets.
 - Upgrade filters: the Upgrades panel now defaults to an "Unlocked now" view so only instant-install picks show until you opt to browse the full catalog.
 - Upgrade taxonomy: tech/house/infra tabs with family sub-sections and slot-aware tooltips make browsing gear lanes intuitive while the new effect engine drives unified payout, time, and quality multipliers.
 - Player screen: new overview tab spotlights character level, skills, education, gear, and hustle momentum in one place.

--- a/docs/features/niche-market-pulse.md
+++ b/docs/features/niche-market-pulse.md
@@ -9,7 +9,7 @@ The niche system links every passive asset to an audience segment with a daily p
 - Keep the mechanic opt-in; unassigned assets continue to earn their baseline quality payouts.
 
 ## Mechanics
-- **Niche definitions** live in `src/game/assets/nicheData.js`. Each niche specifies a whimsical description plus compatible asset tags.
+- **Niche definitions** live in `src/game/assets/nicheData.js`. Each niche now represents a real-world audience segment with an upbeat description plus compatible asset tags.
 - **Popularity rolls** live on `state.niches.popularity`. At the end of every day (`endDay`) the game re-rolls a 25–95 score for each niche, storing yesterday’s value for delta messaging.
 - **Payout multiplier**: The current score maps to a 0.75×–1.3× multiplier. `rollDailyIncome` applies the multiplier before upgrade boosts and records the contribution in the income breakdown.
 - **Assignment**: Asset instances store `nicheId`. Players can pick a niche (or go unassigned) from the instance detail panel. Invalid IDs are scrubbed when state loads.

--- a/src/game/assets/nicheData.js
+++ b/src/game/assets/nicheData.js
@@ -1,39 +1,63 @@
 const NICHE_DEFINITIONS = [
   {
-    id: 'evergreenGuides',
-    name: 'Evergreen Guides',
-    description: 'How-to libraries and niche blogs that reward consistent, helpful storytelling.',
-    tags: ['writing', 'content', 'digital']
-  },
-  {
-    id: 'creatorCollabs',
-    name: 'Creator Collabs',
-    description: 'Livestream takeovers, vlog collabs, and behind-the-scenes drops that thrive on video energy.',
-    tags: ['video', 'visual', 'content', 'studio']
-  },
-  {
-    id: 'marketplaceSpotlight',
-    name: 'Marketplace Spotlight',
-    description: 'Bundled products, photo packs, and digital goods tuned for marketplace bursts.',
-    tags: ['photo', 'visual', 'commerce', 'product']
-  },
-  {
-    id: 'trendChaser',
-    name: 'Trend Chaser',
-    description: 'Dropshipping curations and hot-list products that pivot with every scroll trend.',
-    tags: ['commerce', 'ecommerce', 'content']
-  },
-  {
-    id: 'automationNerds',
-    name: 'Automation Nerds',
-    description: 'SaaS tools, scripts, and workflow boosters that serve the builder crowd.',
+    id: 'techInnovators',
+    name: 'Tech Innovators',
+    description: 'Gadget lovers and software tinkerers who jump on the next productivity breakthrough.',
     tags: ['software', 'tech', 'product']
   },
   {
-    id: 'aestheticObsessed',
-    name: 'Aesthetic Obsessed',
-    description: 'High-style visuals, presets, and branding kits for designers who crave polish.',
-    tags: ['visual', 'photo', 'content', 'digital']
+    id: 'healthWellness',
+    name: 'Health & Wellness',
+    description: 'People chasing healthier routines, mindful habits, and science-backed self-care.',
+    tags: ['writing', 'content', 'digital']
+  },
+  {
+    id: 'personalFinance',
+    name: 'Personal Finance',
+    description: 'Budgeters and investors who devour tips on saving smarter and building wealth.',
+    tags: ['writing', 'content', 'product']
+  },
+  {
+    id: 'sustainableLiving',
+    name: 'Sustainable Living',
+    description: 'Eco-conscious shoppers eager for low-waste swaps, ethical products, and reuse hacks.',
+    tags: ['commerce', 'content', 'ecommerce']
+  },
+  {
+    id: 'fitnessTraining',
+    name: 'Fitness & Training',
+    description: 'Athletes-in-progress streaming workouts, form checks, and at-home training plans.',
+    tags: ['video', 'content', 'studio']
+  },
+  {
+    id: 'travelAdventures',
+    name: 'Travel & Adventure',
+    description: 'Globetrotters scouting itineraries, remote-work escapes, and photo-ready destinations.',
+    tags: ['photo', 'visual', 'content']
+  },
+  {
+    id: 'beautySkincare',
+    name: 'Beauty & Skincare',
+    description: 'Product reviewers and glam squads comparing routines, looks, and ingredient deep dives.',
+    tags: ['photo', 'visual', 'product']
+  },
+  {
+    id: 'homeDIY',
+    name: 'Home & DIY',
+    description: 'Organizers and makers swapping renovation tips, storage wins, and weekend builds.',
+    tags: ['content', 'product', 'digital']
+  },
+  {
+    id: 'parentingSupport',
+    name: 'Parenting Support',
+    description: 'Caregivers trading routines, milestone advice, and sanity-saving family systems.',
+    tags: ['writing', 'content']
+  },
+  {
+    id: 'petCare',
+    name: 'Pet Care & Training',
+    description: 'Pet parents learning enrichment games, nutrition tips, and grooming must-dos.',
+    tags: ['video', 'content', 'commerce']
   }
 ];
 


### PR DESCRIPTION
## Summary
- replace the niche roster with ten real-world audience segments and upbeat descriptions
- refresh the niche feature design note to highlight the realistic market focus
- document the change in the changelog under the Unreleased section

## Testing
- `npm test`

## Manual Testing
- Not run (browser not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68db1abd30a4832c8f032cb63476611d