### PR TITLE
Restore compact auto forward toggle icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,11 +42,12 @@
         <div class="shell__controls-stack">
           <button
             id="auto-forward"
-            class="ghost"
+            class="ghost ghost--icon"
             type="button"
             aria-pressed="false"
+            aria-label="Auto Forward: Paused"
             title="Toggle auto forward to trigger the next action every 2 seconds."
-          >Auto Forward</button>
+          >⏸</button>
           <button id="command-palette-trigger" class="ghost" type="button" aria-haspopup="dialog" aria-controls="command-palette">⌘K</button>
         </div>
         <button id="end-day" class="primary" type="button">End Day</button>

--- a/src/ui/headerAction.js
+++ b/src/ui/headerAction.js
@@ -10,10 +10,15 @@ const AUTO_FORWARD_INTERVALS = {
   current: 2000,
   double: 1000
 };
+const AUTO_FORWARD_ICONS = {
+  paused: '⏸',
+  current: '▶',
+  double: '⏩'
+};
 const AUTO_FORWARD_LABELS = {
   paused: 'Auto Forward: Paused',
-  current: 'Auto Forward: Current',
-  double: 'Auto Forward: 2× Current'
+  current: 'Auto Forward: Current speed',
+  double: 'Auto Forward: Double speed'
 };
 const AUTO_FORWARD_TITLES = {
   paused: 'Tap to let auto forward queue the next action for you.',
@@ -126,7 +131,8 @@ function applyAutoForwardState(mode) {
   if (toggle) {
     toggle.classList.toggle('is-active', isActive);
     toggle.setAttribute('aria-pressed', String(isActive));
-    toggle.textContent = AUTO_FORWARD_LABELS[nextMode];
+    toggle.textContent = AUTO_FORWARD_ICONS[nextMode];
+    toggle.setAttribute('aria-label', AUTO_FORWARD_LABELS[nextMode]);
     toggle.title = AUTO_FORWARD_TITLES[nextMode];
   }
 

--- a/styles.css
+++ b/styles.css
@@ -1259,6 +1259,16 @@ body {
   color: var(--text-subtle);
 }
 
+.ghost--icon {
+  padding: 6px 10px;
+  font-size: 18px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 40px;
+}
+
 .ghost.is-active {
   color: var(--accent-light);
   border-color: rgba(124, 92, 255, 0.6);


### PR DESCRIPTION
## Summary
- shrink the auto forward toggle back to a compact icon-only control
- show pause, play, and fast-forward symbols with accessible labels for each mode
- adjust ghost icon buttons with tighter padding to match the smaller presentation

## Testing
- npm test
- Manual: Loaded local build in a browser to verify the icon-only auto forward toggle renders as expected


------
https://chatgpt.com/codex/tasks/task_e_68db2825098c832c96d1069f68e5f798