### PR TITLE
Revamp analytics outlook and niche pulse

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Analytics makeover: new Daily outlook highlights, redesigned Niche pulse list, and a Momentum board make trend chasing easier to parse.
 - Education curriculum expansion: seven new study programs now award hustle multipliers, passive asset modifiers, and payout log callouts when their bonuses trigger.
 - Dashboard KPIs now jump to their detailed breakdowns, focusing the card, flashing a highlight, and updating the session status so the context change is announced.
 - Maintenance rebalance: daily upkeep hours for core passive assets now average just over five hours so a full portfolio still leaves meaningful manual time within the 14-hour day.

--- a/docs/features/niche-market-pulse.md
+++ b/docs/features/niche-market-pulse.md
@@ -1,7 +1,7 @@
 # Niche Market Pulse
 
 ## Overview
-The niche system links every passive asset to an audience segment with a daily popularity roll. Assigning each build to a niche lets players chase trends for extra payout multipliers (or mitigate a slump) without rewriting asset definitions. The Analytics panel now surfaces a "Niche pulse" card that lists every niche, today’s hype score, and the resulting payout impact.
+The niche system links every passive asset to an audience segment with a daily popularity roll. Assigning each build to a niche lets players chase trends for extra payout multipliers (or mitigate a slump) without rewriting asset definitions. The Analytics panel now spotlights a "Daily outlook" hero with headline highlights, a refreshed "Niche pulse" list, and a "Momentum board" that groups rising and cooling segments so players can plan pivots at a glance.
 
 ## Goals
 - Give passive assets a lightweight layer of strategic choice that refreshes each in-game day.
@@ -15,7 +15,9 @@ The niche system links every passive asset to an audience segment with a daily p
 - **Assignment**: Asset instances store `nicheId`. Players can pick a niche (or go unassigned) from the instance detail panel. Invalid IDs are scrubbed when state loads.
 
 ## UI Notes
-- Analytics widget lists all niches sorted by current popularity, with tone-based highlights and payout impact callouts.
+- The Daily outlook card celebrates the hype leader, the biggest positive delta, and the shakiest segment with cheerful summary copy so players can triage focus quickly.
+- Niche pulse now presents each audience in a score bar layout with shift and multiplier callouts plus optional lore snippets.
+- The Momentum board splits rising and cooling niches to encourage players to double down or rebalance depending on the temperature of the market.
 - Dashboard stays focused on immediate actions while the Analytics tab houses longer-term trend storytelling for niches.
 - Asset detail cards display the active niche (or a prompt to assign one) and provide a dropdown that previews the current multiplier for each option.
 - Log messages celebrate switching into or out of a niche so the event feed reflects strategy changes.

--- a/index.html
+++ b/index.html
@@ -221,12 +221,66 @@
           </div>
         </header>
         <div class="analytics-layout">
+          <article class="card analytics-card analytics-card--hero" aria-labelledby="analytics-overview-heading">
+            <header>
+              <h3 id="analytics-overview-heading">Daily outlook</h3>
+              <p>Scan the biggest swings before you queue your next move.</p>
+            </header>
+            <dl class="analytics-highlight-grid">
+              <div class="analytics-highlight">
+                <dt>Hype leader</dt>
+                <dd>
+                  <span id="analytics-highlight-hot" class="analytics-highlight__value">No readings yet</span>
+                  <p id="analytics-highlight-hot-note" class="analytics-highlight__note">Assign a niche to start tracking buzz.</p>
+                </dd>
+              </div>
+              <div class="analytics-highlight">
+                <dt>Momentum swing</dt>
+                <dd>
+                  <span id="analytics-highlight-swing" class="analytics-highlight__value">Awaiting data</span>
+                  <p id="analytics-highlight-swing-note" class="analytics-highlight__note">Fresh deltas will appear after the first reroll.</p>
+                </dd>
+              </div>
+              <div class="analytics-highlight">
+                <dt>Watch list</dt>
+                <dd>
+                  <span id="analytics-highlight-risk" class="analytics-highlight__value">All calm</span>
+                  <p id="analytics-highlight-risk-note" class="analytics-highlight__note">We’ll flag niches that are cooling off fast.</p>
+                </dd>
+              </div>
+            </dl>
+          </article>
+
           <article class="card analytics-card" aria-labelledby="niche-trends-heading">
             <header>
               <h3 id="niche-trends-heading">Niche pulse</h3>
-              <p>Track which audiences are buzzing today.</p>
+              <p>Every assigned audience with today’s hype score and payout impact.</p>
             </header>
-            <ul id="niche-trends-list" class="niche-widget" aria-live="polite"></ul>
+            <div class="niche-pulse" aria-live="polite">
+              <div class="niche-pulse__legend" aria-hidden="true">
+                <span>Score</span>
+                <span>Shift</span>
+                <span>Impact</span>
+              </div>
+              <ul id="niche-trends-list" class="niche-pulse__list"></ul>
+            </div>
+          </article>
+
+          <article class="card analytics-card" aria-labelledby="niche-momentum-heading">
+            <header>
+              <h3 id="niche-momentum-heading">Momentum board</h3>
+              <p>Rising segments hint at quick wins while cooling trends may need a pivot.</p>
+            </header>
+            <div class="niche-momentum">
+              <section class="niche-momentum__column" aria-labelledby="niche-momentum-rising">
+                <h4 id="niche-momentum-rising">Heating up</h4>
+                <ul id="niche-momentum-rise" class="niche-momentum__list"></ul>
+              </section>
+              <section class="niche-momentum__column" aria-labelledby="niche-momentum-cooling">
+                <h4 id="niche-momentum-cooling">Cooling off</h4>
+                <ul id="niche-momentum-cool" class="niche-momentum__list"></ul>
+              </section>
+            </div>
           </article>
         </div>
       </section>

--- a/src/ui/elements.js
+++ b/src/ui/elements.js
@@ -58,7 +58,15 @@ const elements = {
     studyList: document.getElementById('daily-study-list')
   },
   nicheTrends: {
-    list: document.getElementById('niche-trends-list')
+    list: document.getElementById('niche-trends-list'),
+    highlightHot: document.getElementById('analytics-highlight-hot'),
+    highlightHotNote: document.getElementById('analytics-highlight-hot-note'),
+    highlightSwing: document.getElementById('analytics-highlight-swing'),
+    highlightSwingNote: document.getElementById('analytics-highlight-swing-note'),
+    highlightRisk: document.getElementById('analytics-highlight-risk'),
+    highlightRiskNote: document.getElementById('analytics-highlight-risk-note'),
+    risingList: document.getElementById('niche-momentum-rise'),
+    coolingList: document.getElementById('niche-momentum-cool')
   },
   skills: {
     dashboard: {

--- a/styles.css
+++ b/styles.css
@@ -239,6 +239,7 @@ body {
   overflow-y: auto;
   overscroll-behavior-y: contain;
   min-height: 0;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
 .analytics-card {
@@ -248,7 +249,14 @@ body {
   padding: 20px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 20px;
+  min-height: 0;
+}
+
+.analytics-card--hero {
+  grid-column: 1 / -1;
+  background: linear-gradient(160deg, rgba(124, 92, 255, 0.16), rgba(59, 130, 246, 0.08));
+  border-color: rgba(124, 92, 255, 0.32);
 }
 
 .analytics-card header h3 {
@@ -260,6 +268,275 @@ body {
   margin: 6px 0 0;
   font-size: 14px;
   color: var(--text-subtle);
+}
+
+.analytics-highlight-grid {
+  display: grid;
+  gap: 18px;
+  margin: 0;
+}
+
+.analytics-highlight {
+  display: grid;
+  gap: 8px;
+}
+
+.analytics-highlight dt {
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(203, 213, 255, 0.7);
+  margin: 0;
+}
+
+.analytics-highlight dd {
+  margin: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.analytics-highlight__value {
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.analytics-highlight__note {
+  margin: 0;
+  font-size: 14px;
+  color: rgba(203, 213, 255, 0.85);
+}
+
+.niche-pulse {
+  display: grid;
+  gap: 12px;
+}
+
+.niche-pulse__legend {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(203, 213, 255, 0.65);
+}
+
+.niche-pulse__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 14px;
+}
+
+.niche-pulse__item {
+  background: var(--surface-muted);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  padding: 16px 18px;
+  display: grid;
+  gap: 12px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.niche-pulse__item[data-tone='hot'] {
+  border-color: rgba(244, 114, 182, 0.6);
+  box-shadow: 0 4px 18px rgba(244, 114, 182, 0.12);
+}
+
+.niche-pulse__item[data-tone='warm'] {
+  border-color: rgba(251, 191, 36, 0.55);
+  box-shadow: 0 4px 18px rgba(251, 191, 36, 0.12);
+}
+
+.niche-pulse__item[data-tone='steady'] {
+  border-color: rgba(124, 92, 255, 0.45);
+}
+
+.niche-pulse__item[data-tone='cool'] {
+  border-color: rgba(96, 165, 250, 0.4);
+}
+
+.niche-pulse__item[data-tone='cold'] {
+  border-color: rgba(148, 163, 184, 0.3);
+  opacity: 0.92;
+}
+
+.niche-pulse__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.niche-pulse__identity {
+  display: grid;
+  gap: 6px;
+  min-width: 160px;
+}
+
+.niche-pulse__name {
+  font-weight: 700;
+  font-size: 16px;
+}
+
+.niche-pulse__badge {
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(124, 92, 255, 0.18);
+  color: var(--accent-strong);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  width: fit-content;
+}
+
+.niche-pulse__item[data-tone='hot'] .niche-pulse__badge {
+  background: rgba(244, 114, 182, 0.18);
+  color: #fda4af;
+}
+
+.niche-pulse__item[data-tone='warm'] .niche-pulse__badge {
+  background: rgba(251, 191, 36, 0.18);
+  color: #facc15;
+}
+
+.niche-pulse__score {
+  display: grid;
+  gap: 6px;
+  flex: 1;
+  min-width: 180px;
+}
+
+.niche-pulse__score-value {
+  font-weight: 600;
+  font-size: 15px;
+}
+
+.niche-pulse__bar {
+  position: relative;
+  height: 8px;
+  background: rgba(148, 163, 184, 0.24);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.niche-pulse__bar-fill {
+  position: absolute;
+  inset: 0;
+  width: var(--width, 0%);
+  background: linear-gradient(90deg, rgba(124, 92, 255, 0.8), rgba(59, 130, 246, 0.9));
+}
+
+.niche-pulse__delta {
+  font-size: 13px;
+  color: rgba(203, 213, 255, 0.85);
+}
+
+.niche-pulse__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  font-size: 13px;
+  color: rgba(203, 213, 255, 0.78);
+}
+
+.niche-pulse__impact {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.niche-pulse__status {
+  margin: 0;
+  font-size: 14px;
+  color: rgba(203, 213, 255, 0.88);
+}
+
+.niche-pulse__description {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(203, 213, 255, 0.72);
+  line-height: 1.5;
+}
+
+.niche-pulse__empty {
+  margin: 0;
+  padding: 16px;
+  border-radius: var(--radius-md);
+  border: 1px dashed var(--border);
+  background: var(--surface-muted);
+  font-size: 14px;
+  color: var(--text-subtle);
+}
+
+.niche-momentum {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.niche-momentum__column {
+  display: grid;
+  gap: 12px;
+}
+
+.niche-momentum__column h4 {
+  margin: 0;
+  font-size: 14px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(203, 213, 255, 0.7);
+}
+
+.niche-momentum__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.niche-momentum__item {
+  border-radius: var(--radius-md);
+  background: var(--surface-muted);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 12px 14px;
+  display: grid;
+  gap: 6px;
+}
+
+.niche-momentum__item[data-trend='up'] {
+  border-color: rgba(34, 197, 94, 0.45);
+}
+
+.niche-momentum__item[data-trend='down'] {
+  border-color: rgba(239, 68, 68, 0.45);
+}
+
+.niche-momentum__name {
+  font-weight: 600;
+  font-size: 15px;
+}
+
+.niche-momentum__change {
+  font-size: 13px;
+  color: rgba(203, 213, 255, 0.85);
+}
+
+.niche-momentum__impact {
+  font-size: 13px;
+  color: var(--text);
+  font-weight: 600;
+}
+
+.niche-momentum__empty {
+  margin: 0;
+  padding: 12px 14px;
+  font-size: 14px;
+  color: var(--text-subtle);
+  border-radius: var(--radius-md);
+  border: 1px dashed var(--border);
+  background: var(--surface-muted);
 }
 
 .player-overview {
@@ -877,116 +1154,6 @@ body {
   padding: 0;
   display: grid;
   gap: 12px;
-}
-
-.niche-widget {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 12px;
-}
-
-.niche-widget__empty {
-  margin: 0;
-  padding: 12px 16px;
-  background: var(--surface-muted);
-  border-radius: var(--radius-md);
-  color: var(--text-subtle);
-  border: 1px dashed var(--border);
-  font-size: 14px;
-}
-
-.niche-widget__item {
-  background: var(--surface-muted);
-  border-radius: var(--radius-md);
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  padding: 14px 18px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.niche-widget__item[data-tone='hot'] {
-  border-color: rgba(244, 114, 182, 0.6);
-  box-shadow: 0 0 0 1px rgba(244, 114, 182, 0.2);
-}
-
-.niche-widget__item[data-tone='warm'] {
-  border-color: rgba(251, 191, 36, 0.55);
-  box-shadow: 0 0 0 1px rgba(251, 191, 36, 0.18);
-}
-
-.niche-widget__item[data-tone='steady'] {
-  border-color: rgba(124, 92, 255, 0.45);
-}
-
-.niche-widget__item[data-tone='cool'] {
-  border-color: rgba(96, 165, 250, 0.4);
-}
-
-.niche-widget__item[data-tone='cold'] {
-  border-color: rgba(148, 163, 184, 0.3);
-  opacity: 0.92;
-}
-
-.niche-widget__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.niche-widget__name {
-  font-weight: 700;
-  font-size: 16px;
-}
-
-.niche-widget__badge {
-  font-size: 12px;
-  padding: 4px 10px;
-  border-radius: 999px;
-  background: rgba(124, 92, 255, 0.18);
-  color: var(--accent-strong);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.niche-widget__item[data-tone='hot'] .niche-widget__badge {
-  background: rgba(244, 114, 182, 0.18);
-  color: #fda4af;
-}
-
-.niche-widget__item[data-tone='warm'] .niche-widget__badge {
-  background: rgba(251, 191, 36, 0.18);
-  color: #facc15;
-}
-
-.niche-widget__meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  font-size: 13px;
-  color: rgba(203, 213, 255, 0.85);
-}
-
-.niche-widget__impact {
-  font-weight: 600;
-  color: var(--text);
-}
-
-.niche-widget__status {
-  margin: 0;
-  font-size: 14px;
-  color: rgba(203, 213, 255, 0.9);
-}
-
-.niche-widget__description {
-  margin: 0;
-  font-size: 13px;
-  color: rgba(203, 213, 255, 0.72);
-  line-height: 1.5;
 }
 
 .skills-widget__item {


### PR DESCRIPTION
## Summary
- redesign the Analytics tab with a Daily outlook hero, refreshed Niche pulse list, and a Momentum board
- update niche rendering logic to feed the new highlights, progress bars, and momentum groupings
- document the analytics makeover in the niche feature note and changelog

## Testing
- npm test
- Manual: Previewed the analytics tab in a headless browser to verify layout and content updates

------
https://chatgpt.com/codex/tasks/task_e_68dbfd76f648832c9ed7537d04559ea0