### PR TITLE
Refactor maintenance formatting helper

### DIFF
--- a/src/game/assets/helpers.js
+++ b/src/game/assets/helpers.js
@@ -178,22 +178,29 @@ export function setupCostDetail(definition) {
   return `💵 Setup Cost: <strong>$${formatMoney(cost)}</strong>`;
 }
 
-export function maintenanceDetail(definition) {
-  const hours = Number(definition.maintenance?.hours) || 0;
-  const cost = Number(definition.maintenance?.cost) || 0;
-  const hasHours = hours > 0;
-  const hasCost = cost > 0;
-  if (!hasHours && !hasCost) {
-    return '🛠 Maintenance: <strong>None</strong>';
-  }
+export function formatMaintenanceSummary(definition) {
+  const maintenance = definition?.maintenance || {};
+  const hours = Number(maintenance.hours) || 0;
+  const cost = Number(maintenance.cost) || 0;
   const parts = [];
-  if (hasHours) {
+  if (hours > 0) {
     parts.push(`${formatHours(hours)}/day`);
   }
-  if (hasCost) {
+  if (cost > 0) {
     parts.push(`$${formatMoney(cost)}/day`);
   }
-  return `🛠 Maintenance: <strong>${parts.join(' + ')}</strong>`;
+  return {
+    parts,
+    hasUpkeep: parts.length > 0
+  };
+}
+
+export function maintenanceDetail(definition) {
+  const summary = formatMaintenanceSummary(definition);
+  if (!summary.hasUpkeep) {
+    return '🛠 Maintenance: <strong>None</strong>';
+  }
+  return `🛠 Maintenance: <strong>${summary.parts.join(' + ')}</strong>`;
 }
 
 export function incomeDetail(definition) {

--- a/src/ui/assetCategoryView.js
+++ b/src/ui/assetCategoryView.js
@@ -1,10 +1,11 @@
 import elements from './elements.js';
-import { formatHours, formatMoney } from '../core/helpers.js';
+import { formatMoney } from '../core/helpers.js';
 import { getAssetState, getState } from '../core/state.js';
 import {
   calculateAssetSalePrice,
   instanceLabel,
-  sellAssetInstance
+  sellAssetInstance,
+  formatMaintenanceSummary
 } from '../game/assets/helpers.js';
 import {
   describeRequirement,
@@ -348,16 +349,7 @@ function createUpgradeHints(definition, skipUpgrades = []) {
 }
 
 function formatMaintenance(definition) {
-  const hours = Number(definition.maintenance?.hours) || 0;
-  const cost = Number(definition.maintenance?.cost) || 0;
-  const parts = [];
-  if (hours > 0) {
-    parts.push(`${formatHours(hours)}/day`);
-  }
-  if (cost > 0) {
-    parts.push(`$${formatMoney(cost)}/day`);
-  }
-  return parts;
+  return formatMaintenanceSummary(definition).parts;
 }
 
 function formatPayout(instance) {

--- a/src/ui/cards.js
+++ b/src/ui/cards.js
@@ -20,7 +20,8 @@ import {
 import {
   calculateAssetSalePrice,
   instanceLabel,
-  sellAssetInstance
+  sellAssetInstance,
+  formatMaintenanceSummary
 } from '../game/assets/helpers.js';
 import {
   assignInstanceToNiche,
@@ -1109,16 +1110,8 @@ function formatInstanceLastPayout(instance) {
 
 function formatInstanceUpkeep(definition) {
   if (!definition) return '';
-  const parts = [];
-  const cost = Number(definition.maintenance?.cost) || 0;
-  if (cost > 0) {
-    parts.push(`$${formatMoney(cost)}/day`);
-  }
-  const hours = Number(definition.maintenance?.hours) || 0;
-  if (hours > 0) {
-    parts.push(`${formatHours(hours)}/day`);
-  }
-  return parts.join(' • ');
+  const summary = formatMaintenanceSummary(definition);
+  return summary.parts.join(' • ');
 }
 
 function formatLaunchEta(instance) {


### PR DESCRIPTION
## Summary
- add a shared `formatMaintenanceSummary` helper for upkeep strings
- update maintenance details, category tables, and cards to use the shared formatter

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbda9f2618832c97e950231ea104ba