### PR TITLE
Rebalance passive upkeep for commerce assets

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,7 @@
 - Upgrade taxonomy: tech/house/infra tabs with family sub-sections and slot-aware tooltips make browsing gear lanes intuitive while the new effect engine drives unified payout, time, and quality multipliers.
 - Player screen: new overview tab spotlights character level, skills, education, gear, and hustle momentum in one place.
 - Asset liquidation rebalance: selling an instance now multiplies the 3× sale value by its quality tier for high-grade exits.
-- Passive economy rebalance: smoother upkeep for blogs, stock photos, dropshipping, and SaaS so late tiers feel rewarding without micromanagement spikes.
+- Passive economy rebalance: trimmed upkeep costs and boosted Quality 0 payouts for stock photos, dropshipping labs, and micro SaaS so each build breaks even before upgrades and reaches its first quality tier faster.
 - Progression refresh: character skills, study scheduling, and celebratory UI now guide players through course-driven bonuses and countdowns.
 - Flow helpers: the "Next" action, Daily Stats card, and header pulse now keep priorities, earnings, and schedules visible at a glance.
 - Auto forward loop: header toggle now cycles through paused, current pace (every two seconds), or a 2× sprint (every second) to keep momentum without constant clicks.

--- a/docs/features/day-driven-assets.md
+++ b/docs/features/day-driven-assets.md
@@ -10,7 +10,7 @@
 
 **Economy notes**
 - Base payouts use per-asset variance (blogs low volatility; SaaS highest) with quality tiers lifting income.
-- Recent tuning ensures early blogs/e-books cover their $3 upkeep soon after hitting Quality 1; Automation Course still doubles blog post progress.
+- Recent tuning ensures early blogs/e-books cover their $3 upkeep soon after hitting Quality 1, while stock photos, dropshipping labs, and micro SaaS now net a small profit at Quality 0 thanks to lighter upkeep and higher baseline payouts; Automation Course still doubles blog post progress.
 
 **Player value**
 - Daily stats call out which builds paid, stalled, or advanced knowledge, helping players adjust tomorrow’s plan.

--- a/src/game/assets/definitions/dropshipping.js
+++ b/src/game/assets/definitions/dropshipping.js
@@ -9,7 +9,7 @@ const dropshippingDefinition = createAssetDefinition({
   tags: ['commerce', 'ecommerce', 'fulfillment'],
   description: 'Prototype products, source suppliers, and automate fulfillment funnels.',
   setup: { days: 6, hoursPerDay: 4, cost: 720 },
-  maintenance: { hours: 1.5, cost: 12 },
+  maintenance: { hours: 1.2, cost: 9 },
   skills: {
     setup: [
       'commerce',
@@ -34,7 +34,7 @@ const dropshippingDefinition = createAssetDefinition({
         level: 0,
         name: 'Prototype Pile',
         description: 'Inconsistent suppliers mean sporadic payouts.',
-        income: { min: 5, max: 9 },
+        income: { min: 12, max: 20 },
         requirements: {}
       },
       {

--- a/src/game/assets/definitions/saas.js
+++ b/src/game/assets/definitions/saas.js
@@ -9,7 +9,7 @@ const saasDefinition = createAssetDefinition({
   tags: ['software', 'tech', 'product'],
   description: 'Design lean software services, onboard early users, and ship updates that keep churn low.',
   setup: { days: 8, hoursPerDay: 4, cost: 960 },
-  maintenance: { hours: 2.2, cost: 24 },
+  maintenance: { hours: 1.8, cost: 18 },
   skills: {
     setup: [
       'software',
@@ -39,7 +39,7 @@ const saasDefinition = createAssetDefinition({
         level: 0,
         name: 'Beta Sandbox',
         description: 'Tiny user base and messy bugs limit revenue.',
-        income: { min: 6, max: 12 },
+        income: { min: 20, max: 32 },
         requirements: {}
       },
       {
@@ -47,7 +47,7 @@ const saasDefinition = createAssetDefinition({
         name: 'Early Traction',
         description: 'Feature roadmap clicks with early adopters.',
         income: { min: 32, max: 48 },
-        requirements: { features: 5 }
+        requirements: { features: 4 }
       },
       {
         level: 2,
@@ -82,8 +82,8 @@ const saasDefinition = createAssetDefinition({
       {
         id: 'shipFeature',
         label: 'Ship Feature',
-        time: 3.5,
-        cost: 32,
+        time: 3.2,
+        cost: 28,
         dailyLimit: 1,
         progressKey: 'features',
         progressAmount: () => 1,

--- a/src/game/assets/definitions/stockPhotos.js
+++ b/src/game/assets/definitions/stockPhotos.js
@@ -9,7 +9,7 @@ const stockPhotosDefinition = createAssetDefinition({
   tags: ['photo', 'visual', 'content'],
   description: 'Stage props, shoot themed collections, and list them across marketplaces.',
   setup: { days: 5, hoursPerDay: 4, cost: 560 },
-  maintenance: { hours: 1.2, cost: 10 },
+  maintenance: { hours: 0.9, cost: 8 },
   skills: {
     setup: [
       'visual',
@@ -34,7 +34,7 @@ const stockPhotosDefinition = createAssetDefinition({
         level: 0,
         name: 'Camera Roll Chaos',
         description: 'Unsorted shoots drip pennies.',
-        income: { min: 4, max: 9 },
+        income: { min: 8, max: 14 },
         requirements: {}
       },
       {


### PR DESCRIPTION
## Summary
- ease stock photo, dropshipping, and SaaS upkeep so Quality 0 payouts now cover daily maintenance
- trim the earliest SaaS feature requirement and action costs to accelerate the climb to Quality 1
- document the economy adjustments in the day-driven asset notes and changelog

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dbeb114854832ca9e7a9105ffeab6f