### PR TITLE
Refactor daily summary selectors and presenters

### DIFF
--- a/src/game/summary.js
+++ b/src/game/summary.js
@@ -1,16 +1,17 @@
-import { getState, getAssetState } from '../core/state.js';
-import { getMetricDefinition } from '../core/state/registry.js';
-import { formatHours, formatMoney } from '../core/helpers.js';
-import { KNOWLEDGE_TRACKS, getKnowledgeProgress } from './requirements.js';
-import { getDailyMetrics } from './metrics.js';
-import { ASSETS } from './assets/registry.js';
+import { getState } from '../core/state.js';
+import {
+  selectDailyCostEntries,
+  selectDailyPayoutEntries,
+  selectDailyTimeEntries,
+  selectStudyProgressEntries
+} from './summary/selectors.js';
 
-function resolveDefinitionReference(metricId) {
-  if (!metricId) return undefined;
-  const reference = getMetricDefinition(metricId);
-  if (!reference) return undefined;
-  const { id, name, category, type, label } = reference;
-  return { id, name, category, type, label };
+function sumEntries(entries, field, predicate = () => true) {
+  return entries.reduce((total, entry) => {
+    if (!predicate(entry)) return total;
+    const value = Number(entry?.[field]);
+    return Number.isFinite(value) ? total + value : total;
+  }, 0);
 }
 
 export function computeDailySummary(state = getState()) {
@@ -36,147 +37,36 @@ export function computeDailySummary(state = getState()) {
     };
   }
 
-  const getCategory = entry => entry?.category || 'general';
-  const sumEntries = (entries, field, predicate = () => true) =>
-    entries.reduce((total, entry) => {
-      if (!predicate(entry)) return total;
-      const value = Number(entry?.[field]);
-      return Number.isFinite(value) ? total + value : total;
-    }, 0);
+  const timeBreakdown = selectDailyTimeEntries(state);
+  const payoutEntries = selectDailyPayoutEntries(state);
+  const passiveBreakdown = payoutEntries.filter(entry => entry.stream !== 'active');
+  const earningsBreakdown = payoutEntries.filter(entry => entry.stream === 'active');
+  const spendBreakdown = selectDailyCostEntries(state);
+  const studyBreakdown = selectStudyProgressEntries(state);
 
-  const metrics = getDailyMetrics(state) || {};
-  const timeEntries = Object.values(metrics.time || {});
-  const earningsEntries = Object.values(metrics.payouts || {});
-  const passiveEntries = earningsEntries.filter(entry =>
-    ['passive', 'offline'].includes(getCategory(entry))
-  );
-  const activeEntries = earningsEntries.filter(entry => !['passive', 'offline'].includes(getCategory(entry)));
-  const spendEntries = Object.values(metrics.costs || {});
-
-  const totalTime = sumEntries(timeEntries, 'hours');
-  const setupHours = sumEntries(timeEntries, 'hours', entry => getCategory(entry) === 'setup');
-  const maintenanceHours = sumEntries(timeEntries, 'hours', entry => getCategory(entry) === 'maintenance');
+  const totalTime = sumEntries(timeBreakdown, 'hours');
+  const setupHours = sumEntries(timeBreakdown, 'hours', entry => entry.category === 'setup');
+  const maintenanceHours = sumEntries(timeBreakdown, 'hours', entry => entry.category === 'maintenance');
   const otherTimeHours = Math.max(0, totalTime - setupHours - maintenanceHours);
 
-  const formatTimeBreakdown = timeEntries
-    .filter(entry => Number(entry?.hours) > 0)
-    .sort((a, b) => Number(b.hours) - Number(a.hours))
-    .map(entry => {
-      const hours = Number(entry?.hours) || 0;
-      const category = getCategory(entry);
-      const result = {
-        key: entry.key,
-        label: entry.label,
-        value: `${formatHours(hours)} today`,
-        hours,
-        category
-      };
-      const definition = resolveDefinitionReference(entry.key);
-      if (definition) {
-        result.definition = definition;
-        if (!result.category && definition.category) {
-          result.category = definition.category;
-        }
-      }
-      return result;
-    });
+  const totalEarnings = sumEntries(payoutEntries, 'amount');
+  const passiveEarnings = sumEntries(passiveBreakdown, 'amount');
+  const activeEarnings = sumEntries(earningsBreakdown, 'amount');
 
-  const totalEarnings = sumEntries(earningsEntries, 'amount');
-  const passiveEarnings = sumEntries(passiveEntries, 'amount');
-  const activeEarnings = sumEntries(activeEntries, 'amount');
-
-  const formatIncomeBreakdown = entries =>
-    entries
-      .filter(entry => Number(entry?.amount) > 0)
-      .sort((a, b) => Number(b.amount) - Number(a.amount))
-      .map(entry => {
-        const result = {
-          key: entry.key,
-          label: entry.label,
-          value: `$${formatMoney(Number(entry.amount))} today`
-        };
-        const definition = resolveDefinitionReference(entry.key);
-        if (definition) {
-          result.definition = definition;
-        }
-        return result;
-      });
-
-  const passiveAssetSummaries = new Map();
-
-  for (const definition of ASSETS) {
-    const assetState = getAssetState(definition.id, state);
-    const instances = Array.isArray(assetState?.instances) ? assetState.instances : [];
-    const earningInstances = instances.filter(
-      instance => instance.status === 'active' && Number(instance.lastIncome) > 0
-    );
-    if (!earningInstances.length) continue;
-    passiveAssetSummaries.set(`asset:${definition.id}:payout`, {
-      count: earningInstances.length,
-      label: definition.singular || definition.name
-    });
-  }
-
-  let passiveBreakdown = formatIncomeBreakdown(passiveEntries).map(entry => {
-    if (!entry?.key) return entry;
-    const summary = passiveAssetSummaries.get(entry.key);
-    if (!summary) return entry;
-    const iconMatch = entry.label.match(/^([^\w]*)/);
-    const prefix = iconMatch ? iconMatch[1] : '';
-    const decoratedLabel = summary.count > 1
-      ? `${summary.label} (${summary.count})`
-      : summary.label;
-    const parts = [prefix ? prefix.trim() : '', decoratedLabel].filter(Boolean);
-    return {
-      ...entry,
-      label: parts.join(' ')
-    };
-  });
-  const earningsBreakdown = formatIncomeBreakdown(activeEntries);
-
-  const totalSpend = sumEntries(spendEntries, 'amount');
-  const upkeepSpend = sumEntries(spendEntries, 'amount', entry =>
-    ['maintenance', 'payroll'].includes(getCategory(entry))
+  const totalSpend = sumEntries(spendBreakdown, 'amount');
+  const upkeepSpend = sumEntries(
+    spendBreakdown,
+    'amount',
+    entry => ['maintenance', 'payroll'].includes(entry.category)
   );
-  const investmentSpend = sumEntries(spendEntries, 'amount', entry =>
-    ['setup', 'investment', 'upgrade', 'consumable'].includes(getCategory(entry))
+  const investmentSpend = sumEntries(
+    spendBreakdown,
+    'amount',
+    entry => ['setup', 'investment', 'upgrade', 'consumable'].includes(entry.category)
   );
 
-  const spendBreakdown = spendEntries
-    .filter(entry => Number(entry?.amount) > 0)
-    .sort((a, b) => Number(b.amount) - Number(a.amount))
-    .map(entry => {
-      const result = {
-        key: entry.key,
-        label: entry.label,
-        value: `$${formatMoney(Number(entry.amount))} today`
-      };
-      const definition = resolveDefinitionReference(entry.key);
-      if (definition) {
-        result.definition = definition;
-      }
-      return result;
-    });
-
-  let knowledgeInProgress = 0;
-  let knowledgePendingToday = 0;
-  const studyBreakdown = [];
-
-  for (const track of Object.values(KNOWLEDGE_TRACKS)) {
-    const progress = getKnowledgeProgress(track.id, state);
-    if (!progress.enrolled || progress.completed) continue;
-    knowledgeInProgress += 1;
-    if (!progress.studiedToday) {
-      knowledgePendingToday += 1;
-    }
-
-    const remainingDays = Math.max(0, track.days - progress.daysCompleted);
-    const status = progress.studiedToday ? 'scheduled' : 'waiting';
-    studyBreakdown.push({
-      label: `📘 ${track.name}`,
-      value: `${formatHours(track.hoursPerDay)} / day • ${remainingDays} day${remainingDays === 1 ? '' : 's'} left (${status})`
-    });
-  }
+  const knowledgeInProgress = studyBreakdown.length;
+  const knowledgePendingToday = studyBreakdown.filter(entry => !entry.studiedToday).length;
 
   return {
     totalTime,
@@ -191,10 +81,10 @@ export function computeDailySummary(state = getState()) {
     investmentSpend,
     knowledgeInProgress,
     knowledgePendingToday,
-    timeBreakdown: formatTimeBreakdown,
+    timeBreakdown,
     earningsBreakdown,
-    spendBreakdown,
     passiveBreakdown,
+    spendBreakdown,
     studyBreakdown
   };
 }

--- a/src/game/summary/selectors.js
+++ b/src/game/summary/selectors.js
@@ -1,0 +1,146 @@
+import { getState, getAssetState } from '../../core/state.js';
+import { getMetricDefinition } from '../../core/state/registry.js';
+import { getDailyMetrics } from '../metrics.js';
+import { KNOWLEDGE_TRACKS, getKnowledgeProgress } from '../requirements.js';
+import { ASSETS } from '../assets/registry.js';
+
+function resolveMetricDefinition(metricId) {
+  if (!metricId) return undefined;
+  const definition = getMetricDefinition(metricId);
+  if (!definition) return undefined;
+  const { id, name, category, type, label } = definition;
+  return { id, name, category, type, label };
+}
+
+function normalizeCategory(entryCategory, fallbackCategory) {
+  const source = entryCategory ?? fallbackCategory;
+  if (typeof source === 'string' && source.trim()) {
+    return source.trim();
+  }
+  return 'general';
+}
+
+export function selectPassiveAssetSources(state = getState()) {
+  if (!state) return new Map();
+  const summaries = new Map();
+
+  for (const definition of ASSETS) {
+    const assetState = getAssetState(definition.id, state);
+    const instances = Array.isArray(assetState?.instances) ? assetState.instances : [];
+    const earningInstances = instances.filter(
+      instance => instance?.status === 'active' && Number(instance?.lastIncome) > 0
+    );
+    if (!earningInstances.length) continue;
+
+    summaries.set(`asset:${definition.id}:payout`, {
+      type: 'asset',
+      assetId: definition.id,
+      name: definition.singular || definition.name,
+      count: earningInstances.length
+    });
+  }
+
+  return summaries;
+}
+
+export function selectDailyTimeEntries(state = getState()) {
+  if (!state) return [];
+  const metrics = getDailyMetrics(state) || {};
+  const timeEntries = Object.values(metrics.time || {});
+
+  return timeEntries
+    .map(entry => {
+      const hours = Number(entry?.hours);
+      const numericHours = Number.isFinite(hours) ? hours : 0;
+      const definition = resolveMetricDefinition(entry?.key);
+      const category = normalizeCategory(entry?.category, definition?.category);
+      return {
+        key: entry?.key,
+        label: entry?.label,
+        hours: numericHours,
+        category,
+        definition
+      };
+    })
+    .filter(entry => entry.hours > 0)
+    .sort((a, b) => b.hours - a.hours);
+}
+
+function classifyPayoutCategory(category) {
+  if (category === 'offline') return 'offline';
+  if (category === 'passive') return 'passive';
+  return 'active';
+}
+
+export function selectDailyPayoutEntries(state = getState()) {
+  if (!state) return [];
+  const metrics = getDailyMetrics(state) || {};
+  const payoutEntries = Object.values(metrics.payouts || {});
+  const assetSources = selectPassiveAssetSources(state);
+
+  return payoutEntries
+    .map(entry => {
+      const amount = Number(entry?.amount);
+      const numericAmount = Number.isFinite(amount) ? amount : 0;
+      const definition = resolveMetricDefinition(entry?.key);
+      const rawCategory = normalizeCategory(entry?.category, definition?.category);
+      const stream = classifyPayoutCategory(rawCategory);
+      const source = assetSources.get(entry?.key);
+      return {
+        key: entry?.key,
+        label: entry?.label,
+        amount: numericAmount,
+        category: rawCategory,
+        stream,
+        definition,
+        ...(source ? { source } : {})
+      };
+    })
+    .filter(entry => entry.amount > 0)
+    .sort((a, b) => b.amount - a.amount);
+}
+
+export function selectDailyCostEntries(state = getState()) {
+  if (!state) return [];
+  const metrics = getDailyMetrics(state) || {};
+  const costEntries = Object.values(metrics.costs || {});
+
+  return costEntries
+    .map(entry => {
+      const amount = Number(entry?.amount);
+      const numericAmount = Number.isFinite(amount) ? amount : 0;
+      const definition = resolveMetricDefinition(entry?.key);
+      const category = normalizeCategory(entry?.category, definition?.category);
+      return {
+        key: entry?.key,
+        label: entry?.label,
+        amount: numericAmount,
+        category,
+        definition
+      };
+    })
+    .filter(entry => entry.amount > 0)
+    .sort((a, b) => b.amount - a.amount);
+}
+
+export function selectStudyProgressEntries(state = getState()) {
+  if (!state) return [];
+  const entries = [];
+
+  for (const track of Object.values(KNOWLEDGE_TRACKS)) {
+    const progress = getKnowledgeProgress(track.id, state);
+    if (!progress?.enrolled || progress?.completed) continue;
+
+    const remainingDays = Math.max(0, Number(track.days) - Number(progress.daysCompleted || 0));
+    entries.push({
+      trackId: track.id,
+      name: track.name,
+      hoursPerDay: Number(track.hoursPerDay) || 0,
+      remainingDays,
+      studiedToday: Boolean(progress.studiedToday),
+      status: progress.studiedToday ? 'scheduled' : 'waiting'
+    });
+  }
+
+  return entries;
+}

--- a/tests/summary.test.js
+++ b/tests/summary.test.js
@@ -14,6 +14,12 @@ const {
   resetDailyMetrics
 } = await import('../src/game/metrics.js');
 const { computeDailySummary } = await import('../src/game/summary.js');
+const {
+  selectDailyTimeEntries,
+  selectDailyPayoutEntries,
+  selectDailyCostEntries,
+  selectStudyProgressEntries
+} = await import('../src/game/summary/selectors.js');
 
 test('daily summary aggregates metrics into category totals', () => {
   configureRegistry(registry);
@@ -71,6 +77,11 @@ test('daily summary aggregates metrics into category totals', () => {
   assert.equal(summary.passiveBreakdown.length, 1);
   assert.equal(summary.earningsBreakdown.length, 1);
   assert.equal(summary.spendBreakdown.length, 2);
+
+  assert.equal(summary.timeBreakdown[0].hours, 3);
+  assert.equal(summary.earningsBreakdown[0].amount, 24);
+  assert.equal(summary.passiveBreakdown[0].stream, 'passive');
+  assert.equal(summary.spendBreakdown[0].amount, 42);
 });
 
 test('daily summary attaches definition references for canonical metrics', () => {
@@ -113,6 +124,64 @@ test('daily summary attaches definition references for canonical metrics', () =>
   );
   assert.ok(maintenanceEntry?.definition, 'spend entry should include definition metadata');
   assert.equal(maintenanceEntry.definition.category, 'maintenance');
+});
+
+test('raw selectors return numeric breakdown entries', () => {
+  configureRegistry(registry);
+  const state = initializeState();
+  resetDailyMetrics(state);
+
+  recordTimeContribution({
+    key: 'selector:time',
+    label: '⌛ Selector Time',
+    hours: 4,
+    category: 'maintenance'
+  });
+
+  recordPayoutContribution({
+    key: 'selector:earnings',
+    label: '💼 Selector Earnings',
+    amount: 75,
+    category: 'passive'
+  });
+
+  recordCostContribution({
+    key: 'selector:cost',
+    label: '🔧 Selector Cost',
+    amount: 18,
+    category: 'maintenance'
+  });
+
+  state.progress = state.progress || {};
+  state.progress.knowledge = {
+    outlineMastery: {
+      enrolled: true,
+      completed: false,
+      daysCompleted: 1,
+      studiedToday: false
+    }
+  };
+
+  const timeEntries = selectDailyTimeEntries(state);
+  const payoutEntries = selectDailyPayoutEntries(state);
+  const costEntries = selectDailyCostEntries(state);
+  const studyEntries = selectStudyProgressEntries(state);
+
+  assert.equal(timeEntries.length, 1);
+  assert.equal(timeEntries[0].hours, 4);
+  assert.equal(timeEntries[0].category, 'maintenance');
+
+  assert.equal(payoutEntries.length, 1);
+  assert.equal(payoutEntries[0].amount, 75);
+  assert.equal(payoutEntries[0].stream, 'passive');
+
+  assert.equal(costEntries.length, 1);
+  assert.equal(costEntries[0].amount, 18);
+  assert.equal(costEntries[0].category, 'maintenance');
+
+  assert.equal(studyEntries.length, 1);
+  assert.equal(studyEntries[0].remainingDays, 4);
+  assert.equal(studyEntries[0].status, 'waiting');
 });
 
 test('lifetime totals accumulate alongside daily metrics', () => {

--- a/tests/ui/dashboardModel.test.js
+++ b/tests/ui/dashboardModel.test.js
@@ -17,14 +17,41 @@ function createSummary(overrides = {}) {
     otherTimeHours: 3,
     totalTime: 6,
     timeBreakdown: [
-      { key: 'queue-1', label: 'Prototype sprint', value: '2h', hours: 2, category: 'active' }
+      { key: 'queue-1', label: 'Prototype sprint', hours: 2, category: 'active' }
     ],
     earningsBreakdown: [
-      { label: 'Freelance gig', value: '$180', definition: { id: 'earn-1', name: 'Freelance' } }
+      {
+        key: 'earn-1',
+        label: 'Freelance gig',
+        amount: 180,
+        category: 'active',
+        stream: 'active',
+        definition: { id: 'earn-1', name: 'Freelance' }
+      }
     ],
-    passiveBreakdown: [],
-    spendBreakdown: [],
-    studyBreakdown: [],
+    passiveBreakdown: [
+      {
+        key: 'asset:rig:payout',
+        label: '💰 Rig payout',
+        amount: 220,
+        category: 'passive',
+        stream: 'passive',
+        source: { type: 'asset', name: 'Analytics Rig', count: 2 }
+      }
+    ],
+    spendBreakdown: [
+      { key: 'spend-1', label: '🛠 Maintenance', amount: 60, category: 'maintenance' }
+    ],
+    studyBreakdown: [
+      {
+        trackId: 'outlineMastery',
+        name: 'Outline Mastery Workshop',
+        hoursPerDay: 2,
+        remainingDays: 3,
+        studiedToday: false,
+        status: 'waiting'
+      }
+    ],
     knowledgeInProgress: 1,
     knowledgePendingToday: 1
   };
@@ -80,6 +107,24 @@ test('buildDashboardViewModel produces derived dashboard sections', t => {
 
   assert.equal(viewModel.queue.items[0].label, 'Prototype sprint');
   assert.ok(viewModel.queue.items[0].hoursLabel.includes('h'));
+
+  const timeEntries = viewModel.dailyStats.time.entries;
+  assert.equal(timeEntries[0].value.includes('today'), true);
+
+  const activeEntry = viewModel.dailyStats.earnings.active.entries[0];
+  assert.equal(activeEntry.label, 'Freelance gig');
+  assert.ok(activeEntry.value.includes('$180'));
+
+  const passiveEntry = viewModel.dailyStats.earnings.passive.entries[0];
+  assert.ok(passiveEntry.label.includes('Analytics Rig'));
+  assert.ok(passiveEntry.label.includes('(2)'));
+
+  const spendEntry = viewModel.dailyStats.spend.entries[0];
+  assert.ok(spendEntry.value.includes('$60'));
+
+  const studyEntry = viewModel.dailyStats.study.entries[0];
+  assert.ok(studyEntry.label.startsWith('📘'));
+  assert.ok(studyEntry.value.includes('waiting'));
 
   assert.ok(Array.isArray(viewModel.quickActions.entries));
   assert.ok(Array.isArray(viewModel.assetActions.entries));


### PR DESCRIPTION
## Summary
- add a summary selectors module that exposes raw numeric breakdowns for daily metrics
- refactor `computeDailySummary` to build totals from the selectors and return unformatted data
- update dashboard presenters to format display strings and extend unit tests to cover selectors and view models

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc87dca64c832c85dcb707d7792f53