### PR TITLE
Redesign dashboard quick actions and move niche analytics

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Dashboard quick actions and asset upgrade suggestions now use uniform action cards so critical buttons stay aligned and easy to scan.
+- Introduced an Analytics tab that houses the niche popularity pulse, keeping the dashboard focused on immediate actions.
 - Dashboard quick actions now focus on hustle-ready tasks instead of education enrollment, keeping the header recommendation in sync.
 - Niche realism: swapped in ten real-world audience niches so daily trend chasing mirrors recognizable markets.
 - Upgrade filters: the Upgrades panel now defaults to an "Unlocked now" view so only instant-install picks show until you opt to browse the full catalog.

--- a/docs/features/niche-market-pulse.md
+++ b/docs/features/niche-market-pulse.md
@@ -1,7 +1,7 @@
 # Niche Market Pulse
 
 ## Overview
-The niche system links every passive asset to an audience segment with a daily popularity roll. Assigning each build to a niche lets players chase trends for extra payout multipliers (or mitigate a slump) without rewriting asset definitions. The dashboard now surfaces a "Niche pulse" card that lists every niche, today’s hype score, and the resulting payout impact.
+The niche system links every passive asset to an audience segment with a daily popularity roll. Assigning each build to a niche lets players chase trends for extra payout multipliers (or mitigate a slump) without rewriting asset definitions. The Analytics panel now surfaces a "Niche pulse" card that lists every niche, today’s hype score, and the resulting payout impact.
 
 ## Goals
 - Give passive assets a lightweight layer of strategic choice that refreshes each in-game day.
@@ -15,7 +15,8 @@ The niche system links every passive asset to an audience segment with a daily p
 - **Assignment**: Asset instances store `nicheId`. Players can pick a niche (or go unassigned) from the instance detail panel. Invalid IDs are scrubbed when state loads.
 
 ## UI Notes
-- Dashboard widget lists all niches sorted by current popularity, with tone-based highlights and payout impact callouts.
+- Analytics widget lists all niches sorted by current popularity, with tone-based highlights and payout impact callouts.
+- Dashboard stays focused on immediate actions while the Analytics tab houses longer-term trend storytelling for niches.
 - Asset detail cards display the active niche (or a prompt to assign one) and provide a dropdown that previews the current multiplier for each option.
 - Log messages celebrate switching into or out of a niche so the event feed reflects strategy changes.
 

--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
 
     <nav class="shell__tabs" role="tablist" aria-label="Primary">
       <button id="tab-dashboard" class="shell__tab is-active" role="tab" aria-selected="true" aria-controls="panel-dashboard">Dashboard</button>
+      <button id="tab-analytics" class="shell__tab" role="tab" aria-selected="false" aria-controls="panel-analytics">Analytics</button>
       <button id="tab-player" class="shell__tab" role="tab" aria-selected="false" aria-controls="panel-player">Player</button>
       <button id="tab-hustles" class="shell__tab" role="tab" aria-selected="false" aria-controls="panel-hustles">Hustles</button>
       <button id="tab-assets" class="shell__tab" role="tab" aria-selected="false" aria-controls="panel-assets">Assets</button>
@@ -155,7 +156,7 @@
                   <h2 id="quick-actions-heading">Quick actions</h2>
                   <p>High-impact moves you can trigger now.</p>
                 </header>
-                <ul id="quick-actions" class="quick-actions" aria-live="polite"></ul>
+                <ul id="quick-actions" class="action-list quick-actions" aria-live="polite"></ul>
               </article>
 
               <article class="card dashboard-card" aria-labelledby="asset-upgrades-heading">
@@ -163,7 +164,7 @@
                   <h2 id="asset-upgrades-heading">Asset upgrade</h2>
                   <p>Cheer on underperformers with the next quality-friendly push.</p>
                 </header>
-                <ul id="asset-upgrade-actions" class="quick-actions upgrade-actions" aria-live="polite"></ul>
+                <ul id="asset-upgrade-actions" class="action-list upgrade-actions" aria-live="polite"></ul>
               </article>
             </div>
 
@@ -180,14 +181,6 @@
                   </div>
                   <ul id="dashboard-skills-list" class="skills-widget__list" aria-live="polite"></ul>
                 </div>
-              </article>
-
-              <article class="card dashboard-card" aria-labelledby="niche-trends-heading">
-                <header>
-                  <h2 id="niche-trends-heading">Niche pulse</h2>
-                  <p>Track which audiences are buzzing today.</p>
-                </header>
-                <ul id="niche-trends-list" class="niche-widget" aria-live="polite"></ul>
               </article>
 
               <article class="card dashboard-card" aria-labelledby="notifications-heading">
@@ -217,6 +210,24 @@
               </article>
             </div>
           </section>
+        </div>
+      </section>
+
+      <section id="panel-analytics" class="panel" role="tabpanel" aria-labelledby="tab-analytics" hidden>
+        <header class="panel__header">
+          <div>
+            <h2>Analytics</h2>
+            <p>Dig into trendlines and popularity pulses to plan your next bet.</p>
+          </div>
+        </header>
+        <div class="analytics-layout">
+          <article class="card analytics-card" aria-labelledby="niche-trends-heading">
+            <header>
+              <h3 id="niche-trends-heading">Niche pulse</h3>
+              <p>Track which audiences are buzzing today.</p>
+            </header>
+            <ul id="niche-trends-list" class="niche-widget" aria-live="polite"></ul>
+          </article>
         </div>
       </section>
 

--- a/src/ui/dashboard.js
+++ b/src/ui/dashboard.js
@@ -37,11 +37,13 @@ function createDailyListItem(entry) {
 function renderActionSection(container, entries, { emptyMessage, buttonClass, defaultLabel } = {}) {
   if (!container) return;
   container.innerHTML = '';
+  container.classList.add('action-list');
 
   const list = Array.isArray(entries) ? entries.filter(Boolean) : [];
   if (!list.length) {
     if (!emptyMessage) return;
     const empty = document.createElement('li');
+    empty.className = 'action-list__empty';
     empty.textContent = emptyMessage;
     container.appendChild(empty);
     return;
@@ -49,32 +51,54 @@ function renderActionSection(container, entries, { emptyMessage, buttonClass, de
 
   list.forEach(entry => {
     const item = document.createElement('li');
-    const info = document.createElement('div');
-    info.className = 'quick-actions__info';
+    item.className = 'action-list__item';
+
+    const content = document.createElement('div');
+    content.className = 'action-list__content';
 
     const title = document.createElement('span');
+    title.className = 'action-list__title';
     title.textContent = entry.title || '';
-    const subtitle = document.createElement('span');
-    subtitle.textContent = entry.subtitle || '';
-    subtitle.className = 'quick-actions__subtitle';
-    info.append(title, subtitle);
+    content.appendChild(title);
+
+    if (entry.subtitle) {
+      const subtitle = document.createElement('span');
+      subtitle.className = 'action-list__subtitle';
+      subtitle.textContent = entry.subtitle;
+      content.appendChild(subtitle);
+    }
 
     if (entry.meta) {
       const meta = document.createElement('span');
+      const metaClasses = ['action-list__meta'];
+      if (entry.metaClass) {
+        metaClasses.push(entry.metaClass);
+      }
+      meta.className = metaClasses.join(' ');
       meta.textContent = entry.meta;
-      meta.className = entry.metaClass || 'quick-actions__meta';
-      info.append(meta);
+      content.appendChild(meta);
     }
+
+    const actions = document.createElement('div');
+    actions.className = 'action-list__actions';
 
     const button = document.createElement('button');
     button.type = 'button';
-    button.className = buttonClass || 'primary';
+    const buttonClasses = ['action-list__button'];
+    if (buttonClass) {
+      buttonClasses.push(...String(buttonClass).split(' ').filter(Boolean));
+    } else {
+      buttonClasses.push('primary');
+    }
+    button.className = buttonClasses.join(' ');
     button.textContent = entry.buttonLabel || defaultLabel || 'Select';
     if (typeof entry.onClick === 'function') {
       button.addEventListener('click', () => entry.onClick?.());
     }
 
-    item.append(info, button);
+    actions.appendChild(button);
+
+    item.append(content, actions);
     container.appendChild(item);
   });
 }

--- a/styles.css
+++ b/styles.css
@@ -230,6 +230,38 @@ body {
   display: none;
 }
 
+.analytics-layout {
+  padding-inline: 8px;
+  padding-bottom: 16px;
+  display: grid;
+  gap: 20px;
+  align-content: start;
+  overflow-y: auto;
+  overscroll-behavior-y: contain;
+  min-height: 0;
+}
+
+.analytics-card {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.analytics-card header h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.analytics-card header p {
+  margin: 6px 0 0;
+  font-size: 14px;
+  color: var(--text-subtle);
+}
+
 .player-overview {
   padding-inline: 8px;
   overflow-y: auto;
@@ -577,19 +609,13 @@ body {
 
 .dashboard__top-row .quick-actions,
 .dashboard__top-row .upgrade-actions {
-  --dashboard-action-item-height: 72px;
-  --dashboard-action-gap: 12px;
-  --dashboard-action-button-width: 148px;
+  --dashboard-action-button-width: 200px;
   flex: 1 1 auto;
   height: 100%;
-  max-height: calc((var(--dashboard-action-item-height) * 5) + (var(--dashboard-action-gap) * 4));
+  max-height: 100%;
   overflow-y: auto;
   padding-right: 4px;
   scrollbar-gutter: stable both-edges;
-}
-
-.dashboard__top-row .upgrade-actions {
-  max-height: calc((var(--dashboard-action-item-height) * 6) + (var(--dashboard-action-gap) * 5));
 }
 
 .dashboard-card {
@@ -663,7 +689,126 @@ body {
   font-size: 13px;
 }
 
-.quick-actions,
+.action-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.action-list__item {
+  display: grid;
+  gap: 14px;
+  padding: 16px 18px;
+  background: var(--action-background, var(--surface-muted));
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--action-border, rgba(148, 163, 184, 0.28));
+  box-shadow: var(--action-shadow, none);
+  position: relative;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.action-list__item:hover,
+.action-list__item:focus-within {
+  border-color: var(--action-border-hover, rgba(148, 163, 184, 0.42));
+  box-shadow: var(--action-shadow-hover, var(--shadow-sm));
+  transform: translateY(-1px);
+}
+
+.action-list__content {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.action-list__title {
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--text);
+}
+
+.action-list__subtitle {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-subtle);
+}
+
+.action-list__meta {
+  font-size: 12px;
+  color: var(--text-subtle);
+  background: rgba(148, 163, 184, 0.18);
+  border-radius: var(--radius-md);
+  padding: 6px 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+}
+
+.action-list__actions {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.action-list__button {
+  inline-size: min(100%, var(--dashboard-action-button-width, 192px));
+  min-height: 40px;
+  padding: 10px 14px;
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  line-height: 1.3;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  white-space: normal;
+}
+
+.action-list__empty {
+  margin: 0;
+  padding: 16px 18px;
+  border-radius: var(--radius-md);
+  border: 1px dashed var(--border);
+  color: var(--text-subtle);
+  font-size: 14px;
+  text-align: center;
+}
+
+.quick-actions {
+  --action-border: rgba(99, 102, 241, 0.35);
+  --action-border-hover: rgba(99, 102, 241, 0.55);
+  --action-background: rgba(99, 102, 241, 0.12);
+  --action-shadow: 0 4px 16px rgba(79, 70, 229, 0.22);
+}
+
+.quick-actions .action-list__title {
+  color: rgba(224, 231, 255, 0.95);
+}
+
+.quick-actions .action-list__subtitle {
+  color: rgba(199, 210, 254, 0.85);
+}
+
+.quick-actions .action-list__meta {
+  background: rgba(129, 140, 248, 0.2);
+  color: rgba(224, 231, 255, 0.9);
+}
+
+.upgrade-actions {
+  --action-border: rgba(56, 189, 248, 0.4);
+  --action-border-hover: rgba(56, 189, 248, 0.7);
+  --action-background: rgba(56, 189, 248, 0.12);
+  --action-shadow: 0 4px 16px rgba(14, 165, 233, 0.22);
+}
+
+.upgrade-actions__meta {
+  color: rgba(125, 211, 252, 0.95);
+  background: rgba(14, 165, 233, 0.18);
+}
+
 .notifications {
   list-style: none;
   margin: 0;
@@ -672,7 +817,6 @@ body {
   gap: 12px;
 }
 
-.quick-actions li,
 .notifications li {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -682,15 +826,6 @@ body {
   border-radius: var(--radius-md);
   padding: 12px 16px;
   border: 1px solid transparent;
-}
-
-.quick-actions li {
-  gap: var(--dashboard-action-gap, 12px);
-  min-height: var(--dashboard-action-item-height, 64px);
-}
-
-.notifications li {
-  grid-template-columns: minmax(0, 1fr);
 }
 
 .skills-widget {
@@ -910,14 +1045,12 @@ body {
   border-color: rgba(129, 140, 248, 0.35);
 }
 
-.quick-actions__info,
 .notifications__info {
   display: grid;
   gap: 6px;
   min-width: 0;
 }
 
-.quick-actions__info > span,
 .notifications__info > span,
 .upgrade-actions__meta {
   line-height: 1.4;
@@ -1002,7 +1135,7 @@ body {
   padding: 10px 0;
 }
 
-.quick-actions__subtitle,
+.action-list__subtitle,
 .notifications__message {
   font-size: 13px;
   color: var(--text-subtle);
@@ -1010,22 +1143,6 @@ body {
 
 .upgrade-actions__meta {
   font-size: 12px;
-  color: var(--text-subtle);
-}
-
-.quick-actions li button {
-  inline-size: auto;
-  justify-self: end;
-  max-inline-size: min(100%, var(--dashboard-action-button-width, 140px));
-  min-height: 32px;
-  padding: 4px 10px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  white-space: normal;
-  line-height: 1.25;
-  align-self: start;
 }
 
 .notifications li button {
@@ -1033,14 +1150,28 @@ body {
   align-self: start;
 }
 
+@media (min-width: 720px) {
+  .action-list__item {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+  }
+
+  .action-list__actions {
+    align-items: flex-end;
+  }
+}
+
 @media (max-width: 720px) {
-  .quick-actions li {
+  .action-list__item {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .quick-actions li button {
-    justify-self: stretch;
-    width: 100%;
+  .action-list__actions {
+    align-items: stretch;
+  }
+
+  .action-list__button {
+    inline-size: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- restyled the dashboard quick actions and asset upgrade lists with consistent action cards and aligned buttons
- added an Analytics tab and relocated the niche pulse widget out of the dashboard
- updated changelog and niche market pulse documentation to reflect the new layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbce44d400832ca2936f1f946e8e4c