### PR TITLE
Remove unused helpers and exports

### DIFF
--- a/src/core/persistence/index.js
+++ b/src/core/persistence/index.js
@@ -257,4 +257,3 @@ export class StatePersistence {
   }
 }
 
-export { DEFAULT_MIGRATIONS };

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -155,16 +155,6 @@ export const getUpgradeState = (...args) => stateManager.getUpgradeState(...args
 export const countActiveAssetInstances = (...args) => stateManager.countActiveAssetInstances(...args);
 
 export {
-  ensureHustleSlice,
-  getHustleSliceState,
-  ensureAssetSlice,
-  getAssetSliceState,
-  ensureUpgradeSlice,
-  getUpgradeSliceState,
-  ensureProgressSlice
-};
-
-export {
   configureRegistry,
   getRegistrySnapshot,
   getHustleDefinition,

--- a/src/game/assets/helpers.js
+++ b/src/game/assets/helpers.js
@@ -43,7 +43,7 @@ function getEffectiveSetupHours(definition) {
   return base * (Number.isFinite(effect.multiplier) ? effect.multiplier : 1);
 }
 
-function getAssetMetricId(definition, scope, type) {
+export function getAssetMetricId(definition, scope, type) {
   if (!definition) return null;
   const metricIds = definition.metricIds || {};
   const scoped = metricIds[scope];
@@ -507,4 +507,3 @@ export function qualityProgressDetail(definition) {
   return `📈 Roadmap: ${lines}`;
 }
 
-export { assetActionLabel, isAssetPurchaseDisabled, startAsset, getAssetMetricId };

--- a/src/game/hustles.js
+++ b/src/game/hustles.js
@@ -7,6 +7,4 @@ const KNOWLEDGE_HUSTLES = createKnowledgeHustles();
 
 export const HUSTLES = [...INSTANT_HUSTLES, ...KNOWLEDGE_HUSTLES];
 
-export { createKnowledgeHustles };
-export { INSTANT_HUSTLES };
 export * from './hustles/helpers.js';

--- a/src/game/skills/index.js
+++ b/src/game/skills/index.js
@@ -14,8 +14,6 @@ import {
   normalizeSkillState
 } from './data.js';
 
-export { SKILL_DEFINITIONS, SKILL_LEVELS, CHARACTER_LEVELS, getSkillDefinition, normalizeSkillList } from './data.js';
-
 const TIME_XP_RATE = 5;
 const MONEY_XP_INTERVAL = 25;
 

--- a/src/ui/cards.js
+++ b/src/ui/cards.js
@@ -66,4 +66,3 @@ export function refreshUpgradeSections() {
   classicRefreshUpgradeSections();
 }
 
-export { classicCardsPresenter };

--- a/src/ui/cards/model.js
+++ b/src/ui/cards/model.js
@@ -184,41 +184,6 @@ export function formatInstanceUpkeep(definition) {
   return parts.join(' • ');
 }
 
-export function buildAssetGroups(definitions = [], state = getState()) {
-  const groups = new Map();
-  definitions.forEach(definition => {
-    const groupId = getAssetGroupId(definition);
-    const label = getAssetGroupLabel(definition);
-    if (!groups.has(groupId)) {
-      groups.set(groupId, {
-        id: groupId,
-        label,
-        note: getAssetGroupNote(label),
-        icon: ASSET_GROUP_ICONS[label] || '✨',
-        definitions: [],
-        instances: []
-      });
-    }
-    const entry = groups.get(groupId);
-    entry.definitions.push(definition);
-    const assetState = getAssetState(definition.id, state);
-    const instances = Array.isArray(assetState?.instances) ? assetState.instances : [];
-    instances.forEach((instance, index) => {
-      const id = instance?.id ?? `${definition.id}-${index}`;
-      const status = instance?.status || 'setup';
-      entry.instances.push({
-        id,
-        index,
-        status,
-        definitionId: definition.id,
-        definition,
-        instance: instance || null
-      });
-    });
-  });
-  return Array.from(groups.values());
-}
-
 export function describeAssetLaunchAvailability(definition, state = getState()) {
   if (!definition) {
     return { disabled: true, reasons: ['Definition missing.'], hours: 0, cost: 0 };
@@ -738,10 +703,3 @@ export function buildEducationModels(definitions = [], helpers = {}) {
   };
 }
 
-export {
-  UPGRADE_CATEGORY_ORDER,
-  UPGRADE_CATEGORY_COPY,
-  UPGRADE_FAMILY_COPY,
-  ASSET_GROUP_NOTES,
-  ASSET_GROUP_ICONS
-};

--- a/src/ui/dashboard.js
+++ b/src/ui/dashboard.js
@@ -2,8 +2,6 @@ import { getState } from '../core/state.js';
 import { buildDashboardViewModel } from './dashboard/model.js';
 import { getActiveView } from './viewManager.js';
 
-export { buildDashboardViewModel } from './dashboard/model.js';
-
 export function renderDashboard(state, summary, presenter) {
   const currentState = state ?? getState();
   if (!currentState) return;

--- a/src/ui/views/classic/index.js
+++ b/src/ui/views/classic/index.js
@@ -1,4 +1,4 @@
-import resolvers, { classicResolvers } from './resolvers.js';
+import resolvers from './resolvers.js';
 import { renderDashboard as baseRenderDashboard } from '../../dashboard.js';
 import dashboardPresenter from './dashboardPresenter.js';
 import cardsPresenter from './cardsPresenter.js';
@@ -16,5 +16,4 @@ const classicView = {
   }
 };
 
-export { classicResolvers };
 export default classicView;

--- a/src/ui/views/classic/resolvers.js
+++ b/src/ui/views/classic/resolvers.js
@@ -183,5 +183,4 @@ const resolvers = {
   })
 };
 
-export { resolvers as classicResolvers };
 export default resolvers;


### PR DESCRIPTION
## Summary
- drop the unused buildAssetGroups helper and redundant asset grouping exports
- prune unused re-exports across cards, dashboard, hustles, persistence, and skills modules
- keep getAssetMetricId available for lifecycle logic while reducing dead surface area

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc854733ec832cb3a459852d6fe488