### PR TITLE
Clarify study queue auto-scheduling copy

### DIFF
--- a/docs/features/education-auto-scheduler.md
+++ b/docs/features/education-auto-scheduler.md
@@ -11,6 +11,7 @@
 **UI cues**
 - Education cards show countdowns, tuition, and daily load straight from definitions with badges like Ready, Enrolled, Logged today, Graduated.
 - Progress strips pair percentage with "days complete / days left" so graduation timing stays obvious.
+- The study queue header spells out the auto-scheduled ordering and flags that manual tweaks are still on deck.
 
 **Design notes**
 - Study time reserves before maintenance, keeping promises consistent.

--- a/index.html
+++ b/index.html
@@ -434,7 +434,8 @@
         <section class="study-queue" aria-labelledby="study-queue-heading">
           <header>
             <h3 id="study-queue-heading">Study queue</h3>
-            <p>Drag to arrange; we cap daily hours.</p>
+            <p>Courses auto-schedule by urgency and we keep the daily cap in sight.</p>
+            <p class="queue__note">Manual reordering is warming up in the wings.</p>
           </header>
           <ol id="study-queue-list" class="queue"></ol>
           <div class="study-queue__meta">


### PR DESCRIPTION
## Summary
- refresh the Education tab study queue header to describe auto-scheduling and flag planned manual reordering
- update the auto-scheduler design note so documentation matches the new in-game messaging

## Testing
- npm test
- Manual: Viewed Education tab in browser to confirm copy

------
https://chatgpt.com/codex/tasks/task_e_68dbda91c4c8832c9a15783f9518c136