### PR TITLE
Refactor UI view initialization with view manager

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -8,10 +8,11 @@ import { registry } from './game/registry.js';
 import { resetTick, startGameLoop } from './game/loop.js';
 import { handleOfflineProgress } from './game/offline.js';
 import { initHeaderActionControls } from './ui/headerAction.js';
-import { initElementRegistry } from './ui/elements/registry.js';
+import { setActiveView } from './ui/viewManager.js';
+import classicView from './ui/views/classic/index.js';
 
 configureRegistry(registry);
-initElementRegistry(document);
+setActiveView(classicView, document);
 const { returning, lastSaved } = loadState({
   onFirstLoad: () =>
     addLog('Welcome to Online Hustle Simulator! Time to make that side cash.', 'info'),

--- a/src/ui/elements/registry.js
+++ b/src/ui/elements/registry.js
@@ -1,13 +1,15 @@
 const DEFAULT_DOCUMENT = typeof document !== 'undefined' ? document : null;
 
 class ElementRegistry {
-  constructor(root = DEFAULT_DOCUMENT) {
+  constructor(root = DEFAULT_DOCUMENT, resolvers = {}) {
     this.document = root;
+    this.resolvers = resolvers || {};
     this.cache = new Map();
   }
 
-  initialize(root = DEFAULT_DOCUMENT) {
+  initialize(root = DEFAULT_DOCUMENT, resolvers = this.resolvers) {
     this.document = root;
+    this.resolvers = resolvers || {};
     this.cache.clear();
   }
 
@@ -15,303 +17,157 @@ class ElementRegistry {
     return this.document || DEFAULT_DOCUMENT;
   }
 
-  resolve(key, resolver) {
+  resolve(key) {
     if (!this.cache.has(key)) {
+      const resolver = this.resolvers?.[key];
       const root = this.getRoot();
-      this.cache.set(key, root ? resolver(root) : null);
+      const value = resolver && root ? resolver(root) : null;
+      this.cache.set(key, value);
     }
     return this.cache.get(key);
   }
 
   getMoneyNode() {
-    return this.resolve('money', root => root.getElementById('money'));
+    return this.resolve('money');
   }
 
   getSessionStatusNode() {
-    return this.resolve('sessionStatus', root => root.getElementById('session-status'));
+    return this.resolve('sessionStatus');
   }
 
   getHeaderActionButtons() {
-    return this.resolve('headerActionButtons', root => ({
-      endDayButton: root.getElementById('end-day'),
-      autoForwardButton: root.getElementById('auto-forward')
-    }));
+    return this.resolve('headerActionButtons');
   }
 
   getShellNavigation() {
-    return this.resolve('shellNavigation', root => ({
-      shellTabs: Array.from(root.querySelectorAll('.shell__tab')),
-      panels: Array.from(root.querySelectorAll('.panel'))
-    }));
+    return this.resolve('shellNavigation');
   }
 
   getHeaderStats() {
-    return this.resolve('headerStats', root => ({
-      dailyPlus: {
-        value: root.getElementById('header-daily-plus'),
-        note: root.getElementById('header-daily-plus-note')
-      },
-      dailyMinus: {
-        value: root.getElementById('header-daily-minus'),
-        note: root.getElementById('header-daily-minus-note')
-      },
-      timeAvailable: {
-        value: root.getElementById('header-time-available'),
-        note: root.getElementById('header-time-available-note')
-      },
-      timeReserved: {
-        value: root.getElementById('header-time-reserved'),
-        note: root.getElementById('header-time-reserved-note')
-      }
-    }));
+    return this.resolve('headerStats');
   }
 
   getKpiNodes() {
-    return this.resolve('kpis', root => ({
-      cash: root.getElementById('kpi-cash'),
-      net: root.getElementById('kpi-net'),
-      hours: root.getElementById('kpi-hours'),
-      upkeep: root.getElementById('kpi-upkeep'),
-      ventures: root.getElementById('kpi-ventures'),
-      study: root.getElementById('kpi-study')
-    }));
+    return this.resolve('kpis');
   }
 
   getKpiNotes() {
-    return this.resolve('kpiNotes', root => ({
-      cash: root.getElementById('kpi-cash-note'),
-      net: root.getElementById('kpi-net-note'),
-      hours: root.getElementById('kpi-hours-note'),
-      upkeep: root.getElementById('kpi-upkeep-note'),
-      ventures: root.getElementById('kpi-ventures-note'),
-      study: root.getElementById('kpi-study-note')
-    }));
+    return this.resolve('kpiNotes');
   }
 
   getKpiValues() {
-    return this.resolve('kpiValues', root => ({
-      net: root.getElementById('kpi-net-value'),
-      hours: root.getElementById('kpi-hours-value'),
-      upkeep: root.getElementById('kpi-upkeep-value'),
-      ventures: root.getElementById('kpi-ventures-value'),
-      study: root.getElementById('kpi-study-value')
-    }));
+    return this.resolve('kpiValues');
   }
 
   getDailyStats() {
-    return this.resolve('dailyStats', root => ({
-      timeSummary: root.getElementById('daily-time-summary'),
-      timeList: root.getElementById('daily-time-list'),
-      earningsSummary: root.getElementById('daily-earnings-summary'),
-      earningsActive: root.getElementById('daily-earnings-active'),
-      earningsPassive: root.getElementById('daily-earnings-passive'),
-      spendSummary: root.getElementById('daily-spend-summary'),
-      spendList: root.getElementById('daily-spend-list'),
-      studySummary: root.getElementById('daily-study-summary'),
-      studyList: root.getElementById('daily-study-list')
-    }));
+    return this.resolve('dailyStats');
   }
 
   getNicheTrends() {
-    return this.resolve('nicheTrends', root => ({
-      highlightHot: root.getElementById('analytics-highlight-hot'),
-      highlightHotNote: root.getElementById('analytics-highlight-hot-note'),
-      highlightSwing: root.getElementById('analytics-highlight-swing'),
-      highlightSwingNote: root.getElementById('analytics-highlight-swing-note'),
-      highlightRisk: root.getElementById('analytics-highlight-risk'),
-      highlightRiskNote: root.getElementById('analytics-highlight-risk-note'),
-      board: root.getElementById('niche-board'),
-      sortButtons: Array.from(root.querySelectorAll('[data-niche-sort]')),
-      filterInvested: root.getElementById('niche-filter-invested'),
-      filterWatchlist: root.getElementById('niche-filter-watchlist')
-    }));
+    return this.resolve('nicheTrends');
   }
 
   getSkillSections() {
-    return this.resolve('skillSections', root => ({
-      dashboard: {
-        container: root.getElementById('dashboard-skills'),
-        list: root.getElementById('dashboard-skills-list'),
-        tier: root.getElementById('dashboard-skills-tier'),
-        note: root.getElementById('dashboard-skills-progress')
-      },
-      education: {
-        container: root.getElementById('education-skills'),
-        list: root.getElementById('education-skills-list'),
-        tier: root.getElementById('education-skills-tier'),
-        note: root.getElementById('education-skills-progress')
-      }
-    }));
+    return this.resolve('skillSections');
   }
 
   getQueueNodes() {
-    return this.resolve('queueNodes', root => ({
-      actionQueue: root.getElementById('action-queue'),
-      queuePause: root.getElementById('queue-pause'),
-      queueCancel: root.getElementById('queue-cancel')
-    }));
+    return this.resolve('queueNodes');
   }
 
   getQuickActionsContainer() {
-    return this.resolve('quickActions', root => root.getElementById('quick-actions'));
+    return this.resolve('quickActions');
   }
 
   getAssetUpgradeActionsContainer() {
-    return this.resolve('assetUpgradeActions', root => root.getElementById('asset-upgrade-actions'));
+    return this.resolve('assetUpgradeActions');
   }
 
   getNotificationsContainer() {
-    return this.resolve('notifications', root => root.getElementById('notification-list'));
+    return this.resolve('notifications');
   }
 
   getEventLogPreviewNode() {
-    return this.resolve('eventLogPreview', root => root.getElementById('event-log-preview'));
+    return this.resolve('eventLogPreview');
   }
 
   getEventLogControls() {
-    return this.resolve('eventLogControls', root => ({
-      openEventLog: root.getElementById('open-event-log'),
-      eventLogPanel: root.getElementById('event-log-panel'),
-      eventLogClose: root.getElementById('event-log-close')
-    }));
+    return this.resolve('eventLogControls');
   }
 
   getLogNodes() {
-    return this.resolve('logNodes', root => ({
-      logFeed: root.getElementById('log-feed'),
-      logTemplate: root.getElementById('log-template'),
-      logTip: root.getElementById('log-tip')
-    }));
+    return this.resolve('logNodes');
   }
 
   getHustleControls() {
-    return this.resolve('hustleControls', root => ({
-      hustleSearch: root.getElementById('hustle-search'),
-      hustleCategoryChips: root.getElementById('hustle-category-chips'),
-      hustleRequirementChips: root.getElementById('hustle-req-chips'),
-      hustleAvailableToggle: root.getElementById('hustle-available-toggle'),
-      hustleSort: root.getElementById('hustle-sort'),
-      hustleList: root.getElementById('hustle-list')
-    }));
+    return this.resolve('hustleControls');
   }
 
   getAssetFilters() {
-    return this.resolve('assetFilters', root => ({
-      activeOnly: root.getElementById('venture-active-toggle'),
-      maintenance: root.getElementById('venture-maintenance-toggle'),
-      lowRisk: root.getElementById('venture-risk-toggle')
-    }));
+    return this.resolve('assetFilters');
   }
 
   getAssetGallery() {
-    return this.resolve('assetGallery', root => root.getElementById('venture-gallery'));
+    return this.resolve('assetGallery');
   }
 
   getUpgradeFilters() {
-    return this.resolve('upgradeFilters', root => ({
-      unlocked: root.getElementById('upgrade-unlocked-toggle')
-    }));
+    return this.resolve('upgradeFilters');
   }
 
   getUpgradeOverview() {
-    return this.resolve('upgradeOverview', root => ({
-      container: root.getElementById('upgrade-overview'),
-      purchased: root.getElementById('upgrade-overview-owned'),
-      ready: root.getElementById('upgrade-overview-ready'),
-      note: root.getElementById('upgrade-overview-note')
-    }));
+    return this.resolve('upgradeOverview');
   }
 
   getUpgradeEmptyNode() {
-    return this.resolve('upgradeEmpty', root => root.getElementById('upgrade-empty'));
+    return this.resolve('upgradeEmpty');
   }
 
   getUpgradeLaneList() {
-    return this.resolve('upgradeLaneList', root => root.getElementById('upgrade-lane-list'));
+    return this.resolve('upgradeLaneList');
   }
 
   getUpgradeList() {
-    return this.resolve('upgradeList', root => root.getElementById('upgrade-list'));
+    return this.resolve('upgradeList');
   }
 
   getUpgradeDockList() {
-    return this.resolve('upgradeDockList', root => root.getElementById('upgrade-dock-list'));
+    return this.resolve('upgradeDockList');
   }
 
   getStudyFilters() {
-    return this.resolve('studyFilters', root => ({
-      activeOnly: root.getElementById('study-active-toggle'),
-      hideComplete: root.getElementById('study-hide-complete')
-    }));
+    return this.resolve('studyFilters');
   }
 
   getStudyQueue() {
-    return this.resolve('studyQueue', root => ({
-      list: root.getElementById('study-queue-list'),
-      eta: root.getElementById('study-queue-eta'),
-      cap: root.getElementById('study-queue-cap')
-    }));
+    return this.resolve('studyQueue');
   }
 
   getStudyTrackList() {
-    return this.resolve('studyTrackList', root => root.getElementById('study-track-list'));
+    return this.resolve('studyTrackList');
   }
 
   getSlideOverNodes() {
-    return this.resolve('slideOver', root => ({
-      slideOver: root.getElementById('slide-over'),
-      slideOverBackdrop: root.querySelector('#slide-over .slide-over__backdrop'),
-      slideOverClose: root.getElementById('slide-over-close'),
-      slideOverTitle: root.getElementById('slide-over-title'),
-      slideOverEyebrow: root.getElementById('slide-over-eyebrow'),
-      slideOverContent: root.getElementById('slide-over-content')
-    }));
+    return this.resolve('slideOver');
   }
 
   getCommandPaletteNodes() {
-    return this.resolve('commandPalette', root => ({
-      commandPalette: root.getElementById('command-palette'),
-      commandPaletteTrigger: root.getElementById('command-palette-trigger'),
-      commandPaletteBackdrop: root.querySelector('#command-palette .command-palette__backdrop'),
-      commandPaletteSearch: root.getElementById('command-palette-search'),
-      commandPaletteResults: root.getElementById('command-palette-results')
-    }));
+    return this.resolve('commandPalette');
   }
 
   getPlayerNodes() {
-    return this.resolve('playerNodes', root => ({
-      summary: {
-        tier: root.getElementById('player-summary-tier'),
-        note: root.getElementById('player-summary-note'),
-        money: root.getElementById('player-summary-money'),
-        earned: root.getElementById('player-summary-earned'),
-        spent: root.getElementById('player-summary-spent'),
-        day: root.getElementById('player-summary-day'),
-        time: root.getElementById('player-summary-time')
-      },
-      skills: {
-        list: root.getElementById('player-skills-list'),
-        summary: root.getElementById('player-skills-summary')
-      },
-      educationList: root.getElementById('player-education-list'),
-      equipmentList: root.getElementById('player-equipment-list'),
-      statsList: root.getElementById('player-stats-list')
-    }));
+    return this.resolve('playerNodes');
   }
 
   getDebugCatalogNodes() {
-    return this.resolve('debugCatalog', root => ({
-      debugActionCatalog: root.getElementById('debug-action-catalog'),
-      debugActionCatalogList: root.getElementById('debug-action-catalog-list'),
-      debugActionCatalogSummary: root.getElementById('debug-action-catalog-summary')
-    }));
+    return this.resolve('debugCatalog');
   }
 }
 
 const elementRegistry = new ElementRegistry();
 
-export function initElementRegistry(root) {
-  elementRegistry.initialize(root);
+export function initElementRegistry(root, resolvers) {
+  elementRegistry.initialize(root, resolvers);
 }
 
 export function getMoneyNode() {

--- a/src/ui/viewManager.js
+++ b/src/ui/viewManager.js
@@ -1,0 +1,28 @@
+import elementRegistry from './elements/registry.js';
+
+let activeView = null;
+
+export function setActiveView(view, rootDocument = typeof document !== 'undefined' ? document : null) {
+  activeView = {
+    ...view,
+    root: rootDocument
+  };
+
+  const resolvers = view?.resolvers ?? {};
+  elementRegistry.initialize(rootDocument, resolvers);
+
+  if (typeof view?.onActivate === 'function') {
+    view.onActivate({ root: rootDocument });
+  }
+
+  return activeView;
+}
+
+export function getActiveView() {
+  return activeView;
+}
+
+export default {
+  setActiveView,
+  getActiveView
+};

--- a/src/ui/views/classic/index.js
+++ b/src/ui/views/classic/index.js
@@ -1,0 +1,11 @@
+import resolvers, { classicResolvers } from './resolvers.js';
+
+const classicView = {
+  id: 'classic',
+  name: 'Classic Dashboard',
+  resolvers,
+  presenters: {}
+};
+
+export { classicResolvers };
+export default classicView;

--- a/src/ui/views/classic/resolvers.js
+++ b/src/ui/views/classic/resolvers.js
@@ -1,0 +1,187 @@
+const resolvers = {
+  money: root => root.getElementById('money'),
+  sessionStatus: root => root.getElementById('session-status'),
+  headerActionButtons: root => ({
+    endDayButton: root.getElementById('end-day'),
+    autoForwardButton: root.getElementById('auto-forward')
+  }),
+  shellNavigation: root => ({
+    shellTabs: Array.from(root.querySelectorAll('.shell__tab')),
+    panels: Array.from(root.querySelectorAll('.panel'))
+  }),
+  headerStats: root => ({
+    dailyPlus: {
+      value: root.getElementById('header-daily-plus'),
+      note: root.getElementById('header-daily-plus-note')
+    },
+    dailyMinus: {
+      value: root.getElementById('header-daily-minus'),
+      note: root.getElementById('header-daily-minus-note')
+    },
+    timeAvailable: {
+      value: root.getElementById('header-time-available'),
+      note: root.getElementById('header-time-available-note')
+    },
+    timeReserved: {
+      value: root.getElementById('header-time-reserved'),
+      note: root.getElementById('header-time-reserved-note')
+    }
+  }),
+  kpis: root => ({
+    cash: root.getElementById('kpi-cash'),
+    net: root.getElementById('kpi-net'),
+    hours: root.getElementById('kpi-hours'),
+    upkeep: root.getElementById('kpi-upkeep'),
+    ventures: root.getElementById('kpi-ventures'),
+    study: root.getElementById('kpi-study')
+  }),
+  kpiNotes: root => ({
+    cash: root.getElementById('kpi-cash-note'),
+    net: root.getElementById('kpi-net-note'),
+    hours: root.getElementById('kpi-hours-note'),
+    upkeep: root.getElementById('kpi-upkeep-note'),
+    ventures: root.getElementById('kpi-ventures-note'),
+    study: root.getElementById('kpi-study-note')
+  }),
+  kpiValues: root => ({
+    net: root.getElementById('kpi-net-value'),
+    hours: root.getElementById('kpi-hours-value'),
+    upkeep: root.getElementById('kpi-upkeep-value'),
+    ventures: root.getElementById('kpi-ventures-value'),
+    study: root.getElementById('kpi-study-value')
+  }),
+  dailyStats: root => ({
+    timeSummary: root.getElementById('daily-time-summary'),
+    timeList: root.getElementById('daily-time-list'),
+    earningsSummary: root.getElementById('daily-earnings-summary'),
+    earningsActive: root.getElementById('daily-earnings-active'),
+    earningsPassive: root.getElementById('daily-earnings-passive'),
+    spendSummary: root.getElementById('daily-spend-summary'),
+    spendList: root.getElementById('daily-spend-list'),
+    studySummary: root.getElementById('daily-study-summary'),
+    studyList: root.getElementById('daily-study-list')
+  }),
+  nicheTrends: root => ({
+    highlightHot: root.getElementById('analytics-highlight-hot'),
+    highlightHotNote: root.getElementById('analytics-highlight-hot-note'),
+    highlightSwing: root.getElementById('analytics-highlight-swing'),
+    highlightSwingNote: root.getElementById('analytics-highlight-swing-note'),
+    highlightRisk: root.getElementById('analytics-highlight-risk'),
+    highlightRiskNote: root.getElementById('analytics-highlight-risk-note'),
+    board: root.getElementById('niche-board'),
+    sortButtons: Array.from(root.querySelectorAll('[data-niche-sort]')),
+    filterInvested: root.getElementById('niche-filter-invested'),
+    filterWatchlist: root.getElementById('niche-filter-watchlist')
+  }),
+  skillSections: root => ({
+    dashboard: {
+      container: root.getElementById('dashboard-skills'),
+      list: root.getElementById('dashboard-skills-list'),
+      tier: root.getElementById('dashboard-skills-tier'),
+      note: root.getElementById('dashboard-skills-progress')
+    },
+    education: {
+      container: root.getElementById('education-skills'),
+      list: root.getElementById('education-skills-list'),
+      tier: root.getElementById('education-skills-tier'),
+      note: root.getElementById('education-skills-progress')
+    }
+  }),
+  queueNodes: root => ({
+    actionQueue: root.getElementById('action-queue'),
+    queuePause: root.getElementById('queue-pause'),
+    queueCancel: root.getElementById('queue-cancel')
+  }),
+  quickActions: root => root.getElementById('quick-actions'),
+  assetUpgradeActions: root => root.getElementById('asset-upgrade-actions'),
+  notifications: root => root.getElementById('notification-list'),
+  eventLogPreview: root => root.getElementById('event-log-preview'),
+  eventLogControls: root => ({
+    openEventLog: root.getElementById('open-event-log'),
+    eventLogPanel: root.getElementById('event-log-panel'),
+    eventLogClose: root.getElementById('event-log-close')
+  }),
+  logNodes: root => ({
+    logFeed: root.getElementById('log-feed'),
+    logTemplate: root.getElementById('log-template'),
+    logTip: root.getElementById('log-tip')
+  }),
+  hustleControls: root => ({
+    hustleSearch: root.getElementById('hustle-search'),
+    hustleCategoryChips: root.getElementById('hustle-category-chips'),
+    hustleRequirementChips: root.getElementById('hustle-req-chips'),
+    hustleAvailableToggle: root.getElementById('hustle-available-toggle'),
+    hustleSort: root.getElementById('hustle-sort'),
+    hustleList: root.getElementById('hustle-list')
+  }),
+  assetFilters: root => ({
+    activeOnly: root.getElementById('venture-active-toggle'),
+    maintenance: root.getElementById('venture-maintenance-toggle'),
+    lowRisk: root.getElementById('venture-risk-toggle')
+  }),
+  assetGallery: root => root.getElementById('venture-gallery'),
+  upgradeFilters: root => ({
+    unlocked: root.getElementById('upgrade-unlocked-toggle')
+  }),
+  upgradeOverview: root => ({
+    container: root.getElementById('upgrade-overview'),
+    purchased: root.getElementById('upgrade-overview-owned'),
+    ready: root.getElementById('upgrade-overview-ready'),
+    note: root.getElementById('upgrade-overview-note')
+  }),
+  upgradeEmpty: root => root.getElementById('upgrade-empty'),
+  upgradeLaneList: root => root.getElementById('upgrade-lane-list'),
+  upgradeList: root => root.getElementById('upgrade-list'),
+  upgradeDockList: root => root.getElementById('upgrade-dock-list'),
+  studyFilters: root => ({
+    activeOnly: root.getElementById('study-active-toggle'),
+    hideComplete: root.getElementById('study-hide-complete')
+  }),
+  studyQueue: root => ({
+    list: root.getElementById('study-queue-list'),
+    eta: root.getElementById('study-queue-eta'),
+    cap: root.getElementById('study-queue-cap')
+  }),
+  studyTrackList: root => root.getElementById('study-track-list'),
+  slideOver: root => ({
+    slideOver: root.getElementById('slide-over'),
+    slideOverBackdrop: root.querySelector('#slide-over .slide-over__backdrop'),
+    slideOverClose: root.getElementById('slide-over-close'),
+    slideOverTitle: root.getElementById('slide-over-title'),
+    slideOverEyebrow: root.getElementById('slide-over-eyebrow'),
+    slideOverContent: root.getElementById('slide-over-content')
+  }),
+  commandPalette: root => ({
+    commandPalette: root.getElementById('command-palette'),
+    commandPaletteTrigger: root.getElementById('command-palette-trigger'),
+    commandPaletteBackdrop: root.querySelector('#command-palette .command-palette__backdrop'),
+    commandPaletteSearch: root.getElementById('command-palette-search'),
+    commandPaletteResults: root.getElementById('command-palette-results')
+  }),
+  playerNodes: root => ({
+    summary: {
+      tier: root.getElementById('player-summary-tier'),
+      note: root.getElementById('player-summary-note'),
+      money: root.getElementById('player-summary-money'),
+      earned: root.getElementById('player-summary-earned'),
+      spent: root.getElementById('player-summary-spent'),
+      day: root.getElementById('player-summary-day'),
+      time: root.getElementById('player-summary-time')
+    },
+    skills: {
+      list: root.getElementById('player-skills-list'),
+      summary: root.getElementById('player-skills-summary')
+    },
+    educationList: root.getElementById('player-education-list'),
+    equipmentList: root.getElementById('player-equipment-list'),
+    statsList: root.getElementById('player-stats-list')
+  }),
+  debugCatalog: root => ({
+    debugActionCatalog: root.getElementById('debug-action-catalog'),
+    debugActionCatalogList: root.getElementById('debug-action-catalog-list'),
+    debugActionCatalogSummary: root.getElementById('debug-action-catalog-summary')
+  })
+};
+
+export { resolvers as classicResolvers };
+export default resolvers;

--- a/tests/helpers/gameTestHarness.js
+++ b/tests/helpers/gameTestHarness.js
@@ -23,8 +23,10 @@ export async function getGameTestHarness() {
   const storageModule = await import('../../src/core/storage.js');
   const offlineModule = await import('../../src/game/offline.js');
   const elementRegistryModule = await import('../../src/ui/elements/registry.js');
+  const viewManagerModule = await import('../../src/ui/viewManager.js');
+  const classicViewModule = await import('../../src/ui/views/classic/index.js');
 
-  elementRegistryModule.initElementRegistry(document);
+  viewManagerModule.setActiveView(classicViewModule.default, document);
 
   registryModule.configureRegistry({
     assets: assetsModule.ASSETS,

--- a/tests/helpers/setupDom.js
+++ b/tests/helpers/setupDom.js
@@ -1,5 +1,7 @@
 import { JSDOM } from 'jsdom';
 import { webcrypto } from 'node:crypto';
+import { setActiveView } from '../../src/ui/viewManager.js';
+import classicView from '../../src/ui/views/classic/index.js';
 
 let dom;
 
@@ -138,6 +140,8 @@ export function ensureTestDom() {
   global.performance = window.performance;
   Object.defineProperty(global, 'crypto', { value: webcrypto, configurable: true });
   Object.defineProperty(window, 'crypto', { value: webcrypto, configurable: true });
+
+  setActiveView(classicView, window.document);
 
   return dom;
 }

--- a/tests/ui/elements/registry.test.js
+++ b/tests/ui/elements/registry.test.js
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  getLogNodes,
+  getMoneyNode,
+  initElementRegistry
+} from '../../../src/ui/elements/registry.js';
+import { setActiveView } from '../../../src/ui/viewManager.js';
+import classicView from '../../../src/ui/views/classic/index.js';
+
+test('uses injected resolvers to look up DOM nodes', t => {
+  const calls = [];
+  const fakeRoot = {
+    lookup(key) {
+      calls.push(key);
+      return `${key}-node`;
+    }
+  };
+
+  const resolvers = {
+    money: root => root.lookup('money'),
+    logNodes: root => ({
+      logFeed: root.lookup('log'),
+      logTip: root.lookup('tip')
+    })
+  };
+
+  initElementRegistry(fakeRoot, resolvers);
+
+  t.after(() => {
+    const root = typeof document !== 'undefined' ? document : null;
+    setActiveView(classicView, root);
+  });
+
+  assert.equal(getMoneyNode(), 'money-node');
+  assert.equal(getMoneyNode(), 'money-node', 'reuses cached value');
+  assert.deepEqual(calls, ['money']);
+
+  const logNodes = getLogNodes();
+  assert.deepEqual(logNodes, { logFeed: 'log-node', logTip: 'tip-node' });
+  assert.deepEqual(calls, ['money', 'log', 'tip']);
+});
+
+test('returns null when no resolver is provided', t => {
+  const fakeRoot = {};
+  initElementRegistry(fakeRoot, {});
+
+  t.after(() => {
+    const root = typeof document !== 'undefined' ? document : null;
+    setActiveView(classicView, root);
+  });
+
+  assert.equal(getMoneyNode(), null);
+});


### PR DESCRIPTION
## Summary
- introduce a view manager that activates the classic UI view and feeds its resolvers into the element registry
- move classic view DOM resolvers into a dedicated module and update the registry to consume injected resolver maps
- refresh main startup, test helpers, and add focused element registry unit tests to exercise resolver injection

## Testing
- npm test
- Manual testing not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dc4aaff180832c90cdf9af4bd7667c