### PR TITLE
refactor: remove unused hustle requirement summary renderer

### DIFF
--- a/src/game/content/schema.js
+++ b/src/game/content/schema.js
@@ -830,10 +830,6 @@ export function createUpgrade(config) {
   return definition;
 }
 
-export function renderHustleRequirementSummary(requirements) {
-  return summarizeAssetRequirements(requirements);
-}
-
 export function hustleRequirementsMet(requirements) {
   return meetsAssetRequirements(requirements);
 }


### PR DESCRIPTION
## Summary
- remove the unused `renderHustleRequirementSummary` helper from the content schema module
- confirm there are no remaining references to the helper

## Testing
- npm test

## Manual Testing
- not run (environment-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dc141aede4832c9d320b2f3d9c2a2c