### PR TITLE
Revamp analytics momentum board

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-- Analytics makeover: new Daily outlook highlights, redesigned Niche pulse list, and a Momentum board make trend chasing easier to parse.
+- Analytics makeover: Daily outlook hero highlights and a sortable niche card grid with watchlist filters surface earnings, asset exposure, and trend swings at a glance.
 - Education curriculum expansion: seven new study programs now award hustle multipliers, passive asset modifiers, and payout log callouts when their bonuses trigger.
 - Dashboard KPIs now jump to their detailed breakdowns, focusing the card, flashing a highlight, and updating the session status so the context change is announced.
 - Maintenance rebalance: daily upkeep hours for core passive assets now average just over five hours so a full portfolio still leaves meaningful manual time within the 14-hour day.

--- a/docs/features/niche-market-pulse.md
+++ b/docs/features/niche-market-pulse.md
@@ -1,7 +1,7 @@
 # Niche Market Pulse
 
 ## Overview
-The niche system links every passive asset to an audience segment with a daily popularity roll. Assigning each build to a niche lets players chase trends for extra payout multipliers (or mitigate a slump) without rewriting asset definitions. The Analytics panel now spotlights a "Daily outlook" hero with headline highlights, a refreshed "Niche pulse" list, and a "Momentum board" that groups rising and cooling segments so players can plan pivots at a glance.
+The niche system links every passive asset to an audience segment with a daily popularity roll. Assigning each build to a niche lets players chase trends for extra payout multipliers (or mitigate a slump) without rewriting asset definitions. The Analytics panel now spotlights a "Daily outlook" hero with headline highlights and a Momentum board that renders every niche as its own actionable card, blending world hype with the player’s earnings, asset count, and watchlist state at a glance.
 
 ## Goals
 - Give passive assets a lightweight layer of strategic choice that refreshes each in-game day.
@@ -15,9 +15,10 @@ The niche system links every passive asset to an audience segment with a daily p
 - **Assignment**: Asset instances store `nicheId`. Players can pick a niche (or go unassigned) from the instance detail panel. Invalid IDs are scrubbed when state loads.
 
 ## UI Notes
-- The Daily outlook card celebrates the hype leader, the biggest positive delta, and the shakiest segment with cheerful summary copy so players can triage focus quickly.
-- Niche pulse now presents each audience in a score bar layout with shift and multiplier callouts plus optional lore snippets.
-- The Momentum board splits rising and cooling niches to encourage players to double down or rebalance depending on the temperature of the market.
+- The Daily outlook card celebrates the biggest boost, fastest swing, and riskiest cooling segment with cheerful summary copy so players can triage focus quickly.
+- The Momentum board is now a responsive grid of niche cards that surface score, delta, payout impact, player asset counts, earnings, and trend gain/loss in a single glance.
+- Card actions jump straight to the Assets tab with matching builds spotlighted, toggle watchlist state, and hint at future "Queue recommended hustle" automation.
+- Sort controls (impact, assets invested, trend movement) and filters (invested only, watchlist only) keep large rosters scannable.
 - Dashboard stays focused on immediate actions while the Analytics tab houses longer-term trend storytelling for niches.
 - Asset detail cards display the active niche (or a prompt to assign one) and provide a dropdown that previews the current multiplier for each option.
 - Log messages celebrate switching into or out of a niche so the event feed reflects strategy changes.

--- a/index.html
+++ b/index.html
@@ -224,25 +224,25 @@
           <article class="card analytics-card analytics-card--hero" aria-labelledby="analytics-overview-heading">
             <header>
               <h3 id="analytics-overview-heading">Daily outlook</h3>
-              <p>Scan the biggest swings before you queue your next move.</p>
+              <p>Spot the headline niches shaping your empire before you make the next call.</p>
             </header>
             <dl class="analytics-highlight-grid">
               <div class="analytics-highlight">
-                <dt>Hype leader</dt>
+                <dt>Top boost</dt>
                 <dd>
                   <span id="analytics-highlight-hot" class="analytics-highlight__value">No readings yet</span>
                   <p id="analytics-highlight-hot-note" class="analytics-highlight__note">Assign a niche to start tracking buzz.</p>
                 </dd>
               </div>
               <div class="analytics-highlight">
-                <dt>Momentum swing</dt>
+                <dt>Big swing</dt>
                 <dd>
                   <span id="analytics-highlight-swing" class="analytics-highlight__value">Awaiting data</span>
                   <p id="analytics-highlight-swing-note" class="analytics-highlight__note">Fresh deltas will appear after the first reroll.</p>
                 </dd>
               </div>
               <div class="analytics-highlight">
-                <dt>Watch list</dt>
+                <dt>Cooling risk</dt>
                 <dd>
                   <span id="analytics-highlight-risk" class="analytics-highlight__value">All calm</span>
                   <p id="analytics-highlight-risk-note" class="analytics-highlight__note">We’ll flag niches that are cooling off fast.</p>
@@ -251,36 +251,37 @@
             </dl>
           </article>
 
-          <article class="card analytics-card" aria-labelledby="niche-trends-heading">
+          <article class="card analytics-card analytics-card--controls" aria-labelledby="niche-controls-heading">
             <header>
-              <h3 id="niche-trends-heading">Niche pulse</h3>
-              <p>Every assigned audience with today’s hype score and payout impact.</p>
+              <h3 id="niche-controls-heading">Trend controls</h3>
+              <p>Sort niches by what matters right now and filter to zero in on your plays.</p>
             </header>
-            <div class="niche-pulse" aria-live="polite">
-              <div class="niche-pulse__legend" aria-hidden="true">
-                <span>Score</span>
-                <span>Shift</span>
-                <span>Impact</span>
+            <div class="niche-controls" aria-live="polite">
+              <div class="niche-controls__group" role="group" aria-label="Sort niches">
+                <span class="niche-controls__label">Sort by</span>
+                <button type="button" class="ghost niche-controls__button is-active" data-niche-sort="impact" aria-pressed="true">Highest payout impact</button>
+                <button type="button" class="ghost niche-controls__button" data-niche-sort="assets" aria-pressed="false">Most assets invested</button>
+                <button type="button" class="ghost niche-controls__button" data-niche-sort="movement" aria-pressed="false">Fastest trend movement</button>
               </div>
-              <ul id="niche-trends-list" class="niche-pulse__list"></ul>
+              <div class="niche-controls__filters" role="group" aria-label="Niche filters">
+                <label class="niche-controls__toggle">
+                  <input type="checkbox" id="niche-filter-invested" />
+                  <span>Invested niches only</span>
+                </label>
+                <label class="niche-controls__toggle">
+                  <input type="checkbox" id="niche-filter-watchlist" />
+                  <span>Watchlist only</span>
+                </label>
+              </div>
             </div>
           </article>
 
-          <article class="card analytics-card" aria-labelledby="niche-momentum-heading">
+          <article class="card analytics-card analytics-card--board" aria-labelledby="niche-momentum-heading">
             <header>
               <h3 id="niche-momentum-heading">Momentum board</h3>
-              <p>Rising segments hint at quick wins while cooling trends may need a pivot.</p>
+              <p>Each niche gets its own spotlight with today’s hype score, your exposure, and the cash swing from its trend.</p>
             </header>
-            <div class="niche-momentum">
-              <section class="niche-momentum__column" aria-labelledby="niche-momentum-rising">
-                <h4 id="niche-momentum-rising">Heating up</h4>
-                <ul id="niche-momentum-rise" class="niche-momentum__list"></ul>
-              </section>
-              <section class="niche-momentum__column" aria-labelledby="niche-momentum-cooling">
-                <h4 id="niche-momentum-cooling">Cooling off</h4>
-                <ul id="niche-momentum-cool" class="niche-momentum__list"></ul>
-              </section>
-            </div>
+            <div id="niche-board" class="niche-board" role="list" aria-live="polite"></div>
           </article>
         </div>
       </section>

--- a/src/ui/cards.js
+++ b/src/ui/cards.js
@@ -2054,6 +2054,11 @@ function createAssetInstanceCard(definition, instance, index, state = getState()
   card.dataset.instance = instance.id;
   card.dataset.group = getAssetGroupId(definition);
   card.dataset.state = instance.status === 'active' ? 'active' : 'setup';
+  if (typeof instance.nicheId === 'string') {
+    card.dataset.niche = instance.nicheId;
+  } else {
+    delete card.dataset.niche;
+  }
   const needsMaintenance = instance.status === 'active' && !instance.maintenanceFundedToday;
   card.dataset.needsMaintenance = needsMaintenance ? 'true' : 'false';
   card.dataset.risk = definition.tag?.type === 'advanced' ? 'high' : 'medium';

--- a/src/ui/dashboard.js
+++ b/src/ui/dashboard.js
@@ -13,7 +13,8 @@ import {
 import { instanceLabel } from '../game/assets/helpers.js';
 import { KNOWLEDGE_TRACKS, getKnowledgeProgress } from '../game/requirements.js';
 import { getTimeCap } from '../game/time.js';
-import { getNicheRoster } from '../game/assets/niches.js';
+import { getNicheRoster, getNicheWatchlist, setNicheWatchlist } from '../game/assets/niches.js';
+import { activateShellPanel } from './layout.js';
 
 function createDailyListItem(entry) {
   const li = document.createElement('li');
@@ -538,319 +539,559 @@ function renderDailyStats(summary) {
   renderDailyList(studyList, summary.studyBreakdown, 'Your courses will list here once enrolled.', 3);
 }
 
+const nicheViewState = {
+  sort: 'impact',
+  investedOnly: false,
+  watchlistOnly: false
+};
+let nicheControlsBound = false;
+let assetHighlightTimer = null;
+
+function refreshNicheWidget() {
+  const state = getState();
+  if (state) {
+    renderNicheWidget(state);
+  }
+}
+
+function setupNicheControls() {
+  if (nicheControlsBound) return;
+  const refs = elements.nicheTrends || {};
+  const buttons = Array.isArray(refs.sortButtons) ? refs.sortButtons : [];
+  buttons.forEach(button => {
+    button.addEventListener('click', () => {
+      const sort = button.dataset.nicheSort || 'impact';
+      if (sort === nicheViewState.sort) return;
+      nicheViewState.sort = sort;
+      refreshNicheWidget();
+    });
+  });
+  refs.filterInvested?.addEventListener('change', event => {
+    nicheViewState.investedOnly = Boolean(event.target?.checked);
+    refreshNicheWidget();
+  });
+  refs.filterWatchlist?.addEventListener('change', event => {
+    nicheViewState.watchlistOnly = Boolean(event.target?.checked);
+    refreshNicheWidget();
+  });
+  nicheControlsBound = true;
+}
+
+function updateNicheControlStates({ watchlistCount = 0 } = {}) {
+  const refs = elements.nicheTrends || {};
+  const buttons = Array.isArray(refs.sortButtons) ? refs.sortButtons : [];
+  buttons.forEach(button => {
+    const isActive = (button.dataset.nicheSort || 'impact') === nicheViewState.sort;
+    button.classList.toggle('is-active', isActive);
+    button.setAttribute('aria-pressed', String(isActive));
+  });
+  if (refs.filterInvested) {
+    refs.filterInvested.checked = nicheViewState.investedOnly;
+  }
+  if (refs.filterWatchlist) {
+    const disabled = watchlistCount === 0;
+    refs.filterWatchlist.disabled = disabled;
+    if (disabled) {
+      refs.filterWatchlist.checked = false;
+      refs.filterWatchlist.title = 'Add niches to your watchlist to use this filter.';
+      if (nicheViewState.watchlistOnly) {
+        nicheViewState.watchlistOnly = false;
+      }
+    } else {
+      refs.filterWatchlist.checked = nicheViewState.watchlistOnly;
+      refs.filterWatchlist.title = '';
+    }
+  }
+}
+
+function clampScore(value) {
+  if (!Number.isFinite(value)) return null;
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function describeDelta(popularity = {}) {
+  const raw = Number(popularity.delta);
+  if (!Number.isFinite(raw)) return 'Fresh reading';
+  if (raw === 0) return 'Holding steady';
+  const sign = raw > 0 ? '+' : '';
+  return `${sign}${raw} vs yesterday`;
+}
+
+function formatPercent(value) {
+  if (!Number.isFinite(value)) return '0%';
+  const percent = Math.round(value * 100);
+  const sign = percent > 0 ? '+' : '';
+  return `${sign}${percent}%`;
+}
+
+function describeTrendStatus(entry) {
+  if (!entry) return 'Steady';
+  const { popularity = {}, assetCount, watchlisted } = entry;
+  if (watchlisted && assetCount === 0) return 'Watchlist';
+  const delta = Number(popularity.delta);
+  if (Number.isFinite(delta)) {
+    if (delta >= 6) return 'Heating Up';
+    if (delta <= -6) return 'Cooling Off';
+  }
+  const score = Number(popularity.score);
+  if (Number.isFinite(score)) {
+    if (score >= 70) return 'Trending';
+    if (score <= 40) return 'Cooling Off';
+  }
+  return 'Steady';
+}
+
+function buildNicheAnalytics(state) {
+  const roster = getNicheRoster(state) || [];
+  const watchlist = getNicheWatchlist(state);
+  const stats = new Map();
+  roster.forEach(entry => {
+    const id = entry?.definition?.id;
+    if (!id) return;
+    stats.set(id, {
+      id,
+      definition: entry.definition,
+      popularity: entry.popularity || {},
+      watchlisted: watchlist.has(id),
+      assetCount: 0,
+      netEarnings: 0,
+      trendImpact: 0,
+      baselineEarnings: 0,
+      assetBreakdown: new Map()
+    });
+  });
+
+  registry.assets.forEach(asset => {
+    const assetState = getAssetState(asset.id, state);
+    const instances = Array.isArray(assetState?.instances) ? assetState.instances : [];
+    instances.forEach(instance => {
+      if (!instance) return;
+      const nicheId = typeof instance.nicheId === 'string' ? instance.nicheId : null;
+      if (!nicheId) return;
+      const target = stats.get(nicheId);
+      if (!target) return;
+      target.assetCount += 1;
+      const label = asset.singular || asset.name || 'Asset';
+      target.assetBreakdown.set(label, (target.assetBreakdown.get(label) || 0) + 1);
+
+      const breakdownData = instance.lastIncomeBreakdown;
+      const total = Number(breakdownData?.total);
+      const payout = Number.isFinite(total) ? total : Number(instance.lastIncome);
+      const actual = Math.max(0, Number.isFinite(payout) ? payout : 0);
+      const entries = Array.isArray(breakdownData?.entries) ? breakdownData.entries : [];
+      const trendDelta = entries.reduce((sum, item) => {
+        if (!item || item.type !== 'niche') return sum;
+        const amount = Number(item.amount);
+        return sum + (Number.isFinite(amount) ? amount : 0);
+      }, 0);
+      const baseline = actual - trendDelta;
+      target.netEarnings += actual;
+      target.trendImpact += trendDelta;
+      target.baselineEarnings += Math.max(0, baseline);
+    });
+  });
+
+  return Array.from(stats.values()).map(entry => {
+    const assetBreakdown = Array.from(entry.assetBreakdown.entries()).map(([name, count]) => ({ name, count }));
+    return {
+      ...entry,
+      assetBreakdown,
+      netEarnings: Math.round(entry.netEarnings * 100) / 100,
+      trendImpact: Math.round(entry.trendImpact * 100) / 100,
+      baselineEarnings: Math.round(entry.baselineEarnings * 100) / 100,
+      status: describeTrendStatus(entry)
+    };
+  });
+}
+
+function focusAssetsForNiche(nicheId, { hasAssets = false, nicheName = '' } = {}) {
+  if (!nicheId) return;
+  activateShellPanel('panel-assets');
+  const { assetGallery, sessionStatus } = elements;
+  if (!assetGallery) return;
+  window.requestAnimationFrame(() => {
+    const cards = Array.from(assetGallery.querySelectorAll('[data-asset]'));
+    const matches = cards.filter(card => card.dataset.niche === nicheId);
+    cards.forEach(card => card.classList.remove('asset-overview-card--spotlight'));
+    if (!matches.length) {
+      if (sessionStatus) {
+        sessionStatus.textContent = hasAssets
+          ? 'No payouts recorded yet. Fund upkeep to roll today\'s earnings.'
+          : 'No assets targeting this niche yet. Open an asset card to assign one.';
+      }
+      return;
+    }
+    if (sessionStatus) {
+      const label = nicheName || 'this niche';
+      sessionStatus.textContent = `Spotlighting assets tuned to ${label}.`;
+    }
+    matches.forEach(card => card.classList.add('asset-overview-card--spotlight'));
+    const first = matches[0];
+    first.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    if (assetHighlightTimer) clearTimeout(assetHighlightTimer);
+    assetHighlightTimer = setTimeout(() => {
+      matches.forEach(card => card.classList.remove('asset-overview-card--spotlight'));
+    }, 2200);
+  });
+}
+
+function createNicheCard(entry) {
+  if (!entry) return null;
+  const card = document.createElement('article');
+  card.className = 'niche-card';
+  card.setAttribute('role', 'listitem');
+  if (entry.popularity?.tone) {
+    card.dataset.tone = entry.popularity.tone;
+  }
+  card.dataset.invested = entry.assetCount > 0 ? 'true' : 'false';
+  card.dataset.watchlisted = entry.watchlisted ? 'true' : 'false';
+
+  const header = document.createElement('header');
+  header.className = 'niche-card__header';
+
+  const titleWrap = document.createElement('div');
+  titleWrap.className = 'niche-card__title';
+
+  const name = document.createElement('h4');
+  name.className = 'niche-card__name';
+  name.textContent = entry.definition?.name || 'Untitled niche';
+  titleWrap.appendChild(name);
+
+  const status = document.createElement('span');
+  status.className = 'niche-card__status';
+  status.textContent = entry.status || 'Steady';
+  titleWrap.appendChild(status);
+
+  header.appendChild(titleWrap);
+
+  const score = document.createElement('p');
+  score.className = 'niche-card__score';
+  const normalizedScore = clampScore(entry.popularity?.score);
+  score.textContent = normalizedScore !== null ? normalizedScore : '–';
+  header.appendChild(score);
+
+  card.appendChild(header);
+
+  const meter = document.createElement('div');
+  meter.className = 'niche-card__meter';
+  meter.setAttribute('role', 'progressbar');
+  meter.setAttribute('aria-valuemin', '0');
+  meter.setAttribute('aria-valuemax', '100');
+  meter.setAttribute('aria-valuenow', normalizedScore !== null ? String(normalizedScore) : '0');
+  const fill = document.createElement('div');
+  fill.className = 'niche-card__meter-fill';
+  fill.style.setProperty('--fill', normalizedScore !== null ? `${normalizedScore}%` : '0%');
+  meter.appendChild(fill);
+  card.appendChild(meter);
+
+  const globalSection = document.createElement('section');
+  globalSection.className = 'niche-card__section';
+  const globalHeading = document.createElement('h5');
+  globalHeading.textContent = 'Global momentum';
+  globalSection.appendChild(globalHeading);
+
+  const multiplier = Number(entry.popularity?.multiplier);
+  const payoutText = Number.isFinite(multiplier)
+    ? (multiplier === 1 ? 'Baseline payouts' : `${formatPercent(multiplier - 1)} payouts`)
+    : 'Payout data pending';
+  const globalStat = document.createElement('p');
+  globalStat.className = 'niche-card__stat';
+  globalStat.textContent = payoutText;
+  globalSection.appendChild(globalStat);
+
+  const globalNote = document.createElement('p');
+  globalNote.className = 'niche-card__note';
+  const noteParts = [];
+  if (normalizedScore !== null) noteParts.push(`Score ${normalizedScore}`);
+  const deltaText = describeDelta(entry.popularity);
+  if (deltaText) noteParts.push(deltaText);
+  if (entry.popularity?.label) noteParts.push(entry.popularity.label);
+  globalNote.textContent = noteParts.join(' • ') || 'Trend scan warming up.';
+  globalSection.appendChild(globalNote);
+
+  card.appendChild(globalSection);
+
+  const playerSection = document.createElement('section');
+  playerSection.className = 'niche-card__section';
+  const playerHeading = document.createElement('h5');
+  playerHeading.textContent = 'Your empire';
+  playerSection.appendChild(playerHeading);
+
+  const playerStat = document.createElement('p');
+  playerStat.className = 'niche-card__stat';
+  if (entry.assetCount > 0) {
+    playerStat.textContent = entry.assetCount === 1
+      ? '1 asset active'
+      : `${entry.assetCount} assets active`;
+  } else if (entry.watchlisted) {
+    playerStat.textContent = 'On your watchlist';
+  } else {
+    playerStat.textContent = 'No assets assigned yet';
+  }
+  playerSection.appendChild(playerStat);
+
+  const earningsLine = document.createElement('p');
+  earningsLine.className = 'niche-card__metric';
+  if (entry.assetCount > 0) {
+    earningsLine.textContent = entry.netEarnings > 0
+      ? `$${formatMoney(entry.netEarnings)} earned today`
+      : 'No payouts logged today.';
+  } else {
+    earningsLine.textContent = 'Assign an asset to tap this trend.';
+  }
+  playerSection.appendChild(earningsLine);
+
+  if (entry.assetCount > 0) {
+    const trendLine = document.createElement('p');
+    trendLine.className = 'niche-card__trend';
+    if (Math.abs(entry.trendImpact) >= 0.5) {
+      const prefix = entry.trendImpact >= 0 ? '+' : '-';
+      trendLine.textContent = `${prefix}$${formatMoney(Math.abs(entry.trendImpact))} from today's trend`;
+      trendLine.classList.add(entry.trendImpact >= 0 ? 'niche-card__trend--positive' : 'niche-card__trend--negative');
+      playerSection.appendChild(trendLine);
+
+      const baselineNote = document.createElement('p');
+      baselineNote.className = 'niche-card__note';
+      baselineNote.textContent = `Baseline would land around $${formatMoney(entry.baselineEarnings)}.`;
+      playerSection.appendChild(baselineNote);
+    } else {
+      trendLine.textContent = 'Trend impact is neutral today.';
+      trendLine.classList.add('niche-card__trend--neutral');
+      playerSection.appendChild(trendLine);
+    }
+  } else if (entry.watchlisted) {
+    const watchNote = document.createElement('p');
+    watchNote.className = 'niche-card__note';
+    watchNote.textContent = 'Keep tabs on this niche and pivot when the hype spikes.';
+    playerSection.appendChild(watchNote);
+  }
+
+  if (entry.assetBreakdown?.length) {
+    const breakdown = document.createElement('p');
+    breakdown.className = 'niche-card__note';
+    const parts = entry.assetBreakdown.map(({ name, count }) =>
+      count > 1 ? `${name} (${count})` : name
+    );
+    breakdown.textContent = `Assets: ${parts.join(', ')}`;
+    playerSection.appendChild(breakdown);
+  }
+
+  card.appendChild(playerSection);
+
+  const actions = document.createElement('div');
+  actions.className = 'niche-card__actions';
+
+  const viewButton = document.createElement('button');
+  viewButton.type = 'button';
+  viewButton.className = 'ghost niche-card__action';
+  viewButton.textContent = entry.assetCount > 0
+    ? 'View assets in this niche'
+    : 'Find assets for this niche';
+  viewButton.addEventListener('click', () => {
+    focusAssetsForNiche(entry.id, {
+      hasAssets: entry.assetCount > 0,
+      nicheName: entry.definition?.name
+    });
+  });
+  actions.appendChild(viewButton);
+
+  const watchlistButton = document.createElement('button');
+  watchlistButton.type = 'button';
+  watchlistButton.className = 'ghost niche-card__action';
+  watchlistButton.textContent = entry.watchlisted ? 'Remove from watchlist' : 'Add to watchlist';
+  watchlistButton.setAttribute('aria-pressed', String(entry.watchlisted));
+  watchlistButton.addEventListener('click', () => {
+    setNicheWatchlist(entry.id, !entry.watchlisted);
+  });
+  actions.appendChild(watchlistButton);
+
+  const recommendButton = document.createElement('button');
+  recommendButton.type = 'button';
+  recommendButton.className = 'ghost niche-card__action';
+  recommendButton.textContent = 'Queue recommended hustle';
+  recommendButton.disabled = true;
+  recommendButton.title = 'Coming soon: auto-queue the best hustle for this niche.';
+  actions.appendChild(recommendButton);
+
+  card.appendChild(actions);
+
+  return card;
+}
+
+function updateDailyHighlights(analytics, refs) {
+  const {
+    highlightHot,
+    highlightHotNote,
+    highlightSwing,
+    highlightSwingNote,
+    highlightRisk,
+    highlightRiskNote
+  } = refs;
+
+  const invested = analytics.filter(entry => entry.assetCount > 0);
+  const relevant = invested.length ? invested : analytics;
+  const topImpact = relevant.slice().sort((a, b) => Math.abs(b.trendImpact) - Math.abs(a.trendImpact))[0];
+  const fastestMove = analytics.slice().sort((a, b) => Math.abs(Number(b.popularity?.delta) || 0) - Math.abs(Number(a.popularity?.delta) || 0))[0];
+  const negativePool = (invested.length ? invested : analytics).filter(entry => entry.trendImpact < 0);
+  const biggestLoss = negativePool.sort((a, b) => a.trendImpact - b.trendImpact)[0];
+
+  if (!topImpact) {
+    if (highlightHot) highlightHot.textContent = 'No readings yet';
+    if (highlightHotNote) highlightHotNote.textContent = 'Assign a niche to start tracking buzz.';
+  } else {
+    const impactValue = Math.abs(topImpact.trendImpact);
+    const isPositive = topImpact.trendImpact >= 0;
+    const impactLabel = impactValue >= 0.5
+      ? `${isPositive ? '+' : '-'}$${formatMoney(impactValue)} trend ${isPositive ? 'boost' : 'drag'}`
+      : `${formatPercent((Number(topImpact.popularity?.multiplier) || 1) - 1)} payouts`;
+    if (highlightHot) {
+      highlightHot.textContent = `${topImpact.definition?.name || 'Untitled niche'} • ${impactLabel}`;
+    }
+    if (highlightHotNote) {
+      if (topImpact.assetCount > 0) {
+        const payoutText = `$${formatMoney(Math.max(0, topImpact.netEarnings))}`;
+        highlightHotNote.textContent = `Your ${topImpact.assetCount} asset${topImpact.assetCount === 1 ? '' : 's'} made ${payoutText} today with ${formatPercent((Number(topImpact.popularity?.multiplier) || 1) - 1)} payouts.`;
+      } else {
+        highlightHotNote.textContent = `Queue an asset to capture ${formatPercent((Number(topImpact.popularity?.multiplier) || 1) - 1)} payouts from this niche.`;
+      }
+    }
+  }
+
+  if (!fastestMove || !Number.isFinite(Number(fastestMove.popularity?.delta))) {
+    if (highlightSwing) highlightSwing.textContent = 'Awaiting data';
+    if (highlightSwingNote) highlightSwingNote.textContent = 'Fresh deltas will appear after the first reroll.';
+  } else {
+    if (highlightSwing) {
+      const deltaText = describeDelta(fastestMove.popularity);
+      highlightSwing.textContent = `${fastestMove.definition?.name || 'Untitled niche'} • ${deltaText}`;
+    }
+    if (highlightSwingNote) {
+      const score = clampScore(fastestMove.popularity?.score);
+      const payoutText = formatPercent((Number(fastestMove.popularity?.multiplier) || 1) - 1);
+      const scoreText = score !== null ? `score ${score}` : 'score pending';
+      highlightSwingNote.textContent = `${payoutText} payouts • ${scoreText}.`;
+    }
+  }
+
+  if (!biggestLoss) {
+    if (highlightRisk) highlightRisk.textContent = 'All calm';
+    if (highlightRiskNote) highlightRiskNote.textContent = 'We’ll flag niches that are cooling off fast.';
+  } else {
+    const lossValue = Math.abs(biggestLoss.trendImpact);
+    if (highlightRisk) {
+      highlightRisk.textContent = `${biggestLoss.definition?.name || 'Untitled niche'} • -$${formatMoney(lossValue)} trend drag`;
+    }
+    if (highlightRiskNote) {
+      if (biggestLoss.assetCount > 0) {
+        highlightRiskNote.textContent = `${biggestLoss.assetCount} asset${biggestLoss.assetCount === 1 ? '' : 's'} lost ${formatPercent((Number(biggestLoss.popularity?.multiplier) || 1) - 1)} vs baseline today.`;
+      } else {
+        highlightRiskNote.textContent = 'No assets invested yet, so you are safe from this downswing.';
+      }
+    }
+  }
+}
+
 function renderNicheWidget(state) {
   const refs = elements.nicheTrends || {};
   const {
-    list,
     highlightHot,
     highlightHotNote,
     highlightSwing,
     highlightSwingNote,
     highlightRisk,
     highlightRiskNote,
-    risingList,
-    coolingList
+    board
   } = refs;
 
-  if (list) list.innerHTML = '';
-  if (risingList) risingList.innerHTML = '';
-  if (coolingList) coolingList.innerHTML = '';
+  setupNicheControls();
 
-  const setHighlight = (valueEl, noteEl, valueText, noteText) => {
-    if (valueEl) valueEl.textContent = valueText;
-    if (noteEl) noteEl.textContent = noteText;
-  };
-
-  const roster = getNicheRoster(state) || [];
-  if (!roster.length) {
-    setHighlight(
-      highlightHot,
-      highlightHotNote,
-      'No readings yet',
-      'Assign a niche to start tracking buzz.'
-    );
-    setHighlight(
-      highlightSwing,
-      highlightSwingNote,
-      'Awaiting data',
-      'Fresh deltas will appear after the first reroll.'
-    );
-    setHighlight(
-      highlightRisk,
-      highlightRiskNote,
-      'All calm',
-      'We’ll flag niches that are cooling off fast.'
-    );
-
-    if (list) {
-      const empty = document.createElement('li');
-      empty.className = 'niche-pulse__empty';
+  const analytics = buildNicheAnalytics(state);
+  if (!analytics.length) {
+    if (highlightHot) highlightHot.textContent = 'No readings yet';
+    if (highlightHotNote) highlightHotNote.textContent = 'Assign a niche to start tracking buzz.';
+    if (highlightSwing) highlightSwing.textContent = 'Awaiting data';
+    if (highlightSwingNote) highlightSwingNote.textContent = 'Fresh deltas will appear after the first reroll.';
+    if (highlightRisk) highlightRisk.textContent = 'All calm';
+    if (highlightRiskNote) highlightRiskNote.textContent = 'We’ll flag niches that are cooling off fast.';
+    if (board) {
+      board.innerHTML = '';
+      const empty = document.createElement('p');
+      empty.className = 'niche-board__empty';
       empty.textContent = 'Assign a niche to an asset to start tracking demand swings.';
-      list.appendChild(empty);
+      board.appendChild(empty);
     }
-
-    const emptyMomentum = text => {
-      const item = document.createElement('li');
-      item.className = 'niche-momentum__empty';
-      item.textContent = text;
-      return item;
-    };
-
-    if (risingList) {
-      risingList.appendChild(emptyMomentum('No rising trends yet.')); 
-    }
-    if (coolingList) {
-      coolingList.appendChild(emptyMomentum('No cooling trends yet.'));
-    }
+    updateNicheControlStates({ watchlistCount: 0 });
     return;
   }
 
-  const sanitizeScore = score => {
-    if (!Number.isFinite(score)) return null;
-    return Math.max(0, Math.min(100, Math.round(score)));
-  };
+  const watchlistCount = analytics.filter(entry => entry.watchlisted).length;
+  updateNicheControlStates({ watchlistCount });
 
-  const formatDelta = delta => {
-    if (!Number.isFinite(delta)) return 'Fresh reading';
-    if (delta === 0) return 'Holding steady';
-    const sign = delta > 0 ? '+' : '';
-    return `${sign}${delta} vs yesterday`;
-  };
-
-  const formatImpact = multiplier => {
-    if (!Number.isFinite(multiplier)) return 'Payout impact ±0%';
-    const percent = Math.round((multiplier - 1) * 100);
-    const sign = percent > 0 ? '+' : '';
-    return `Payout impact ${sign}${percent}%`;
-  };
-
-  const buildSummaryNote = (entry, fallback) => {
-    if (!entry) return fallback;
-    const popularity = entry.popularity || {};
-    const parts = [];
-    const score = sanitizeScore(popularity.score);
-    if (score !== null) parts.push(`${score}/100 interest`);
-    if (popularity.label) parts.push(popularity.label.toLowerCase());
-    const multiplier = Number(popularity.multiplier);
-    if (Number.isFinite(multiplier)) {
-      const percent = Math.round((multiplier - 1) * 100);
-      const sign = percent > 0 ? '+' : '';
-      parts.push(`payout ${sign}${percent}%`);
-    }
-    const summary = popularity.summary;
-    const text = parts.length ? parts.join(' • ') : null;
-    return summary ? `${text ? `${text}. ` : ''}${summary}` : text || fallback;
-  };
-
-  const hottest = roster.find(entry => Number.isFinite(entry?.popularity?.score)) || roster[0];
-  if (hottest) {
-    const name = hottest.definition?.name || 'Untitled niche';
-    setHighlight(
-      highlightHot,
-      highlightHotNote,
-      name,
-      buildSummaryNote(hottest, 'Popularity data incoming soon.')
-    );
-  }
-
-  const deltaEntries = roster.filter(entry => Number.isFinite(entry?.popularity?.delta));
-  const risingEntries = deltaEntries
-    .filter(entry => Number(entry.popularity.delta) > 0)
-    .sort((a, b) => Number(b.popularity.delta) - Number(a.popularity.delta));
-  const coolingEntries = deltaEntries
-    .filter(entry => Number(entry.popularity.delta) < 0)
-    .sort((a, b) => Number(a.popularity.delta) - Number(b.popularity.delta));
-
-  const swingSource = risingEntries.length
-    ? risingEntries[0]
-    : deltaEntries.sort((a, b) => Number(b.popularity.delta) - Number(a.popularity.delta))[0];
-
-  if (swingSource) {
-    const name = swingSource.definition?.name || 'Untitled niche';
-    const delta = Number(swingSource.popularity?.delta) || 0;
-    const sign = delta > 0 ? '+' : '';
-    setHighlight(
-      highlightSwing,
-      highlightSwingNote,
-      `${name} ${sign}${delta}`,
-      swingSource.popularity?.summary || formatDelta(delta)
-    );
-  } else {
-    setHighlight(
-      highlightSwing,
-      highlightSwingNote,
-      'Awaiting data',
-      'Fresh deltas will appear after the first reroll.'
-    );
-  }
-
-  let riskSource = null;
-  let lowestMultiplier = Infinity;
-  roster.forEach(entry => {
-    const multiplier = Number(entry?.popularity?.multiplier);
-    if (Number.isFinite(multiplier) && multiplier < lowestMultiplier) {
-      lowestMultiplier = multiplier;
-      riskSource = entry;
-    }
-  });
-  if (!riskSource && coolingEntries.length) {
-    riskSource = coolingEntries[0];
-  }
-  if (!riskSource && roster.length) {
-    riskSource = roster[roster.length - 1];
-  }
-
-  if (riskSource) {
-    const name = riskSource.definition?.name || 'Untitled niche';
-    const multiplier = Number(riskSource.popularity?.multiplier);
-    const percent = Number.isFinite(multiplier)
-      ? Math.round((multiplier - 1) * 100)
-      : 0;
-    const sign = percent > 0 ? '+' : '';
-    const value = Number.isFinite(multiplier)
-      ? `${name} ${sign}${percent}%`
-      : name;
-    setHighlight(
-      highlightRisk,
-      highlightRiskNote,
-      value,
-      riskSource.popularity?.summary || formatDelta(Number(riskSource.popularity?.delta))
-    );
-  }
-
-  const createPulseItem = entry => {
-    const definition = entry.definition || {};
-    const popularity = entry.popularity || {};
-    const item = document.createElement('li');
-    item.className = 'niche-pulse__item';
-    if (popularity.tone) {
-      item.dataset.tone = popularity.tone;
-    }
-
-    const row = document.createElement('div');
-    row.className = 'niche-pulse__row';
-
-    const identity = document.createElement('div');
-    identity.className = 'niche-pulse__identity';
-
-    const name = document.createElement('span');
-    name.className = 'niche-pulse__name';
-    name.textContent = definition.name || 'Untitled niche';
-    identity.appendChild(name);
-
-    const badge = document.createElement('span');
-    badge.className = 'niche-pulse__badge';
-    badge.textContent = popularity.label || 'Unknown';
-    identity.appendChild(badge);
-
-    row.appendChild(identity);
-
-    const scoreWrap = document.createElement('div');
-    scoreWrap.className = 'niche-pulse__score';
-
-    const scoreValue = document.createElement('span');
-    scoreValue.className = 'niche-pulse__score-value';
-    const normalizedScore = sanitizeScore(popularity.score);
-    scoreValue.textContent = normalizedScore !== null
-      ? `${normalizedScore}/100 interest`
-      : 'Interest pending';
-    scoreWrap.appendChild(scoreValue);
-
-    const bar = document.createElement('div');
-    bar.className = 'niche-pulse__bar';
-    bar.setAttribute('role', 'presentation');
-    const fill = document.createElement('div');
-    fill.className = 'niche-pulse__bar-fill';
-    const width = normalizedScore !== null ? `${normalizedScore}%` : '0%';
-    fill.style.setProperty('--width', width);
-    bar.appendChild(fill);
-    scoreWrap.appendChild(bar);
-
-    const delta = document.createElement('span');
-    delta.className = 'niche-pulse__delta';
-    delta.textContent = formatDelta(Number(popularity.delta));
-    scoreWrap.appendChild(delta);
-
-    row.appendChild(scoreWrap);
-    item.appendChild(row);
-
-    const meta = document.createElement('div');
-    meta.className = 'niche-pulse__meta';
-
-    const impact = document.createElement('span');
-    impact.className = 'niche-pulse__impact';
-    impact.textContent = formatImpact(Number(popularity.multiplier));
-    meta.appendChild(impact);
-
-    const status = document.createElement('span');
-    status.textContent = popularity.summary || 'Popularity data incoming soon.';
-    meta.appendChild(status);
-
-    item.appendChild(meta);
-
-    if (definition.description) {
-      const description = document.createElement('p');
-      description.className = 'niche-pulse__description';
-      description.textContent = definition.description;
-      item.appendChild(description);
-    }
-
-    return item;
-  };
-
-  roster.forEach(entry => {
-    if (!entry || !list) return;
-    list.appendChild(createPulseItem(entry));
+  updateDailyHighlights(analytics, {
+    highlightHot,
+    highlightHotNote,
+    highlightSwing,
+    highlightSwingNote,
+    highlightRisk,
+    highlightRiskNote
   });
 
-  const renderMomentum = (target, entries, emptyText, trend) => {
-    if (!target) return;
+  let entries = analytics.slice();
+  if (nicheViewState.watchlistOnly) {
+    entries = entries.filter(entry => entry.watchlisted);
+  }
+  if (nicheViewState.investedOnly) {
+    entries = entries.filter(entry => entry.assetCount > 0);
+  }
+
+  const sorters = {
+    impact: (a, b) => {
+      const impactDiff = Math.abs(b.trendImpact) - Math.abs(a.trendImpact);
+      if (impactDiff !== 0) return impactDiff;
+      const assetDiff = b.assetCount - a.assetCount;
+      if (assetDiff !== 0) return assetDiff;
+      return (clampScore(b.popularity?.score) || 0) - (clampScore(a.popularity?.score) || 0);
+    },
+    assets: (a, b) => {
+      const assetDiff = b.assetCount - a.assetCount;
+      if (assetDiff !== 0) return assetDiff;
+      const impactDiff = Math.abs(b.trendImpact) - Math.abs(a.trendImpact);
+      if (impactDiff !== 0) return impactDiff;
+      return (clampScore(b.popularity?.score) || 0) - (clampScore(a.popularity?.score) || 0);
+    },
+    movement: (a, b) => {
+      const deltaA = Math.abs(Number(a.popularity?.delta) || 0);
+      const deltaB = Math.abs(Number(b.popularity?.delta) || 0);
+      if (deltaB !== deltaA) return deltaB - deltaA;
+      return Math.abs(b.trendImpact) - Math.abs(a.trendImpact);
+    }
+  };
+
+  const sorter = sorters[nicheViewState.sort] || sorters.impact;
+  entries.sort(sorter);
+
+  if (board) {
+    board.innerHTML = '';
     if (!entries.length) {
-      const empty = document.createElement('li');
-      empty.className = 'niche-momentum__empty';
-      empty.textContent = emptyText;
-      target.appendChild(empty);
-      return;
+      const empty = document.createElement('p');
+      empty.className = 'niche-board__empty';
+      if (nicheViewState.watchlistOnly) {
+        empty.textContent = 'No watchlisted niches match the current filters.';
+      } else if (nicheViewState.investedOnly) {
+        empty.textContent = 'You haven’t assigned any assets that fit this filter yet.';
+      } else {
+        empty.textContent = 'Assign a niche to an asset to start tracking demand swings.';
+      }
+      board.appendChild(empty);
+    } else {
+      const fragment = document.createDocumentFragment();
+      entries.forEach(entry => {
+        const card = createNicheCard(entry);
+        if (card) fragment.appendChild(card);
+      });
+      board.appendChild(fragment);
     }
-
-    entries.slice(0, 4).forEach(entry => {
-      const popularity = entry.popularity || {};
-      const item = document.createElement('li');
-      item.className = 'niche-momentum__item';
-      item.dataset.trend = trend;
-
-      const name = document.createElement('span');
-      name.className = 'niche-momentum__name';
-      name.textContent = entry.definition?.name || 'Untitled niche';
-      item.appendChild(name);
-
-      const change = document.createElement('span');
-      change.className = 'niche-momentum__change';
-      change.textContent = formatDelta(Number(popularity.delta));
-      item.appendChild(change);
-
-      const impact = document.createElement('span');
-      impact.className = 'niche-momentum__impact';
-      impact.textContent = formatImpact(Number(popularity.multiplier));
-      item.appendChild(impact);
-
-      target.appendChild(item);
-    });
-  };
-
-  renderMomentum(
-    risingList,
-    risingEntries,
-    'No rising trends yet.',
-    'up'
-  );
-
-  renderMomentum(
-    coolingList,
-    coolingEntries,
-    'No cooling trends yet.',
-    'down'
-  );
+  }
 }
 
 export function renderDashboard(summary) {

--- a/src/ui/elements.js
+++ b/src/ui/elements.js
@@ -58,15 +58,16 @@ const elements = {
     studyList: document.getElementById('daily-study-list')
   },
   nicheTrends: {
-    list: document.getElementById('niche-trends-list'),
     highlightHot: document.getElementById('analytics-highlight-hot'),
     highlightHotNote: document.getElementById('analytics-highlight-hot-note'),
     highlightSwing: document.getElementById('analytics-highlight-swing'),
     highlightSwingNote: document.getElementById('analytics-highlight-swing-note'),
     highlightRisk: document.getElementById('analytics-highlight-risk'),
     highlightRiskNote: document.getElementById('analytics-highlight-risk-note'),
-    risingList: document.getElementById('niche-momentum-rise'),
-    coolingList: document.getElementById('niche-momentum-cool')
+    board: document.getElementById('niche-board'),
+    sortButtons: Array.from(document.querySelectorAll('[data-niche-sort]')),
+    filterInvested: document.getElementById('niche-filter-invested'),
+    filterWatchlist: document.getElementById('niche-filter-watchlist')
   },
   skills: {
     dashboard: {

--- a/src/ui/layout.js
+++ b/src/ui/layout.js
@@ -1,5 +1,7 @@
 import elements from './elements.js';
 
+let activePanelController = null;
+
 function emitLayoutEvent(name) {
   if (typeof document?.createEvent === 'function') {
     const event = document.createEvent('Event');
@@ -46,11 +48,23 @@ function setupTabs() {
     }
   };
 
+  activePanelController = activate;
+
   shellTabs.forEach(tab => {
     tab.addEventListener('click', () => activate(tab.getAttribute('aria-controls')));
   });
 
   activate('panel-dashboard');
+}
+
+export function activateShellPanel(panelId) {
+  if (!panelId) return;
+  if (typeof activePanelController === 'function') {
+    activePanelController(panelId);
+    return;
+  }
+  const tab = (elements.shellTabs || []).find(button => button?.getAttribute('aria-controls') === panelId);
+  tab?.click?.();
 }
 
 function setupEventLog() {

--- a/styles.css
+++ b/styles.css
@@ -306,237 +306,260 @@ body {
   color: rgba(203, 213, 255, 0.85);
 }
 
-.niche-pulse {
-  display: grid;
-  gap: 12px;
+
+.analytics-card--controls {
+  grid-column: 1 / -1;
 }
 
-.niche-pulse__legend {
-  display: grid;
-  grid-template-columns: 2fr 1fr 1fr;
+.analytics-card--board {
+  grid-column: 1 / -1;
+}
+
+.niche-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.niche-controls__group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.niche-controls__label {
   font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: rgba(203, 213, 255, 0.65);
+  color: var(--text-subtle);
 }
 
-.niche-pulse__list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 14px;
+.niche-controls__button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  white-space: nowrap;
 }
 
-.niche-pulse__item {
-  background: var(--surface-muted);
-  border-radius: var(--radius-md);
-  border: 1px solid rgba(148, 163, 184, 0.24);
-  padding: 16px 18px;
-  display: grid;
-  gap: 12px;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.niche-pulse__item[data-tone='hot'] {
-  border-color: rgba(244, 114, 182, 0.6);
-  box-shadow: 0 4px 18px rgba(244, 114, 182, 0.12);
-}
-
-.niche-pulse__item[data-tone='warm'] {
-  border-color: rgba(251, 191, 36, 0.55);
-  box-shadow: 0 4px 18px rgba(251, 191, 36, 0.12);
-}
-
-.niche-pulse__item[data-tone='steady'] {
-  border-color: rgba(124, 92, 255, 0.45);
-}
-
-.niche-pulse__item[data-tone='cool'] {
-  border-color: rgba(96, 165, 250, 0.4);
-}
-
-.niche-pulse__item[data-tone='cold'] {
-  border-color: rgba(148, 163, 184, 0.3);
-  opacity: 0.92;
-}
-
-.niche-pulse__row {
+.niche-controls__filters {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
-  justify-content: space-between;
   align-items: center;
 }
 
-.niche-pulse__identity {
+.niche-controls__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: var(--text-subtle);
+}
+
+.niche-controls__toggle input {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--accent-light);
+}
+
+.niche-board {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.niche-board__empty {
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  border-radius: var(--radius-lg);
+  padding: 20px;
+  font-size: 14px;
+  color: rgba(203, 213, 255, 0.75);
+  text-align: center;
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.niche-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: var(--surface-muted);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.niche-card[data-tone='hot'] {
+  border-color: rgba(244, 114, 182, 0.55);
+  box-shadow: 0 6px 22px rgba(244, 114, 182, 0.16);
+}
+
+.niche-card[data-tone='warm'] {
+  border-color: rgba(251, 191, 36, 0.5);
+  box-shadow: 0 6px 22px rgba(251, 191, 36, 0.15);
+}
+
+.niche-card[data-tone='steady'] {
+  border-color: rgba(124, 92, 255, 0.45);
+}
+
+.niche-card[data-tone='cool'] {
+  border-color: rgba(96, 165, 250, 0.45);
+}
+
+.niche-card[data-tone='cold'] {
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.niche-card[data-invested='true'] {
+  box-shadow: 0 8px 28px rgba(45, 212, 191, 0.18);
+}
+
+.niche-card[data-watchlisted='true'][data-invested='false'] {
+  border-style: dashed;
+  border-color: rgba(96, 165, 250, 0.4);
+}
+
+.niche-card:hover,
+.niche-card:focus-within {
+  transform: translateY(-2px);
+  border-color: rgba(124, 92, 255, 0.5);
+  box-shadow: 0 10px 28px rgba(124, 92, 255, 0.18);
+}
+
+.niche-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.niche-card__title {
   display: grid;
   gap: 6px;
-  min-width: 160px;
 }
 
-.niche-pulse__name {
+.niche-card__name {
+  margin: 0;
+  font-size: 18px;
   font-weight: 700;
-  font-size: 16px;
 }
 
-.niche-pulse__badge {
+.niche-card__status {
   font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   padding: 4px 10px;
   border-radius: 999px;
-  background: rgba(124, 92, 255, 0.18);
-  color: var(--accent-strong);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  width: fit-content;
+  background: rgba(148, 163, 255, 0.18);
+  color: rgba(203, 213, 255, 0.85);
+  justify-self: start;
 }
 
-.niche-pulse__item[data-tone='hot'] .niche-pulse__badge {
+.niche-card[data-tone='hot'] .niche-card__status {
   background: rgba(244, 114, 182, 0.18);
-  color: #fda4af;
+  color: #f472b6;
 }
 
-.niche-pulse__item[data-tone='warm'] .niche-pulse__badge {
+.niche-card[data-tone='warm'] .niche-card__status {
   background: rgba(251, 191, 36, 0.18);
-  color: #facc15;
+  color: #fbbf24;
 }
 
-.niche-pulse__score {
-  display: grid;
-  gap: 6px;
-  flex: 1;
-  min-width: 180px;
+.niche-card[data-tone='cool'] .niche-card__status {
+  background: rgba(56, 189, 248, 0.18);
+  color: #38bdf8;
 }
 
-.niche-pulse__score-value {
-  font-weight: 600;
-  font-size: 15px;
+.niche-card__score {
+  font-size: 24px;
+  font-weight: 700;
+  margin: 0;
+  color: var(--text);
 }
 
-.niche-pulse__bar {
+.niche-card__meter {
   position: relative;
-  height: 8px;
-  background: rgba(148, 163, 184, 0.24);
+  width: 100%;
+  height: 6px;
   border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
   overflow: hidden;
 }
 
-.niche-pulse__bar-fill {
+.niche-card__meter-fill {
   position: absolute;
   inset: 0;
-  width: var(--width, 0%);
-  background: linear-gradient(90deg, rgba(124, 92, 255, 0.8), rgba(59, 130, 246, 0.9));
+  width: var(--fill, 0%);
+  background: linear-gradient(90deg, rgba(124, 92, 255, 0.25), rgba(59, 130, 246, 0.6));
 }
 
-.niche-pulse__delta {
+.niche-card__section {
+  display: grid;
+  gap: 8px;
+}
+
+.niche-card__section h5 {
+  margin: 0;
   font-size: 13px;
-  color: rgba(203, 213, 255, 0.85);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-subtle);
 }
 
-.niche-pulse__meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
+.niche-card__stat {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.niche-card__metric {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 500;
+}
+
+.niche-card__trend {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.niche-card__trend--positive {
+  color: #34d399;
+}
+
+.niche-card__trend--negative {
+  color: #f87171;
+}
+
+.niche-card__trend--neutral {
+  color: var(--text-subtle);
+}
+
+.niche-card__note {
+  margin: 0;
   font-size: 13px;
   color: rgba(203, 213, 255, 0.78);
 }
 
-.niche-pulse__impact {
-  font-weight: 600;
-  color: var(--text);
-}
-
-.niche-pulse__status {
-  margin: 0;
-  font-size: 14px;
-  color: rgba(203, 213, 255, 0.88);
-}
-
-.niche-pulse__description {
-  margin: 0;
-  font-size: 13px;
-  color: rgba(203, 213, 255, 0.72);
-  line-height: 1.5;
-}
-
-.niche-pulse__empty {
-  margin: 0;
-  padding: 16px;
-  border-radius: var(--radius-md);
-  border: 1px dashed var(--border);
-  background: var(--surface-muted);
-  font-size: 14px;
-  color: var(--text-subtle);
-}
-
-.niche-momentum {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.niche-momentum__column {
-  display: grid;
-  gap: 12px;
-}
-
-.niche-momentum__column h4 {
-  margin: 0;
-  font-size: 14px;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  color: rgba(203, 213, 255, 0.7);
-}
-
-.niche-momentum__list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
+.niche-card__actions {
+  display: flex;
+  flex-wrap: wrap;
   gap: 10px;
+  margin-top: auto;
 }
 
-.niche-momentum__item {
-  border-radius: var(--radius-md);
-  background: var(--surface-muted);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  padding: 12px 14px;
-  display: grid;
-  gap: 6px;
+.niche-card__action {
+  flex: 1 1 150px;
+  justify-content: center;
 }
 
-.niche-momentum__item[data-trend='up'] {
-  border-color: rgba(34, 197, 94, 0.45);
-}
-
-.niche-momentum__item[data-trend='down'] {
-  border-color: rgba(239, 68, 68, 0.45);
-}
-
-.niche-momentum__name {
-  font-weight: 600;
-  font-size: 15px;
-}
-
-.niche-momentum__change {
-  font-size: 13px;
-  color: rgba(203, 213, 255, 0.85);
-}
-
-.niche-momentum__impact {
-  font-size: 13px;
-  color: var(--text);
-  font-weight: 600;
-}
-
-.niche-momentum__empty {
-  margin: 0;
-  padding: 12px 14px;
-  font-size: 14px;
-  color: var(--text-subtle);
-  border-radius: var(--radius-md);
-  border: 1px dashed var(--border);
-  background: var(--surface-muted);
+.niche-card__action[disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
 .player-overview {
@@ -1917,6 +1940,12 @@ body {
   transform: translateY(-2px);
   border-color: rgba(124, 92, 255, 0.45);
   box-shadow: var(--shadow-md);
+}
+
+.asset-overview-card--spotlight {
+  border-color: rgba(124, 92, 255, 0.7);
+  box-shadow: 0 0 0 3px rgba(124, 92, 255, 0.28), 0 14px 36px rgba(124, 92, 255, 0.22);
+  transform: translateY(-2px);
 }
 
 .asset-overview-card:focus-visible {


### PR DESCRIPTION
## Summary
- redesign the analytics panel with a daily outlook hero, trend controls, and a responsive momentum board of niche cards
- add niche watchlist persistence and UI hooks for sorting, filtering, and asset spotlighting
- align asset cards and documentation with the niche-focused analytics experience

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc089315b8832cb51b701ed9c888b3