### PR TITLE
Refactor log rendering through view presenters

### DIFF
--- a/src/ui/log/model.js
+++ b/src/ui/log/model.js
@@ -1,0 +1,42 @@
+const TIME_FORMAT_OPTIONS = {
+  hour: '2-digit',
+  minute: '2-digit'
+};
+
+function formatLogEntry(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+
+  const timestamp = Number(entry.timestamp);
+  const date = Number.isFinite(timestamp) ? new Date(timestamp) : null;
+
+  return {
+    id: entry.id ?? null,
+    type: entry.type || 'info',
+    message: String(entry.message ?? ''),
+    timestamp: timestamp,
+    timeLabel: date ? date.toLocaleTimeString([], TIME_FORMAT_OPTIONS) : ''
+  };
+}
+
+export function buildLogModel(state) {
+  const logEntries = Array.isArray(state?.log) ? state.log : [];
+
+  const entries = logEntries
+    .slice()
+    .sort((a, b) => {
+      const aTime = Number(a?.timestamp) || 0;
+      const bTime = Number(b?.timestamp) || 0;
+      return bTime - aTime;
+    })
+    .map(formatLogEntry)
+    .filter(Boolean);
+
+  return {
+    entries,
+    isEmpty: entries.length === 0
+  };
+}
+
+export default buildLogModel;

--- a/src/ui/views/classic/index.js
+++ b/src/ui/views/classic/index.js
@@ -6,6 +6,7 @@ import playerPresenter from './playerPresenter.js';
 import skillsWidgetPresenter from './skillsWidgetPresenter.js';
 import headerActionPresenter from './headerActionPresenter.js';
 import layoutPresenter from './layoutPresenter.js';
+import logPresenter from './logPresenter.js';
 
 const classicView = {
   id: 'classic',
@@ -17,7 +18,8 @@ const classicView = {
     player: playerPresenter,
     skillsWidget: skillsWidgetPresenter,
     headerAction: headerActionPresenter,
-    layout: layoutPresenter
+    layout: layoutPresenter,
+    log: logPresenter
   },
   renderDashboard(state, summary) {
     baseRenderDashboard(state, summary, dashboardPresenter);

--- a/src/ui/views/classic/logPresenter.js
+++ b/src/ui/views/classic/logPresenter.js
@@ -1,0 +1,72 @@
+import { getElement } from '../../elements/registry.js';
+
+function toggleLogTip(logTip, isEmpty) {
+  if (!logTip) return;
+  logTip.hidden = !isEmpty;
+  if (logTip.style) {
+    logTip.style.display = isEmpty ? 'block' : 'none';
+  }
+}
+
+function createEntryNode(template, entry) {
+  if (!template?.content) {
+    return null;
+  }
+
+  const fragment = template.content.cloneNode(true);
+  const entryRoot = fragment.querySelector('.log-entry');
+  if (entryRoot) {
+    const typeClass = entry.type ? `type-${entry.type}` : '';
+    if (typeClass) {
+      entryRoot.classList.add(typeClass);
+    }
+    if (entry.id) {
+      entryRoot.dataset.logEntryId = entry.id;
+    }
+  }
+
+  const timestampEl = fragment.querySelector('.timestamp');
+  if (timestampEl) {
+    timestampEl.textContent = entry.timeLabel || '';
+  }
+
+  const messageEl = fragment.querySelector('.message');
+  if (messageEl) {
+    messageEl.textContent = entry.message || '';
+  }
+
+  return fragment;
+}
+
+export function render(model = {}) {
+  const { logFeed, logTemplate, logTip } = getElement('logNodes') || {};
+  if (!logFeed || !logTemplate) {
+    return;
+  }
+
+  const entries = Array.isArray(model?.entries) ? model.entries : [];
+  const isEmpty = model?.isEmpty ?? entries.length === 0;
+
+  toggleLogTip(logTip, isEmpty);
+
+  logFeed.innerHTML = '';
+
+  if (isEmpty) {
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  entries.forEach(entry => {
+    const node = createEntryNode(logTemplate, entry);
+    if (node) {
+      fragment.appendChild(node);
+    }
+  });
+
+  logFeed.appendChild(fragment);
+  logFeed.scrollTop = 0;
+}
+
+const logPresenter = { render };
+
+export default logPresenter;


### PR DESCRIPTION
## Summary
- add a log view-model builder to prepare formatted entries for presenters
- introduce a classic log presenter and register it with the view definition
- update core log rendering to use the active view presenter with a classic fallback

## Testing
- npm test --silent
- Manual QA: not run (non-browser environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd376eea6c832c81debab34ef1042a