### PR TITLE
Remove unused buildBaseState export

### DIFF
--- a/src/core/state.js
+++ b/src/core/state.js
@@ -194,7 +194,6 @@ export default stateManager;
 export const createEmptyDailyMetrics = (...args) => stateManager.createEmptyDailyMetrics(...args);
 export const ensureDailyMetrics = (...args) => stateManager.ensureDailyMetrics(...args);
 export const ensureStateShape = (...args) => stateManager.ensureStateShape(...args);
-export const buildBaseState = (...args) => stateManager.buildBaseState(...args);
 export const buildDefaultState = (...args) => stateManager.buildDefaultState(...args);
 export const initializeState = (...args) => stateManager.initializeState(...args);
 export const replaceState = (...args) => stateManager.replaceState(...args);


### PR DESCRIPTION
## Summary
- remove the unused `buildBaseState` export from the state manager module

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc141be3f8832cad2a5566544bea4c