### PR TITLE
Redesign assets tab into venture hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Online Hustle Simulator is a browser-based incremental game about orchestrating 
 
 ### Interface Overview
 - **Top Bar & Snapshot** – Money, time, and day stay pinned at the top. A collapsible Daily Snapshot panel now highlights per-stat breakdowns (time invested, money earned, passive streams, cash spent, study momentum) without overwhelming the main view. Passive earnings even call out which assets (and how many instances) delivered today’s cash, so you can immediately see what worked.
-- **Tabbed Workspace** – Hustles, Education, Passive Assets, and Upgrades each live in their own tab with dedicated copy and per-tab filters. Global toggles hide locked or completed cards, and you can spotlight only actionable options.
+- **Tabbed Workspace** – Hustles, Education, Passive Ventures, and Upgrades each live in their own tab with dedicated copy and per-tab filters. Global toggles hide locked or completed cards, and you can spotlight only actionable options.
 - **Categorised Collections** – Passive assets surface in Foundation, Creative, Commerce, and Advanced groupings with a collapsed-card option for rapid scanning. Each grouping now sports a "View launched assets" toggle that opens a management roster listing upkeep, yesterday’s payout, and upgrade/sell controls for every instance. Upgrades now live inside Tech, House, Infra, and Support tabs, each with friendly family sub-sections (phones, workflow suites, automation chains, daily boosts) so progression lanes read clearly at a glance.
 - **Event Log Controls** – The log dock keeps its running commentary but now includes a summary/detailed toggle when you want a lighter feed during long sessions.
 
@@ -37,7 +37,7 @@ Online Hustle Simulator is a browser-based incremental game about orchestrating 
 - **Gallery Licensing Summit** – Pay $240 upfront; 2.25h/day for 5 days to pitch curators (+30% Event Photo Gig bookings and +22% Stock Photo Gallery passive income).
 - **Syndication Residency** – Pay $300 upfront; 2h/day for 6 days cultivating partnerships (+20% Freelance Writing payouts, +$2 Street Promo Sprint stipends, and +18% Personal Blog Network income).
 
-### Passive Assets (Daily Payouts)
+### Passive Ventures (Daily Payouts)
 Each asset supports multiple instances, tracks setup progress, and rolls a daily income range once active. Quality actions unique to each asset increase payouts and stability, and you can liquidate any instance directly from the card—or from the category roster—for yesterday’s payout ×3 × (Quality level + 1). The asset briefing modal doubles as an instance inspector, outlining status, upkeep, yesterday’s earnings, and which upgrades are owned or still locked.
 - Select quality actions now include a visible cooldown so big-impact moves (SEO sprints, ad bursts, and marketplace pitches) can only be run every few in-game days, nudging players to rotate through their portfolio.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -38,6 +38,7 @@
 - Quality system refresh: daily-use counters replace cooldown timers on passive actions, with UI, saves, and docs updated to celebrate remaining uses each day.
 - Niche market pulse: assign each passive asset to a daily-trending niche, gain payout multipliers from hot audiences, and track every niche’s popularity from the dashboard widget.
 - Asset command center: the assets page now opens with a launch hub and refreshed build cards that bundle niche assignment, payout breakdowns, quality progress, and quick category blueprints in one glance.
+- Venture hub celebration: the renamed Ventures tab sports a slim summary strip, gallery-style category sections, showcase venture cards with trend badges, and a festive launcher drawer for new builds.
 
 ## Recent Highlights
 - Passive assets gained Quality 4–5 milestones with higher payouts and refreshed modifiers.

--- a/docs/features/venture-hub-redesign.md
+++ b/docs/features/venture-hub-redesign.md
@@ -1,0 +1,19 @@
+# Venture Hub Redesign
+
+## Goals
+- Reframe the assets tab as the Venture Hub so players see it as their primary home base.
+- Celebrate owned ventures with showcase-style cards, clear category theming, and trend badges.
+- Reduce the visual weight of stat counters while keeping a quick-glance summary bar available.
+- Make launching a new venture feel like a celebratory action instead of a utilitarian form.
+
+## Player Impact
+- Players now land on a hero summary strip that quietly surfaces total ventures, active runs, incubation count, and upkeep at a glance.
+- Venture categories (Foundation, Creative, Commerce, Tech) gain iconography and warmer copy, turning each group into its own mini world.
+- Each venture card highlights niche momentum, quality progress, payout breakdowns, and key metrics without overwhelming text.
+- The floating launch tray turns discovering and starting new ventures into a rewarded moment with richer feedback when a build fires.
+
+## Implementation Notes
+- Rebranded player-facing copy from “Assets” to “Ventures” across the UI, dashboard callouts, and documentation.
+- Introduced new CSS for venture summaries, category dividers, and card layouts that emphasize whitespace and consistent spacing.
+- Added trend-aware niche badges, a padded metrics block, and modal-driven detail buttons to keep cards compact.
+- Launch feedback and slide-over details reuse existing state helpers, so no gameplay balance was altered.

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
       <button id="tab-analytics" class="shell__tab" role="tab" aria-selected="false" aria-controls="panel-analytics">Analytics</button>
       <button id="tab-player" class="shell__tab" role="tab" aria-selected="false" aria-controls="panel-player">Player</button>
       <button id="tab-hustles" class="shell__tab" role="tab" aria-selected="false" aria-controls="panel-hustles">Hustles</button>
-      <button id="tab-assets" class="shell__tab" role="tab" aria-selected="false" aria-controls="panel-assets">Assets</button>
+      <button id="tab-ventures" class="shell__tab" role="tab" aria-selected="false" aria-controls="panel-ventures">Ventures</button>
       <button id="tab-upgrades" class="shell__tab" role="tab" aria-selected="false" aria-controls="panel-upgrades">Upgrades</button>
       <button id="tab-education" class="shell__tab" role="tab" aria-selected="false" aria-controls="panel-education">Education</button>
     </nav>
@@ -88,10 +88,10 @@
               <span class="kpi__value" id="kpi-upkeep-value">$0</span>
               <span class="kpi__sub" id="kpi-upkeep-note">Next 24h</span>
             </button>
-            <button class="kpi" id="kpi-assets" type="button" data-detail="assets">
-              <span class="kpi__label">Active assets</span>
-              <span class="kpi__value" id="kpi-assets-value">0</span>
-              <span class="kpi__sub" id="kpi-assets-note">Making money</span>
+            <button class="kpi" id="kpi-ventures" type="button" data-detail="ventures">
+              <span class="kpi__label">Active ventures</span>
+              <span class="kpi__value" id="kpi-ventures-value">0</span>
+              <span class="kpi__sub" id="kpi-ventures-note">Making money</span>
             </button>
             <button class="kpi" id="kpi-study" type="button" data-detail="study">
               <span class="kpi__label">Study progress</span>
@@ -390,28 +390,28 @@
         <div id="hustle-list" class="list" data-view="cards" aria-live="polite"></div>
       </section>
 
-      <section id="panel-assets" class="panel" role="tabpanel" aria-labelledby="tab-assets" hidden>
-        <header class="panel__header">
-          <div>
-            <h2>Assets</h2>
-            <p>Passive plays that need smart upkeep.</p>
+      <section id="panel-ventures" class="panel" role="tabpanel" aria-labelledby="tab-ventures" hidden>
+        <header class="panel__header venture-panel__header">
+          <div class="venture-panel__intro">
+            <h2>Ventures</h2>
+            <p>Your empire’s living showcase — bask in every build you’ve launched.</p>
           </div>
-          <div class="filter-bar" role="group" aria-label="Asset filters">
+          <div class="filter-bar venture-panel__filters" role="group" aria-label="Venture filters">
             <label class="filter-toggle">
-              <input id="asset-active-toggle" type="checkbox" />
+              <input id="venture-active-toggle" type="checkbox" />
               <span>Active only</span>
             </label>
             <label class="filter-toggle">
-              <input id="asset-maintenance-toggle" type="checkbox" />
-              <span>Needs maintenance</span>
+              <input id="venture-maintenance-toggle" type="checkbox" />
+              <span>Needs upkeep</span>
             </label>
             <label class="filter-toggle">
-              <input id="asset-risk-toggle" type="checkbox" />
+              <input id="venture-risk-toggle" type="checkbox" />
               <span>Hide high risk</span>
             </label>
           </div>
         </header>
-        <div class="asset-gallery" id="asset-gallery" aria-live="polite"></div>
+        <div class="asset-gallery venture-gallery" id="venture-gallery" aria-live="polite"></div>
       </section>
 
       <section id="panel-upgrades" class="panel" role="tabpanel" aria-labelledby="tab-upgrades" hidden>

--- a/src/ui/cards.js
+++ b/src/ui/cards.js
@@ -180,10 +180,17 @@ const UPGRADE_FAMILY_COPY = {
 };
 
 const ASSET_GROUP_NOTES = {
-  Foundation: 'Reliable launchpads that get your empire compounding.',
-  Creative: 'Audience magnets that thrive on storytelling and flair.',
-  Commerce: 'Automation loops that keep the checkout bell ringing.',
-  Tech: 'Systems and platforms with bigger upkeep but massive reach.'
+  Foundation: 'Steady launchpads that bankroll the rest of your ventureverse.',
+  Creative: 'Audience magnets that shimmer with story, art, and charisma.',
+  Commerce: 'Commerce engines that keep carts chiming and partners smiling.',
+  Tech: 'High-powered systems with upkeep, but outrageous reach when fueled.'
+};
+
+const ASSET_GROUP_ICONS = {
+  Foundation: '🏗️',
+  Creative: '🎨',
+  Commerce: '🛍️',
+  Tech: '🚀'
 };
 
 function showSlideOver({ eyebrow, title, body }) {
@@ -1426,6 +1433,7 @@ function buildAssetGroups(definitions = [], state = getState()) {
         id: groupId,
         label,
         note: getAssetGroupNote(label),
+        icon: ASSET_GROUP_ICONS[label] || '✨',
         definitions: [],
         instances: []
       });
@@ -1478,7 +1486,7 @@ function describeAssetLaunchAvailability(definition, state = getState()) {
 }
 
 function buildLaunchFeedbackMessage(definition) {
-  const singular = definition.singular || definition.name || 'Asset';
+  const singular = definition.singular || definition.name || 'Venture';
   return `New ${singular.toLowerCase()} is being set up.`;
 }
 
@@ -1486,31 +1494,31 @@ function buildAssetLaunchTile(definition, state = getState()) {
   if (!definition?.action?.onClick) return null;
 
   const tile = document.createElement('article');
-  tile.className = 'asset-launcher__tile';
+  tile.className = 'venture-launcher__tile';
 
   const heading = document.createElement('div');
-  heading.className = 'asset-launcher__heading';
+  heading.className = 'venture-launcher__heading';
   const title = document.createElement('h4');
-  title.className = 'asset-launcher__title';
-  title.textContent = definition.name || definition.id || 'Asset';
+  title.className = 'venture-launcher__title';
+  title.textContent = definition.name || definition.id || 'Venture';
   heading.appendChild(title);
 
   const tag = document.createElement('span');
-  tag.className = 'asset-launcher__type';
-  tag.textContent = definition.singular || 'Passive asset';
+  tag.className = 'venture-launcher__type';
+  tag.textContent = definition.singular || 'Passive venture';
   heading.appendChild(tag);
   tile.appendChild(heading);
 
   const summaryCopy = describeAssetCardSummary(definition);
   if (summaryCopy) {
     const summary = document.createElement('p');
-    summary.className = 'asset-launcher__summary';
+    summary.className = 'venture-launcher__summary';
     summary.textContent = summaryCopy;
     tile.appendChild(summary);
   }
 
   const stats = document.createElement('p');
-  stats.className = 'asset-launcher__meta';
+  stats.className = 'venture-launcher__meta';
   const parts = [];
   const setupDays = Number(definition.setup?.days) || 0;
   const setupHours = Number(definition.setup?.hoursPerDay) || 0;
@@ -1535,10 +1543,10 @@ function buildAssetLaunchTile(definition, state = getState()) {
 
   const button = document.createElement('button');
   button.type = 'button';
-  button.className = 'asset-launcher__button';
+  button.className = 'venture-launcher__button';
   button.textContent = typeof definition.action.label === 'function'
     ? definition.action.label(state)
-    : definition.action.label || `Launch ${definition.singular || definition.name}`;
+    : definition.action.label || `Launch ${definition.singular || definition.name || 'venture'}`;
   button.disabled = availability.disabled;
   if (availability.reasons.length) {
     button.title = availability.reasons.join(' • ');
@@ -1553,7 +1561,7 @@ function buildAssetLaunchTile(definition, state = getState()) {
   }
 
   const feedback = document.createElement('p');
-  feedback.className = 'asset-launcher__feedback';
+  feedback.className = 'venture-launcher__feedback';
   feedback.hidden = true;
   tile.appendChild(feedback);
 
@@ -1569,10 +1577,10 @@ function buildAssetLaunchTile(definition, state = getState()) {
       if (afterCount > beforeCount) {
         feedback.textContent = buildLaunchFeedbackMessage(definition);
         feedback.hidden = false;
-        tile.classList.add('asset-launcher__tile--success');
+        tile.classList.add('venture-launcher__tile--success');
         setTimeout(() => {
           feedback.hidden = true;
-          tile.classList.remove('asset-launcher__tile--success');
+          tile.classList.remove('venture-launcher__tile--success');
         }, 2400);
         renderAssets(currentAssetDefinitions);
         applyCardFilters();
@@ -1594,14 +1602,14 @@ function buildAssetLaunchPanel(definitions = [], state = getState()) {
   }
 
   const container = document.createElement('section');
-  container.className = 'asset-launcher';
+  container.className = 'venture-launcher';
 
   const trigger = document.createElement('button');
   trigger.type = 'button';
-  trigger.className = 'asset-launcher__trigger primary';
-  trigger.textContent = assetLaunchPanelExpanded ? 'Hide launch options' : 'Launch a new asset';
+  trigger.className = 'venture-launcher__trigger primary';
+  trigger.textContent = assetLaunchPanelExpanded ? 'Hide launch options' : 'Launch a new venture';
   trigger.setAttribute('aria-expanded', assetLaunchPanelExpanded ? 'true' : 'false');
-  const contentId = 'asset-launcher-options';
+  const contentId = 'venture-launcher-options';
   trigger.setAttribute('aria-controls', contentId);
   if (assetLaunchPanelExpanded) {
     trigger.classList.add('is-open');
@@ -1609,24 +1617,24 @@ function buildAssetLaunchPanel(definitions = [], state = getState()) {
   container.appendChild(trigger);
 
   const content = document.createElement('div');
-  content.className = 'asset-launcher__content';
+  content.className = 'venture-launcher__content';
   content.id = contentId;
   content.hidden = !assetLaunchPanelExpanded;
 
   const header = document.createElement('div');
-  header.className = 'asset-launcher__header';
+  header.className = 'venture-launcher__header';
   const title = document.createElement('h3');
-  title.className = 'asset-launcher__heading-title';
-  title.textContent = 'Launch a new asset';
+  title.className = 'venture-launcher__heading-title';
+  title.textContent = 'Launch a new venture';
   header.appendChild(title);
   const note = document.createElement('p');
-  note.className = 'asset-launcher__note';
-  note.textContent = 'Pick a build to spin up a fresh income stream.';
+  note.className = 'venture-launcher__note';
+  note.textContent = 'Pick a build to celebrate a brand-new income stream.';
   header.appendChild(note);
   content.appendChild(header);
 
   const grid = document.createElement('div');
-  grid.className = 'asset-launcher__grid';
+  grid.className = 'venture-launcher__grid';
   tiles.forEach(tile => grid.appendChild(tile));
   content.appendChild(grid);
   container.appendChild(content);
@@ -1636,7 +1644,7 @@ function buildAssetLaunchPanel(definitions = [], state = getState()) {
     assetLaunchPanelExpanded = !assetLaunchPanelExpanded;
     content.hidden = !assetLaunchPanelExpanded;
     trigger.setAttribute('aria-expanded', assetLaunchPanelExpanded ? 'true' : 'false');
-    trigger.textContent = assetLaunchPanelExpanded ? 'Hide launch options' : 'Launch a new asset';
+    trigger.textContent = assetLaunchPanelExpanded ? 'Hide launch options' : 'Launch a new venture';
     trigger.classList.toggle('is-open', assetLaunchPanelExpanded);
   });
   return container;
@@ -1673,32 +1681,32 @@ function buildAssetSummary(groups = []) {
 
   if (totals.total === 0) {
     const empty = document.createElement('section');
-    empty.className = 'asset-hub__summary asset-hub__summary--empty';
+    empty.className = 'venture-summary venture-summary--empty';
     const message = document.createElement('p');
-    message.className = 'asset-hub__empty';
-    message.textContent = 'No launched assets yet. Kick off a build to start the passive flow!';
+    message.className = 'venture-summary__empty';
+    message.textContent = 'No ventures launched yet. Spin up your first build to start the passive flow!';
     empty.appendChild(message);
     return empty;
   }
 
   const summary = document.createElement('section');
-  summary.className = 'asset-hub__summary';
+  summary.className = 'venture-summary';
 
   const stats = [
-    { label: 'Total builds', value: totals.total },
-    { label: 'Active & earning', value: totals.active },
-    { label: 'In setup', value: totals.setup },
+    { label: 'Ventures launched', value: totals.total },
+    { label: 'Active & thriving', value: totals.active },
+    { label: 'In incubation', value: totals.setup },
     { label: 'Daily upkeep', value: formatUpkeepTotals(totals.upkeepCost, totals.upkeepHours) }
   ];
 
   stats.forEach(entry => {
     const stat = document.createElement('div');
-    stat.className = 'asset-hub__stat';
+    stat.className = 'venture-summary__stat';
     const value = document.createElement('span');
-    value.className = 'asset-hub__stat-value';
+    value.className = 'venture-summary__value';
     value.textContent = entry.value;
     const label = document.createElement('span');
-    label.className = 'asset-hub__stat-label';
+    label.className = 'venture-summary__label';
     label.textContent = entry.label;
     stat.append(value, label);
     summary.appendChild(stat);
@@ -1713,7 +1721,7 @@ function buildAssetHub(definitions, groups, state) {
   if (!summary && !launchPanel) return null;
 
   const container = document.createElement('div');
-  container.className = 'asset-hub';
+  container.className = 'venture-hub';
   if (summary) container.appendChild(summary);
   if (launchPanel) container.appendChild(launchPanel);
   return container;
@@ -1744,6 +1752,16 @@ function buildMetricsRow(definition, instance, state, riskLabel) {
     metrics.appendChild(createMetric('Net / hour', netLabel));
   }
 
+  const nicheInfo = getInstanceNicheInfo(instance, state);
+  const trend = nicheInfo?.popularity;
+  if (trend) {
+    const impact = Number(trend.multiplier);
+    const impactLabel = Number.isFinite(impact) ? formatPercent(impact - 1) : null;
+    const descriptor = trend.label || (impact > 1 ? 'Hot streak' : impact < 1 ? 'Cooling' : 'Steady');
+    const value = impactLabel ? `${descriptor} • ${impactLabel}` : descriptor;
+    metrics.appendChild(createMetric('Trend', value));
+  }
+
   return metrics;
 }
 
@@ -1758,14 +1776,17 @@ function buildNicheField(definition, instance, state) {
 
   const info = getInstanceNicheInfo(instance, state);
   if (info) {
-    const value = document.createElement('span');
-    value.className = 'asset-overview-card__value';
-    value.textContent = info.definition?.name || 'Assigned';
-    field.appendChild(value);
-
+    field.dataset.locked = 'true';
+    const badge = document.createElement('span');
+    badge.className = 'asset-overview-card__badge';
+    badge.textContent = info.definition?.name || 'Assigned';
     const impact = Number(info.popularity?.multiplier);
     const percent = Number.isFinite(impact) ? formatPercent(impact - 1) : null;
     const summary = info.popularity?.summary || 'Demand shifts update daily.';
+    if (Number.isFinite(impact)) {
+      badge.dataset.trend = impact > 1 ? 'up' : impact < 1 ? 'down' : 'steady';
+    }
+    field.appendChild(badge);
     const note = document.createElement('span');
     note.className = 'asset-overview-card__note';
     note.textContent = percent ? `${summary} • Impact ${percent}` : summary;
@@ -1802,7 +1823,7 @@ function buildNicheField(definition, instance, state) {
   field.appendChild(select);
   const hint = document.createElement('span');
   hint.className = 'asset-overview-card__note';
-  hint.textContent = 'Lock in a niche to tap into daily popularity rolls.';
+  hint.textContent = 'Lock in a niche to let this venture ride daily popularity rolls.';
   field.appendChild(hint);
   return field;
 }
@@ -1928,7 +1949,7 @@ function buildPayoutBlock(definition, instance) {
   container.appendChild(breakdown);
 
   if (instance.status !== 'active') {
-    summary.textContent = 'Launch the asset to start logging payouts.';
+    summary.textContent = 'Launch the venture to start logging payouts.';
     const note = document.createElement('p');
     note.className = 'asset-overview-card__payout-note';
     note.textContent = 'No payout breakdown until the build goes live.';
@@ -1984,13 +2005,13 @@ function createAssetInstanceCard(definition, instance, index, state = getState()
   const status = document.createElement('span');
   status.className = 'asset-overview-card__status';
   if (instance.status === 'active') {
-    status.textContent = needsMaintenance ? 'Active • Upkeep due' : 'Active';
+    status.textContent = needsMaintenance ? 'Earning • upkeep due' : 'Earning';
   } else {
     const remaining = Number(instance.daysRemaining);
     if (Number.isFinite(remaining) && remaining > 0) {
-      status.textContent = `Setup • ${remaining} day${remaining === 1 ? '' : 's'} left`;
+      status.textContent = `Incubating • ${remaining} day${remaining === 1 ? '' : 's'} left`;
     } else {
-      status.textContent = 'Setup';
+      status.textContent = 'Incubating';
     }
   }
   heading.appendChild(status);
@@ -2075,7 +2096,7 @@ function renderAssets(definitions = []) {
   if (!groups.length) {
     const empty = document.createElement('p');
     empty.className = 'asset-gallery__empty';
-    empty.textContent = 'No passive assets discovered yet. Story beats will unlock them soon.';
+    empty.textContent = 'No passive ventures discovered yet. Story beats will unlock them soon.';
     gallery.appendChild(empty);
     return;
   }
@@ -2094,9 +2115,15 @@ function renderAssets(definitions = []) {
 
     const heading = document.createElement('div');
     heading.className = 'asset-portfolio__heading';
+    if (group.icon) {
+      const emblem = document.createElement('span');
+      emblem.className = 'asset-portfolio__icon';
+      emblem.textContent = group.icon;
+      heading.appendChild(emblem);
+    }
     const title = document.createElement('h3');
     title.className = 'asset-portfolio__title';
-    title.textContent = `${group.label} assets`;
+    title.textContent = `${group.label} ventures`;
     heading.appendChild(title);
     if (group.note) {
       const note = document.createElement('p');
@@ -2121,8 +2148,8 @@ function renderAssets(definitions = []) {
     const count = document.createElement('span');
     count.className = 'asset-portfolio__count';
     count.textContent = group.instances.length
-      ? `${group.instances.length} build${group.instances.length === 1 ? '' : 's'}`
-      : 'No builds yet';
+      ? `${group.instances.length} venture${group.instances.length === 1 ? '' : 's'}`
+      : 'No ventures yet';
     toolbar.appendChild(count);
 
     header.appendChild(toolbar);
@@ -2154,7 +2181,7 @@ function renderAssets(definitions = []) {
     if (!grid.childElementCount) {
       const emptyGroup = document.createElement('p');
       emptyGroup.className = 'asset-portfolio__empty';
-      emptyGroup.textContent = 'No launched assets in this category yet.';
+      emptyGroup.textContent = 'No launched ventures in this category yet.';
       grid.appendChild(emptyGroup);
     }
 
@@ -2167,7 +2194,7 @@ function renderAssets(definitions = []) {
   if (totalInstances === 0) {
     const empty = document.createElement('p');
     empty.className = 'asset-gallery__empty';
-    empty.textContent = 'Launch an asset to see it here. Each build gets its own action card once active.';
+    empty.textContent = 'Launch a venture to see it here. Each build gets its own showcase card once active.';
     gallery.appendChild(empty);
   }
 
@@ -2220,7 +2247,7 @@ function openAssetGroupDetails(group) {
 
     const title = document.createElement('h3');
     title.className = 'asset-category-detail__title';
-    title.textContent = definition.name || definition.id || 'Asset';
+    title.textContent = definition.name || definition.id || 'Venture';
     header.appendChild(title);
 
     const summaryCopy = describeAssetCardSummary(definition);
@@ -2243,8 +2270,8 @@ function openAssetGroupDetails(group) {
   });
 
   showSlideOver({
-    eyebrow: 'Asset category',
-    title: `${group.label} assets`,
+    eyebrow: 'Venture category',
+    title: `${group.label} ventures`,
     body: container
   });
 }

--- a/src/ui/dashboard.js
+++ b/src/ui/dashboard.js
@@ -302,7 +302,7 @@ function buildNotifications(state) {
         label: `${asset.name} needs upkeep`,
         message: `${maintenanceDue.length} build${maintenanceDue.length === 1 ? '' : 's'} waiting for maintenance`,
         action: () => {
-          shellTabs.find(tab => tab.id === 'tab-assets')?.click();
+          shellTabs.find(tab => tab.id === 'tab-ventures')?.click();
         }
       });
     }
@@ -368,7 +368,7 @@ function renderQuickActions(state) {
   }));
 
   renderActionSection(container, entries, {
-    emptyMessage: 'No ready actions. Check upgrades or assets.',
+    emptyMessage: 'No ready actions. Check upgrades or ventures.',
     buttonClass: 'primary',
     defaultLabel: 'Queue'
   });
@@ -387,7 +387,7 @@ function renderAssetUpgradeActions(state) {
   }));
 
   renderActionSection(container, entries, {
-    emptyMessage: 'Every asset is humming along. Check back after today’s upkeep.',
+    emptyMessage: 'Every venture is humming along. Check back after today’s upkeep.',
     buttonClass: 'secondary',
     defaultLabel: 'Boost'
   });
@@ -721,7 +721,7 @@ function buildNicheAnalytics(state) {
 
 function focusAssetsForNiche(nicheId, { hasAssets = false, nicheName = '' } = {}) {
   if (!nicheId) return;
-  activateShellPanel('panel-assets');
+  activateShellPanel('panel-ventures');
   const assetGallery = getAssetGallery();
   const sessionStatus = getSessionStatusNode();
   if (!assetGallery) return;
@@ -733,13 +733,13 @@ function focusAssetsForNiche(nicheId, { hasAssets = false, nicheName = '' } = {}
       if (sessionStatus) {
         sessionStatus.textContent = hasAssets
           ? 'No payouts recorded yet. Fund upkeep to roll today\'s earnings.'
-          : 'No assets targeting this niche yet. Open an asset card to assign one.';
+          : 'No ventures targeting this niche yet. Open a venture card to assign one.';
       }
       return;
     }
     if (sessionStatus) {
       const label = nicheName || 'this niche';
-      sessionStatus.textContent = `Spotlighting assets tuned to ${label}.`;
+    sessionStatus.textContent = `Spotlighting ventures tuned to ${label}.`;
     }
     matches.forEach(card => card.classList.add('asset-overview-card--spotlight'));
     const first = matches[0];
@@ -837,12 +837,12 @@ function createNicheCard(entry) {
   playerStat.className = 'niche-card__stat';
   if (entry.assetCount > 0) {
     playerStat.textContent = entry.assetCount === 1
-      ? '1 asset active'
-      : `${entry.assetCount} assets active`;
+      ? '1 venture active'
+      : `${entry.assetCount} ventures active`;
   } else if (entry.watchlisted) {
     playerStat.textContent = 'On your watchlist';
   } else {
-    playerStat.textContent = 'No assets assigned yet';
+    playerStat.textContent = 'No ventures assigned yet';
   }
   playerSection.appendChild(playerStat);
 
@@ -853,7 +853,7 @@ function createNicheCard(entry) {
       ? `$${formatMoney(entry.netEarnings)} earned today`
       : 'No payouts logged today.';
   } else {
-    earningsLine.textContent = 'Assign an asset to tap this trend.';
+  earningsLine.textContent = 'Assign a venture to tap this trend.';
   }
   playerSection.appendChild(earningsLine);
 
@@ -901,8 +901,8 @@ function createNicheCard(entry) {
   viewButton.type = 'button';
   viewButton.className = 'ghost niche-card__action';
   viewButton.textContent = entry.assetCount > 0
-    ? 'View assets in this niche'
-    : 'Find assets for this niche';
+    ? 'View ventures in this niche'
+    : 'Find ventures for this niche';
   viewButton.addEventListener('click', () => {
     focusAssetsForNiche(entry.id, {
       hasAssets: entry.assetCount > 0,
@@ -966,9 +966,9 @@ function updateDailyHighlights(analytics, refs) {
     if (highlightHotNote) {
       if (topImpact.assetCount > 0) {
         const payoutText = `$${formatMoney(Math.max(0, topImpact.netEarnings))}`;
-        highlightHotNote.textContent = `Your ${topImpact.assetCount} asset${topImpact.assetCount === 1 ? '' : 's'} made ${payoutText} today with ${formatPercent((Number(topImpact.popularity?.multiplier) || 1) - 1)} payouts.`;
+        highlightHotNote.textContent = `Your ${topImpact.assetCount} venture${topImpact.assetCount === 1 ? '' : 's'} made ${payoutText} today with ${formatPercent((Number(topImpact.popularity?.multiplier) || 1) - 1)} payouts.`;
       } else {
-        highlightHotNote.textContent = `Queue an asset to capture ${formatPercent((Number(topImpact.popularity?.multiplier) || 1) - 1)} payouts from this niche.`;
+        highlightHotNote.textContent = `Queue a venture to capture ${formatPercent((Number(topImpact.popularity?.multiplier) || 1) - 1)} payouts from this niche.`;
       }
     }
   }
@@ -999,9 +999,9 @@ function updateDailyHighlights(analytics, refs) {
     }
     if (highlightRiskNote) {
       if (biggestLoss.assetCount > 0) {
-        highlightRiskNote.textContent = `${biggestLoss.assetCount} asset${biggestLoss.assetCount === 1 ? '' : 's'} lost ${formatPercent((Number(biggestLoss.popularity?.multiplier) || 1) - 1)} vs baseline today.`;
+        highlightRiskNote.textContent = `${biggestLoss.assetCount} venture${biggestLoss.assetCount === 1 ? '' : 's'} lost ${formatPercent((Number(biggestLoss.popularity?.multiplier) || 1) - 1)} vs baseline today.`;
       } else {
-        highlightRiskNote.textContent = 'No assets invested yet, so you are safe from this downswing.';
+        highlightRiskNote.textContent = 'No ventures invested yet, so you are safe from this downswing.';
       }
     }
   }
@@ -1033,7 +1033,7 @@ function renderNicheWidget(state) {
       board.innerHTML = '';
       const empty = document.createElement('p');
       empty.className = 'niche-board__empty';
-      empty.textContent = 'Assign a niche to an asset to start tracking demand swings.';
+      empty.textContent = 'Assign a niche to a venture to start tracking demand swings.';
       board.appendChild(empty);
     }
     updateNicheControlStates({ watchlistCount: 0 });
@@ -1096,7 +1096,7 @@ function renderNicheWidget(state) {
       } else if (nicheViewState.investedOnly) {
         empty.textContent = 'You haven’t assigned any assets that fit this filter yet.';
       } else {
-        empty.textContent = 'Assign a niche to an asset to start tracking demand swings.';
+        empty.textContent = 'Assign a niche to a venture to start tracking demand swings.';
       }
       board.appendChild(empty);
     } else {
@@ -1202,10 +1202,10 @@ export function renderDashboard(summary) {
 
   const { activeAssets, upkeepDue } = computeAssetMetrics(state);
   setText(kpiValues.upkeep, `$${formatMoney(upkeepDue)}`);
-  setText(kpiNotes.upkeep, upkeepDue > 0 ? 'Maintain assets soon.' : 'Upkeep funded.');
+  setText(kpiNotes.upkeep, upkeepDue > 0 ? 'Maintain ventures soon.' : 'Upkeep funded.');
 
-  setText(kpiValues.assets, String(activeAssets));
-  setText(kpiNotes.assets, activeAssets > 0 ? 'Streams humming.' : 'Launch your first asset.');
+  setText(kpiValues.ventures, String(activeAssets));
+  setText(kpiNotes.ventures, activeAssets > 0 ? 'Streams humming.' : 'Launch your first venture.');
 
   const { percent, summary: studySummary } = computeStudyProgress(state);
   setText(kpiValues.study, `${percent}%`);

--- a/src/ui/elements/registry.js
+++ b/src/ui/elements/registry.js
@@ -72,7 +72,7 @@ class ElementRegistry {
       net: root.getElementById('kpi-net'),
       hours: root.getElementById('kpi-hours'),
       upkeep: root.getElementById('kpi-upkeep'),
-      assets: root.getElementById('kpi-assets'),
+      ventures: root.getElementById('kpi-ventures'),
       study: root.getElementById('kpi-study')
     }));
   }
@@ -83,7 +83,7 @@ class ElementRegistry {
       net: root.getElementById('kpi-net-note'),
       hours: root.getElementById('kpi-hours-note'),
       upkeep: root.getElementById('kpi-upkeep-note'),
-      assets: root.getElementById('kpi-assets-note'),
+      ventures: root.getElementById('kpi-ventures-note'),
       study: root.getElementById('kpi-study-note')
     }));
   }
@@ -93,7 +93,7 @@ class ElementRegistry {
       net: root.getElementById('kpi-net-value'),
       hours: root.getElementById('kpi-hours-value'),
       upkeep: root.getElementById('kpi-upkeep-value'),
-      assets: root.getElementById('kpi-assets-value'),
+      ventures: root.getElementById('kpi-ventures-value'),
       study: root.getElementById('kpi-study-value')
     }));
   }
@@ -197,14 +197,14 @@ class ElementRegistry {
 
   getAssetFilters() {
     return this.resolve('assetFilters', root => ({
-      activeOnly: root.getElementById('asset-active-toggle'),
-      maintenance: root.getElementById('asset-maintenance-toggle'),
-      lowRisk: root.getElementById('asset-risk-toggle')
+      activeOnly: root.getElementById('venture-active-toggle'),
+      maintenance: root.getElementById('venture-maintenance-toggle'),
+      lowRisk: root.getElementById('venture-risk-toggle')
     }));
   }
 
   getAssetGallery() {
-    return this.resolve('assetGallery', root => root.getElementById('asset-gallery'));
+    return this.resolve('assetGallery', root => root.getElementById('venture-gallery'));
   }
 
   getUpgradeFilters() {

--- a/src/ui/layout.js
+++ b/src/ui/layout.js
@@ -222,7 +222,7 @@ function setupKpiShortcuts() {
     net: 'Reviewing how today’s inflows and outflows balance.',
     time: 'Hopping down to the time ledger for today.',
     upkeep: 'Checking upkeep reminders and notifications.',
-    assets: 'Spotlighting active assets and upgrade prospects.',
+    assets: 'Spotlighting active ventures and upgrade prospects.',
     study: 'Beaming over to the study progress section.'
   };
 

--- a/src/ui/player.js
+++ b/src/ui/player.js
@@ -222,7 +222,7 @@ function renderStats(state, summary) {
   const assistantState = getUpgradeState('assistant', state);
   const stats = [
     {
-      label: 'Active assets',
+      label: 'Active ventures',
       value: String(countActiveAssets(state))
     },
     {

--- a/styles.css
+++ b/styles.css
@@ -16,6 +16,7 @@
   --warning: #fbbf24;
   --success: #34d399;
   --focus: rgba(148, 163, 255, 0.45);
+  --radius-xl: 24px;
   --radius-lg: 18px;
   --radius-md: 12px;
   --radius-sm: 8px;
@@ -1424,6 +1425,23 @@ body {
   color: var(--text-subtle);
 }
 
+.venture-panel__header {
+  align-items: flex-start;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.venture-panel__intro {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-width: 560px;
+}
+
+.venture-panel__filters {
+  align-self: flex-end;
+}
+
 .filter-bar {
   display: flex;
   flex-wrap: wrap;
@@ -1628,6 +1646,10 @@ body {
   gap: 32px;
 }
 
+.venture-gallery {
+  position: relative;
+}
+
 .asset-gallery__empty {
   margin: 0;
   padding: 32px;
@@ -1639,52 +1661,32 @@ body {
   font-size: 15px;
 }
 
-.asset-hub {
+.venture-hub {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 18px;
 }
 
-.asset-hub__summary {
-  display: grid;
+.venture-summary {
+  display: flex;
   gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  padding: 20px;
+  padding: 12px 18px;
   border-radius: var(--radius-lg);
   border: 1px solid rgba(124, 92, 255, 0.25);
-  background: linear-gradient(145deg, rgba(31, 41, 79, 0.85), rgba(21, 32, 60, 0.85));
+  background: linear-gradient(145deg, rgba(31, 41, 79, 0.75), rgba(21, 32, 60, 0.85));
+  box-shadow: var(--shadow-sm);
+  overflow-x: auto;
 }
 
-.asset-hub__summary--empty {
-  padding: 0;
-  border: none;
+.venture-summary--empty {
+  justify-content: center;
   background: none;
+  border: none;
+  box-shadow: none;
+  padding: 0;
 }
 
-.asset-hub__stat {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 14px 16px;
-  border-radius: var(--radius-md);
-  background: rgba(15, 23, 42, 0.7);
-  box-shadow: inset 0 0 0 1px rgba(124, 92, 255, 0.25);
-}
-
-.asset-hub__stat-value {
-  font-size: 24px;
-  font-weight: 700;
-  color: var(--text);
-}
-
-.asset-hub__stat-label {
-  font-size: 13px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(203, 213, 255, 0.74);
-}
-
-.asset-hub__empty {
+.venture-summary__empty {
   margin: 0;
   padding: 20px;
   border-radius: var(--radius-lg);
@@ -1695,125 +1697,153 @@ body {
   text-align: center;
 }
 
-.asset-launcher {
+.venture-summary__stat {
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  padding: 24px;
-  border-radius: var(--radius-lg);
-  border: 1px solid rgba(148, 163, 184, 0.24);
-  background: rgba(14, 22, 38, 0.92);
-  box-shadow: var(--shadow-sm);
+  gap: 4px;
+  min-width: 160px;
 }
 
-.asset-launcher__trigger {
-  align-self: flex-start;
+.venture-summary__value {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.venture-summary__label {
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(203, 213, 255, 0.7);
+}
+
+.venture-launcher {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 16px;
+}
+
+.venture-launcher__trigger {
+  position: relative;
+  border-radius: 999px;
+  padding: 12px 22px;
+  font-size: 15px;
+  font-weight: 600;
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  font-size: 15px;
-  padding-inline: 18px;
+  box-shadow: var(--shadow-sm);
 }
 
-.asset-launcher__trigger.is-open {
+.venture-launcher__trigger::after {
+  content: '✨';
+  font-size: 16px;
+}
+
+.venture-launcher__trigger.is-open {
   box-shadow: 0 0 0 3px rgba(124, 92, 255, 0.35);
 }
 
-.asset-launcher__content {
+.venture-launcher__content {
+  width: 100%;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(12, 20, 36, 0.92);
+  padding: 20px;
   display: grid;
   gap: 20px;
+  box-shadow: var(--shadow-sm);
 }
 
-.asset-launcher__header {
+.venture-launcher__header {
   display: flex;
   flex-direction: column;
   gap: 6px;
 }
 
-.asset-launcher__heading-title {
+.venture-launcher__heading-title {
   margin: 0;
-  font-size: 20px;
+  font-size: 18px;
   font-weight: 700;
   color: var(--text);
 }
 
-.asset-launcher__note {
+.venture-launcher__note {
   margin: 0;
   font-size: 14px;
   color: rgba(203, 213, 255, 0.78);
 }
 
-.asset-launcher__grid {
+.venture-launcher__grid {
   display: grid;
   gap: 18px;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.asset-launcher__tile {
-  display: flex;
-  flex-direction: column;
+.venture-launcher__tile {
+  display: grid;
   gap: 12px;
   padding: 18px;
-  border-radius: var(--radius-md);
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  background: rgba(20, 31, 54, 0.9);
-  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(124, 92, 255, 0.25);
+  background: linear-gradient(165deg, rgba(24, 34, 62, 0.9), rgba(16, 24, 42, 0.85));
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.asset-launcher__tile:hover {
+.venture-launcher__tile:hover {
   transform: translateY(-2px);
-  border-color: rgba(124, 92, 255, 0.45);
   box-shadow: var(--shadow-md);
 }
 
-.asset-launcher__tile.is-disabled {
+.venture-launcher__tile.is-disabled {
   opacity: 0.65;
-  box-shadow: none;
-  transform: none;
 }
 
-.asset-launcher__tile--success {
-  border-color: rgba(52, 211, 153, 0.6);
-  box-shadow: 0 0 0 2px rgba(52, 211, 153, 0.28);
+.venture-launcher__tile--success {
+  border-color: rgba(129, 231, 199, 0.75);
+  box-shadow: 0 0 0 2px rgba(129, 231, 199, 0.4);
 }
 
-.asset-launcher__heading {
+.venture-launcher__heading {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 10px;
 }
 
-.asset-launcher__title {
+.venture-launcher__title {
   margin: 0;
-  font-size: 17px;
+  font-size: 16px;
   font-weight: 600;
   color: var(--text);
 }
 
-.asset-launcher__type {
+.venture-launcher__type {
   font-size: 12px;
-  text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: rgba(203, 213, 255, 0.7);
+  text-transform: uppercase;
+  color: rgba(203, 213, 255, 0.68);
 }
 
-.asset-launcher__summary {
+.venture-launcher__summary {
   margin: 0;
   font-size: 14px;
   line-height: 1.5;
   color: rgba(203, 213, 255, 0.86);
 }
 
-.asset-launcher__meta {
+.venture-launcher__meta {
   margin: 0;
   font-size: 13px;
   color: rgba(203, 213, 255, 0.74);
 }
 
-.asset-launcher__button {
+.venture-launcher__button {
   align-self: flex-start;
-  border-radius: var(--radius-md);
-  padding: 10px 14px;
+  border-radius: 999px;
+  padding: 10px 18px;
   border: 1px solid rgba(124, 92, 255, 0.5);
   background: linear-gradient(135deg, rgba(124, 92, 255, 0.25), rgba(124, 92, 255, 0.15));
   color: var(--text);
@@ -1822,12 +1852,12 @@ body {
   transition: transform 0.18s ease, box-shadow 0.18s ease;
 }
 
-.asset-launcher__button:hover {
+.venture-launcher__button:hover {
   transform: translateY(-1px);
   box-shadow: var(--shadow-sm);
 }
 
-.asset-launcher__button:disabled {
+.venture-launcher__button:disabled {
   cursor: not-allowed;
   background: rgba(15, 23, 42, 0.65);
   border-color: rgba(148, 163, 184, 0.3);
@@ -1836,7 +1866,7 @@ body {
   box-shadow: none;
 }
 
-.asset-launcher__feedback {
+.venture-launcher__feedback {
   margin: 0;
   font-size: 13px;
   color: var(--success);
@@ -1849,34 +1879,52 @@ body {
 }
 
 .asset-portfolio__group {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 18px;
-  padding: 26px;
-  border-radius: var(--radius-lg);
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  background: rgba(15, 23, 42, 0.85);
-  box-shadow: var(--shadow-sm);
+  gap: 24px;
+  padding: 32px;
+  border-radius: var(--radius-xl);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: linear-gradient(165deg, rgba(17, 24, 43, 0.92), rgba(27, 39, 68, 0.82));
+  box-shadow: var(--shadow-md);
+  overflow: hidden;
 }
 
+.asset-portfolio__group::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(124, 92, 255, 0.28), transparent 55%);
+  pointer-events: none;
+}
+
+
 .asset-portfolio__header {
+  position: relative;
   display: flex;
   justify-content: space-between;
   gap: 18px;
   flex-wrap: wrap;
-  align-items: flex-start;
+  align-items: center;
 }
 
 .asset-portfolio__heading {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
-  max-width: 520px;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  max-width: 560px;
+}
+
+.asset-portfolio__icon {
+  font-size: 26px;
+  filter: drop-shadow(0 4px 12px rgba(124, 92, 255, 0.35));
 }
 
 .asset-portfolio__title {
   margin: 0;
-  font-size: 19px;
+  font-size: 20px;
   font-weight: 700;
   color: var(--text);
 }
@@ -1885,6 +1933,7 @@ body {
   margin: 0;
   font-size: 14px;
   color: rgba(203, 213, 255, 0.78);
+  flex-basis: 100%;
 }
 
 .asset-portfolio__toolbar {
@@ -1900,52 +1949,55 @@ body {
 
 .asset-portfolio__count {
   font-size: 13px;
-  color: rgba(203, 213, 255, 0.74);
-  padding: 6px 12px;
+  color: rgba(203, 213, 255, 0.78);
+  padding: 6px 16px;
   border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.32);
-  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.7);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
 .asset-portfolio__cards {
   display: grid;
-  gap: 18px;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
 }
 
 .asset-portfolio__empty {
   margin: 0;
-  padding: 18px;
+  padding: 20px;
   text-align: center;
-  border-radius: var(--radius-md);
-  border: 1px dashed rgba(148, 163, 184, 0.3);
-  background: rgba(15, 23, 42, 0.55);
-  color: var(--text-subtle);
+  border-radius: var(--radius-lg);
+  border: 1px dashed rgba(148, 163, 184, 0.32);
+  background: rgba(15, 23, 42, 0.6);
+  color: rgba(203, 213, 255, 0.72);
   font-size: 14px;
 }
+
 
 .asset-overview-card {
   display: flex;
   flex-direction: column;
-  gap: 18px;
-  padding: 22px;
-  border-radius: var(--radius-md);
-  border: 1px solid transparent;
-  background: linear-gradient(160deg, rgba(18, 26, 46, 0.95), rgba(33, 49, 86, 0.8));
-  box-shadow: var(--shadow-sm);
-  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  gap: 20px;
+  padding: 26px;
+  border-radius: var(--radius-xl);
+  border: 1px solid rgba(124, 92, 255, 0.24);
+  background: linear-gradient(170deg, rgba(17, 25, 45, 0.96), rgba(32, 49, 88, 0.82));
+  box-shadow: var(--shadow-md);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  min-height: 100%;
 }
 
 .asset-overview-card:hover {
-  transform: translateY(-2px);
-  border-color: rgba(124, 92, 255, 0.45);
-  box-shadow: var(--shadow-md);
+  transform: translateY(-3px);
+  border-color: rgba(166, 139, 255, 0.6);
+  box-shadow: 0 18px 34px rgba(0, 0, 0, 0.35);
 }
 
 .asset-overview-card--spotlight {
-  border-color: rgba(124, 92, 255, 0.7);
-  box-shadow: 0 0 0 3px rgba(124, 92, 255, 0.28), 0 14px 36px rgba(124, 92, 255, 0.22);
-  transform: translateY(-2px);
+  border-color: rgba(166, 139, 255, 0.75);
+  box-shadow: 0 0 0 3px rgba(166, 139, 255, 0.35), 0 18px 40px rgba(124, 92, 255, 0.25);
+  transform: translateY(-3px);
 }
 
 .asset-overview-card:focus-visible {
@@ -1957,6 +2009,7 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
+  gap: 12px;
 }
 
 .asset-overview-card__heading {
@@ -1967,7 +2020,7 @@ body {
 
 .asset-overview-card__status {
   font-size: 12px;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   color: rgba(203, 213, 255, 0.7);
 }
@@ -1996,19 +2049,55 @@ body {
 
 .asset-overview-card__body {
   display: grid;
-  gap: 16px;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
 .asset-overview-card__field {
   display: grid;
-  gap: 4px;
+  gap: 6px;
+}
+
+.asset-overview-card__field--niche {
+  padding: 16px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(124, 92, 255, 0.24);
+  background: rgba(15, 23, 42, 0.65);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.asset-overview-card__field--niche[data-locked='true'] {
+  border-color: rgba(129, 231, 199, 0.4);
+}
+
+.asset-overview-card__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.18);
+  color: var(--text);
+  width: fit-content;
+}
+
+.asset-overview-card__badge[data-trend='up'] {
+  background: rgba(34, 197, 94, 0.18);
+  color: rgba(134, 239, 172, 0.95);
+}
+
+.asset-overview-card__badge[data-trend='down'] {
+  background: rgba(248, 113, 113, 0.18);
+  color: rgba(252, 165, 165, 0.95);
 }
 
 .asset-overview-card__label {
   font-size: 12px;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: rgba(203, 213, 255, 0.68);
+  letter-spacing: 0.12em;
+  color: rgba(203, 213, 255, 0.66);
 }
 
 .asset-overview-card__value {
@@ -2019,7 +2108,7 @@ body {
 
 .asset-overview-card__note {
   font-size: 12px;
-  color: rgba(203, 213, 255, 0.72);
+  color: rgba(203, 213, 255, 0.74);
 }
 
 .asset-overview-card__niche-select {
@@ -2033,12 +2122,12 @@ body {
 }
 
 .asset-overview-card__quality {
-  border-radius: var(--radius-md);
-  border: 1px solid rgba(124, 92, 255, 0.32);
-  background: rgba(28, 38, 68, 0.7);
-  padding: 14px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(124, 92, 255, 0.28);
+  background: rgba(28, 38, 68, 0.65);
+  padding: 18px;
   display: grid;
-  gap: 10px;
+  gap: 12px;
 }
 
 .asset-overview-card__quality-heading {
@@ -2085,11 +2174,11 @@ body {
 
 .asset-overview-card__payout {
   display: grid;
-  gap: 10px;
-  border-radius: var(--radius-md);
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  background: rgba(18, 26, 46, 0.7);
-  padding: 14px;
+  gap: 12px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  background: rgba(18, 26, 46, 0.64);
+  padding: 18px;
 }
 
 .asset-overview-card__payout-header {
@@ -2106,9 +2195,9 @@ body {
 }
 
 .asset-overview-card__payout-details {
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-md);
   background: rgba(12, 18, 32, 0.75);
-  padding: 10px;
+  padding: 12px;
   display: grid;
   gap: 8px;
 }
@@ -2158,20 +2247,23 @@ body {
 .asset-overview-card__metrics {
   display: grid;
   gap: 12px;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  padding: 16px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(15, 23, 42, 0.6);
 }
 
 .asset-overview-card__metric {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+  display: grid;
+  gap: 6px;
 }
 
 .asset-overview-card__metric-label {
   font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: rgba(203, 213, 255, 0.64);
+  color: rgba(203, 213, 255, 0.66);
 }
 
 .asset-overview-card__metric-value {
@@ -2186,6 +2278,8 @@ body {
   align-items: flex-start;
   gap: 12px;
   flex-wrap: wrap;
+  padding-top: 12px;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
 }
 
 .asset-overview-card__actions {
@@ -2197,6 +2291,7 @@ body {
 
 .asset-overview-card__action {
   font-size: 14px;
+  border-radius: 999px;
 }
 
 .asset-overview-card__upgrade-action {
@@ -2239,6 +2334,7 @@ body {
   display: flex;
   gap: 8px;
   align-items: center;
+  justify-content: flex-end;
 }
 .upgrade-panel__header {
   align-items: flex-start;

--- a/tests/helpers/setupDom.js
+++ b/tests/helpers/setupDom.js
@@ -47,7 +47,7 @@ export function ensureTestDom() {
         <nav class="shell__tabs" role="tablist">
           <button id="tab-dashboard" class="shell__tab" aria-controls="panel-dashboard"></button>
           <button id="tab-hustles" class="shell__tab" aria-controls="panel-hustles"></button>
-          <button id="tab-assets" class="shell__tab" aria-controls="panel-assets"></button>
+          <button id="tab-ventures" class="shell__tab" aria-controls="panel-ventures"></button>
           <button id="tab-upgrades" class="shell__tab" aria-controls="panel-upgrades"></button>
           <button id="tab-education" class="shell__tab" aria-controls="panel-education"></button>
         </nav>
@@ -58,7 +58,7 @@ export function ensureTestDom() {
               <button id="kpi-net"><span id="kpi-net-value"></span><span id="kpi-net-note"></span></button>
               <button id="kpi-hours"><span id="kpi-hours-value"></span><span id="kpi-hours-note"></span></button>
               <button id="kpi-upkeep"><span id="kpi-upkeep-value"></span><span id="kpi-upkeep-note"></span></button>
-              <button id="kpi-assets"><span id="kpi-assets-value"></span><span id="kpi-assets-note"></span></button>
+              <button id="kpi-ventures"><span id="kpi-ventures-value"></span><span id="kpi-ventures-note"></span></button>
               <button id="kpi-study"><span id="kpi-study-value"></span><span id="kpi-study-note"></span></button>
             </section>
             <section class="dashboard__grid">
@@ -86,10 +86,10 @@ export function ensureTestDom() {
             <select id="hustle-sort"></select>
             <div id="hustle-list"></div>
           </section>
-          <section id="panel-assets" class="panel" hidden>
-            <input id="asset-active-toggle" type="checkbox" />
-            <input id="asset-maintenance-toggle" type="checkbox" />
-            <input id="asset-risk-toggle" type="checkbox" />
+          <section id="panel-ventures" class="panel" hidden>
+            <input id="venture-active-toggle" type="checkbox" />
+            <input id="venture-maintenance-toggle" type="checkbox" />
+            <input id="venture-risk-toggle" type="checkbox" />
             <table>
               <tbody id="asset-table-body"></tbody>
             </table>


### PR DESCRIPTION
## Summary
- Rebrand the assets tab and dashboard copy to talk about ventures, including KPI labels and player stats.
- Refresh the venture hub layout with a compact summary strip, category icons, showcase-style cards, and celebratory launcher styling.
- Document the venture hub redesign with a new feature note and changelog entry.

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc3699b900832c89f377dbd093ea2c