### PR TITLE
Refine asset hub interactions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Asset hub polish: launcher hides behind a dedicated button, asset cards always surface payout breakdowns, and upgrade buttons
+  clearly show when a boost is ready versus locked.
 - Dashboard quick actions now focus on hustle-ready tasks instead of education enrollment, keeping the header recommendation in sync.
 - Niche realism: swapped in ten real-world audience niches so daily trend chasing mirrors recognizable markets.
 - Upgrade filters: the Upgrades panel now defaults to an "Unlocked now" view so only instant-install picks show until you opt to browse the full catalog.

--- a/styles.css
+++ b/styles.css
@@ -1368,6 +1368,24 @@ body {
   box-shadow: var(--shadow-sm);
 }
 
+.asset-launcher__trigger {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 15px;
+  padding-inline: 18px;
+}
+
+.asset-launcher__trigger.is-open {
+  box-shadow: 0 0 0 3px rgba(124, 92, 255, 0.35);
+}
+
+.asset-launcher__content {
+  display: grid;
+  gap: 20px;
+}
+
 .asset-launcher__header {
   display: flex;
   flex-direction: column;
@@ -1732,18 +1750,9 @@ body {
 
 .asset-overview-card__payout-header {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
   gap: 12px;
-}
-
-.asset-overview-card__payout-toggle {
-  font-size: 12px;
-  padding: 6px 10px;
-}
-
-.asset-overview-card__payout-toggle:disabled {
-  opacity: 0.6;
 }
 
 .asset-overview-card__payout-summary {
@@ -1756,6 +1765,14 @@ body {
   border-radius: var(--radius-sm);
   background: rgba(12, 18, 32, 0.75);
   padding: 10px;
+  display: grid;
+  gap: 8px;
+}
+
+.asset-overview-card__payout-note {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(203, 213, 255, 0.72);
 }
 
 .asset-overview-card__payout-list {
@@ -1836,6 +1853,42 @@ body {
 
 .asset-overview-card__action {
   font-size: 14px;
+}
+
+.asset-overview-card__upgrade-action {
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease, background 0.2s ease;
+}
+
+.asset-overview-card__action--available {
+  border-color: rgba(124, 92, 255, 0.55);
+  background: rgba(65, 40, 125, 0.6);
+  color: var(--accent-light);
+}
+
+.asset-overview-card__action--available:hover,
+.asset-overview-card__action--available:focus-visible {
+  color: var(--text);
+  border-color: rgba(166, 139, 255, 0.9);
+  box-shadow: 0 0 0 2px rgba(124, 92, 255, 0.35);
+}
+
+.asset-overview-card__action--locked {
+  border-style: dashed;
+  border-color: rgba(148, 163, 184, 0.45);
+  background: rgba(17, 27, 48, 0.6);
+  color: rgba(203, 213, 255, 0.6);
+  cursor: not-allowed;
+}
+
+.asset-overview-card__action--locked:hover,
+.asset-overview-card__action--locked:focus-visible {
+  box-shadow: none;
+  color: rgba(203, 213, 255, 0.7);
+  border-color: rgba(148, 163, 184, 0.5);
+}
+
+.asset-overview-card__action--locked:disabled {
+  opacity: 1;
 }
 
 .asset-overview-card__links {


### PR DESCRIPTION
## Summary
- Hide the asset launch grid behind a dedicated toggle so the hub stays compact until needed
- Keep asset payout breakdowns visible by default and remove the unused maintenance action
- Style upgrade buttons to distinguish ready actions from locked ones with explanatory tooltips

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbcc76f018832cad299ad6ff5b99a1