### PR TITLE
Redesign assets page into per-instance cards

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,7 @@
 - Creative upgrade ladder: editorial pipeline, syndication suite, and immersive story worlds stack payouts and progress boosts across blogs, e-books, and vlogs.
 - Quality system refresh: daily-use counters replace cooldown timers on passive actions, with UI, saves, and docs updated to celebrate remaining uses each day.
 - Niche market pulse: assign each passive asset to a daily-trending niche, gain payout multipliers from hot audiences, and track every niche’s popularity from the dashboard widget.
+- Asset page redesign: category headers now list every build as its own action card with inline maintain, niche, and quality progress so upkeep happens without a secondary panel.
 
 ## Recent Highlights
 - Passive assets gained Quality 4–5 milestones with higher payouts and refreshed modifiers.

--- a/docs/features/passive-asset-dashboard.md
+++ b/docs/features/passive-asset-dashboard.md
@@ -1,19 +1,19 @@
 # Passive Asset Dashboard Refresh
 
 **Purpose**
-- Make passive management a one-stop view: yesterday’s payouts, upkeep status, upgrade nudges, and sell buttons all live on the cards.
+- Present every launched asset as a workstation-style action card so upkeep, payouts, and quality goals are handled without jumping to a secondary panel.
 
 **Key pieces**
-- Category cards show launch counts, upkeep, and last income even when collapsed; toggles reveal instance rosters with ROI, sell, and quick-buy upgrade buttons.
-- The scrolling "Asset upgrade" card surfaces up to eight nudges with percent-to-go callouts.
-- Instance modals highlight current quality, next milestones, and pinned quality actions; the briefing variant reuses live setup data for confident launches.
-- Active build cards now surface the current quality tier, remaining steps for the next upgrade, and a breakdown of yesterday’s payout (base roll, upgrade boosts, bonuses).
+- Category dividers (Foundation, Creative, Commerce, Tech) now act as section headers. Each header shows build counts plus launch buttons for every blueprint unlocked in that lane.
+- Every active or queued instance renders as an `asset-card asset-instance-card` element with inline data: niche assignment, current quality tier, next milestone target, and a live progress bar that aggregates track requirements.
+- Metric rows on each card surface latest payout, rolling daily haul averages, upkeep cost/time, and risk level so filters can act on `data-state`, `data-needs-maintenance`, and `data-risk` attributes.
+- Action footer combines a primary **Maintain** button with special quality actions (Write Post, SEO Sprint, etc.) and a Details link that opens the legacy modal for deep history and selling options.
 
 **Player benefit**
 - Faster comparisons and upgrades without digging through logs.
 - Clear visibility into upkeep obligations and ROI before reallocating time.
 
 **Implementation reminders**
-- Use `asset-card__*` layouts and `assetCategoryView` helpers for roster rows.
-- Quick-buy buttons and upgrade hints rely on `src/ui/assetUpgrades.js`.
-- Consider adding filters (e.g., "show assets with payouts today") if oversight still feels noisy.
+- Instance cards rely on the shared `asset-card__*` styling plus the new `asset-instance-card__*` utility classes for progress and action layout.
+- Launch buttons reuse the existing `definition.action` wiring; keep button labels dynamic by calling `definition.action.label(state)` when available.
+- Filters in `layout.js` toggle visibility via the card datasets—ensure new cards continue to set `data-state`, `data-needs-maintenance`, and `data-risk`.

--- a/index.html
+++ b/index.html
@@ -338,23 +338,6 @@
           </div>
         </header>
         <div class="asset-gallery" id="asset-gallery" aria-live="polite"></div>
-        <footer class="asset-batch" aria-live="polite">
-          <div class="asset-batch__selection" id="asset-selection-note">No assets selected.</div>
-          <div class="asset-batch__actions">
-            <button id="asset-batch-maintain" class="ghost" type="button">Maintain</button>
-            <button id="asset-batch-pause" class="ghost" type="button">Pause</button>
-            <button id="asset-batch-preset" class="ghost" type="button">Apply preset</button>
-          </div>
-        </footer>
-        <section id="asset-launched" class="asset-launched" aria-live="polite">
-          <header class="asset-launched__header">
-            <h2 id="asset-launched-title">Launched builds</h2>
-            <p id="asset-launched-note">Select an asset to explore active and queued builds.</p>
-          </header>
-          <div id="asset-launched-content" class="asset-launched__content">
-            <p class="asset-launched__empty">No asset selected yet. Tap a card to review its build roster.</p>
-          </div>
-        </section>
       </section>
 
       <section id="panel-upgrades" class="panel" role="tabpanel" aria-labelledby="tab-upgrades" hidden>

--- a/src/game/assets/index.js
+++ b/src/game/assets/index.js
@@ -1,5 +1,5 @@
 import { ASSETS } from './registry.js';
-import { allocateAssetMaintenance, closeOutDay } from './lifecycle.js';
+import { allocateAssetMaintenance, closeOutDay, maintainAssetInstance } from './lifecycle.js';
 import {
   getIncomeRangeForDisplay,
   calculateAssetSalePrice,
@@ -24,6 +24,7 @@ import {
 const assetsSystem = {
   list: ASSETS,
   allocateMaintenance: allocateAssetMaintenance,
+  maintainInstance: maintainAssetInstance,
   closeOutDay,
   getIncomeRangeForDisplay,
   performQualityAction,
@@ -56,6 +57,7 @@ export {
   getQualityTracks,
   sellAssetInstance,
   calculateAssetSalePrice,
+  maintainAssetInstance,
   assignInstanceToNiche,
   getAssignableNicheSummaries,
   getInstanceNicheEffect,

--- a/src/ui/elements.js
+++ b/src/ui/elements.js
@@ -98,18 +98,6 @@ const elements = {
     lowRisk: document.getElementById('asset-risk-toggle')
   },
   assetGallery: document.getElementById('asset-gallery'),
-  assetSelectionNote: document.getElementById('asset-selection-note'),
-  assetBatchButtons: {
-    maintain: document.getElementById('asset-batch-maintain'),
-    pause: document.getElementById('asset-batch-pause'),
-    preset: document.getElementById('asset-batch-preset')
-  },
-  assetLaunched: {
-    container: document.getElementById('asset-launched'),
-    title: document.getElementById('asset-launched-title'),
-    note: document.getElementById('asset-launched-note'),
-    content: document.getElementById('asset-launched-content')
-  },
   upgradeFilters: {
     unlocked: document.getElementById('upgrade-unlocked-toggle')
   },

--- a/styles.css
+++ b/styles.css
@@ -1296,6 +1296,12 @@ body {
   flex-wrap: wrap;
 }
 
+.asset-group__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .asset-group__heading {
   display: flex;
   flex-direction: column;
@@ -1329,6 +1335,17 @@ body {
   display: grid;
   gap: 18px;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.asset-group__empty {
+  margin: 0;
+  padding: 16px;
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  color: var(--text-subtle);
+  text-align: center;
+  font-size: 14px;
+  background: rgba(15, 23, 42, 0.4);
 }
 
 .asset-card {
@@ -1541,74 +1558,109 @@ body {
   outline-offset: 2px;
 }
 
-.asset-builds {
+
+.asset-instance-card {
   display: grid;
+  gap: 16px;
+}
+
+.asset-instance-card__body {
+  display: grid;
+  gap: 14px;
+}
+
+.asset-instance-card__field {
+  display: grid;
+  gap: 2px;
+}
+
+.asset-instance-card__label {
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-subtle);
+}
+
+.asset-instance-card__value {
+  font-size: 14px;
+  color: var(--text-strong);
+}
+
+.asset-instance-card__quality {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 12px;
+  display: grid;
+  gap: 8px;
+  background: var(--surface-muted);
+}
+
+.asset-instance-card__quality-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
   gap: 12px;
 }
 
-.asset-builds__summary {
-  margin: 0;
+.asset-instance-card__quality-current {
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.asset-instance-card__quality-next {
   font-size: 13px;
   color: var(--text-subtle);
 }
 
-.asset-builds__empty {
-  margin: 0;
-  font-size: 14px;
-  color: var(--text-subtle);
+.asset-instance-card__progress {
+  display: grid;
+  gap: 6px;
 }
 
-.asset-batch {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  background: var(--surface-muted);
-  border-radius: var(--radius-md);
-  border: 1px solid var(--border);
-  padding: 12px 16px;
-  gap: 16px;
-}
-
-.asset-batch__actions {
-  display: flex;
-  gap: 12px;
-}
-
-.asset-launched {
-  margin-top: 28px;
+.asset-instance-card__progress-track {
+  position: relative;
+  height: 8px;
+  border-radius: 999px;
   background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 20px 24px;
-  display: grid;
-  gap: 20px;
-  box-shadow: var(--shadow-sm);
+  overflow: hidden;
 }
 
-.asset-launched__header {
-  display: grid;
-  gap: 4px;
+.asset-instance-card__progress-fill {
+  position: absolute;
+  inset: 0;
+  width: calc(var(--progress, 0) * 100%);
+  background: var(--accent-soft);
+  border-radius: inherit;
+  transition: width 0.3s ease;
 }
 
-.asset-launched__header h2 {
-  margin: 0;
-  font-size: 18px;
-}
-
-.asset-launched__header p {
-  margin: 0;
-  font-size: 14px;
+.asset-instance-card__progress-label {
+  font-size: 12px;
   color: var(--text-subtle);
 }
 
-.asset-launched__content {
-  display: grid;
-  gap: 16px;
+.asset-instance-card__footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
 }
 
-.asset-launched__empty {
-  margin: 0;
-  font-size: 14px;
+.asset-instance-card__primary-actions,
+.asset-instance-card__secondary-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.asset-instance-card__secondary-actions {
+  justify-content: flex-end;
+}
+
+.asset-instance-card__note {
+  font-size: 12px;
   color: var(--text-subtle);
 }
 


### PR DESCRIPTION
## Summary
- replace the legacy assets layout with workstation-style cards that list every launched instance inline
- add a manual maintain action for individual builds and surface niche, quality, payout, and upkeep metrics on each card
- remove the old bottom builds panel while updating docs and styles to reflect the new card layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db21c56178832cb953606013f47971