### PR TITLE
Refactor upgrade shortcut builders

### DIFF
--- a/src/ui/assetCategoryView.js
+++ b/src/ui/assetCategoryView.js
@@ -16,11 +16,8 @@ import {
   describeInstanceEarnings,
   describeInstanceNetHourly
 } from './assetInstances.js';
-import {
-  getPendingEquipmentUpgrades,
-  getUpgradeButtonLabel,
-  isUpgradeDisabled
-} from './assetUpgrades.js';
+import { getPendingEquipmentUpgrades } from './assetUpgrades.js';
+import { createAssetUpgradeShortcuts } from './assetUpgradeShortcuts.js';
 
 const categoryState = {
   definitionsByCategory: new Map(),
@@ -245,54 +242,16 @@ function buildInstanceRows(definitions) {
 }
 
 function createUpgradeShortcuts(upgrades = []) {
-  if (!Array.isArray(upgrades) || upgrades.length === 0) {
-    return null;
-  }
-
-  const limit = Math.min(upgrades.length, 2);
-  if (limit <= 0) return null;
-
-  const container = document.createElement('div');
-  container.className = 'asset-category__upgrade-shortcuts';
-
-  const title = document.createElement('span');
-  title.className = 'asset-category__upgrade-title';
-  title.textContent = limit > 1 ? 'Next upgrades' : 'Next upgrade';
-  container.appendChild(title);
-
-  const buttonRow = document.createElement('div');
-  buttonRow.className = 'asset-category__upgrade-buttons';
-  container.appendChild(buttonRow);
-
-  for (let index = 0; index < limit; index += 1) {
-    const upgrade = upgrades[index];
-    if (!upgrade) continue;
-    const button = document.createElement('button');
-    button.type = 'button';
-    button.className = 'asset-category__upgrade-button';
-    button.dataset.upgradeId = upgrade.id;
-    button.textContent = getUpgradeButtonLabel(upgrade);
-    button.disabled = isUpgradeDisabled(upgrade);
-    if (upgrade.description) {
-      button.title = upgrade.description;
-    }
-    button.addEventListener('click', event => {
-      event.preventDefault();
-      if (button.disabled) return;
-      upgrade.action?.onClick?.();
-    });
-    buttonRow.appendChild(button);
-  }
-
-  const remaining = upgrades.length - limit;
-  if (remaining > 0) {
-    const more = document.createElement('span');
-    more.className = 'asset-category__upgrade-more';
-    more.textContent = `+${remaining} more upgrades`;
-    container.appendChild(more);
-  }
-
-  return container;
+  return createAssetUpgradeShortcuts(upgrades, {
+    containerClass: 'asset-category__upgrade-shortcuts',
+    titleClass: 'asset-category__upgrade-title',
+    buttonRowClass: 'asset-category__upgrade-buttons',
+    buttonClass: 'asset-category__upgrade-button',
+    moreClass: 'asset-category__upgrade-more',
+    singularTitle: 'Next upgrade',
+    pluralTitle: 'Next upgrades',
+    moreLabel: count => `+${count} more upgrades`
+  });
 }
 
 function createUpgradeHints(definition, skipUpgrades = []) {

--- a/src/ui/assetUpgradeShortcuts.js
+++ b/src/ui/assetUpgradeShortcuts.js
@@ -1,0 +1,142 @@
+import { formatHours } from '../core/helpers.js';
+import { getUpgradeButtonLabel, isUpgradeDisabled } from './assetUpgrades.js';
+
+function defaultFormatTimeEstimate(hours) {
+  return formatHours(hours);
+}
+
+function resolveTimeEstimate({ includeTimeEstimate, getTimeEstimate, upgrade }) {
+  if (!includeTimeEstimate || typeof getTimeEstimate !== 'function') {
+    return 0;
+  }
+
+  const raw = Number(getTimeEstimate(upgrade));
+  if (!Number.isFinite(raw) || raw <= 0) {
+    return 0;
+  }
+
+  return raw;
+}
+
+export function createAssetUpgradeShortcuts(upgrades = [], options = {}) {
+  if (!Array.isArray(upgrades) || upgrades.length === 0) {
+    return null;
+  }
+
+  const {
+    limit = 2,
+    containerClass = '',
+    titleClass = '',
+    buttonRowClass = '',
+    buttonClass = '',
+    moreClass = '',
+    singularTitle = 'Upgrade',
+    pluralTitle = 'Upgrades',
+    titleFormatter,
+    includeTimeEstimate = false,
+    getTimeEstimate,
+    formatTimeEstimate = defaultFormatTimeEstimate,
+    buttonLabelFormatter,
+    tooltipFormatter,
+    moreLabel = count => `+${count} more`
+  } = options;
+
+  const resolvedLimit = Math.min(limit, upgrades.length);
+  if (resolvedLimit <= 0) {
+    return null;
+  }
+
+  const container = document.createElement('div');
+  if (containerClass) {
+    container.className = containerClass;
+  }
+
+  const titleText = typeof titleFormatter === 'function'
+    ? titleFormatter(upgrades.length)
+    : upgrades.length > 1
+      ? pluralTitle
+      : singularTitle;
+
+  if (titleText) {
+    const title = document.createElement('span');
+    if (titleClass) {
+      title.className = titleClass;
+    }
+    title.textContent = titleText;
+    container.appendChild(title);
+  }
+
+  const buttonRow = document.createElement('div');
+  if (buttonRowClass) {
+    buttonRow.className = buttonRowClass;
+  }
+  container.appendChild(buttonRow);
+
+  for (let index = 0; index < resolvedLimit; index += 1) {
+    const upgrade = upgrades[index];
+    if (!upgrade) continue;
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    if (buttonClass) {
+      button.className = buttonClass;
+    }
+    if (upgrade.id) {
+      button.dataset.upgradeId = upgrade.id;
+    }
+
+    const baseLabel = getUpgradeButtonLabel(upgrade);
+    const hours = resolveTimeEstimate({
+      includeTimeEstimate,
+      getTimeEstimate,
+      upgrade
+    });
+    const timeLabel = hours > 0 ? formatTimeEstimate(hours) : '';
+
+    const label = typeof buttonLabelFormatter === 'function'
+      ? buttonLabelFormatter({ upgrade, baseLabel, hours, timeLabel })
+      : timeLabel
+        ? `${baseLabel} (${timeLabel})`
+        : baseLabel;
+    button.textContent = label;
+
+    button.disabled = isUpgradeDisabled(upgrade);
+
+    const baseDescription = upgrade.description || '';
+    const tooltip = typeof tooltipFormatter === 'function'
+      ? tooltipFormatter({ upgrade, baseDescription, hours, timeLabel })
+      : baseDescription
+        ? timeLabel
+          ? `${baseDescription} • ≈${timeLabel} install`
+          : baseDescription
+        : '';
+    if (tooltip) {
+      button.title = tooltip;
+    }
+
+    button.addEventListener('click', event => {
+      event.preventDefault();
+      if (button.disabled) return;
+      upgrade.action?.onClick?.();
+    });
+
+    buttonRow.appendChild(button);
+  }
+
+  const remaining = upgrades.length - resolvedLimit;
+  if (remaining > 0) {
+    const more = document.createElement('span');
+    if (moreClass) {
+      more.className = moreClass;
+    }
+    const text = typeof moreLabel === 'function' ? moreLabel(remaining) : moreLabel;
+    more.textContent = text;
+    container.appendChild(more);
+  }
+
+  return container;
+}
+
+export default {
+  createAssetUpgradeShortcuts
+};

--- a/src/ui/cards.js
+++ b/src/ui/cards.js
@@ -29,7 +29,6 @@ import {
 } from '../game/assets/niches.js';
 import {
   getPendingEquipmentUpgrades,
-  getUpgradeButtonLabel,
   isUpgradeDisabled
 } from './assetUpgrades.js';
 import { getAssetEffectMultiplier } from '../game/upgrades/effects.js';
@@ -48,6 +47,7 @@ import {
 } from '../game/assets/quality.js';
 import { getSkillDefinition, normalizeSkillList } from '../game/skills/data.js';
 import { applyCardFilters } from './layout.js';
+import { createAssetUpgradeShortcuts } from './assetUpgradeShortcuts.js';
 
 const hustleUi = new Map();
 const upgradeUi = new Map();
@@ -1156,56 +1156,19 @@ function getUpgradeTimeEstimate(upgrade) {
 
 function createEquipmentShortcuts(definition, state) {
   const pending = getPendingEquipmentUpgrades(definition, state);
-  if (!Array.isArray(pending) || pending.length === 0) {
-    return null;
-  }
-
-  const limit = Math.min(2, pending.length);
-  if (limit <= 0) return null;
-
-  const container = document.createElement('div');
-  container.className = 'asset-detail__upgrade-shortcuts';
-
-  const title = document.createElement('span');
-  title.className = 'asset-detail__upgrade-title';
-  title.textContent = pending.length > 1 ? 'Equipment boosts' : 'Equipment boost';
-  container.appendChild(title);
-
-  const buttonRow = document.createElement('div');
-  buttonRow.className = 'asset-detail__upgrade-buttons';
-  container.appendChild(buttonRow);
-
-  for (let index = 0; index < limit; index += 1) {
-    const upgrade = pending[index];
-    if (!upgrade) continue;
-    const button = document.createElement('button');
-    button.type = 'button';
-    button.className = 'asset-detail__upgrade-button';
-    button.dataset.upgradeId = upgrade.id;
-    const timeEstimate = getUpgradeTimeEstimate(upgrade);
-    const baseLabel = getUpgradeButtonLabel(upgrade);
-    button.textContent = timeEstimate > 0 ? `${baseLabel} (${formatHours(timeEstimate)})` : baseLabel;
-    button.disabled = isUpgradeDisabled(upgrade);
-    if (upgrade.description) {
-      const timeLabel = timeEstimate > 0 ? ` • ≈${formatHours(timeEstimate)} install` : '';
-      button.title = `${upgrade.description}${timeLabel}`;
-    }
-    button.addEventListener('click', event => {
-      event.preventDefault();
-      if (button.disabled) return;
-      upgrade.action?.onClick?.();
-    });
-    buttonRow.appendChild(button);
-  }
-
-  if (pending.length > limit) {
-    const more = document.createElement('span');
-    more.className = 'asset-detail__upgrade-more';
-    more.textContent = `+${pending.length - limit} more`;
-    container.appendChild(more);
-  }
-
-  return container;
+  return createAssetUpgradeShortcuts(pending, {
+    containerClass: 'asset-detail__upgrade-shortcuts',
+    titleClass: 'asset-detail__upgrade-title',
+    buttonRowClass: 'asset-detail__upgrade-buttons',
+    buttonClass: 'asset-detail__upgrade-button',
+    moreClass: 'asset-detail__upgrade-more',
+    singularTitle: 'Equipment boost',
+    pluralTitle: 'Equipment boosts',
+    includeTimeEstimate: true,
+    getTimeEstimate: getUpgradeTimeEstimate,
+    formatTimeEstimate: formatHours,
+    moreLabel: count => `+${count} more`
+  });
 }
 
 function renderHustleCard(definition, container) {


### PR DESCRIPTION
## Summary
- extract reusable DOM helper for asset upgrade shortcut buttons with configurable styling and copy
- refactor asset category and card views to use the shared helper while preserving existing labels and layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbda9d0284832c8448487764bc8944