### PR TITLE
Fix hustle card requirement summaries updating

### DIFF
--- a/src/ui/views/classic/hustleCards.js
+++ b/src/ui/views/classic/hustleCards.js
@@ -90,7 +90,8 @@ function renderHustleCard(definition, model, container) {
   header.appendChild(title);
   const badges = document.createElement('div');
   badges.className = 'badges';
-  model.badges.forEach(text => {
+  const badgeList = Array.isArray(model.badges) ? model.badges : [];
+  badgeList.forEach(text => {
     if (!text) return;
     badges.appendChild(createBadge(text));
   });
@@ -144,7 +145,13 @@ function renderHustleCard(definition, model, container) {
   card.appendChild(actions);
   container.appendChild(card);
 
-  hustleUi.set(definition.id, { card, queueButton, limitDetail });
+  hustleUi.set(definition.id, {
+    card,
+    queueButton,
+    limitDetail,
+    requirementsSummary: meta,
+    badges
+  });
 }
 
 export function cacheHustleModels(models = [], { skipCacheReset = false } = {}) {
@@ -200,6 +207,19 @@ export function updateHustleCard(definition, model, { emitEvent } = {}) {
     ui.queueButton.className = model.action.className || 'primary';
     ui.queueButton.disabled = model.action.disabled;
     ui.queueButton.textContent = model.action.label;
+  }
+
+  if (ui.badges) {
+    ui.badges.innerHTML = '';
+    const badgeList = Array.isArray(model.badges) ? model.badges : [];
+    badgeList.forEach(text => {
+      if (!text) return;
+      ui.badges.appendChild(createBadge(text));
+    });
+  }
+
+  if (ui.requirementsSummary) {
+    ui.requirementsSummary.textContent = model.requirements.summary;
   }
 
   if (ui.limitDetail) {


### PR DESCRIPTION
## Summary
- cache the requirement summary and badge containers when rendering hustle cards
- refresh cached requirement summaries and badge lists whenever hustle models update

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd22ee32d4832c9157a9d9f617ecdf