### PR TITLE
Remove redundant default exports from UI modules

### DIFF
--- a/src/ui/assetUpgradeShortcuts.js
+++ b/src/ui/assetUpgradeShortcuts.js
@@ -137,6 +137,3 @@ export function createAssetUpgradeShortcuts(upgrades = [], options = {}) {
   return container;
 }
 
-export default {
-  createAssetUpgradeShortcuts
-};

--- a/src/ui/player.js
+++ b/src/ui/player.js
@@ -267,4 +267,3 @@ export function renderPlayerPanel(state, summary) {
   renderStats(state, summary);
 }
 
-export default { renderPlayerPanel };

--- a/src/ui/skills/helpers.js
+++ b/src/ui/skills/helpers.js
@@ -60,11 +60,3 @@ export function describeCharacter(character = {}) {
   };
 }
 
-export default {
-  numberFormatter,
-  formatXp,
-  findSkillTier,
-  findNextSkillTier,
-  describeSkill,
-  describeCharacter
-};

--- a/src/ui/skillsWidget.js
+++ b/src/ui/skillsWidget.js
@@ -78,4 +78,3 @@ export function renderSkillWidgets(state = getState()) {
   renderTarget(elements.skills?.education, state);
 }
 
-export default { renderSkillWidgets };


### PR DESCRIPTION
## Summary
- remove default export wrappers from skills widget, player panel, and asset upgrade shortcut modules
- delete the unused default export object from skills helper utilities

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbfbe876b4832c9fe2dc2ab6e2574b