### PR TITLE
Fix venture gallery rendering and filters

### DIFF
--- a/tests/education.test.js
+++ b/tests/education.test.js
@@ -7,10 +7,10 @@ const { document } = dom.window;
 
 test('renderCardCollections synthesizes models when omitted', async () => {
   const hustleList = document.getElementById('hustle-list');
-  const assetTable = document.getElementById('asset-table-body');
+  const ventureGallery = document.getElementById('venture-gallery');
   hustleList.innerHTML = '';
-  if (assetTable) {
-    assetTable.innerHTML = '';
+  if (ventureGallery) {
+    ventureGallery.innerHTML = '';
   }
 
   const stateModule = await import('../src/core/state.js');
@@ -40,10 +40,10 @@ test('renderCardCollections synthesizes models when omitted', async () => {
     });
 
     const hustleCards = document.querySelectorAll('.hustle-card');
-    const assetRows = document.querySelectorAll('#asset-table-body tr');
+    const assetCards = document.querySelectorAll('#venture-gallery [data-asset]');
     assert.ok(
-      hustleCards.length > 0 || assetRows.length > 0,
-      'fallback render should show hustles or assets without provided models'
+      hustleCards.length > 0 || assetCards.length > 0,
+      'fallback render should show hustles or ventures without provided models'
     );
   } finally {
     viewManager.setActiveView(classicModule.default, document);

--- a/tests/helpers/setupDom.js
+++ b/tests/helpers/setupDom.js
@@ -89,16 +89,27 @@ export function ensureTestDom() {
             <div id="hustle-list"></div>
           </section>
           <section id="panel-ventures" class="panel" hidden>
-            <input id="venture-active-toggle" type="checkbox" />
-            <input id="venture-maintenance-toggle" type="checkbox" />
-            <input id="venture-risk-toggle" type="checkbox" />
-            <table>
-              <tbody id="asset-table-body"></tbody>
-            </table>
-            <div id="asset-selection-note"></div>
-            <button id="asset-batch-maintain"></button>
-            <button id="asset-batch-pause"></button>
-            <button id="asset-batch-preset"></button>
+            <header class="panel__header venture-panel__header">
+              <div class="venture-panel__intro">
+                <h2>Ventures</h2>
+                <p>Test venture hub</p>
+              </div>
+              <div class="filter-bar venture-panel__filters" role="group" aria-label="Venture filters">
+                <label class="filter-toggle">
+                  <input id="venture-active-toggle" type="checkbox" />
+                  <span>Active only</span>
+                </label>
+                <label class="filter-toggle">
+                  <input id="venture-maintenance-toggle" type="checkbox" />
+                  <span>Needs upkeep</span>
+                </label>
+                <label class="filter-toggle">
+                  <input id="venture-risk-toggle" type="checkbox" />
+                  <span>Hide high risk</span>
+                </label>
+              </div>
+            </header>
+            <div class="asset-gallery venture-gallery" id="venture-gallery"></div>
           </section>
           <section id="panel-upgrades" class="panel" hidden>
             <input id="upgrade-unlocked-toggle" type="checkbox" checked />

--- a/tests/ui/update.integration.test.js
+++ b/tests/ui/update.integration.test.js
@@ -6,7 +6,29 @@ import { getGameTestHarness } from '../helpers/gameTestHarness.js';
 test('classic view update flow routes through cards presenter with dashboard and filters intact', async t => {
   ensureTestDom();
   const harness = await getGameTestHarness();
-  harness.resetState();
+  const state = harness.resetState();
+
+  const advancedAsset = harness.assetsModule.ASSETS.find(asset => asset.tag?.type === 'advanced')
+    || harness.assetsModule.ASSETS[0];
+  const ventureRiskLevel = advancedAsset?.tag?.type === 'advanced' ? 'high' : 'medium';
+  const { createAssetInstance, getAssetState } = harness.stateModule;
+  const activeInstance = createAssetInstance(
+    advancedAsset,
+    {
+      status: 'active',
+      maintenanceFundedToday: false,
+      lastIncome: 48,
+      totalIncome: 96
+    },
+    { state }
+  );
+  const setupInstance = createAssetInstance(
+    advancedAsset,
+    { status: 'setup', daysRemaining: 2 },
+    { state }
+  );
+  const assetState = getAssetState(advancedAsset.id, state);
+  assetState.instances = [activeInstance, setupInstance];
 
   const updateModule = await import('../../src/ui/update.js');
   const layoutModule = await import('../../src/ui/layout.js');
@@ -79,5 +101,48 @@ test('classic view update flow routes through cards presenter with dashboard and
   // Reset filters for cleanliness.
   availableToggle.checked = false;
   searchInput.value = '';
+  layoutModule.applyCardFilters();
+
+  const ventureGallery = document.getElementById('venture-gallery');
+  const ventureCards = () => Array.from(ventureGallery.querySelectorAll('[data-asset]'));
+  const visibleVentures = () => ventureCards().filter(card => !card.hidden);
+  assert.ok(ventureCards().length >= 2, 'expected venture cards to render for filtering');
+
+  const ventureActiveToggle = document.getElementById('venture-active-toggle');
+  ventureActiveToggle.checked = true;
+  layoutModule.applyCardFilters();
+  assert.ok(
+    visibleVentures().every(card => card.dataset.state === 'active'),
+    'expected active filter to show only active ventures'
+  );
+
+  ventureActiveToggle.checked = false;
+  const ventureMaintenanceToggle = document.getElementById('venture-maintenance-toggle');
+  ventureMaintenanceToggle.checked = true;
+  layoutModule.applyCardFilters();
+  assert.ok(
+    visibleVentures().every(card => card.dataset.needsMaintenance === 'true'),
+    'expected maintenance filter to surface upkeep-needy ventures'
+  );
+
+  ventureMaintenanceToggle.checked = false;
+  const ventureRiskToggle = document.getElementById('venture-risk-toggle');
+  ventureRiskToggle.checked = true;
+  layoutModule.applyCardFilters();
+  if (ventureRiskLevel === 'high') {
+    assert.equal(
+      visibleVentures().length,
+      0,
+      'expected risk filter to hide high-risk ventures'
+    );
+  } else {
+    assert.equal(
+      visibleVentures().length,
+      ventureCards().length,
+      'expected risk filter to keep medium-risk ventures visible'
+    );
+  }
+
+  ventureRiskToggle.checked = false;
   layoutModule.applyCardFilters();
 });


### PR DESCRIPTION
## Summary
- make venture cards resilient by resolving actual asset instances before rendering and attaching filter-friendly data attributes
- ensure quality insights use instance context and guard slide-over helpers when no instance exists
- update the classic view test DOM plus integration coverage to exercise venture filters alongside hustle filtering

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd16fd5b3c832ca0a62a18fc7b056b