### PR TITLE
Remove unused helper functions across UI and game modules

### DIFF
--- a/src/game/assets/lifecycle.js
+++ b/src/game/assets/lifecycle.js
@@ -14,10 +14,6 @@ import {
 import { getAssetEffectMultiplier } from '../upgrades/effects.js';
 import { formatEducationBonusSummary } from '../educationEffects.js';
 
-function findAssetDefinition(assetId) {
-  return ASSETS.find(entry => entry.id === assetId) || null;
-}
-
 export function allocateAssetMaintenance() {
   const state = getState();
   if (!state) return;

--- a/src/game/assets/niches.js
+++ b/src/game/assets/niches.js
@@ -194,11 +194,6 @@ export function getNicheWatchlist(state = getState()) {
   return new Set(entries.filter(id => typeof id === 'string'));
 }
 
-export function isNicheWatchlisted(nicheId, state = getState()) {
-  if (!nicheId) return false;
-  return getNicheWatchlist(state).has(nicheId);
-}
-
 export function setNicheWatchlist(nicheId, watchlisted) {
   if (!nicheId) return false;
   let changed = false;
@@ -217,14 +212,6 @@ export function setNicheWatchlist(nicheId, watchlisted) {
     data.watchlist = Array.from(list);
   });
   return changed;
-}
-
-export function toggleNicheWatchlist(nicheId) {
-  if (!nicheId) return false;
-  const state = getState();
-  if (!state) return false;
-  const watchlisted = isNicheWatchlisted(nicheId, state);
-  return setNicheWatchlist(nicheId, !watchlisted);
 }
 
 export function getInstanceNicheEffect(instance, state = getState()) {

--- a/src/game/assets/quality.js
+++ b/src/game/assets/quality.js
@@ -155,11 +155,6 @@ export function getHighestQualityLevel(definition) {
   return levels.at(-1);
 }
 
-export function getQualityProgress(definition, instance) {
-  const quality = ensureInstanceQuality(definition, instance);
-  return quality.progress;
-}
-
 function meetsRequirements(progress, requirements = {}) {
   if (!requirements || !Object.keys(requirements).length) {
     return true;

--- a/src/game/content/schema.js
+++ b/src/game/content/schema.js
@@ -595,11 +595,6 @@ function renderUpgradeRequirement(requirement) {
   }
 }
 
-function upgradeRequirementsMet(requirements) {
-  if (!requirements?.length) return true;
-  return requirements.every(req => upgradeRequirementMet(req));
-}
-
 export function createUpgrade(config) {
   const rawRequirements = [...ensureArray(config.requires), ...ensureArray(config.prerequisites)];
   const requirements = normalizeUpgradeRequirements(rawRequirements);
@@ -828,8 +823,4 @@ export function createUpgrade(config) {
   }
 
   return definition;
-}
-
-export function hustleRequirementsMet(requirements) {
-  return meetsAssetRequirements(requirements);
 }

--- a/src/game/hustles/helpers.js
+++ b/src/game/hustles/helpers.js
@@ -1,6 +1,4 @@
 import { countActiveAssetInstances, getState } from '../../core/state.js';
-import { getHustleDefinition } from '../../core/state/registry.js';
-import { recordPayoutContribution } from '../metrics.js';
 import {
   summarizeAssetRequirements,
   buildAssetRequirementDescriptor
@@ -21,36 +19,6 @@ export const PACK_PARTY_REQUIREMENTS = [{ assetId: 'dropshipping', count: 1 }];
 export const BUG_SQUASH_REQUIREMENTS = [{ assetId: 'saas', count: 1 }];
 export const NARRATION_REQUIREMENTS = [{ assetId: 'ebook', count: 1 }];
 export const STREET_PROMO_REQUIREMENTS = [{ assetId: 'blog', count: 2 }];
-
-export function extractMetricKey(metric) {
-  if (!metric) return null;
-  if (typeof metric === 'string') return metric;
-  if (typeof metric === 'object') return metric.key || null;
-  return null;
-}
-
-function getHustleMetricIds(hustleId) {
-  const definition = getHustleDefinition(hustleId);
-  if (!definition) return {};
-  const actionMetrics = definition.action?.metricIds || definition.action?.metrics || {};
-  const definitionMetrics = definition.metricIds || definition.metrics || {};
-  return {
-    time: extractMetricKey(actionMetrics.time) || extractMetricKey(definitionMetrics.time),
-    cost: extractMetricKey(actionMetrics.cost) || extractMetricKey(definitionMetrics.cost),
-    payout: extractMetricKey(actionMetrics.payout) || extractMetricKey(definitionMetrics.payout)
-  };
-}
-
-function fallbackHustleMetricId(hustleId, type) {
-  const suffix = type === 'payout' ? 'payout' : type;
-  return `hustle:${hustleId}:${suffix}`;
-}
-
-export function recordHustlePayout(hustleId, { label, amount, category }) {
-  const metrics = getHustleMetricIds(hustleId);
-  const key = metrics.payout || fallbackHustleMetricId(hustleId, 'payout');
-  recordPayoutContribution({ key, label, amount, category });
-}
 
 export function getHustleRequirements(definition) {
   if (!definition) return [];

--- a/src/game/requirements.js
+++ b/src/game/requirements.js
@@ -698,12 +698,6 @@ export function getKnowledgeProgress(id, target = getState()) {
   return progress;
 }
 
-export function markKnowledgeStudied(id) {
-  const progress = getKnowledgeProgress(id);
-  if (progress.completed || !progress.enrolled) return;
-  progress.studiedToday = true;
-}
-
 export function enrollInKnowledgeTrack(id) {
   const state = getState();
   const track = KNOWLEDGE_TRACKS[id];
@@ -809,10 +803,6 @@ export function allocateDailyStudy({ trackIds, triggeredByEnrollment = false } =
   if (timeSkipped.length) {
     addLog(`${formatList(timeSkipped)} could not fit into today\'s schedule.`, 'warning');
   }
-}
-
-export function knowledgeRequirementMet(id) {
-  return isKnowledgeComplete(id);
 }
 
 export function advanceKnowledgeTracks() {

--- a/src/ui/assetInstances.js
+++ b/src/ui/assetInstances.js
@@ -1,5 +1,4 @@
 import { formatMoney } from '../core/helpers.js';
-import { getAssetState } from '../core/state.js';
 import { calculateAssetSalePrice, instanceLabel, sellAssetInstance } from '../game/assets/helpers.js';
 
 export function describeInstance(definition, instance) {
@@ -12,17 +11,6 @@ export function describeInstance(definition, instance) {
   }
   const level = Number(instance.quality?.level) || 0;
   return `Active • Quality ${level}`;
-}
-
-export function describeInstanceEarnings(instance) {
-  if (instance.status !== 'active') {
-    return '💤 No earnings until launch';
-  }
-  const lastIncome = Math.max(0, Number(instance.lastIncome) || 0);
-  if (lastIncome > 0) {
-    return `💰 $${formatMoney(lastIncome)} yesterday`;
-  }
-  return '💤 No payout yesterday';
 }
 
 export function calculateInstanceNetDaily(definition, instance) {
@@ -52,93 +40,4 @@ export function describeInstanceNetHourly(definition, instance) {
   const formatted = formatMoney(Math.round(absolute * 100) / 100);
   const prefix = netHourly < 0 ? '-$' : '$';
   return `${prefix}${formatted}/hr`;
-}
-
-function renderInstanceList(definition, state, ui) {
-  const container = ui?.extra?.instanceList;
-  if (!container) return;
-  const assetState = getAssetState(definition.id, state);
-  const instances = assetState?.instances || [];
-
-  container.innerHTML = '';
-
-  if (!instances.length) {
-    const empty = document.createElement('p');
-    empty.className = 'asset-instance-empty';
-    empty.textContent = 'No builds launched yet.';
-    container.appendChild(empty);
-    return;
-  }
-
-  const list = document.createElement('ul');
-  list.className = 'asset-instance-list';
-
-  instances.forEach((instance, index) => {
-    const item = document.createElement('li');
-    item.className = 'asset-instance-item';
-    item.dataset.instanceId = instance.id;
-
-    const info = document.createElement('div');
-    info.className = 'asset-instance-info';
-
-    const title = document.createElement('span');
-    title.className = 'asset-instance-name';
-    title.textContent = instanceLabel(definition, index);
-
-    const status = document.createElement('span');
-    status.className = 'asset-instance-status';
-    status.textContent = describeInstance(definition, instance);
-
-    const earnings = document.createElement('span');
-    earnings.className = 'asset-instance-earnings';
-    earnings.textContent = describeInstanceEarnings(instance);
-
-    info.append(title, status, earnings);
-
-    const actions = document.createElement('div');
-    actions.className = 'asset-instance-actions';
-
-    const price = calculateAssetSalePrice(instance);
-    const sellButton = document.createElement('button');
-    sellButton.type = 'button';
-    sellButton.className = 'secondary';
-    sellButton.textContent = price > 0
-      ? `Sell for $${formatMoney(price)}`
-      : 'No buyer yet';
-    sellButton.disabled = price <= 0;
-    sellButton.addEventListener('click', event => {
-      event.preventDefault();
-      event.stopPropagation();
-      sellAssetInstance(definition, instance.id);
-    });
-
-    actions.appendChild(sellButton);
-
-    item.append(info, actions);
-    list.appendChild(item);
-  });
-
-  container.appendChild(list);
-}
-
-export function enableAssetInstanceList(definition) {
-  if (!definition || definition.__instancesEnabled) return;
-  definition.__instancesEnabled = true;
-
-  const originalExtra = definition.extraContent;
-  definition.extraContent = (card, state) => {
-    const extra = typeof originalExtra === 'function' ? (originalExtra(card, state) || {}) : {};
-    const container = document.createElement('div');
-    container.className = 'asset-instance-section';
-    card.appendChild(container);
-    return { ...extra, instanceList: container };
-  };
-
-  const originalUpdate = definition.update;
-  definition.update = (state, ui) => {
-    if (typeof originalUpdate === 'function') {
-      originalUpdate(state, ui);
-    }
-    renderInstanceList(definition, state, ui);
-  };
 }

--- a/src/ui/cards.js
+++ b/src/ui/cards.js
@@ -587,88 +587,6 @@ function createInstanceNicheSelector(definition, instance) {
   return container;
 }
 
-function createInstanceListSection(definition, state, instancesOverride) {
-  const instances = Array.isArray(instancesOverride)
-    ? instancesOverride
-    : (() => {
-        const assetState = getAssetState(definition.id, state);
-        return Array.isArray(assetState?.instances) ? assetState.instances : [];
-      })();
-
-  const section = document.createElement('section');
-  section.className = 'asset-detail__section asset-detail__section--instances';
-  const heading = document.createElement('h3');
-  heading.textContent = 'Launched builds';
-  section.appendChild(heading);
-
-  if (!instances.length) {
-    const empty = document.createElement('p');
-    empty.className = 'asset-detail__empty';
-    empty.textContent = 'No builds launched yet. Spin one up to start earning.';
-    section.appendChild(empty);
-    return section;
-  }
-
-  const activeCards = [];
-  const queuedCards = [];
-  instances.forEach((instance, index) => {
-    const card = createInstanceCard(definition, instance, index, state);
-    if (!card) return;
-    if (instance.status === 'active') {
-      activeCards.push(card);
-    } else {
-      queuedCards.push(card);
-    }
-  });
-
-  if (activeCards.length) {
-    section.appendChild(
-      createInstanceGroup(
-        'Active builds',
-        'These crews are live — keep tuning upgrades to lift your payouts.',
-        activeCards
-      )
-    );
-  }
-
-  if (queuedCards.length) {
-    section.appendChild(
-      createInstanceGroup(
-        'Launch queue',
-        'Setup runs are staging here until they’re ready to go live.',
-        queuedCards
-      )
-    );
-  }
-
-  return section;
-}
-
-function createInstanceGroup(title, subtitle, items) {
-  const group = document.createElement('div');
-  group.className = 'asset-detail__instance-group';
-
-  const header = document.createElement('div');
-  header.className = 'asset-detail__group-header';
-  const groupTitle = document.createElement('h4');
-  groupTitle.className = 'asset-detail__group-title';
-  groupTitle.textContent = title;
-  header.appendChild(groupTitle);
-  if (subtitle) {
-    const note = document.createElement('p');
-    note.className = 'asset-detail__group-subtitle';
-    note.textContent = subtitle;
-    header.appendChild(note);
-  }
-  group.appendChild(header);
-
-  const list = document.createElement('ul');
-  list.className = 'asset-detail__instances';
-  items.forEach(item => list.appendChild(item));
-  group.appendChild(list);
-  return group;
-}
-
 function createInstanceCard(definition, instance, index, state) {
   const item = document.createElement('li');
   item.className = 'asset-detail__instance';
@@ -1358,30 +1276,6 @@ function describeAssetCardSummary(definition) {
   const trimmed = copy.trim();
   if (trimmed.length <= 140) return trimmed;
   return `${trimmed.slice(0, 137)}…`;
-}
-
-function describeInstanceNicheSummary(instance) {
-  const info = getInstanceNicheInfo(instance);
-  if (!info) {
-    return {
-      value: 'Unassigned',
-      note: 'Set a niche from Details to lock in demand bonuses.'
-    };
-  }
-  const label = info.definition?.name || 'Niche';
-  const mood = info.popularity?.label ? ` — ${info.popularity.label}` : '';
-  const multiplier = Number(info.popularity?.multiplier);
-  let impact = '±0%';
-  if (Number.isFinite(multiplier)) {
-    const percent = Math.round((multiplier - 1) * 100);
-    const sign = percent > 0 ? '+' : '';
-    impact = `${sign}${percent}%`;
-  }
-  const summary = info.popularity?.summary || 'Demand shifts every day.';
-  return {
-    value: `${label}${mood}`,
-    note: `${summary} • Payout impact ${impact}`
-  };
 }
 
 function calculateInstanceProgress(definition, instance) {


### PR DESCRIPTION
## Summary
- remove unused asset instance UI helpers and niche watchlist toggles
- drop obsolete quality, hustle, and knowledge helpers that no longer had callers
- streamline card rendering helpers by pruning dormant instance detail utilities

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc165871c0832c89b25e320fedf2f1