### PR TITLE
Refactor card collection loading into service

### DIFF
--- a/src/ui/cards/collectionService.js
+++ b/src/ui/cards/collectionService.js
@@ -8,15 +8,24 @@ import {
   buildUpgradeModels
 } from './model.js';
 
-let hasEnsuredRegistry = false;
 let cachedRegistries = null;
 let cachedModels = null;
+let lastRegistrySnapshot = null;
+
+function updateSnapshot(snapshot) {
+  if (snapshot !== lastRegistrySnapshot) {
+    lastRegistrySnapshot = snapshot;
+    cachedRegistries = null;
+    cachedModels = null;
+  }
+
+  return snapshot;
+}
 
 function ensureRegistrySnapshot() {
   try {
     const snapshot = getRegistry();
-    hasEnsuredRegistry = true;
-    return snapshot;
+    return updateSnapshot(snapshot);
   } catch (error) {
     const message = typeof error?.message === 'string' ? error.message : '';
     const registryMissing = message.includes('Registry definitions have not been loaded');
@@ -25,11 +34,10 @@ function ensureRegistrySnapshot() {
       throw error;
     }
 
-    hasEnsuredRegistry = false;
     loadDefaultRegistry();
     configureRegistry();
-    hasEnsuredRegistry = true;
-    return getRegistry();
+    const snapshot = getRegistry();
+    return updateSnapshot(snapshot);
   }
 }
 

--- a/src/ui/cards/collectionService.js
+++ b/src/ui/cards/collectionService.js
@@ -19,10 +19,13 @@ function ensureRegistrySnapshot() {
     return snapshot;
   } catch (error) {
     const message = typeof error?.message === 'string' ? error.message : '';
-    if (hasEnsuredRegistry || !message.includes('Registry definitions have not been loaded')) {
+    const registryMissing = message.includes('Registry definitions have not been loaded');
+
+    if (!registryMissing) {
       throw error;
     }
 
+    hasEnsuredRegistry = false;
     loadDefaultRegistry();
     configureRegistry();
     hasEnsuredRegistry = true;

--- a/src/ui/cards/collectionService.js
+++ b/src/ui/cards/collectionService.js
@@ -1,0 +1,82 @@
+import { configureRegistry } from '../../core/state/registry.js';
+import { getRegistry } from '../../game/registryService.js';
+import { loadDefaultRegistry } from '../../game/registryLoader.js';
+import {
+  buildAssetModels,
+  buildEducationModels,
+  buildHustleModels,
+  buildUpgradeModels
+} from './model.js';
+
+let hasEnsuredRegistry = false;
+let cachedRegistries = null;
+let cachedModels = null;
+
+function ensureRegistrySnapshot() {
+  try {
+    const snapshot = getRegistry();
+    hasEnsuredRegistry = true;
+    return snapshot;
+  } catch (error) {
+    const message = typeof error?.message === 'string' ? error.message : '';
+    if (hasEnsuredRegistry || !message.includes('Registry definitions have not been loaded')) {
+      throw error;
+    }
+
+    loadDefaultRegistry();
+    configureRegistry();
+    hasEnsuredRegistry = true;
+    return getRegistry();
+  }
+}
+
+function buildRegistries() {
+  const registry = ensureRegistrySnapshot();
+  const hustles = registry.hustles.filter(hustle => hustle.tag?.type !== 'study');
+  const education = registry.hustles.filter(hustle => hustle.tag?.type === 'study');
+  const assets = registry.assets;
+  const upgrades = registry.upgrades;
+
+  return {
+    hustles,
+    education,
+    assets,
+    upgrades
+  };
+}
+
+function buildModels(registries) {
+  return {
+    hustles: buildHustleModels(registries.hustles),
+    education: buildEducationModels(registries.education),
+    assets: buildAssetModels(registries.assets),
+    upgrades: buildUpgradeModels(registries.upgrades)
+  };
+}
+
+function getCollections() {
+  if (!cachedRegistries) {
+    cachedRegistries = buildRegistries();
+  }
+
+  if (!cachedModels) {
+    cachedModels = buildModels(cachedRegistries);
+  }
+
+  return {
+    registries: cachedRegistries,
+    models: cachedModels
+  };
+}
+
+function refreshCollections({ registries: refreshRegistries = false } = {}) {
+  cachedModels = null;
+  if (refreshRegistries) {
+    cachedRegistries = null;
+  }
+}
+
+export default {
+  getCollections,
+  refreshCollections
+};


### PR DESCRIPTION
## Summary
- add a card collection service that ensures the registry is loaded once and caches filtered definitions
- update UI update/render flows to consume the shared `{ registries, models }` payload from the service

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68dd3f77257c832c8aa643f855db5e43