### PR TITLE
Add multi-speed auto forward toggle

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,7 +9,7 @@
 - Passive economy rebalance: smoother upkeep for blogs, stock photos, dropshipping, and SaaS so late tiers feel rewarding without micromanagement spikes.
 - Progression refresh: character skills, study scheduling, and celebratory UI now guide players through course-driven bonuses and countdowns.
 - Flow helpers: the "Next" action, Daily Stats card, and header pulse now keep priorities, earnings, and schedules visible at a glance.
-- Auto forward loop: header toggle can fire the primary action every two seconds so momentum continues without constant clicks.
+- Auto forward loop: header toggle now cycles through paused, current pace (every two seconds), or a 2× sprint (every second) to keep momentum without constant clicks.
 - Asset stewardship: detail panels, sell controls, and recommendations highlight ROI, upkeep costs, and upgrade shortcuts for each build.
 - Active build cards surface quality tiers, remaining steps to the next milestone, and yesterday’s payout breakdown so upgrades feel tangible.
 - Automation & infrastructure: broader instant gigs, smarter assistant load balancing, and new studio/server tiers expand long-term play.

--- a/docs/features/auto-forward-loop.md
+++ b/docs/features/auto-forward-loop.md
@@ -5,7 +5,7 @@
 
 **Behavior**
 - Adds an "Auto Forward" toggle above the command palette trigger in the shell header.
-- When enabled, the toggle presses the primary header action every two seconds, whether it's a recommended move or ending the day.
+- Tapping the toggle cycles through paused, current speed (fires every two seconds), and 2× speed (fires every second) modes.
 - The toggle highlights its active state, respects disabled buttons, and shuts itself off gracefully if the primary action becomes unavailable.
 
 **Player effect**


### PR DESCRIPTION
## Summary
- add a cycling auto forward toggle that supports paused, current pace, and 2× pace modes with refreshed labels
- document the new toggle behavior in the auto forward feature note and changelog

## Testing
- npm test
- Manual: Loaded local build and cycled auto forward states.

------
https://chatgpt.com/codex/tasks/task_e_68db25260638832cbd71c72f9a3d766d