### PR TITLE
Remove unused formatTimePair helper

### DIFF
--- a/src/game/summary.js
+++ b/src/game/summary.js
@@ -198,7 +198,3 @@ export function computeDailySummary(state = getState()) {
     studyBreakdown
   };
 }
-
-export function formatTimePair(hours) {
-  return formatHours(Math.max(0, hours));
-}


### PR DESCRIPTION
## Summary
- remove the unused `formatTimePair` export from the daily summary module

## Testing
- npm test
- Manual testing not run (not feasible in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc141dc534832cba9f84538380a69c