### PR TITLE
Add dashboard KPI jump shortcuts

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Dashboard KPIs now jump to their detailed breakdowns, focusing the card, flashing a highlight, and updating the session status so the context change is announced.
 - Asset hub polish: launcher hides behind a dedicated button, asset cards always surface payout breakdowns, and upgrade buttons
   clearly show when a boost is ready versus locked.
 - Dashboard quick actions and asset upgrade suggestions now use uniform action cards so critical buttons stay aligned and easy to scan.

--- a/docs/features/header-metrics.md
+++ b/docs/features/header-metrics.md
@@ -11,3 +11,4 @@
 **Player benefit**
 - Net-positive or upkeep-heavy days are obvious without opening the snapshot.
 - Long-term momentum stays visible even while scrolling away from dashboard cards.
+- KPI buttons double as quick jumps into the matching dashboard sections so players can instantly review the detailed lists the stat hints at.

--- a/src/ui/layout.js
+++ b/src/ui/layout.js
@@ -18,6 +18,7 @@ export function initLayoutControls() {
   setupSlideOver();
   setupCommandPalette();
   setupFilterHandlers();
+  setupKpiShortcuts();
 }
 
 export function applyCardFilters() {
@@ -152,6 +153,78 @@ function setupFilterHandlers() {
 
   elements.studyFilters.activeOnly?.addEventListener('change', applyStudyFilters);
   elements.studyFilters.hideComplete?.addEventListener('change', applyStudyFilters);
+}
+
+function setupKpiShortcuts() {
+  const buttons = Object.values(elements.kpis || {}).filter(Boolean);
+  if (!buttons.length) return;
+
+  const targetLookup = {
+    cash: () => elements.dailyStats.earningsActive?.closest('.daily-stats__section')
+      || elements.dailyStats.earningsActive
+      || elements.dailyStats.earningsSummary,
+    net: () => elements.dailyStats.spendList?.closest('.daily-stats__section')
+      || elements.dailyStats.spendList
+      || elements.dailyStats.spendSummary,
+    time: () => elements.dailyStats.timeList?.closest('.daily-stats__section')
+      || elements.dailyStats.timeList
+      || elements.dailyStats.timeSummary,
+    upkeep: () => elements.notifications?.closest('.dashboard-card') || elements.notifications,
+    assets: () => elements.assetUpgradeActions?.closest('.dashboard-card') || elements.assetUpgradeActions,
+    study: () => elements.dailyStats.studyList?.closest('.daily-stats__section')
+      || elements.dailyStats.studyList
+      || elements.dailyStats.studySummary
+  };
+
+  const statusMessages = {
+    cash: 'Scooting to the daily earnings breakdown.',
+    net: 'Reviewing how today’s inflows and outflows balance.',
+    time: 'Hopping down to the time ledger for today.',
+    upkeep: 'Checking upkeep reminders and notifications.',
+    assets: 'Spotlighting active assets and upgrade prospects.',
+    study: 'Beaming over to the study progress section.'
+  };
+
+  buttons.forEach(button => {
+    button.addEventListener('click', () => {
+      const detail = button.dataset.detail;
+      const target = targetLookup[detail]?.();
+      if (!target) return;
+
+      focusDashboardSection(target);
+      const message = statusMessages[detail];
+      if (message && elements.sessionStatus) {
+        elements.sessionStatus.textContent = message;
+      }
+    });
+  });
+}
+
+function focusDashboardSection(target) {
+  if (!target) return;
+
+  target.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
+
+  const highlight = target;
+  const focusable = highlight.matches('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')
+    ? highlight
+    : highlight.querySelector('h2, h3, h4, button, [tabindex]:not([tabindex="-1"]), a, input, select, textarea');
+
+  let cleanup;
+  if (focusable) {
+    focusable.focus({ preventScroll: true });
+  } else {
+    highlight.setAttribute('tabindex', '-1');
+    highlight.focus({ preventScroll: true });
+    cleanup = () => highlight.removeAttribute('tabindex');
+  }
+
+  highlight.classList.add('is-kpi-highlight');
+  window.setTimeout(() => highlight.classList.remove('is-kpi-highlight'), 1400);
+
+  if (cleanup) {
+    window.setTimeout(cleanup, 700);
+  }
 }
 
 function applyHustleFilters() {

--- a/styles.css
+++ b/styles.css
@@ -629,6 +629,23 @@ body {
   min-height: 0;
 }
 
+.is-kpi-highlight {
+  animation: kpi-highlight 1.2s ease-out;
+  box-shadow: 0 0 0 0 var(--accent-soft);
+}
+
+@keyframes kpi-highlight {
+  0% {
+    box-shadow: 0 0 0 0 var(--accent-soft);
+  }
+  45% {
+    box-shadow: 0 0 0 6px var(--accent-soft);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(124, 92, 255, 0);
+  }
+}
+
 .dashboard-card--wide {
   grid-column: span 2;
 }


### PR DESCRIPTION
## Summary
- connect dashboard KPI buttons to their related detail sections and focus them with smooth scrolling
- add a transient highlight effect and upbeat status messaging so jumps are noticeable and screen-reader friendly
- document the KPI shortcut behavior in the header metrics notes and changelog

## Testing
- npm test
- Chromium smoke test via Playwright clicking each KPI button

------
https://chatgpt.com/codex/tasks/task_e_68dbda8de694832caa28c9e4339dfd0f