### PR TITLE
Add registry slice factory and refactor state slices

### DIFF
--- a/src/core/state/slices/assets.js
+++ b/src/core/state/slices/assets.js
@@ -1,31 +1,26 @@
 import { normalizeAssetState } from '../assets.js';
-import { getRegistrySnapshot, getAssetDefinition } from '../registry.js';
+import { getAssetDefinition } from '../registry.js';
+import { createRegistrySliceManager } from './factory.js';
 
-export function ensureSlice(state) {
-  if (!state) return {};
-  state.assets = state.assets || {};
-  const registry = getRegistrySnapshot();
-  for (const definition of registry.assets) {
-    const existing = state.assets[definition.id] || {};
-    state.assets[definition.id] = normalizeAssetState(definition, existing, { state });
+const { ensureSlice, getSliceState } = createRegistrySliceManager({
+  sliceKey: 'assets',
+  registryKey: 'assets',
+  definitionLookup: getAssetDefinition,
+  defaultFactory: (definition, { state }) => {
+    if (!definition) {
+      return {};
+    }
+    return normalizeAssetState(definition, {}, { state });
+  },
+  normalizer: (definition, entry = {}, { state }) => {
+    if (!definition) {
+      return entry || {};
+    }
+    return normalizeAssetState(definition, entry || {}, { state });
   }
-  return state.assets;
-}
+});
 
-export function getSliceState(state, id) {
-  if (!state) return {};
-  const assets = ensureSlice(state);
-  if (!id) {
-    return assets;
-  }
-  const definition = getAssetDefinition(id);
-  if (!definition) {
-    assets[id] = assets[id] || {};
-    return assets[id];
-  }
-  assets[id] = normalizeAssetState(definition, assets[id] || {}, { state });
-  return assets[id];
-}
+export { ensureSlice, getSliceState };
 
 export default {
   ensureSlice,

--- a/src/core/state/slices/factory.js
+++ b/src/core/state/slices/factory.js
@@ -1,0 +1,132 @@
+import { structuredClone } from '../../helpers.js';
+import { getRegistrySnapshot } from '../registry.js';
+
+function resolveDefinitionById(registryKey, id) {
+  if (!registryKey || !id) {
+    return undefined;
+  }
+  const registry = getRegistrySnapshot();
+  const definitions = Array.isArray(registry[registryKey]) ? registry[registryKey] : [];
+  return definitions.find(definition => definition?.id === id);
+}
+
+export function createRegistrySliceManager({
+  sliceKey,
+  registryKey,
+  defaultFactory = (definition) => structuredClone(definition?.defaultState || {}),
+  normalizer = (_, entry) => entry,
+  definitionLookup,
+  ensureHook,
+  getHook
+} = {}) {
+  if (!sliceKey) {
+    throw new Error('sliceKey is required when creating a registry slice manager');
+  }
+
+  const resolveDefinition = typeof definitionLookup === 'function'
+    ? definitionLookup
+    : (id) => resolveDefinitionById(registryKey, id);
+
+  function ensureSlice(state, context = {}) {
+    if (!state) return {};
+
+    if (!state[sliceKey] || typeof state[sliceKey] !== 'object') {
+      state[sliceKey] = {};
+    }
+
+    const sliceState = state[sliceKey];
+    const managerContext = {
+      state,
+      sliceState,
+      sliceKey,
+      context
+    };
+
+    if (registryKey) {
+      const registry = getRegistrySnapshot();
+      const definitions = Array.isArray(registry[registryKey]) ? registry[registryKey] : [];
+      for (const definition of definitions) {
+        const id = definition?.id;
+        if (!id) continue;
+
+        if (sliceState[id] === undefined) {
+          sliceState[id] = defaultFactory(definition, managerContext);
+        }
+
+        const normalized = normalizer(definition, sliceState[id], managerContext);
+        if (normalized !== sliceState[id]) {
+          sliceState[id] = normalized;
+        }
+      }
+    }
+
+    if (typeof ensureHook === 'function') {
+      ensureHook(managerContext);
+    }
+
+    return sliceState;
+  }
+
+  function getSliceState(state, id, context = {}) {
+    if (!state) return {};
+
+    const sliceState = ensureSlice(state, context);
+    if (!id) {
+      if (typeof getHook === 'function') {
+        getHook({
+          state,
+          sliceState,
+          sliceKey,
+          context
+        });
+      }
+      return sliceState;
+    }
+
+    if (sliceState[id] === undefined) {
+      const definition = resolveDefinition(id);
+      sliceState[id] = defaultFactory(definition, {
+        state,
+        sliceState,
+        sliceKey,
+        context,
+        id
+      });
+    }
+
+    const definition = resolveDefinition(id);
+    const normalized = normalizer(definition, sliceState[id], {
+      state,
+      sliceState,
+      sliceKey,
+      context,
+      id
+    });
+    if (normalized !== sliceState[id]) {
+      sliceState[id] = normalized;
+    }
+
+    if (typeof getHook === 'function') {
+      getHook({
+        state,
+        sliceState,
+        sliceKey,
+        context,
+        id,
+        entry: sliceState[id],
+        definition
+      });
+    }
+
+    return sliceState[id];
+  }
+
+  return {
+    ensureSlice,
+    getSliceState
+  };
+}
+
+export default {
+  createRegistrySliceManager
+};

--- a/src/core/state/slices/hustles.js
+++ b/src/core/state/slices/hustles.js
@@ -1,30 +1,28 @@
 import { structuredClone } from '../../helpers.js';
-import { getRegistrySnapshot, getHustleDefinition } from '../registry.js';
+import { getHustleDefinition } from '../registry.js';
+import { createRegistrySliceManager } from './factory.js';
 
-export function ensureSlice(state) {
-  if (!state) return {};
-  state.hustles = state.hustles || {};
-  const registry = getRegistrySnapshot();
-  for (const definition of registry.hustles) {
+const { ensureSlice, getSliceState } = createRegistrySliceManager({
+  sliceKey: 'hustles',
+  registryKey: 'hustles',
+  definitionLookup: getHustleDefinition,
+  defaultFactory: (definition) => {
+    if (!definition) {
+      return {};
+    }
+    return structuredClone(definition.defaultState || {});
+  },
+  normalizer: (definition, entry = {}) => {
+    if (!definition) {
+      return entry || {};
+    }
     const defaults = structuredClone(definition.defaultState || {});
-    const existing = state.hustles[definition.id];
-    state.hustles[definition.id] = existing ? { ...defaults, ...existing } : defaults;
+    const existing = typeof entry === 'object' && entry !== null ? entry : {};
+    return { ...defaults, ...existing };
   }
-  return state.hustles;
-}
+});
 
-export function getSliceState(state, id) {
-  if (!state) return {};
-  const hustles = ensureSlice(state);
-  if (!id) {
-    return hustles;
-  }
-  if (!hustles[id]) {
-    const definition = getHustleDefinition(id);
-    hustles[id] = structuredClone(definition?.defaultState || {});
-  }
-  return hustles[id];
-}
+export { ensureSlice, getSliceState };
 
 export default {
   ensureSlice,

--- a/src/core/state/slices/progress.js
+++ b/src/core/state/slices/progress.js
@@ -1,19 +1,17 @@
-export function ensureSlice(state) {
-  if (!state) return {};
-  state.progress = state.progress || {};
-  state.progress.knowledge = state.progress.knowledge || {};
-  return state.progress;
-}
+import { createRegistrySliceManager } from './factory.js';
 
-export function getSliceState(state, id) {
-  if (!state) return {};
-  const progress = ensureSlice(state);
-  if (!id) {
-    return progress;
+const { ensureSlice, getSliceState } = createRegistrySliceManager({
+  sliceKey: 'progress',
+  defaultFactory: () => ({}),
+  normalizer: (_, entry = {}) => (typeof entry === 'object' && entry !== null ? entry : {}),
+  ensureHook: ({ sliceState }) => {
+    if (!sliceState.knowledge || typeof sliceState.knowledge !== 'object') {
+      sliceState.knowledge = {};
+    }
   }
-  progress[id] = progress[id] || {};
-  return progress[id];
-}
+});
+
+export { ensureSlice, getSliceState };
 
 export default {
   ensureSlice,

--- a/src/core/state/slices/upgrades.js
+++ b/src/core/state/slices/upgrades.js
@@ -1,5 +1,6 @@
 import { structuredClone } from '../../helpers.js';
-import { getRegistrySnapshot, getUpgradeDefinition } from '../registry.js';
+import { getUpgradeDefinition } from '../registry.js';
+import { createRegistrySliceManager } from './factory.js';
 
 function normalizeAssistantState(upgradeState = {}) {
   const normalized = upgradeState;
@@ -16,56 +17,48 @@ function normalizeAssistantState(upgradeState = {}) {
   return normalized;
 }
 
-export function ensureSlice(state) {
-  if (!state) return {};
-  state.upgrades = state.upgrades || {};
-  const registry = getRegistrySnapshot();
-  for (const definition of registry.upgrades) {
-    const defaults = structuredClone(definition.defaultState || {});
-    const existing = state.upgrades[definition.id];
-    if (existing) {
-      const merged = {
-        ...defaults,
-        ...(typeof existing === 'object' && existing !== null ? existing : {})
-      };
-      if (typeof existing === 'object' && existing !== null) {
-        Object.assign(existing, merged);
-        if (definition.id === 'assistant') {
-          normalizeAssistantState(existing);
-        }
-      } else {
-        state.upgrades[definition.id] = merged;
-        if (definition.id === 'assistant') {
-          normalizeAssistantState(state.upgrades[definition.id]);
-        }
-      }
-    } else {
-      const normalized = { ...defaults };
-      if (definition.id === 'assistant') {
-        normalizeAssistantState(normalized);
-      }
-      state.upgrades[definition.id] = normalized;
+const { ensureSlice, getSliceState } = createRegistrySliceManager({
+  sliceKey: 'upgrades',
+  registryKey: 'upgrades',
+  definitionLookup: getUpgradeDefinition,
+  defaultFactory: (definition) => {
+    if (!definition) {
+      return {};
     }
+    const defaults = structuredClone(definition.defaultState || {});
+    if (definition.id === 'assistant') {
+      return normalizeAssistantState(defaults);
+    }
+    return defaults;
+  },
+  normalizer: (definition, entry = {}) => {
+    if (!definition) {
+      return typeof entry === 'object' && entry !== null ? entry : {};
+    }
+    const defaults = structuredClone(definition.defaultState || {});
+    if (typeof entry === 'object' && entry !== null) {
+      for (const [key, value] of Object.entries(defaults)) {
+        if (!(key in entry)) {
+          entry[key] = value;
+        }
+      }
+      if (definition.id === 'assistant') {
+        return normalizeAssistantState(entry);
+      }
+      return entry;
+    }
+    const merged = { ...defaults };
+    if (typeof entry === 'object' && entry !== null) {
+      Object.assign(merged, entry);
+    }
+    if (definition.id === 'assistant') {
+      return normalizeAssistantState(merged);
+    }
+    return merged;
   }
-  return state.upgrades;
-}
+});
 
-export function getSliceState(state, id) {
-  if (!state) return {};
-  const upgrades = ensureSlice(state);
-  if (!id) {
-    return upgrades;
-  }
-  if (!upgrades[id]) {
-    const definition = getUpgradeDefinition(id);
-    const defaults = structuredClone(definition?.defaultState || {});
-    upgrades[id] = defaults;
-  }
-  if (id === 'assistant') {
-    normalizeAssistantState(upgrades[id]);
-  }
-  return upgrades[id];
-}
+export { ensureSlice, getSliceState };
 
 export default {
   ensureSlice,


### PR DESCRIPTION
## Summary
- add a reusable registry slice manager to standardize ensure/get behavior
- refactor asset, hustle, upgrade, and progress slices to build on the shared factory
- preserve assistant upgrade normalization while allowing per-slice hooks such as knowledge tracking

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd46b70ef0832c9c6b5c5bf0991dac