### PR TITLE
Refine analytics dashboard cards and outlook

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Niche analytics refinement: daily outlook now breaks down player exposure, flags missed opportunities, and niche cards read like mini dashboards with 7-day earnings, trend swings, invested/uninvested grouping, and future hooks for sparklines and auto recommendations.
 - Tech refactor: Hustle helpers, definitions, and knowledge flows now live in dedicated modules so new gigs slot in without tou
   ching core loop logic.
 - Analytics makeover: Daily outlook hero highlights and a sortable niche card grid with watchlist filters surface earnings, asset exposure, and trend swings at a glance.

--- a/docs/features/niche-market-pulse.md
+++ b/docs/features/niche-market-pulse.md
@@ -13,12 +13,14 @@ The niche system links every passive asset to an audience segment with a daily p
 - **Popularity rolls** live on `state.niches.popularity`. At the end of every day (`endDay`) the game re-rolls a 25–95 score for each niche, storing yesterday’s value for delta messaging.
 - **Payout multiplier**: The current score maps to a 0.75×–1.3× multiplier. `rollDailyIncome` applies the multiplier before upgrade boosts and records the contribution in the income breakdown.
 - **Assignment**: Asset instances store `nicheId`. Players can pick a niche (or go unassigned) from the instance detail panel. Invalid IDs are scrubbed when state loads.
+- **Recent earnings**: Asset instances now maintain a seven-day `recentIncome` history alongside their lifetime totals. The analytics widget sums that window per niche so cards can report rolling earnings instead of single-day spikes.
 
 ## UI Notes
-- The Daily outlook card celebrates the biggest boost, fastest swing, and riskiest cooling segment with cheerful summary copy so players can triage focus quickly.
-- The Momentum board is now a responsive grid of niche cards that surface score, delta, payout impact, player asset counts, earnings, and trend gain/loss in a single glance.
-- Card actions jump straight to the Assets tab with matching builds spotlighted, toggle watchlist state, and hint at future "Queue recommended hustle" automation.
-- Sort controls (impact, assets invested, trend movement) and filters (invested only, watchlist only) keep large rosters scannable.
+- The Daily outlook hero highlights the biggest boost, fastest swing, riskiest cooling segment, **and** the loudest missed opportunity. Each row now calls out player exposure (asset count, seven-day earnings, and baseline comparisons) so the context is personal, not just global trend data.
+- The Momentum board frames each niche card as a mini performance dashboard: the top banner spotlights the trend swing versus baseline, the middle row pairs payout multiplier with the normalized score and a future sparkline hook, and the player panel reports assets, trailing seven-day earnings, yesterday’s haul, and lifetime totals.
+- Board sections collapse into "Invested" and "Not invested" buckets to keep late-game scans tidy. The default view favors invested niches, with a quick toggle for showing unassigned opportunities and a new sort for the "Largest missed opportunity" slice.
+- Card actions jump straight to the Assets tab with matching builds spotlighted, offer a "Find assets" shortcut for empty niches, and continue to toggle watchlist state. A recommendation preview footer seeds the future auto-suggestion system.
+- Sort controls (impact, assets invested, trend movement, largest missed opportunity) and filters (invested only, watchlist only) keep large rosters scannable.
 - Dashboard stays focused on immediate actions while the Analytics tab houses longer-term trend storytelling for niches.
 - Asset detail cards display the active niche (or a prompt to assign one) and provide a dropdown that previews the current multiplier for each option.
 - Log messages celebrate switching into or out of a niche so the event feed reflects strategy changes.

--- a/index.html
+++ b/index.html
@@ -248,6 +248,13 @@
                   <p id="analytics-highlight-risk-note" class="analytics-highlight__note">We’ll flag niches that are cooling off fast.</p>
                 </dd>
               </div>
+              <div class="analytics-highlight">
+                <dt>Missed opportunity</dt>
+                <dd>
+                  <span id="analytics-highlight-miss" class="analytics-highlight__value">Nothing slipping yet</span>
+                  <p id="analytics-highlight-miss-note" class="analytics-highlight__note">We’ll shout when a hot niche lacks your assets.</p>
+                </dd>
+              </div>
             </dl>
           </article>
 
@@ -262,11 +269,12 @@
                 <button type="button" class="ghost niche-controls__button is-active" data-niche-sort="impact" aria-pressed="true">Highest payout impact</button>
                 <button type="button" class="ghost niche-controls__button" data-niche-sort="assets" aria-pressed="false">Most assets invested</button>
                 <button type="button" class="ghost niche-controls__button" data-niche-sort="movement" aria-pressed="false">Fastest trend movement</button>
+                <button type="button" class="ghost niche-controls__button" data-niche-sort="missed" aria-pressed="false">Largest missed opportunity</button>
               </div>
               <div class="niche-controls__filters" role="group" aria-label="Niche filters">
                 <label class="niche-controls__toggle">
                   <input type="checkbox" id="niche-filter-invested" />
-                  <span>Invested niches only</span>
+                  <span>Show only invested niches</span>
                 </label>
                 <label class="niche-controls__toggle">
                   <input type="checkbox" id="niche-filter-watchlist" />

--- a/src/core/state/assets.js
+++ b/src/core/state/assets.js
@@ -84,6 +84,19 @@ export function normalizeAssetInstance(definition, instance = {}, context = {}) 
   const totalIncome = Number(normalized.totalIncome);
   normalized.totalIncome = Number.isFinite(totalIncome) ? totalIncome : 0;
 
+  const recentIncome = Array.isArray(normalized.recentIncome)
+    ? normalized.recentIncome
+        .map(value => {
+          const amount = Number(value);
+          return Number.isFinite(amount) ? Math.max(0, Math.round(amount * 100) / 100) : null;
+        })
+        .filter(value => value !== null)
+    : [];
+  while (recentIncome.length > 7) {
+    recentIncome.shift();
+  }
+  normalized.recentIncome = recentIncome;
+
   const createdOnDay = Number(normalized.createdOnDay);
   normalized.createdOnDay = Number.isFinite(createdOnDay)
     ? Math.max(1, createdOnDay)
@@ -124,6 +137,7 @@ export function createAssetInstance(definition, overrides = {}, context = {}) {
     lastIncomeBreakdown: null,
     pendingIncome: 0,
     totalIncome: 0,
+    recentIncome: [],
     createdOnDay: resolveCurrentDay(context),
     quality: {
       level: 0,

--- a/src/ui/elements/registry.js
+++ b/src/ui/elements/registry.js
@@ -120,6 +120,8 @@ class ElementRegistry {
       highlightSwingNote: root.getElementById('analytics-highlight-swing-note'),
       highlightRisk: root.getElementById('analytics-highlight-risk'),
       highlightRiskNote: root.getElementById('analytics-highlight-risk-note'),
+      highlightMiss: root.getElementById('analytics-highlight-miss'),
+      highlightMissNote: root.getElementById('analytics-highlight-miss-note'),
       board: root.getElementById('niche-board'),
       sortButtons: Array.from(root.querySelectorAll('[data-niche-sort]')),
       filterInvested: root.getElementById('niche-filter-invested'),

--- a/styles.css
+++ b/styles.css
@@ -358,6 +358,11 @@ body {
   color: var(--text-subtle);
 }
 
+.niche-controls__toggle.is-disabled {
+  opacity: 0.55;
+  pointer-events: none;
+}
+
 .niche-controls__toggle input {
   width: 18px;
   height: 18px;
@@ -366,8 +371,7 @@ body {
 
 .niche-board {
   display: grid;
-  gap: 18px;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
 }
 
 .niche-board__empty {
@@ -380,15 +384,54 @@ body {
   background: rgba(15, 23, 42, 0.45);
 }
 
-.niche-card {
+.niche-board__group {
+  display: grid;
+  gap: 16px;
+  padding: 16px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.32);
+}
+
+.niche-board__group-header {
   display: flex;
-  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.niche-board__group-header h4 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.niche-board__group-toggle {
+  font-size: 13px;
+  padding: 4px 12px;
+  border-radius: 999px;
+}
+
+.niche-board__group-body {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.niche-board__group-body[hidden] {
+  display: none;
+}
+
+.niche-card {
+  display: grid;
   gap: 16px;
   padding: 20px;
   border-radius: var(--radius-lg);
   border: 1px solid rgba(148, 163, 184, 0.28);
   background: var(--surface-muted);
   transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  min-height: 100%;
 }
 
 .niche-card[data-tone='hot'] {
@@ -430,15 +473,25 @@ body {
 }
 
 .niche-card__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 16px;
+  display: grid;
+  gap: 12px;
 }
 
-.niche-card__title {
-  display: grid;
-  gap: 6px;
+.niche-card__title-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.niche-card__status-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  background: rgba(148, 163, 255, 0.2);
+  font-size: 16px;
 }
 
 .niche-card__name {
@@ -455,7 +508,6 @@ body {
   border-radius: 999px;
   background: rgba(148, 163, 255, 0.18);
   color: rgba(203, 213, 255, 0.85);
-  justify-self: start;
 }
 
 .niche-card[data-tone='hot'] .niche-card__status {
@@ -473,35 +525,94 @@ body {
   color: #38bdf8;
 }
 
-.niche-card__score {
-  font-size: 24px;
-  font-weight: 700;
+.niche-card__impact {
   margin: 0;
-  color: var(--text);
-}
-
-.niche-card__meter {
-  position: relative;
-  width: 100%;
-  height: 6px;
-  border-radius: 999px;
+  padding: 10px 14px;
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  font-size: 15px;
   background: rgba(148, 163, 184, 0.18);
-  overflow: hidden;
+  color: rgba(203, 213, 255, 0.85);
 }
 
-.niche-card__meter-fill {
-  position: absolute;
-  inset: 0;
-  width: var(--fill, 0%);
-  background: linear-gradient(90deg, rgba(124, 92, 255, 0.25), rgba(59, 130, 246, 0.6));
+.niche-card__impact--positive {
+  background: rgba(34, 197, 94, 0.22);
+  color: #4ade80;
 }
 
-.niche-card__section {
+.niche-card__impact--negative {
+  background: rgba(248, 113, 113, 0.22);
+  color: #fca5a5;
+}
+
+.niche-card__impact--missed {
+  background: rgba(250, 204, 21, 0.22);
+  color: #facc15;
+}
+
+.niche-card__impact--neutral {
+  background: rgba(148, 163, 184, 0.16);
+  color: rgba(203, 213, 255, 0.75);
+}
+
+.niche-card__overview {
   display: grid;
-  gap: 8px;
+  gap: 18px;
 }
 
-.niche-card__section h5 {
+@media (min-width: 640px) {
+  .niche-card__overview {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.niche-card__global,
+.niche-card__player {
+  display: grid;
+  gap: 10px;
+}
+
+.niche-card__global {
+  align-content: start;
+}
+
+.niche-card__metrics {
+  margin: 0;
+  display: grid;
+  gap: 6px;
+  font-size: 14px;
+}
+
+.niche-card__metrics dt {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-subtle);
+}
+
+.niche-card__metrics dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.niche-card__sparkline {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  border-radius: var(--radius-md);
+  background: rgba(148, 163, 184, 0.08);
+  color: rgba(203, 213, 255, 0.55);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.niche-card__sparkline-placeholder {
+  opacity: 0.75;
+}
+
+.niche-card__player h5 {
   margin: 0;
   font-size: 13px;
   text-transform: uppercase;
@@ -509,34 +620,25 @@ body {
   color: var(--text-subtle);
 }
 
-.niche-card__stat {
+.niche-card__player-metrics {
   margin: 0;
-  font-size: 16px;
+  display: grid;
+  gap: 6px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  font-size: 13px;
+}
+
+.niche-card__player-metrics dt {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(203, 213, 255, 0.7);
+}
+
+.niche-card__player-metrics dd {
+  margin: 0;
   font-weight: 600;
-}
-
-.niche-card__metric {
-  margin: 0;
-  font-size: 15px;
-  font-weight: 500;
-}
-
-.niche-card__trend {
-  margin: 0;
   font-size: 14px;
-  font-weight: 600;
-}
-
-.niche-card__trend--positive {
-  color: #34d399;
-}
-
-.niche-card__trend--negative {
-  color: #f87171;
-}
-
-.niche-card__trend--neutral {
-  color: var(--text-subtle);
 }
 
 .niche-card__note {
@@ -549,7 +651,6 @@ body {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
-  margin-top: auto;
 }
 
 .niche-card__action {
@@ -557,9 +658,23 @@ body {
   justify-content: center;
 }
 
-.niche-card__action[disabled] {
-  opacity: 0.55;
-  cursor: not-allowed;
+.niche-card__recommendation {
+  border-top: 1px solid rgba(148, 163, 184, 0.18);
+  padding-top: 12px;
+}
+
+.niche-card__recommendation h6 {
+  margin: 0 0 4px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-subtle);
+}
+
+.niche-card__recommendation p {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(203, 213, 255, 0.72);
 }
 
 .player-overview {


### PR DESCRIPTION
## Summary
- track seven-day income windows per asset and surface the totals on niche analytics cards
- redesign the analytics momentum board with trend impact highlights, invested/uninvested grouping, and a missed-opportunity sort
- enrich the daily outlook hero, controls, styles, and documentation to emphasize player exposure and upcoming recommendations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc31f90eac832c90e6cad5a8fe73c5