### PR TITLE
Stop surfacing education in quick actions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Dashboard quick actions now focus on hustle-ready tasks instead of education enrollment, keeping the header recommendation in sync.
 - Niche realism: swapped in ten real-world audience niches so daily trend chasing mirrors recognizable markets.
 - Upgrade filters: the Upgrades panel now defaults to an "Unlocked now" view so only instant-install picks show until you opt to browse the full catalog.
 - Upgrade taxonomy: tech/house/infra tabs with family sub-sections and slot-aware tooltips make browsing gear lanes intuitive while the new effect engine drives unified payout, time, and quality multipliers.

--- a/src/ui/dashboard.js
+++ b/src/ui/dashboard.js
@@ -123,6 +123,7 @@ function describeQueue(summary) {
 export function buildQuickActions(state) {
   const items = [];
   for (const hustle of registry.hustles) {
+    if (hustle?.tag?.type === 'study') continue;
     if (!hustle?.action?.onClick) continue;
     const disabled = typeof hustle.action.disabled === 'function'
       ? hustle.action.disabled(state)


### PR DESCRIPTION
## Summary
- filter study-track hustles out of the dashboard quick actions list so the header recommendation also stays hustle-focused
- note the dashboard quick action change in the changelog

## Testing
- npm test
- Manual: npx http-server -p 4173 (load dashboard)


------
https://chatgpt.com/codex/tasks/task_e_68dbc3272fd4832c9ebc23e886caf81a