### PR TITLE
Remove redundant default exports from asset modules

### DIFF
--- a/src/game/assets/index.js
+++ b/src/game/assets/index.js
@@ -21,29 +21,6 @@ import {
   rerollNichePopularity
 } from './niches.js';
 
-const assetsSystem = {
-  list: ASSETS,
-  allocateMaintenance: allocateAssetMaintenance,
-  closeOutDay,
-  getIncomeRangeForDisplay,
-  performQualityAction,
-  getQualityLevel,
-  getQualityLevelSummary,
-  getQualityActions,
-  getQualityTracks,
-  sellAssetInstance,
-  calculateSalePrice: calculateAssetSalePrice,
-  niches: {
-    assignInstance: assignInstanceToNiche,
-    getAssignableSummaries: getAssignableNicheSummaries,
-    getInstanceEffect: getInstanceNicheEffect,
-    getPopularity: getNichePopularity,
-    getRoster: getNicheRoster,
-    reroll: rerollNichePopularity
-  }
-};
-
-export default assetsSystem;
 export {
   ASSETS,
   allocateAssetMaintenance,

--- a/src/game/assets/niches.js
+++ b/src/game/assets/niches.js
@@ -224,13 +224,3 @@ export function assignInstanceToNiche(assetId, instanceId, nicheId) {
   return changed;
 }
 
-export default {
-  assignInstanceToNiche,
-  getAssignableNiches,
-  getAssignableNicheSummaries,
-  getInstanceNicheEffect,
-  getInstanceNicheInfo,
-  getNichePopularity,
-  getNicheRoster,
-  rerollNichePopularity
-};

--- a/src/game/assets/registry.js
+++ b/src/game/assets/registry.js
@@ -1,7 +1,3 @@
 import definitions from './definitions/index.js';
 
 export const ASSETS = definitions;
-
-export default {
-  list: ASSETS
-};


### PR DESCRIPTION
## Summary
- drop the legacy assetsSystem wrapper and rely on named exports
- remove unused default exports from the asset registry and niches modules
- keep the modules consistent by sharing named exports only

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbfbdead7c832c83ae581f479aa3d8