### PR TITLE
Rebalance virtual assistant payroll economics

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Each asset supports multiple instances, tracks setup progress, and rolls a daily
 - **SaaS Micro-App** – Setup 8 days × 4h ($960) after Automation Architecture, the Server Rack → Cloud Cluster → Edge Delivery ladder, and experience running a dropshipping store plus e-book line. Maintenance 2.2h/day + $24. Squash bugs, ship features, and host support sprints to grow subscriptions from $4–$8/day to $168–$220/day after unlocking the Ecosystem Powerhouse tier at Quality 5.
 
 ### Upgrades & Boosts
-- **Hire Virtual Assistant** – $180 per hire, up to four assistants. Each adds +2h daily but costs $30/day in payroll; fire assistants anytime to cut wages (and hours).
+- **Hire Virtual Assistant** – $180 per hire, up to four assistants. Each adds +3h daily but costs $24/day in payroll; fire assistants anytime to cut wages (and hours).
 - **Turbo Coffee** – $40 per cup, up to three per day, each adding +1h for the current day.
 - **Camera** – $200, unlocks Vlog Channels and Stock Photo Galleries.
 - **Cinema Camera Upgrade** – $480, requires the base camera; trims setup/maintenance time, adds ~25% vlog payouts, and doubles quality progress for video/photo actions.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@
 - Niche realism: swapped in ten real-world audience niches so daily trend chasing mirrors recognizable markets.
 - Upgrade filters: the Upgrades panel now defaults to an "Unlocked now" view so only instant-install picks show until you opt to browse the full catalog.
 - Upgrade taxonomy: tech/house/infra tabs with family sub-sections and slot-aware tooltips make browsing gear lanes intuitive while the new effect engine drives unified payout, time, and quality multipliers.
+- Assistant payroll rebalance: virtual assistants now cover more upkeep hours at a lower $8/hr rate so their freed time beats baseline hustles on value.
 - Player screen: new overview tab spotlights character level, skills, education, gear, and hustle momentum in one place.
 - Asset liquidation rebalance: selling an instance now multiplies the 3× sale value by its quality tier for high-grade exits.
 - Passive economy rebalance: smoother upkeep for blogs, stock photos, dropshipping, and SaaS so late tiers feel rewarding without micromanagement spikes.

--- a/docs/features/assistant-squad.md
+++ b/docs/features/assistant-squad.md
@@ -4,9 +4,9 @@
 - Add a reversible workforce layer: spend cash to gain daily hours, and choose when to shrink the team.
 
 **Current tuning**
-- Up to four assistants; each costs $180 to hire, $30/day payroll, and grants +2h to the upkeep queue.
+- Up to four assistants; each costs $180 to hire, $24/day payroll, and grants +3h to the upkeep queue.
 - Payroll processes before upkeep, so low cash can stall maintenance.
-- Firing is instant, removing the 2h bonus and possibly leaving schedules in the red.
+- Firing is instant, removing the 3h bonus and possibly leaving schedules in the red.
 
 **Player takeaways**
 - Assistants create an ongoing money sink that keeps late-game balances meaningful.

--- a/src/game/assistant.js
+++ b/src/game/assistant.js
@@ -8,8 +8,8 @@ import { awardSkillProgress } from './skills/index.js';
 
 export const ASSISTANT_CONFIG = {
   hiringCost: 180,
-  hourlyRate: 15,
-  hoursPerAssistant: 2,
+  hourlyRate: 8,
+  hoursPerAssistant: 3,
   maxAssistants: 4
 };
 
@@ -102,6 +102,7 @@ export function processAssistantPayroll() {
   if (totalCost <= 0) return;
 
   const hadFunds = state.money >= totalCost;
+  const coveredHours = count * ASSISTANT_CONFIG.hoursPerAssistant;
   spendMoney(totalCost);
   recordCostContribution({
     key: 'assistant:payroll',
@@ -111,10 +112,13 @@ export function processAssistantPayroll() {
   });
   const formatted = formatMoney(totalCost);
   if (hadFunds) {
-    addLog(`Assistant payroll cleared at $${formatted} for ${count} teammate${count === 1 ? '' : 's'}.`, 'info');
+    addLog(
+      `Assistant payroll cleared at $${formatted} for ${count} teammate${count === 1 ? '' : 's'} covering ${coveredHours} upkeep hour${coveredHours === 1 ? '' : 's'}.`,
+      'info'
+    );
   } else {
     addLog(
-      `Assistant payroll of $${formatted} came due, but your balance ran dry. They still handled tasks—just no savings left.`,
+      `Assistant payroll of $${formatted} came due, but your balance ran dry. They still covered ${coveredHours} upkeep hour${coveredHours === 1 ? '' : 's'}—just no cash cushion left.`,
       'warning'
     );
   }

--- a/src/game/upgrades.js
+++ b/src/game/upgrades.js
@@ -20,7 +20,7 @@ const assistantUpgrade = createUpgrade({
   id: 'assistant',
   name: 'Hire Virtual Assistant',
   tag: { label: 'Unlock', type: 'unlock' },
-  description: 'Scale your admin squad. Each hire adds hours but expects daily wages.',
+  description: 'Scale your admin squad. Each hire adds hours at a lean $8/hr upkeep.',
   category: 'infra',
   family: 'automation',
   defaultState: {

--- a/tests/timeAndLifecycle.test.js
+++ b/tests/timeAndLifecycle.test.js
@@ -111,5 +111,9 @@ test('assistant payroll charges wages and firing removes bonus hours', () => {
   assert.equal(fired, true, 'assistant should fire successfully');
   assert.equal(getAssistantCount(), 0, 'no assistants should remain');
   assert.equal(state.bonusTime, baseBonus, 'bonus time should drop back to baseline');
-  assert.equal(state.timeLeft, -1, 'time left should reflect lost support hours');
+  assert.equal(
+    state.timeLeft,
+    1 - ASSISTANT_CONFIG.hoursPerAssistant,
+    'time left should reflect lost support hours'
+  );
 });


### PR DESCRIPTION
## Summary
- Reduce virtual assistant wages to $8/hr while increasing upkeep coverage to 3h so assistants undercut baseline hustle ROI.
- Refresh payroll logging, upgrade copy, docs, and README to match the new assistant efficiency numbers.
- Update assistant lifecycle test expectations and log the rebalance in the changelog.

## Testing
- npm test
- Manual QA: not run (not available in container environment)


------
https://chatgpt.com/codex/tasks/task_e_68dbeb122a20832cb8fd7313db95df7f