### PR TITLE
Refactor card presenters to share prebuilt models

### DIFF
--- a/src/ui/update.js
+++ b/src/ui/update.js
@@ -37,7 +37,8 @@ function buildCollections() {
 
 export function renderCards() {
   const collections = buildCollections();
-  renderCardCollections(collections);
+  const { models = {}, ...registries } = collections;
+  renderCardCollections(registries, models);
   applyCardFilters();
 }
 
@@ -57,7 +58,8 @@ export function updateUI() {
   updateHeaderAction(state);
 
   const collections = buildCollections();
-  updateAllCards(collections);
+  const { models = {}, ...registries } = collections;
+  updateAllCards(registries, models);
   applyCardFilters();
   refreshActionCatalogDebug();
 }

--- a/tests/education.test.js
+++ b/tests/education.test.js
@@ -34,13 +34,19 @@ test('education tracks reflect canonical study data', async () => {
   progress.daysCompleted = 2;
   progress.studiedToday = false;
 
+  const educationDefinitions = registry.hustles.filter(hustle => hustle.tag?.type === 'study');
+  const { buildEducationModels } = await import('../src/ui/cards/model.js');
+  const educationModels = buildEducationModels(educationDefinitions);
   const { renderCardCollections } = await import('../src/ui/cards.js');
-  renderCardCollections({
-    hustles: [],
-    education: registry.hustles.filter(hustle => hustle.tag?.type === 'study'),
-    assets: [],
-    upgrades: []
-  });
+  renderCardCollections(
+    {
+      hustles: [],
+      education: educationDefinitions,
+      assets: [],
+      upgrades: []
+    },
+    { education: educationModels }
+  );
 
   const track = document.querySelector('.study-track');
   assert.ok(track, 'study track should render');
@@ -87,13 +93,19 @@ test('completed study tracks celebrate progress and skills', async () => {
   const requirements = await import('../src/game/requirements.js');
   const { getKnowledgeProgress } = requirements;
 
+  const educationDefinitions = registry.hustles.filter(hustle => hustle.tag?.type === 'study');
+  const { buildEducationModels } = await import('../src/ui/cards/model.js');
   const { renderCardCollections, updateAllCards } = await import('../src/ui/cards.js');
-  renderCardCollections({
-    hustles: [],
-    education: registry.hustles.filter(hustle => hustle.tag?.type === 'study'),
-    assets: [],
-    upgrades: []
-  });
+  const initialModels = buildEducationModels(educationDefinitions);
+  renderCardCollections(
+    {
+      hustles: [],
+      education: educationDefinitions,
+      assets: [],
+      upgrades: []
+    },
+    { education: initialModels }
+  );
 
   const state = getState();
   const progress = getKnowledgeProgress('outlineMastery', state);
@@ -102,12 +114,16 @@ test('completed study tracks celebrate progress and skills', async () => {
   progress.enrolled = false;
   progress.studiedToday = false;
 
-  updateAllCards({
-    hustles: [],
-    education: registry.hustles.filter(hustle => hustle.tag?.type === 'study'),
-    assets: [],
-    upgrades: []
-  });
+  const updatedModels = buildEducationModels(educationDefinitions);
+  updateAllCards(
+    {
+      hustles: [],
+      education: educationDefinitions,
+      assets: [],
+      upgrades: []
+    },
+    { education: updatedModels }
+  );
 
   const track = document.querySelector("[data-track='outlineMastery']");
   assert.ok(track, 'study track should remain visible after completion');


### PR DESCRIPTION
## Summary
- pass precomputed card models from the update flow into card presenters before invoking the legacy DOM fallback
- update the classic card helpers to consume cached hustle and education models when rendering or refreshing UI
- adjust education-focused tests to provide prepared card models for the presenter-aware APIs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc6b493f48832c8d3d48a84773a0a6