### PR TITLE
Refactor state manager slices into dedicated modules

### DIFF
--- a/src/core/state/slices/assets.js
+++ b/src/core/state/slices/assets.js
@@ -1,0 +1,33 @@
+import { normalizeAssetState } from '../assets.js';
+import { getRegistrySnapshot, getAssetDefinition } from '../registry.js';
+
+export function ensureSlice(state) {
+  if (!state) return {};
+  state.assets = state.assets || {};
+  const registry = getRegistrySnapshot();
+  for (const definition of registry.assets) {
+    const existing = state.assets[definition.id] || {};
+    state.assets[definition.id] = normalizeAssetState(definition, existing, { state });
+  }
+  return state.assets;
+}
+
+export function getSliceState(state, id) {
+  if (!state) return {};
+  const assets = ensureSlice(state);
+  if (!id) {
+    return assets;
+  }
+  const definition = getAssetDefinition(id);
+  if (!definition) {
+    assets[id] = assets[id] || {};
+    return assets[id];
+  }
+  assets[id] = normalizeAssetState(definition, assets[id] || {}, { state });
+  return assets[id];
+}
+
+export default {
+  ensureSlice,
+  getSliceState
+};

--- a/src/core/state/slices/hustles.js
+++ b/src/core/state/slices/hustles.js
@@ -1,0 +1,32 @@
+import { structuredClone } from '../../helpers.js';
+import { getRegistrySnapshot, getHustleDefinition } from '../registry.js';
+
+export function ensureSlice(state) {
+  if (!state) return {};
+  state.hustles = state.hustles || {};
+  const registry = getRegistrySnapshot();
+  for (const definition of registry.hustles) {
+    const defaults = structuredClone(definition.defaultState || {});
+    const existing = state.hustles[definition.id];
+    state.hustles[definition.id] = existing ? { ...defaults, ...existing } : defaults;
+  }
+  return state.hustles;
+}
+
+export function getSliceState(state, id) {
+  if (!state) return {};
+  const hustles = ensureSlice(state);
+  if (!id) {
+    return hustles;
+  }
+  if (!hustles[id]) {
+    const definition = getHustleDefinition(id);
+    hustles[id] = structuredClone(definition?.defaultState || {});
+  }
+  return hustles[id];
+}
+
+export default {
+  ensureSlice,
+  getSliceState
+};

--- a/src/core/state/slices/progress.js
+++ b/src/core/state/slices/progress.js
@@ -1,0 +1,21 @@
+export function ensureSlice(state) {
+  if (!state) return {};
+  state.progress = state.progress || {};
+  state.progress.knowledge = state.progress.knowledge || {};
+  return state.progress;
+}
+
+export function getSliceState(state, id) {
+  if (!state) return {};
+  const progress = ensureSlice(state);
+  if (!id) {
+    return progress;
+  }
+  progress[id] = progress[id] || {};
+  return progress[id];
+}
+
+export default {
+  ensureSlice,
+  getSliceState
+};

--- a/src/core/state/slices/upgrades.js
+++ b/src/core/state/slices/upgrades.js
@@ -1,0 +1,63 @@
+import { structuredClone } from '../../helpers.js';
+import { getRegistrySnapshot, getUpgradeDefinition } from '../registry.js';
+
+function normalizeAssistantState(upgradeState = {}) {
+  const normalized = upgradeState;
+  const storedCount = Number(normalized.count);
+  if (!Number.isFinite(storedCount)) {
+    normalized.count = normalized.purchased ? 1 : 0;
+  } else {
+    normalized.count = Math.max(0, storedCount);
+  }
+  if (normalized.purchased && normalized.count === 0) {
+    normalized.count = 1;
+  }
+  delete normalized.purchased;
+  return normalized;
+}
+
+export function ensureSlice(state) {
+  if (!state) return {};
+  state.upgrades = state.upgrades || {};
+  const registry = getRegistrySnapshot();
+  for (const definition of registry.upgrades) {
+    const defaults = structuredClone(definition.defaultState || {});
+    const existing = state.upgrades[definition.id];
+    if (existing) {
+      const merged = { ...defaults, ...existing };
+      Object.assign(existing, merged);
+      if (definition.id === 'assistant') {
+        normalizeAssistantState(existing);
+      }
+    } else {
+      const normalized = { ...defaults };
+      if (definition.id === 'assistant') {
+        normalizeAssistantState(normalized);
+      }
+      state.upgrades[definition.id] = normalized;
+    }
+  }
+  return state.upgrades;
+}
+
+export function getSliceState(state, id) {
+  if (!state) return {};
+  const upgrades = ensureSlice(state);
+  if (!id) {
+    return upgrades;
+  }
+  if (!upgrades[id]) {
+    const definition = getUpgradeDefinition(id);
+    const defaults = structuredClone(definition?.defaultState || {});
+    upgrades[id] = defaults;
+  }
+  if (id === 'assistant') {
+    normalizeAssistantState(upgrades[id]);
+  }
+  return upgrades[id];
+}
+
+export default {
+  ensureSlice,
+  getSliceState
+};

--- a/src/core/state/slices/upgrades.js
+++ b/src/core/state/slices/upgrades.js
@@ -24,10 +24,20 @@ export function ensureSlice(state) {
     const defaults = structuredClone(definition.defaultState || {});
     const existing = state.upgrades[definition.id];
     if (existing) {
-      const merged = { ...defaults, ...existing };
-      Object.assign(existing, merged);
-      if (definition.id === 'assistant') {
-        normalizeAssistantState(existing);
+      const merged = {
+        ...defaults,
+        ...(typeof existing === 'object' && existing !== null ? existing : {})
+      };
+      if (typeof existing === 'object' && existing !== null) {
+        Object.assign(existing, merged);
+        if (definition.id === 'assistant') {
+          normalizeAssistantState(existing);
+        }
+      } else {
+        state.upgrades[definition.id] = merged;
+        if (definition.id === 'assistant') {
+          normalizeAssistantState(state.upgrades[definition.id]);
+        }
       }
     } else {
       const normalized = { ...defaults };

--- a/tests/stateSlices.test.js
+++ b/tests/stateSlices.test.js
@@ -1,0 +1,132 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getGameTestHarness } from './helpers/gameTestHarness.js';
+import {
+  ensureSlice as ensureHustleSlice,
+  getSliceState as getHustleSliceState
+} from '../src/core/state/slices/hustles.js';
+import {
+  ensureSlice as ensureAssetSlice,
+  getSliceState as getAssetSliceState
+} from '../src/core/state/slices/assets.js';
+import {
+  ensureSlice as ensureUpgradeSlice,
+  getSliceState as getUpgradeSliceState
+} from '../src/core/state/slices/upgrades.js';
+import {
+  ensureSlice as ensureProgressSlice,
+  getSliceState as getProgressSliceState
+} from '../src/core/state/slices/progress.js';
+
+const harness = await getGameTestHarness();
+const { hustlesModule, assetsModule, upgradesModule } = harness;
+
+const { HUSTLES } = hustlesModule;
+const { ASSETS } = assetsModule;
+const { UPGRADES } = upgradesModule;
+
+const audienceCallDefinition = HUSTLES.find(hustle => hustle.id === 'audienceCall');
+const blogDefinition = ASSETS.find(asset => asset.id === 'blog');
+const assistantDefinition = UPGRADES.find(upgrade => upgrade.id === 'assistant');
+
+function createBaseState() {
+  return {
+    day: 5,
+    hustles: {},
+    assets: {},
+    upgrades: {},
+    progress: { knowledge: {} }
+  };
+}
+
+test('hustle slice hydrates defaults without clobbering overrides', () => {
+  const state = createBaseState();
+  state.hustles[audienceCallDefinition.id] = { runsToday: 2, note: 'keep me' };
+
+  const hustles = ensureHustleSlice(state);
+  assert.ok(hustles[audienceCallDefinition.id], 'definition entry should exist after ensure');
+  const hustleState = getHustleSliceState(state, audienceCallDefinition.id);
+  assert.equal(hustleState.runsToday, 2, 'existing counters should be preserved');
+  assert.equal(hustleState.note, 'keep me', 'custom fields should survive normalization');
+  assert.equal(
+    hustleState.lastRunDay,
+    audienceCallDefinition.defaultState.lastRunDay,
+    'default metadata should be merged in'
+  );
+
+  const newState = createBaseState();
+  const freshHustleState = getHustleSliceState(newState, audienceCallDefinition.id);
+  assert.deepEqual(
+    freshHustleState,
+    audienceCallDefinition.defaultState,
+    'new entries should clone default hustle state'
+  );
+});
+
+test('asset slice normalizes instances and respects active shortcut', () => {
+  const state = createBaseState();
+  state.assets.blog = {
+    active: true,
+    instances: [
+      {
+        status: 'setup',
+        daysRemaining: -3,
+        daysCompleted: -1,
+        lastIncome: 'nope',
+        createdOnDay: -10
+      }
+    ]
+  };
+
+  const assets = ensureAssetSlice(state);
+  const blogState = getAssetSliceState(state, 'blog');
+  assert.strictEqual(assets, state.assets, 'ensure should return the canonical map');
+  assert.equal(blogState.instances.length, 1, 'instances should remain present after normalization');
+  const instance = blogState.instances[0];
+  assert.equal(instance.status, 'setup');
+  assert.equal(instance.daysRemaining, 0, 'days remaining should clamp to zero');
+  assert.equal(instance.createdOnDay, 1, 'invalid creation days should clamp to day one');
+  assert.equal(blogState.active, undefined, 'legacy active flags should be removed');
+
+  const fallback = getAssetSliceState(state, 'unknownAsset');
+  assert.deepEqual(fallback, {}, 'unknown asset ids should resolve to empty objects');
+
+  const freshState = createBaseState();
+  const seeded = getAssetSliceState(freshState, blogDefinition.id);
+  assert.deepEqual(
+    seeded,
+    blogDefinition.defaultState,
+    'fresh asset slices should seed default state'
+  );
+});
+
+test('upgrade slice sanitizes assistant progress and merges defaults', () => {
+  const state = createBaseState();
+  state.upgrades.assistant = { purchased: true, count: 'not-a-number' };
+
+  const upgrades = ensureUpgradeSlice(state);
+  const assistantState = getUpgradeSliceState(state, 'assistant');
+  assert.strictEqual(upgrades, state.upgrades, 'ensure should preserve map references');
+  assert.equal(assistantState.count, 1, 'assistant count should default to one when purchased');
+  assert.equal(assistantState.purchased, undefined, 'legacy purchased flags should be cleared');
+
+  const freshState = createBaseState();
+  const seededAssistant = getUpgradeSliceState(freshState, assistantDefinition.id);
+  assert.deepEqual(
+    seededAssistant,
+    assistantDefinition.defaultState,
+    'fresh upgrade slices should clone default state'
+  );
+});
+
+test('progress slice guarantees knowledge tracking structures', () => {
+  const state = { progress: { knowledge: null } };
+  const progress = ensureProgressSlice(state);
+  assert.deepEqual(progress.knowledge, {}, 'knowledge map should always be an object');
+
+  const knowledge = getProgressSliceState(state, 'knowledge');
+  assert.strictEqual(knowledge, progress.knowledge, 'slice getter should return canonical buckets');
+
+  const entire = getProgressSliceState(state);
+  assert.strictEqual(entire, state.progress, 'omitting id should return the progress root');
+});


### PR DESCRIPTION
## Summary
- extract hustles, assets, upgrades, and progress normalization into dedicated slice helpers
- slim the state manager to orchestrate root state lifecycle while delegating slice initialization
- add slice-focused unit tests covering hustle, asset, upgrade, and progress normalization rules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc1cd39c34832ca39d234bba895140