### PR TITLE
Refactor element registry accessors

### DIFF
--- a/src/core/log.js
+++ b/src/core/log.js
@@ -1,7 +1,7 @@
 import { MAX_LOG_ENTRIES } from './constants.js';
 import { createId } from './helpers.js';
 import { getState } from './state.js';
-import { getLogNodes } from '../ui/elements/registry.js';
+import { getElement } from '../ui/elements/registry.js';
 
 export function addLog(message, type = 'info') {
   const state = getState();
@@ -22,7 +22,7 @@ export function addLog(message, type = 'info') {
 export function renderLog() {
   const state = getState();
   if (!state) return;
-  const { logFeed, logTemplate, logTip } = getLogNodes() || {};
+  const { logFeed, logTemplate, logTip } = getElement('logNodes') || {};
   if (!logFeed || !logTemplate || !logTip) return;
   if (!state.log.length) {
     logTip.style.display = 'block';

--- a/src/game/currency.js
+++ b/src/game/currency.js
@@ -1,13 +1,13 @@
 import { getState } from '../core/state.js';
 import { addLog } from '../core/log.js';
-import { getMoneyNode } from '../ui/elements/registry.js';
+import { getElement } from '../ui/elements/registry.js';
 import { flashValue } from '../ui/effects.js';
 
 export function addMoney(amount, message, type = 'info') {
   const state = getState();
   if (!state) return;
   state.money = Math.max(0, Number(state.money) + Number(amount));
-  const moneyNode = getMoneyNode();
+  const moneyNode = getElement('money');
   flashValue(moneyNode);
   if (message) {
     addLog(message, type);
@@ -18,6 +18,6 @@ export function spendMoney(amount) {
   const state = getState();
   if (!state) return;
   state.money = Math.max(0, state.money - amount);
-  const moneyNode = getMoneyNode();
+  const moneyNode = getElement('money');
   flashValue(moneyNode, true);
 }

--- a/src/ui/debugCatalog.js
+++ b/src/ui/debugCatalog.js
@@ -1,7 +1,7 @@
 import { formatHours, formatMoney } from '../core/helpers.js';
 import { getState } from '../core/state.js';
 import { listCatalog } from '../game/content/catalog.js';
-import { getDebugCatalogNodes } from './elements/registry.js';
+import { getElement } from './elements/registry.js';
 
 let debugEnabled = false;
 
@@ -109,7 +109,8 @@ function renderActionRows(table, entries) {
 }
 
 function renderDebugCatalog() {
-  const { debugActionCatalogList: table, debugActionCatalogSummary: summary } = getDebugCatalogNodes() || {};
+  const { debugActionCatalogList: table, debugActionCatalogSummary: summary } =
+    getElement('debugCatalog') || {};
   if (!table) return;
   table.textContent = '';
   const state = getState();
@@ -132,7 +133,7 @@ function renderDebugCatalog() {
 }
 
 function enableDebugPanel() {
-  const { debugActionCatalog: panel } = getDebugCatalogNodes() || {};
+  const { debugActionCatalog: panel } = getElement('debugCatalog') || {};
   if (!panel) return;
   debugEnabled = true;
   persistDebugFlag(true);
@@ -142,7 +143,11 @@ function enableDebugPanel() {
 }
 
 function disableDebugPanel() {
-  const { debugActionCatalog: panel, debugActionCatalogList: table, debugActionCatalogSummary: summary } = getDebugCatalogNodes() || {};
+  const {
+    debugActionCatalog: panel,
+    debugActionCatalogList: table,
+    debugActionCatalogSummary: summary
+  } = getElement('debugCatalog') || {};
   if (!panel) return;
   debugEnabled = false;
   persistDebugFlag(false);

--- a/src/ui/elements/registry.js
+++ b/src/ui/elements/registry.js
@@ -27,140 +27,13 @@ class ElementRegistry {
     return this.cache.get(key);
   }
 
-  getMoneyNode() {
-    return this.resolve('money');
-  }
-
-  getSessionStatusNode() {
-    return this.resolve('sessionStatus');
-  }
-
-  getHeaderActionButtons() {
-    return this.resolve('headerActionButtons');
-  }
-
-  getShellNavigation() {
-    return this.resolve('shellNavigation');
-  }
-
-  getHeaderStats() {
-    return this.resolve('headerStats');
-  }
-
-  getKpiNodes() {
-    return this.resolve('kpis');
-  }
-
-  getKpiNotes() {
-    return this.resolve('kpiNotes');
-  }
-
-  getKpiValues() {
-    return this.resolve('kpiValues');
-  }
-
-  getDailyStats() {
-    return this.resolve('dailyStats');
-  }
-
-  getNicheTrends() {
-    return this.resolve('nicheTrends');
-  }
-
-  getSkillSections() {
-    return this.resolve('skillSections');
-  }
-
-  getQueueNodes() {
-    return this.resolve('queueNodes');
-  }
-
-  getQuickActionsContainer() {
-    return this.resolve('quickActions');
-  }
-
-  getAssetUpgradeActionsContainer() {
-    return this.resolve('assetUpgradeActions');
-  }
-
-  getNotificationsContainer() {
-    return this.resolve('notifications');
-  }
-
-  getEventLogPreviewNode() {
-    return this.resolve('eventLogPreview');
-  }
-
-  getEventLogControls() {
-    return this.resolve('eventLogControls');
-  }
-
-  getLogNodes() {
-    return this.resolve('logNodes');
-  }
-
-  getHustleControls() {
-    return this.resolve('hustleControls');
-  }
-
-  getAssetFilters() {
-    return this.resolve('assetFilters');
-  }
-
-  getAssetGallery() {
-    return this.resolve('assetGallery');
-  }
-
-  getUpgradeFilters() {
-    return this.resolve('upgradeFilters');
-  }
-
-  getUpgradeOverview() {
-    return this.resolve('upgradeOverview');
-  }
-
-  getUpgradeEmptyNode() {
-    return this.resolve('upgradeEmpty');
-  }
-
-  getUpgradeLaneList() {
-    return this.resolve('upgradeLaneList');
-  }
-
-  getUpgradeList() {
-    return this.resolve('upgradeList');
-  }
-
-  getUpgradeDockList() {
-    return this.resolve('upgradeDockList');
-  }
-
-  getStudyFilters() {
-    return this.resolve('studyFilters');
-  }
-
-  getStudyQueue() {
-    return this.resolve('studyQueue');
-  }
-
-  getStudyTrackList() {
-    return this.resolve('studyTrackList');
-  }
-
-  getSlideOverNodes() {
-    return this.resolve('slideOver');
-  }
-
-  getCommandPaletteNodes() {
-    return this.resolve('commandPalette');
-  }
-
-  getPlayerNodes() {
-    return this.resolve('playerNodes');
-  }
-
-  getDebugCatalogNodes() {
-    return this.resolve('debugCatalog');
+  /**
+   * Resolve and cache a DOM lookup by key.
+   * @param {string} key
+   * @returns {unknown}
+   */
+  get(key) {
+    return this.resolve(key);
   }
 }
 
@@ -170,140 +43,52 @@ export function initElementRegistry(root, resolvers) {
   elementRegistry.initialize(root, resolvers);
 }
 
-export function getMoneyNode() {
-  return elementRegistry.getMoneyNode();
+const accessors = new Proxy(
+  {},
+  {
+    get(target, key, receiver) {
+      if (typeof key !== 'string') {
+        return Reflect.get(target, key, receiver);
+      }
+      return elementRegistry.get(key);
+    },
+    has(_, key) {
+      if (typeof key !== 'string') return false;
+      return Boolean(elementRegistry.resolvers?.[key]);
+    },
+    ownKeys() {
+      return Object.keys(elementRegistry.resolvers || {});
+    },
+    getOwnPropertyDescriptor(target, key) {
+      if (typeof key !== 'string' || !(key in (elementRegistry.resolvers || {}))) {
+        return Reflect.getOwnPropertyDescriptor(target, key);
+      }
+      return {
+        configurable: true,
+        enumerable: true,
+        get() {
+          return elementRegistry.get(key);
+        }
+      };
+    }
+  }
+);
+
+/**
+ * Resolve a DOM node or group using a registered resolver.
+ * Results are cached until the registry is re-initialized.
+ *
+ * @param {string} key
+ * @returns {unknown}
+ */
+export function getElement(key) {
+  return elementRegistry.get(key);
 }
 
-export function getSessionStatusNode() {
-  return elementRegistry.getSessionStatusNode();
-}
-
-export function getHeaderActionButtons() {
-  return elementRegistry.getHeaderActionButtons();
-}
-
-export function getShellNavigation() {
-  return elementRegistry.getShellNavigation();
-}
-
-export function getHeaderStats() {
-  return elementRegistry.getHeaderStats();
-}
-
-export function getKpiNodes() {
-  return elementRegistry.getKpiNodes();
-}
-
-export function getKpiNotes() {
-  return elementRegistry.getKpiNotes();
-}
-
-export function getKpiValues() {
-  return elementRegistry.getKpiValues();
-}
-
-export function getDailyStats() {
-  return elementRegistry.getDailyStats();
-}
-
-export function getNicheTrends() {
-  return elementRegistry.getNicheTrends();
-}
-
-export function getSkillSections() {
-  return elementRegistry.getSkillSections();
-}
-
-export function getQueueNodes() {
-  return elementRegistry.getQueueNodes();
-}
-
-export function getQuickActionsContainer() {
-  return elementRegistry.getQuickActionsContainer();
-}
-
-export function getAssetUpgradeActionsContainer() {
-  return elementRegistry.getAssetUpgradeActionsContainer();
-}
-
-export function getNotificationsContainer() {
-  return elementRegistry.getNotificationsContainer();
-}
-
-export function getEventLogPreviewNode() {
-  return elementRegistry.getEventLogPreviewNode();
-}
-
-export function getEventLogControls() {
-  return elementRegistry.getEventLogControls();
-}
-
-export function getLogNodes() {
-  return elementRegistry.getLogNodes();
-}
-
-export function getHustleControls() {
-  return elementRegistry.getHustleControls();
-}
-
-export function getAssetFilters() {
-  return elementRegistry.getAssetFilters();
-}
-
-export function getAssetGallery() {
-  return elementRegistry.getAssetGallery();
-}
-
-export function getUpgradeFilters() {
-  return elementRegistry.getUpgradeFilters();
-}
-
-export function getUpgradeOverview() {
-  return elementRegistry.getUpgradeOverview();
-}
-
-export function getUpgradeEmptyNode() {
-  return elementRegistry.getUpgradeEmptyNode();
-}
-
-export function getUpgradeLaneList() {
-  return elementRegistry.getUpgradeLaneList();
-}
-
-export function getUpgradeList() {
-  return elementRegistry.getUpgradeList();
-}
-
-export function getUpgradeDockList() {
-  return elementRegistry.getUpgradeDockList();
-}
-
-export function getStudyFilters() {
-  return elementRegistry.getStudyFilters();
-}
-
-export function getStudyQueue() {
-  return elementRegistry.getStudyQueue();
-}
-
-export function getStudyTrackList() {
-  return elementRegistry.getStudyTrackList();
-}
-
-export function getSlideOverNodes() {
-  return elementRegistry.getSlideOverNodes();
-}
-
-export function getCommandPaletteNodes() {
-  return elementRegistry.getCommandPaletteNodes();
-}
-
-export function getPlayerNodes() {
-  return elementRegistry.getPlayerNodes();
-}
-
-export function getDebugCatalogNodes() {
-  return elementRegistry.getDebugCatalogNodes();
-}
+/**
+ * Proxy that exposes registry lookups as properties.
+ * Accessing `elements.money` resolves the `money` resolver.
+ */
+export const elements = accessors;
 
 export default elementRegistry;

--- a/src/ui/headerAction.js
+++ b/src/ui/headerAction.js
@@ -1,4 +1,4 @@
-import { getHeaderActionButtons } from './elements/registry.js';
+import { getElement } from './elements/registry.js';
 import { endDay } from '../game/lifecycle.js';
 import { buildAssetUpgradeRecommendations, buildQuickActions } from './dashboard/model.js';
 import { formatHours } from '../core/helpers.js';
@@ -32,7 +32,7 @@ const autoForwardState = {
 };
 
 function resolveHeaderButtons() {
-  const { endDayButton, autoForwardButton } = getHeaderActionButtons() || {};
+  const { endDayButton, autoForwardButton } = getElement('headerActionButtons') || {};
   return { endDayButton, autoForwardButton };
 }
 

--- a/src/ui/layout.js
+++ b/src/ui/layout.js
@@ -1,21 +1,4 @@
-import {
-  getAssetFilters,
-  getAssetGallery,
-  getAssetUpgradeActionsContainer,
-  getCommandPaletteNodes,
-  getDailyStats,
-  getEventLogControls,
-  getHustleControls,
-  getKpiNodes,
-  getNotificationsContainer,
-  getSessionStatusNode,
-  getShellNavigation,
-  getSlideOverNodes,
-  getStudyFilters,
-  getStudyTrackList,
-  getUpgradeFilters,
-  getUpgradeList
-} from './elements/registry.js';
+import { getElement } from './elements/registry.js';
 
 let activePanelController = null;
 
@@ -48,7 +31,7 @@ export function applyCardFilters() {
 }
 
 function setupTabs() {
-  const { shellTabs = [], panels = [] } = getShellNavigation() || {};
+  const { shellTabs = [], panels = [] } = getElement('shellNavigation') || {};
   if (!shellTabs.length || !panels.length) return;
 
   const activate = targetId => {
@@ -80,13 +63,13 @@ export function activateShellPanel(panelId) {
     activePanelController(panelId);
     return;
   }
-  const { shellTabs = [] } = getShellNavigation() || {};
+  const { shellTabs = [] } = getElement('shellNavigation') || {};
   const tab = shellTabs.find(button => button?.getAttribute('aria-controls') === panelId);
   tab?.click?.();
 }
 
 function setupEventLog() {
-  const { openEventLog, eventLogPanel, eventLogClose } = getEventLogControls() || {};
+  const { openEventLog, eventLogPanel, eventLogClose } = getElement('eventLogControls') || {};
   if (!openEventLog || !eventLogPanel) return;
 
   const toggle = visible => {
@@ -111,7 +94,7 @@ function setupEventLog() {
 }
 
 function setupSlideOver() {
-  const { slideOver, slideOverBackdrop, slideOverClose } = getSlideOverNodes() || {};
+  const { slideOver, slideOverBackdrop, slideOverClose } = getElement('slideOver') || {};
   if (!slideOver) return;
 
   const hide = () => {
@@ -136,12 +119,8 @@ function setupSlideOver() {
 }
 
 function setupCommandPalette() {
-  const {
-    commandPalette,
-    commandPaletteTrigger,
-    commandPaletteBackdrop,
-    commandPaletteSearch
-  } = getCommandPaletteNodes() || {};
+  const { commandPalette, commandPaletteTrigger, commandPaletteBackdrop, commandPaletteSearch } =
+    getElement('commandPalette') || {};
   if (!commandPalette || !commandPaletteTrigger) return;
 
   const show = () => {
@@ -170,35 +149,35 @@ function setupCommandPalette() {
 }
 
 function setupFilterHandlers() {
-  const hustleControls = getHustleControls() || {};
+  const hustleControls = getElement('hustleControls') || {};
   hustleControls.hustleAvailableToggle?.addEventListener('change', applyHustleFilters);
   hustleControls.hustleSort?.addEventListener('change', applyHustleFilters);
   hustleControls.hustleSearch?.addEventListener('input', debounce(applyHustleFilters, 120));
 
-  const assetFilters = getAssetFilters() || {};
+  const assetFilters = getElement('assetFilters') || {};
   assetFilters.activeOnly?.addEventListener('change', applyAssetFilters);
   assetFilters.maintenance?.addEventListener('change', applyAssetFilters);
   assetFilters.lowRisk?.addEventListener('change', applyAssetFilters);
 
-  const upgradeFilters = getUpgradeFilters() || {};
+  const upgradeFilters = getElement('upgradeFilters') || {};
   upgradeFilters.unlocked?.addEventListener('change', applyUpgradeFilters);
 
   document.addEventListener('upgrades:state-updated', applyUpgradeFilters);
   document.addEventListener('hustles:availability-updated', applyHustleFilters);
 
-  const studyFilters = getStudyFilters() || {};
+  const studyFilters = getElement('studyFilters') || {};
   studyFilters.activeOnly?.addEventListener('change', applyStudyFilters);
   studyFilters.hideComplete?.addEventListener('change', applyStudyFilters);
 }
 
 function setupKpiShortcuts() {
-  const buttons = Object.values(getKpiNodes() || {}).filter(Boolean);
+  const buttons = Object.values(getElement('kpis') || {}).filter(Boolean);
   if (!buttons.length) return;
 
-  const dailyStats = getDailyStats() || {};
-  const notifications = getNotificationsContainer();
-  const assetUpgradeActions = getAssetUpgradeActionsContainer();
-  const sessionStatus = getSessionStatusNode();
+  const dailyStats = getElement('dailyStats') || {};
+  const notifications = getElement('notifications');
+  const assetUpgradeActions = getElement('assetUpgradeActions');
+  const sessionStatus = getElement('sessionStatus');
 
   const targetLookup = {
     cash: () => dailyStats.earningsActive?.closest('.daily-stats__section')
@@ -269,12 +248,8 @@ function focusDashboardSection(target) {
 }
 
 function applyHustleFilters() {
-  const {
-    hustleList,
-    hustleAvailableToggle,
-    hustleSort,
-    hustleSearch
-  } = getHustleControls() || {};
+  const { hustleList, hustleAvailableToggle, hustleSort, hustleSearch } =
+    getElement('hustleControls') || {};
   const cards = Array.from(hustleList?.querySelectorAll('[data-hustle]') || []);
   const availableOnly = Boolean(hustleAvailableToggle?.checked);
   const sortValue = hustleSort?.value || 'roi';
@@ -316,8 +291,8 @@ function applyHustleFilters() {
 }
 
 function applyAssetFilters() {
-  const gallery = getAssetGallery();
-  const filters = getAssetFilters() || {};
+  const gallery = getElement('assetGallery');
+  const filters = getElement('assetFilters') || {};
   const cards = Array.from(gallery?.querySelectorAll('[data-asset]') || []);
   const activeOnly = Boolean(filters.activeOnly?.checked);
   const maintenanceOnly = Boolean(filters.maintenance?.checked);
@@ -333,8 +308,8 @@ function applyAssetFilters() {
 }
 
 function applyUpgradeFilters() {
-  const list = getUpgradeList();
-  const filters = getUpgradeFilters() || {};
+  const list = getElement('upgradeList');
+  const filters = getElement('upgradeFilters') || {};
   const cards = Array.from(list?.querySelectorAll('[data-upgrade]') || []);
   const unlockedOnly = filters.unlocked?.checked !== false;
 
@@ -347,8 +322,8 @@ function applyUpgradeFilters() {
 }
 
 function applyStudyFilters() {
-  const trackList = getStudyTrackList();
-  const filters = getStudyFilters() || {};
+  const trackList = getElement('studyTrackList');
+  const filters = getElement('studyFilters') || {};
   const tracks = Array.from(trackList?.querySelectorAll('[data-track]') || []);
   const activeOnly = Boolean(filters.activeOnly?.checked);
   const hideComplete = Boolean(filters.hideComplete?.checked);

--- a/src/ui/player.js
+++ b/src/ui/player.js
@@ -1,4 +1,4 @@
-import { getPlayerNodes } from './elements/registry.js';
+import { getElement } from './elements/registry.js';
 import setText from './dom.js';
 import { formatHours, formatList, formatMoney } from '../core/helpers.js';
 import { registry } from '../game/registry.js';
@@ -12,7 +12,7 @@ import {
 } from './skills/helpers.js';
 
 function renderSummary(state, summary) {
-  const player = getPlayerNodes() || {};
+  const player = getElement('playerNodes') || {};
   const target = player.summary;
   if (!target) return;
   const info = describeCharacter(state?.character);
@@ -26,7 +26,7 @@ function renderSummary(state, summary) {
 }
 
 function renderSkillList(state) {
-  const player = getPlayerNodes() || {};
+  const player = getElement('playerNodes') || {};
   const target = player.skills;
   if (!target?.list) return;
 
@@ -107,7 +107,7 @@ function formatSkillFocus(skills) {
 }
 
 function renderEquipment(state) {
-  const player = getPlayerNodes() || {};
+  const player = getElement('playerNodes') || {};
   const list = player.equipmentList;
   if (!list) return;
   list.innerHTML = '';
@@ -157,7 +157,7 @@ function formatEducationStatus(progress) {
 }
 
 function renderEducation(state) {
-  const player = getPlayerNodes() || {};
+  const player = getElement('playerNodes') || {};
   const list = player.educationList;
   if (!list) return;
   list.innerHTML = '';
@@ -214,7 +214,7 @@ function countActiveAssets(state) {
 }
 
 function renderStats(state, summary) {
-  const player = getPlayerNodes() || {};
+  const player = getElement('playerNodes') || {};
   const list = player.statsList;
   if (!list) return;
   list.innerHTML = '';

--- a/src/ui/skillsWidget.js
+++ b/src/ui/skillsWidget.js
@@ -1,4 +1,4 @@
-import { getSkillSections } from './elements/registry.js';
+import { getElement } from './elements/registry.js';
 import { getState } from '../core/state.js';
 import { SKILL_DEFINITIONS } from '../game/skills/data.js';
 import {
@@ -74,7 +74,7 @@ function renderTarget(target, state) {
 
 export function renderSkillWidgets(state = getState()) {
   if (!state) return;
-  const sections = getSkillSections() || {};
+  const sections = getElement('skillSections') || {};
   renderTarget(sections.dashboard, state);
   renderTarget(sections.education, state);
 }

--- a/src/ui/views/classic/cardsPresenter.js
+++ b/src/ui/views/classic/cardsPresenter.js
@@ -1,12 +1,4 @@
-import {
-  getAssetGallery,
-  getHustleControls,
-  getUpgradeDockList,
-  getUpgradeEmptyNode,
-  getUpgradeLaneList,
-  getUpgradeList,
-  getUpgradeOverview
-} from '../../elements/registry.js';
+import { getElement } from '../../elements/registry.js';
 import { getAssetState, getState } from '../../../core/state.js';
 import { formatHours, formatMoney } from '../../../core/helpers.js';
 import { describeHustleRequirements, getHustleDailyUsage } from '../../../game/hustles/helpers.js';
@@ -1183,7 +1175,7 @@ function openHustleDetails(definition) {
 }
 
 function renderHustles(definitions, hustleModels = []) {
-  const { hustleList } = getHustleControls() || {};
+  const { hustleList } = getElement('hustleControls') || {};
   const container = hustleList;
   if (!container) return;
   container.innerHTML = '';
@@ -2020,7 +2012,7 @@ function createAssetGroupSection(group, state = getState()) {
 }
 
 function renderAssets(definitions = [], assetModels = currentAssetModels) {
-  const gallery = getAssetGallery();
+  const gallery = getElement('assetGallery');
   if (!gallery) return;
 
   if (assetModels && assetModels !== currentAssetModels) {
@@ -2085,7 +2077,7 @@ function renderAssets(definitions = [], assetModels = currentAssetModels) {
 }
 
 function updateAssetHub() {
-  const gallery = getAssetGallery();
+  const gallery = getElement('assetGallery');
   if (!gallery) return;
 
   const groups = Array.isArray(currentAssetModels.groups) ? currentAssetModels.groups : [];
@@ -2109,7 +2101,7 @@ function updateAssetHub() {
 }
 
 function updateAssetEmptyNotice(totalInstances) {
-  const gallery = getAssetGallery();
+  const gallery = getElement('assetGallery');
   if (!gallery) return;
 
   if (totalInstances === 0) {
@@ -2144,7 +2136,7 @@ function updateAssets(definitions = [], assetModels = currentAssetModels) {
   }
   cacheAssetDefinitions(currentAssetDefinitions);
 
-  const gallery = getAssetGallery();
+  const gallery = getElement('assetGallery');
   if (!gallery) return;
 
   const groups = Array.isArray(currentAssetModels.groups) ? currentAssetModels.groups : [];
@@ -2198,7 +2190,7 @@ function updateAssetGroup(definitionId) {
     return;
   }
 
-  const gallery = getAssetGallery();
+  const gallery = getElement('assetGallery');
   if (!gallery) return;
   if (!assetPortfolioNode || !gallery.contains(assetPortfolioNode)) {
     renderAssets(currentAssetDefinitions, currentAssetModels);
@@ -2387,7 +2379,7 @@ function scrollUpgradeLaneIntoView(categoryId) {
   if (!categoryId) return;
 
   if (categoryId === 'all') {
-    const container = getUpgradeList();
+    const container = getElement('upgradeList');
     if (container) {
       container.scrollIntoView({ behavior: 'smooth', block: 'start' });
       container.focus?.({ preventScroll: true });
@@ -2410,7 +2402,7 @@ function scrollUpgradeLaneIntoView(categoryId) {
 }
 
 function renderUpgradeLaneMap(categories, overview) {
-  const list = getUpgradeLaneList();
+  const list = getElement('upgradeLaneList');
   if (!list) return;
 
   list.innerHTML = '';
@@ -2560,7 +2552,7 @@ function describeOverviewNote({ total, purchased, ready }) {
 }
 
 function renderUpgradeOverview(upgradeModels) {
-  const overview = getUpgradeOverview();
+  const overview = getElement('upgradeOverview');
   if (!overview?.container) return;
   const statsSource = upgradeModels?.overview ?? null;
   const categories = upgradeModels?.categories ?? currentUpgradeModels.categories;
@@ -2604,7 +2596,7 @@ function renderUpgradeOverview(upgradeModels) {
 }
 
 export function refreshUpgradeSections() {
-  const emptyNote = getUpgradeEmptyNode();
+  const emptyNote = getElement('upgradeEmpty');
   let visibleTotal = 0;
 
   upgradeSections.forEach(({ section, list, count, emptyMessage }) => {
@@ -2842,7 +2834,7 @@ function reconcileUpgradeOverviewStats(previousSnapshot, nextSnapshot) {
 }
 
 function renderUpgrades(definitions, upgradeModels) {
-  const list = getUpgradeList();
+  const list = getElement('upgradeList');
   if (!list) return;
   list.tabIndex = -1;
 
@@ -3028,7 +3020,7 @@ function updateUpgrades(definitions, upgradeModels) {
 }
 
 function renderUpgradeDock() {
-  const dock = getUpgradeDockList();
+  const dock = getElement('upgradeDockList');
   if (!dock) return;
   dock.innerHTML = '';
 

--- a/src/ui/views/classic/components/slideOver.js
+++ b/src/ui/views/classic/components/slideOver.js
@@ -1,4 +1,4 @@
-import { getSlideOverNodes } from '../../../elements/registry.js';
+import { getElement } from '../../../elements/registry.js';
 
 export function showSlideOver({ eyebrow, title, body }) {
   const {
@@ -6,7 +6,7 @@ export function showSlideOver({ eyebrow, title, body }) {
     slideOverContent,
     slideOverEyebrow,
     slideOverTitle
-  } = getSlideOverNodes() || {};
+  } = getElement('slideOver') || {};
   if (!slideOver || !slideOverContent) return;
   slideOverEyebrow.textContent = eyebrow || '';
   slideOverTitle.textContent = title || '';

--- a/src/ui/views/classic/dashboardPresenter.js
+++ b/src/ui/views/classic/dashboardPresenter.js
@@ -1,17 +1,4 @@
-import {
-  getAssetUpgradeActionsContainer,
-  getDailyStats,
-  getEventLogPreviewNode,
-  getHeaderStats,
-  getKpiNotes,
-  getKpiValues,
-  getMoneyNode,
-  getNotificationsContainer,
-  getQueueNodes,
-  getQuickActionsContainer,
-  getSessionStatusNode,
-  getShellNavigation
-} from '../../elements/registry.js';
+import { getElement } from '../../elements/registry.js';
 import setText from '../../dom.js';
 import { renderNicheWidget } from './nichePresenter.js';
 
@@ -126,7 +113,7 @@ function renderDailyList(container, entries, emptyMessage, limit = 3) {
 }
 
 function renderQueueSection(queue = {}) {
-  const container = getQueueNodes()?.actionQueue;
+  const container = getElement('queueNodes')?.actionQueue;
   if (!container) return;
   container.innerHTML = '';
   const items = Array.isArray(queue.items) ? queue.items : [];
@@ -156,7 +143,7 @@ function renderQueueSection(queue = {}) {
 }
 
 function renderQuickActionsSection(quickActions = {}) {
-  const container = getQuickActionsContainer();
+  const container = getElement('quickActions');
   const entries = Array.isArray(quickActions.entries) ? quickActions.entries : [];
   renderActionSection(container, entries, {
     emptyMessage: quickActions.emptyMessage,
@@ -166,7 +153,7 @@ function renderQuickActionsSection(quickActions = {}) {
 }
 
 function renderAssetActionsSection(assetActions = {}) {
-  const container = getAssetUpgradeActionsContainer();
+  const container = getElement('assetUpgradeActions');
   const entries = Array.isArray(assetActions.entries) ? assetActions.entries : [];
   renderActionSection(container, entries, {
     emptyMessage: assetActions.emptyMessage,
@@ -180,7 +167,7 @@ function resolveNotificationAction(entry) {
   if (entry.action.type === 'shell-tab') {
     const tabId = entry.action.tabId;
     return () => {
-      const { shellTabs = [] } = getShellNavigation() || {};
+      const { shellTabs = [] } = getElement('shellNavigation') || {};
       shellTabs.find(tab => tab.id === tabId)?.click();
     };
   }
@@ -191,7 +178,7 @@ function resolveNotificationAction(entry) {
 }
 
 function renderNotificationsSection(notifications = {}) {
-  const container = getNotificationsContainer();
+  const container = getElement('notifications');
   if (!container) return;
   container.innerHTML = '';
   const entries = Array.isArray(notifications.entries) ? notifications.entries : [];
@@ -230,7 +217,7 @@ function renderNotificationsSection(notifications = {}) {
 }
 
 function renderEventLogSection(eventLog = {}) {
-  const container = getEventLogPreviewNode();
+  const container = getElement('eventLogPreview');
   if (!container) return;
   container.innerHTML = '';
   const entries = Array.isArray(eventLog.entries) ? eventLog.entries : [];
@@ -258,7 +245,7 @@ function renderEventLogSection(eventLog = {}) {
 }
 
 function renderDailyStatsSection(dailyStats = {}) {
-  const refs = getDailyStats() || {};
+  const refs = getElement('dailyStats') || {};
   if (!refs) return;
 
   if (dailyStats.time) {
@@ -284,7 +271,7 @@ function renderDailyStatsSection(dailyStats = {}) {
 }
 
 function applyHeaderMetrics(headerMetrics = {}) {
-  const refs = getHeaderStats() || {};
+  const refs = getElement('headerStats') || {};
   const sections = ['dailyPlus', 'dailyMinus', 'timeAvailable', 'timeReserved'];
   sections.forEach(key => {
     const target = headerMetrics[key];
@@ -295,8 +282,8 @@ function applyHeaderMetrics(headerMetrics = {}) {
 }
 
 function applyKpiStats(kpis = {}) {
-  const values = getKpiValues() || {};
-  const notes = getKpiNotes() || {};
+  const values = getElement('kpiValues') || {};
+  const notes = getElement('kpiNotes') || {};
   const entries = ['net', 'hours', 'upkeep', 'ventures', 'study'];
   entries.forEach(key => {
     const target = kpis[key];
@@ -306,9 +293,9 @@ function applyKpiStats(kpis = {}) {
 }
 
 function renderSession(session = {}) {
-  const sessionStatus = getSessionStatusNode();
+  const sessionStatus = getElement('sessionStatus');
   setText(sessionStatus, session.statusText || '');
-  setText(getMoneyNode(), session.moneyText || '');
+  setText(getElement('money'), session.moneyText || '');
 }
 
 function renderDashboard(viewModel = {}) {

--- a/src/ui/views/classic/nichePresenter.js
+++ b/src/ui/views/classic/nichePresenter.js
@@ -1,8 +1,4 @@
-import {
-  getAssetGallery,
-  getNicheTrends,
-  getSessionStatusNode
-} from '../../elements/registry.js';
+import { getElement } from '../../elements/registry.js';
 import { formatMoney } from '../../../core/helpers.js';
 import { activateShellPanel } from '../../layout.js';
 import { setNicheWatchlist } from '../../../game/assets/niches.js';
@@ -55,7 +51,7 @@ function requestRender() {
 }
 
 function updateControlStates({ watchlistCount = 0 } = {}) {
-  const refs = getNicheTrends() || {};
+  const refs = getElement('nicheTrends') || {};
   const buttons = Array.isArray(refs.sortButtons) ? refs.sortButtons : [];
   buttons.forEach(button => {
     const isActive = (button.dataset.nicheSort || 'impact') === nicheViewState.sort;
@@ -85,7 +81,7 @@ function updateControlStates({ watchlistCount = 0 } = {}) {
 
 function setupNicheControls() {
   if (nicheControlsBound) return;
-  const refs = getNicheTrends() || {};
+  const refs = getElement('nicheTrends') || {};
   const buttons = Array.isArray(refs.sortButtons) ? refs.sortButtons : [];
   buttons.forEach(button => {
     button.addEventListener('click', () => {
@@ -129,8 +125,8 @@ function describeTrendStatus(entry) {
 function focusAssetsForNiche(nicheId, { hasAssets = false, nicheName = '' } = {}) {
   if (!nicheId) return;
   activateShellPanel('panel-ventures');
-  const assetGallery = getAssetGallery();
-  const sessionStatus = getSessionStatusNode();
+  const assetGallery = getElement('assetGallery');
+  const sessionStatus = getElement('sessionStatus');
   if (!assetGallery) return;
   const raf = typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function'
     ? window.requestAnimationFrame
@@ -422,7 +418,7 @@ function renderBoard(boardNode, entries, emptyMessages = DEFAULT_EMPTY_MESSAGES)
 export function renderNicheWidget(viewModel) {
   currentViewModel = viewModel;
   setupNicheControls();
-  const refs = getNicheTrends() || {};
+  const refs = getElement('nicheTrends') || {};
   if (!refs) return;
 
   const highlights = viewModel?.highlights || DEFAULT_HIGHLIGHTS;

--- a/src/ui/views/classic/studySection.js
+++ b/src/ui/views/classic/studySection.js
@@ -1,4 +1,4 @@
-import { getStudyQueue, getStudyTrackList } from '../../elements/registry.js';
+import { getElement } from '../../elements/registry.js';
 import { getState } from '../../../core/state.js';
 import { formatDays, formatHours, formatMoney } from '../../../core/helpers.js';
 import { KNOWLEDGE_TRACKS, getKnowledgeProgress } from '../../../game/requirements.js';
@@ -285,7 +285,7 @@ function renderStudyTrack(definition) {
 
 function renderStudyQueue(educationModels) {
   const models = ensureEducationModels(educationModels);
-  const { list: queue, eta: queueEta, cap: capNode } = getStudyQueue() || {};
+  const { list: queue, eta: queueEta, cap: capNode } = getElement('studyQueue') || {};
   if (!queue) return;
   queue.innerHTML = '';
   const queueModel = models?.queue;
@@ -309,7 +309,7 @@ function renderStudyQueue(educationModels) {
 }
 
 export function renderStudySection(definitions, educationModels) {
-  const list = getStudyTrackList();
+  const list = getElement('studyTrackList');
   if (!list) return;
   ensureEducationModels(educationModels);
   list.innerHTML = '';

--- a/tests/helpers/gameTestHarness.js
+++ b/tests/helpers/gameTestHarness.js
@@ -36,36 +36,36 @@ export async function getGameTestHarness() {
 
   const elements = {
     get money() {
-      return elementRegistryModule.getMoneyNode();
+      return elementRegistryModule.getElement('money');
     },
     get logFeed() {
-      return (elementRegistryModule.getLogNodes() || {}).logFeed;
+      return (elementRegistryModule.getElement('logNodes') || {}).logFeed;
     },
     get logTip() {
-      return (elementRegistryModule.getLogNodes() || {}).logTip;
+      return (elementRegistryModule.getElement('logNodes') || {}).logTip;
     },
     get day() {
-      return (elementRegistryModule.getPlayerNodes() || {}).summary?.day;
+      return (elementRegistryModule.getElement('playerNodes') || {}).summary?.day;
     },
     get time() {
-      return (elementRegistryModule.getPlayerNodes() || {}).summary?.time;
+      return (elementRegistryModule.getElement('playerNodes') || {}).summary?.time;
     }
   };
 
   const resetState = () => {
     const nextState = stateModule.initializeState(stateModule.buildDefaultState());
-    const logNodes = elementRegistryModule.getLogNodes() || {};
+    const logNodes = elementRegistryModule.getElement('logNodes') || {};
     if (logNodes.logFeed) {
       logNodes.logFeed.innerHTML = '';
     }
     if (logNodes.logTip) {
       logNodes.logTip.style.display = 'block';
     }
-    const moneyNode = elementRegistryModule.getMoneyNode();
+    const moneyNode = elementRegistryModule.getElement('money');
     if (moneyNode) {
       moneyNode.textContent = '';
     }
-    const playerSummary = elementRegistryModule.getPlayerNodes()?.summary || {};
+    const playerSummary = elementRegistryModule.getElement('playerNodes')?.summary || {};
     if (playerSummary.time) {
       playerSummary.time.textContent = '';
     }

--- a/tests/ui/elements/registry.test.js
+++ b/tests/ui/elements/registry.test.js
@@ -2,8 +2,8 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
-  getLogNodes,
-  getMoneyNode,
+  elements,
+  getElement,
   initElementRegistry
 } from '../../../src/ui/elements/registry.js';
 import { setActiveView } from '../../../src/ui/viewManager.js';
@@ -33,12 +33,20 @@ test('uses injected resolvers to look up DOM nodes', t => {
     setActiveView(classicView, root);
   });
 
-  assert.equal(getMoneyNode(), 'money-node');
-  assert.equal(getMoneyNode(), 'money-node', 'reuses cached value');
+  assert.equal(getElement('money'), 'money-node');
+  assert.equal(getElement('money'), 'money-node', 'reuses cached value');
   assert.deepEqual(calls, ['money']);
 
-  const logNodes = getLogNodes();
+  const logNodes = getElement('logNodes');
   assert.deepEqual(logNodes, { logFeed: 'log-node', logTip: 'tip-node' });
+  assert.deepEqual(calls, ['money', 'log', 'tip']);
+
+  assert.equal(elements.money, 'money-node');
+  assert.equal(elements.money, 'money-node', 'proxy uses cached value');
+  assert.deepEqual(calls, ['money', 'log', 'tip']);
+
+  const proxyLogNodes = elements.logNodes;
+  assert.deepEqual(proxyLogNodes, { logFeed: 'log-node', logTip: 'tip-node' });
   assert.deepEqual(calls, ['money', 'log', 'tip']);
 });
 
@@ -51,5 +59,6 @@ test('returns null when no resolver is provided', t => {
     setActiveView(classicView, root);
   });
 
-  assert.equal(getMoneyNode(), null);
+  assert.equal(getElement('money'), null);
+  assert.equal(elements.money, null);
 });


### PR DESCRIPTION
## Summary
- replace ElementRegistry-specific getters with a generic getElement API and proxy accessors
- update UI modules to rely on the new element lookup helpers
- expand ElementRegistry tests to cover caching and proxy-based access

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc87dcbd68832c9d239e3a65a6f173