### PR TITLE
Refactor debug catalog into model and presenter

### DIFF
--- a/src/ui/debugCatalog.js
+++ b/src/ui/debugCatalog.js
@@ -1,9 +1,15 @@
-import { formatHours, formatMoney } from '../core/helpers.js';
-import { getState } from '../core/state.js';
-import { listCatalog } from '../game/content/catalog.js';
-import { getElement } from './elements/registry.js';
+import { buildDebugCatalogViewModel } from './debugCatalog/model.js';
+import { getActiveView } from './viewManager.js';
+import classicDebugCatalogPresenter from './views/classic/debugCatalogPresenter.js';
 
 let debugEnabled = false;
+let activePresenter = null;
+
+export const noopDebugCatalogPresenter = Object.freeze({
+  show() {},
+  hide() {},
+  render() {}
+});
 
 function shouldEnableDebugPanel() {
   if (typeof window === 'undefined') return false;
@@ -35,130 +41,60 @@ function persistDebugFlag(value) {
   }
 }
 
-function renderRequirementSummary(requirements = []) {
-  if (!requirements.length) return 'None';
-  return requirements
-    .map(req => {
-      const status = req.met === false ? '⚠️' : '✅';
-      const label = req.label || req.type || 'Requirement';
-      return `${status} ${label}`;
-    })
-    .join(' • ');
+function resolvePresenter() {
+  const activeView = getActiveView();
+  if (activeView?.presenters && Object.prototype.hasOwnProperty.call(activeView.presenters, 'debugCatalog')) {
+    return activeView.presenters.debugCatalog || null;
+  }
+  return classicDebugCatalogPresenter;
 }
 
-function renderActionRows(table, entries) {
-  const header = document.createElement('thead');
-  const headerRow = document.createElement('tr');
-  ['Source', 'Action', 'Category', 'Time', 'Cost', 'Available', 'Requirements'].forEach(text => {
-    const th = document.createElement('th');
-    th.scope = 'col';
-    th.textContent = text;
-    headerRow.appendChild(th);
-  });
-  header.appendChild(headerRow);
-
-  const body = document.createElement('tbody');
-  entries.forEach(entry => {
-    const row = document.createElement('tr');
-    row.dataset.available = entry.available ? 'true' : 'false';
-    row.classList.toggle('is-available', entry.available);
-
-    const sourceCell = document.createElement('td');
-    sourceCell.textContent = `${entry.sourceName}`;
-    sourceCell.title = `${entry.sourceType}:${entry.sourceId}`;
-
-    const actionCell = document.createElement('td');
-    actionCell.textContent = entry.label;
-    actionCell.title = entry.actionId;
-
-    const categoryCell = document.createElement('td');
-    categoryCell.textContent = entry.category;
-
-    const timeCell = document.createElement('td');
-    timeCell.textContent = entry.timeCost ? formatHours(entry.timeCost) : '—';
-    timeCell.className = entry.timeSatisfied ? '' : 'is-missing';
-
-    const costCell = document.createElement('td');
-    costCell.textContent = entry.moneyCost ? `$${formatMoney(entry.moneyCost)}` : '—';
-    costCell.className = entry.moneySatisfied ? '' : 'is-missing';
-
-    const availableCell = document.createElement('td');
-    availableCell.textContent = entry.available ? 'Yes' : 'No';
-
-    const requirementCell = document.createElement('td');
-    requirementCell.textContent = renderRequirementSummary(entry.requirements);
-    if (entry.requirements.some(req => req.met === false)) {
-      requirementCell.classList.add('is-missing');
+function usePresenter(presenter, { show = false } = {}) {
+  if (!presenter) {
+    if (activePresenter) {
+      activePresenter.hide?.();
+      activePresenter = null;
     }
-
-    [
-      sourceCell,
-      actionCell,
-      categoryCell,
-      timeCell,
-      costCell,
-      availableCell,
-      requirementCell
-    ].forEach(cell => row.appendChild(cell));
-
-    body.appendChild(row);
-  });
-
-  table.appendChild(header);
-  table.appendChild(body);
-}
-
-function renderDebugCatalog() {
-  const { debugActionCatalogList: table, debugActionCatalogSummary: summary } =
-    getElement('debugCatalog') || {};
-  if (!table) return;
-  table.textContent = '';
-  const state = getState();
-  const entries = listCatalog(state).sort((a, b) => {
-    if (a.sourceType === b.sourceType) {
-      if (a.sourceName === b.sourceName) {
-        return a.label.localeCompare(b.label);
-      }
-      return a.sourceName.localeCompare(b.sourceName);
-    }
-    return a.sourceType.localeCompare(b.sourceType);
-  });
-
-  if (summary) {
-    const availableCount = entries.filter(entry => entry.available).length;
-    summary.textContent = `${availableCount} of ${entries.length} actions currently available`;
+    return null;
   }
 
-  renderActionRows(table, entries);
+  if (activePresenter && activePresenter !== presenter) {
+    activePresenter.hide?.();
+  }
+
+  activePresenter = presenter;
+
+  if (show) {
+    presenter.show?.();
+  }
+
+  return presenter;
+}
+
+function renderCatalog(presenter) {
+  if (!presenter) return;
+  usePresenter(presenter, { show: true });
+  const viewModel = buildDebugCatalogViewModel();
+  presenter.render?.(viewModel);
 }
 
 function enableDebugPanel() {
-  const { debugActionCatalog: panel } = getElement('debugCatalog') || {};
-  if (!panel) return;
+  const presenter = resolvePresenter();
+  if (!presenter) {
+    debugEnabled = false;
+    usePresenter(null);
+    return;
+  }
+
   debugEnabled = true;
   persistDebugFlag(true);
-  panel.hidden = false;
-  panel.setAttribute('aria-hidden', 'false');
-  renderDebugCatalog();
+  renderCatalog(presenter);
 }
 
 function disableDebugPanel() {
-  const {
-    debugActionCatalog: panel,
-    debugActionCatalogList: table,
-    debugActionCatalogSummary: summary
-  } = getElement('debugCatalog') || {};
-  if (!panel) return;
-  debugEnabled = false;
   persistDebugFlag(false);
-  panel.hidden = true;
-  panel.setAttribute('aria-hidden', 'true');
-  if (table) {
-    table.textContent = '';
-  }
-  if (summary) {
-    summary.textContent = '';
-  }
+  debugEnabled = false;
+  usePresenter(null);
 }
 
 export function initActionCatalogDebug() {
@@ -166,7 +102,7 @@ export function initActionCatalogDebug() {
     window.debugActions = {
       enable: enableDebugPanel,
       disable: disableDebugPanel,
-      refresh: renderDebugCatalog
+      refresh: refreshActionCatalogDebug
     };
   }
 
@@ -177,5 +113,16 @@ export function initActionCatalogDebug() {
 
 export function refreshActionCatalogDebug() {
   if (!debugEnabled) return;
-  renderDebugCatalog();
+  const presenter = resolvePresenter();
+  if (!presenter) {
+    usePresenter(null);
+    return;
+  }
+  renderCatalog(presenter);
 }
+
+export default {
+  initActionCatalogDebug,
+  refreshActionCatalogDebug,
+  noopDebugCatalogPresenter
+};

--- a/src/ui/debugCatalog/model.js
+++ b/src/ui/debugCatalog/model.js
@@ -1,0 +1,73 @@
+import { formatHours, formatMoney } from '../../core/helpers.js';
+import { getState } from '../../core/state.js';
+import { listCatalog } from '../../game/content/catalog.js';
+
+function renderRequirementSummary(requirements = []) {
+  if (!Array.isArray(requirements) || requirements.length === 0) {
+    return 'None';
+  }
+  return requirements
+    .map(requirement => {
+      const status = requirement?.met === false ? '⚠️' : '✅';
+      const label = requirement?.label || requirement?.type || 'Requirement';
+      return `${status} ${label}`;
+    })
+    .join(' • ');
+}
+
+function normalizeEntry(entry) {
+  const requirements = Array.isArray(entry?.requirements) ? entry.requirements : [];
+  const hasMissingRequirement = requirements.some(requirement => requirement?.met === false);
+  return {
+    id: entry.actionId,
+    source: entry.sourceName,
+    sourceTitle: `${entry.sourceType}:${entry.sourceId}`,
+    action: entry.label,
+    actionTitle: entry.actionId,
+    category: entry.category,
+    timeText: entry.timeCost ? formatHours(entry.timeCost) : '—',
+    timeSatisfied: entry.timeSatisfied !== false,
+    moneyText: entry.moneyCost ? `$${formatMoney(entry.moneyCost)}` : '—',
+    moneySatisfied: entry.moneySatisfied !== false,
+    available: Boolean(entry.available),
+    requirementSummary: renderRequirementSummary(requirements),
+    requirementsSatisfied: !hasMissingRequirement
+  };
+}
+
+function sortEntries(entries = []) {
+  return [...entries].sort((a, b) => {
+    const sourceTypeA = a?.sourceType || '';
+    const sourceTypeB = b?.sourceType || '';
+    if (sourceTypeA === sourceTypeB) {
+      const sourceNameA = a?.sourceName || '';
+      const sourceNameB = b?.sourceName || '';
+      if (sourceNameA === sourceNameB) {
+        const labelA = a?.label || '';
+        const labelB = b?.label || '';
+        return labelA.localeCompare(labelB);
+      }
+      return sourceNameA.localeCompare(sourceNameB);
+    }
+    return sourceTypeA.localeCompare(sourceTypeB);
+  });
+}
+
+export function buildDebugCatalogViewModel(state = getState()) {
+  const evaluatedEntries = listCatalog(state);
+  const rows = sortEntries(evaluatedEntries).map(normalizeEntry);
+  const availableCount = rows.filter(row => row.available).length;
+  const summaryLabel = `${availableCount} of ${rows.length} actions currently available`;
+  return {
+    rows,
+    summary: {
+      total: rows.length,
+      available: availableCount,
+      label: summaryLabel
+    }
+  };
+}
+
+export default {
+  buildDebugCatalogViewModel
+};

--- a/src/ui/views/classic/debugCatalogPresenter.js
+++ b/src/ui/views/classic/debugCatalogPresenter.js
@@ -1,0 +1,106 @@
+import { getElement } from '../../elements/registry.js';
+
+const COLUMN_HEADERS = ['Source', 'Action', 'Category', 'Time', 'Cost', 'Available', 'Requirements'];
+
+function getNodes() {
+  return getElement('debugCatalog') || {};
+}
+
+function createHeader() {
+  const thead = document.createElement('thead');
+  const row = document.createElement('tr');
+  COLUMN_HEADERS.forEach(label => {
+    const th = document.createElement('th');
+    th.scope = 'col';
+    th.textContent = label;
+    row.appendChild(th);
+  });
+  thead.appendChild(row);
+  return thead;
+}
+
+function createCell(text, { title, className } = {}) {
+  const td = document.createElement('td');
+  td.textContent = text ?? '';
+  if (title) {
+    td.title = title;
+  }
+  if (className) {
+    td.className = className;
+  }
+  return td;
+}
+
+function createRow(entry) {
+  const row = document.createElement('tr');
+  row.dataset.available = entry.available ? 'true' : 'false';
+  row.classList.toggle('is-available', Boolean(entry.available));
+
+  const timeClass = entry.timeSatisfied === false ? 'is-missing' : '';
+  const moneyClass = entry.moneySatisfied === false ? 'is-missing' : '';
+  const requirementClass = entry.requirementsSatisfied === false ? 'is-missing' : '';
+
+  const cells = [
+    createCell(entry.source, { title: entry.sourceTitle }),
+    createCell(entry.action, { title: entry.actionTitle }),
+    createCell(entry.category || '—'),
+    createCell(entry.timeText || '—', { className: timeClass }),
+    createCell(entry.moneyText || '—', { className: moneyClass }),
+    createCell(entry.available ? 'Yes' : 'No'),
+    createCell(entry.requirementSummary || 'None', { className: requirementClass })
+  ];
+
+  cells.forEach(cell => row.appendChild(cell));
+  return row;
+}
+
+function renderTable(table, rows = []) {
+  table.textContent = '';
+  table.appendChild(createHeader());
+  const tbody = document.createElement('tbody');
+  rows.forEach(entry => {
+    if (!entry) return;
+    tbody.appendChild(createRow(entry));
+  });
+  table.appendChild(tbody);
+}
+
+function renderSummary(summaryNode, summary) {
+  if (!summaryNode) return;
+  summaryNode.textContent = summary?.label || '';
+}
+
+function show() {
+  const { debugActionCatalog: panel } = getNodes();
+  if (!panel) return;
+  panel.hidden = false;
+  panel.setAttribute('aria-hidden', 'false');
+}
+
+function hide() {
+  const { debugActionCatalog: panel, debugActionCatalogList: table, debugActionCatalogSummary: summary } = getNodes();
+  if (panel) {
+    panel.hidden = true;
+    panel.setAttribute('aria-hidden', 'true');
+  }
+  if (table) {
+    table.textContent = '';
+  }
+  if (summary) {
+    summary.textContent = '';
+  }
+}
+
+function render(viewModel = {}) {
+  const { debugActionCatalogList: table, debugActionCatalogSummary: summary } = getNodes();
+  if (!table) return;
+  const rows = Array.isArray(viewModel.rows) ? viewModel.rows : [];
+  renderTable(table, rows);
+  renderSummary(summary, viewModel.summary);
+}
+
+export default {
+  show,
+  hide,
+  render
+};

--- a/src/ui/views/classic/index.js
+++ b/src/ui/views/classic/index.js
@@ -6,6 +6,7 @@ import playerPresenter from './playerPresenter.js';
 import skillsWidgetPresenter from './skillsWidgetPresenter.js';
 import headerActionPresenter from './headerActionPresenter.js';
 import layoutPresenter from './layoutPresenter.js';
+import debugCatalogPresenter from './debugCatalogPresenter.js';
 
 const classicView = {
   id: 'classic',
@@ -17,7 +18,8 @@ const classicView = {
     player: playerPresenter,
     skillsWidget: skillsWidgetPresenter,
     headerAction: headerActionPresenter,
-    layout: layoutPresenter
+    layout: layoutPresenter,
+    debugCatalog: debugCatalogPresenter
   },
   renderDashboard(state, summary) {
     baseRenderDashboard(state, summary, dashboardPresenter);


### PR DESCRIPTION
## Summary
- extract a debug catalog view-model builder to normalize catalog data
- add a classic debug catalog presenter that renders via the element registry
- update the debug catalog module to resolve presenters per view and register the classic presenter

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68dd38575374832c935163acaf43da50