### PR TITLE
Remove unused ensureSkills helper

### DIFF
--- a/src/game/skills/index.js
+++ b/src/game/skills/index.js
@@ -40,11 +40,6 @@ function ensureSkillContainers(state) {
   }
 }
 
-export function ensureSkills(state = getState()) {
-  if (!state) return;
-  ensureSkillContainers(state);
-}
-
 function logSkillLevelUp(skillId, level) {
   const skill = getSkillDefinition(skillId) || { name: skillId };
   const tier = findSkillTier(level);


### PR DESCRIPTION
## Summary
- remove the unused `ensureSkills` helper export from the skills module

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68dc141e9788832c83419c9275588643