### PR TITLE
Add asset category details slide-over

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@
 - Flow helpers: the "Next" action, Daily Stats card, and header pulse now keep priorities, earnings, and schedules visible at a glance.
 - Auto forward loop: header toggle now cycles through paused, current pace (every two seconds), or a 2× sprint (every second) to keep momentum without constant clicks.
 - Asset stewardship: detail panels, sell controls, and recommendations highlight ROI, upkeep costs, and upgrade shortcuts for each build.
+- Asset category insights: every category header sports a Details slider that surfaces launch requirements, upkeep schedules, payout ranges, and quality ladders for its assets.
 - Active build cards surface quality tiers, remaining steps to the next milestone, and yesterday’s payout breakdown so upgrades feel tangible.
 - Automation & infrastructure: broader instant gigs, smarter assistant load balancing, and new studio/server tiers expand long-term play.
 - Commerce ladder: fulfillment automation, global supply mesh, and white-label alliances stack payouts for thriving dropshipping empires.

--- a/docs/features/asset-category-details.md
+++ b/docs/features/asset-category-details.md
@@ -1,0 +1,24 @@
+# Asset Category Details Slider
+
+## Feature Goals
+- Give players immediate access to launch requirements, upkeep expectations, and earning projections for each asset category.
+- Celebrate each asset's quality journey so players can plan upgrades without opening individual instances.
+- Keep information dense yet readable inside the existing slide-over pattern for consistency with other detail views.
+
+## Player Impact
+- Reduces guesswork before committing time or money to a new asset build.
+- Encourages comparing categories by surfacing upkeep and payout ranges side-by-side.
+- Highlights quality milestone requirements, making it easier to target study and equipment upgrades.
+
+## Implementation Notes
+- Each asset category header now includes a **Details** button that opens the global slide-over.
+- The slide-over lists every asset in that category. Each entry reuses the `createAssetDetailHighlights` blueprint to present:
+  - Setup duration and cost.
+  - Daily upkeep cost/time expectations.
+  - Income ranges and latest yield summaries.
+  - Requirement callouts plus full quality progression ladders.
+- Styling tweaks ensure the blueprint cards read well in the slide-over context while matching the existing aesthetic.
+
+## Tuning Hooks
+- Asset definitions already manage their `detailEntries`; the slider automatically reflects future tuning to setup, upkeep, or quality data.
+- Category notes (`ASSET_GROUP_NOTES`) feed the intro copy, so narrative teams can adjust tone per group without code changes.

--- a/src/ui/cards.js
+++ b/src/ui/cards.js
@@ -1801,12 +1801,24 @@ function renderAssets(definitions = []) {
 
     const actions = document.createElement('div');
     actions.className = 'asset-group__actions';
+
+    const categoryDetailsButton = document.createElement('button');
+    categoryDetailsButton.type = 'button';
+    categoryDetailsButton.className = 'ghost asset-group__details-button';
+    categoryDetailsButton.textContent = 'Details';
+    categoryDetailsButton.addEventListener('click', event => {
+      event.preventDefault();
+      openAssetGroupDetails(group);
+    });
+    actions.appendChild(categoryDetailsButton);
+
     group.definitions.forEach(definition => {
       const button = createLaunchButton(definition, state);
       if (button) {
         actions.appendChild(button);
       }
     });
+
     if (actions.childElementCount) {
       header.appendChild(actions);
     }
@@ -1876,6 +1888,61 @@ function openInstanceDetails(definition, instance, index, state = getState()) {
     eyebrow: getAssetGroupLabel(definition),
     title: instanceLabel(definition, index),
     body
+  });
+}
+
+function openAssetGroupDetails(group) {
+  if (!group || !Array.isArray(group.definitions) || !group.definitions.length) {
+    return;
+  }
+
+  const container = document.createElement('div');
+  container.className = 'asset-category-detail';
+
+  if (group.note) {
+    const intro = document.createElement('p');
+    intro.className = 'asset-category-detail__intro';
+    intro.textContent = group.note;
+    container.appendChild(intro);
+  }
+
+  group.definitions.forEach(definition => {
+    if (!definition) return;
+
+    const card = document.createElement('article');
+    card.className = 'asset-category-detail__card';
+
+    const header = document.createElement('header');
+    header.className = 'asset-category-detail__header';
+
+    const title = document.createElement('h3');
+    title.className = 'asset-category-detail__title';
+    title.textContent = definition.name || definition.id || 'Asset';
+    header.appendChild(title);
+
+    const summaryCopy = describeAssetCardSummary(definition);
+    if (summaryCopy) {
+      const summary = document.createElement('p');
+      summary.className = 'asset-category-detail__summary';
+      summary.textContent = summaryCopy;
+      header.appendChild(summary);
+    }
+
+    card.appendChild(header);
+
+    const highlights = createAssetDetailHighlights(definition);
+    if (highlights) {
+      highlights.classList.add('asset-category-detail__blueprint');
+      card.appendChild(highlights);
+    }
+
+    container.appendChild(card);
+  });
+
+  showSlideOver({
+    eyebrow: 'Asset category',
+    title: `${group.label} assets`,
+    body: container
   });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1324,6 +1324,12 @@ body {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+  align-items: center;
+}
+
+.asset-group__details-button {
+  font-size: 13px;
+  padding-inline: 12px;
 }
 
 .asset-group__heading {
@@ -2575,6 +2581,65 @@ body {
 .definition-list__value {
   font-size: 14px;
   font-weight: 600;
+}
+
+.asset-category-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  padding: 8px 4px 20px;
+}
+
+.asset-category-detail__intro {
+  margin: 0;
+  font-size: 15px;
+  color: var(--text-subtle);
+}
+
+.asset-category-detail__card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.6);
+  box-shadow: var(--shadow-sm);
+}
+
+.asset-category-detail__header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.asset-category-detail__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.asset-category-detail__summary {
+  margin: 0;
+  font-size: 14px;
+  color: rgba(203, 213, 255, 0.78);
+}
+
+.asset-category-detail__card .asset-detail__section {
+  margin-top: 8px;
+}
+
+.asset-category-detail__card .asset-detail__summary-card {
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.asset-category-detail__card .asset-detail__summary-card h4 {
+  color: var(--text);
+}
+
+.asset-category-detail__card .asset-detail__summary-item strong {
+  color: var(--text);
 }
 
 .asset-detail {


### PR DESCRIPTION
## Summary
- add Details actions to every asset category header and open a slide-over with full blueprint summaries for each asset type
- style the new slider cards for readability and document the feature in the changelog and feature notes

## Testing
- npm test
- Manual: Loaded the app in a browser, opened the Assets tab, and triggered the category Details slide-over

------
https://chatgpt.com/codex/tasks/task_e_68db2948a4e8832cbd84b7c5362c204f