### PR TITLE
Add browser chrome entry point and view scaffolding

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Online Hustle Simulator — Browser Shell</title>
+  <link rel="stylesheet" href="styles/browser.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body data-ui-view="browser">
+  <div class="browser-shell" data-theme="night">
+    <header class="browser-chrome" aria-label="Browser chrome">
+      <div class="browser-chrome__cluster" aria-label="Navigation controls">
+        <button id="browser-nav-back" class="browser-button" type="button" title="Go back">⟵</button>
+        <button id="browser-nav-forward" class="browser-button" type="button" title="Go forward">⟶</button>
+        <button id="browser-nav-refresh" class="browser-button" type="button" title="Refresh page">⟳</button>
+      </div>
+      <form id="browser-address" class="browser-address" role="search">
+        <label for="browser-address-input" class="browser-address__label">Address</label>
+        <input
+          id="browser-address-input"
+          class="browser-address__input"
+          type="search"
+          name="address"
+          placeholder="Search hustles, niches, or paste a link"
+          autocomplete="off"
+        />
+      </form>
+      <div class="browser-chrome__cluster" aria-label="Session controls">
+        <button id="browser-home-button" class="browser-button" type="button">Home</button>
+        <button id="browser-command-button" class="browser-button" type="button">⌘K</button>
+        <button id="browser-session-button" class="browser-button browser-button--primary" type="button">End Day</button>
+      </div>
+    </header>
+
+    <div class="browser-layout">
+      <aside class="browser-sidebar" aria-labelledby="browser-sites-heading">
+        <header class="browser-sidebar__header">
+          <h2 id="browser-sites-heading">Favorite Stations</h2>
+          <p id="browser-sites-note">Pin your go-to dashboards for lightning hops.</p>
+        </header>
+        <ul id="browser-site-list" class="browser-site-list" aria-live="polite"></ul>
+        <button id="browser-add-site" class="browser-sidebar__action" type="button">Add site</button>
+      </aside>
+
+      <main class="browser-main" aria-live="polite">
+        <section id="browser-home" class="browser-home" aria-labelledby="browser-home-heading">
+          <header class="browser-home__header">
+            <h1 id="browser-home-heading">Browser Homepage</h1>
+            <p id="browser-home-tagline">Your empire’s launchpad with shortcuts, streaks, and story beats.</p>
+          </header>
+
+          <div class="browser-home__widgets">
+            <section class="browser-widget" aria-labelledby="browser-widget-focus-heading">
+              <header class="browser-widget__header">
+                <h2 id="browser-widget-focus-heading">Focus streak</h2>
+                <p id="browser-widget-focus-note">Keep the daily rhythm humming.</p>
+              </header>
+              <div id="browser-widget-focus" class="browser-widget__body"></div>
+            </section>
+
+            <section class="browser-widget" aria-labelledby="browser-widget-updates-heading">
+              <header class="browser-widget__header">
+                <h2 id="browser-widget-updates-heading">Latest updates</h2>
+                <p id="browser-widget-updates-note">Fresh highlights from your ventures.</p>
+              </header>
+              <ul id="browser-widget-updates" class="browser-widget__list"></ul>
+            </section>
+
+            <section class="browser-widget" aria-labelledby="browser-widget-shortcuts-heading">
+              <header class="browser-widget__header">
+                <h2 id="browser-widget-shortcuts-heading">Quick shortcuts</h2>
+                <p id="browser-widget-shortcuts-note">Jump straight into your next power move.</p>
+              </header>
+              <div id="browser-widget-shortcuts" class="browser-widget__body browser-widget__body--grid"></div>
+            </section>
+          </div>
+        </section>
+      </main>
+    </div>
+  </div>
+
+  <script type="module" src="src/main.js"></script>
+</body>
+</html>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Browser shell entry experiments ship a homepage chrome with pinned sites and dedicated widgets while sharing the core game lo
+op with the classic dashboard.
 - Modular UI view-model builders keep player overview, skills, header actions, and layout filters aligned while making alternate shells easy to drop in.
 - Passive asset economy has lower upkeep, clearer payout ladders, and milestone callouts so builds pay off earlier.
 - Education and hustle systems link courses to gig bonuses with celebratory progress cues and smarter scheduling buffers.

--- a/docs/features/browser-shell.md
+++ b/docs/features/browser-shell.md
@@ -1,0 +1,17 @@
+# Browser Shell View
+
+## Goals
+- Provide a browser-inspired chrome for the incremental game to explore multi-surface UI experiments.
+- Highlight top-level navigation (address bar, session controls, pinned sites) as composable widgets.
+- Keep gameplay logic intact by reusing the existing state, registry, and command pipeline.
+
+## Player Impact
+- Players gain a high-level "homepage" where shortcuts and streak trackers can surface before diving into deeper dashboards.
+- The pinned site rail encourages quick swapping between feature areas without overwhelming the main dashboard.
+- Session controls remain reachable in the chrome, reinforcing end-of-day and command palette actions.
+
+## Implementation Notes
+- Introduced `browser.html` as an alternate entry point that loads the existing game scripts with a new DOM skeleton.
+- Added `src/ui/views/browser/` with dedicated resolvers wired to the browser chrome and widget containers.
+- A standalone stylesheet (`styles/browser.css`) scopes the new visual language without touching the classic layout.
+- `src/main.js` now detects `data-ui-view` on the document body to pick between the classic and browser views during boot.

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
-<body>
+<body data-ui-view="classic">
   <div class="shell" data-theme="night">
     <header class="shell__header">
       <div class="shell__brand">

--- a/src/main.js
+++ b/src/main.js
@@ -9,11 +9,21 @@ import { handleOfflineProgress } from './game/offline.js';
 import { initHeaderActionControls } from './ui/headerAction/index.js';
 import { setActiveView } from './ui/viewManager.js';
 import classicView from './ui/views/classic/index.js';
+import browserView from './ui/views/browser/index.js';
 import { loadDefaultRegistry } from './game/registryLoader.js';
+
+function resolveInitialView(rootDocument = typeof document !== 'undefined' ? document : null) {
+  const viewId = rootDocument?.body?.dataset?.uiView;
+  if (viewId === browserView.id) {
+    return browserView;
+  }
+  return classicView;
+}
 
 loadDefaultRegistry();
 configureRegistry();
-setActiveView(classicView, document);
+const initialView = resolveInitialView(document);
+setActiveView(initialView, document);
 const { returning, lastSaved } = loadState({
   onFirstLoad: () =>
     addLog('Welcome to Online Hustle Simulator! Time to make that side cash.', 'info'),

--- a/src/ui/views/browser/index.js
+++ b/src/ui/views/browser/index.js
@@ -1,0 +1,10 @@
+import resolvers from './resolvers.js';
+
+const browserView = {
+  id: 'browser',
+  name: 'Browser Chrome',
+  resolvers,
+  presenters: {}
+};
+
+export default browserView;

--- a/src/ui/views/browser/resolvers.js
+++ b/src/ui/views/browser/resolvers.js
@@ -1,0 +1,40 @@
+const resolvers = {
+  browserNavigation: root => ({
+    backButton: root.getElementById('browser-nav-back'),
+    forwardButton: root.getElementById('browser-nav-forward'),
+    refreshButton: root.getElementById('browser-nav-refresh')
+  }),
+  browserAddress: root => ({
+    form: root.getElementById('browser-address'),
+    input: root.getElementById('browser-address-input')
+  }),
+  browserSessionControls: root => ({
+    homeButton: root.getElementById('browser-home-button'),
+    commandButton: root.getElementById('browser-command-button'),
+    endDayButton: root.getElementById('browser-session-button')
+  }),
+  siteList: root => root.getElementById('browser-site-list'),
+  siteListNote: root => root.getElementById('browser-sites-note'),
+  addSiteButton: root => root.getElementById('browser-add-site'),
+  homepage: root => ({
+    container: root.getElementById('browser-home'),
+    heading: root.getElementById('browser-home-heading'),
+    tagline: root.getElementById('browser-home-tagline')
+  }),
+  homepageWidgets: root => ({
+    focus: {
+      container: root.getElementById('browser-widget-focus'),
+      note: root.getElementById('browser-widget-focus-note')
+    },
+    updates: {
+      list: root.getElementById('browser-widget-updates'),
+      note: root.getElementById('browser-widget-updates-note')
+    },
+    shortcuts: {
+      container: root.getElementById('browser-widget-shortcuts'),
+      note: root.getElementById('browser-widget-shortcuts-note')
+    }
+  })
+};
+
+export default resolvers;

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -1,0 +1,244 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+  background: #0f1015;
+  color: #f1f4ff;
+}
+
+.browser-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(79, 110, 255, 0.15), transparent 55%), #08090f;
+}
+
+.browser-chrome {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  background: rgba(16, 18, 30, 0.92);
+  border-bottom: 1px solid rgba(113, 118, 214, 0.35);
+  box-shadow: 0 6px 24px rgba(5, 6, 18, 0.65);
+}
+
+.browser-chrome__cluster {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.browser-button {
+  font: inherit;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid rgba(134, 138, 255, 0.4);
+  background: rgba(38, 43, 96, 0.4);
+  color: inherit;
+  cursor: pointer;
+  transition: background 150ms ease, transform 150ms ease;
+}
+
+.browser-button:hover {
+  background: rgba(96, 104, 255, 0.55);
+}
+
+.browser-button:active {
+  transform: translateY(1px);
+}
+
+.browser-button--primary {
+  background: linear-gradient(135deg, #ff7adf 0%, #7b8bff 100%);
+  border-color: transparent;
+  color: #0f1015;
+  font-weight: 700;
+}
+
+.browser-address {
+  display: grid;
+  grid-template-columns: min-content 1fr;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 16px;
+  background: rgba(23, 26, 49, 0.85);
+  border: 1px solid rgba(88, 96, 204, 0.45);
+}
+
+.browser-address__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(197, 204, 255, 0.75);
+}
+
+.browser-address__input {
+  width: 100%;
+  padding: 0.4rem 0.3rem;
+  font: inherit;
+  font-size: 1rem;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: inherit;
+}
+
+.browser-layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 2.5rem;
+  padding: 2rem 3rem 3rem;
+  flex: 1 1 auto;
+}
+
+.browser-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  background: rgba(17, 19, 34, 0.78);
+  border: 1px solid rgba(88, 96, 204, 0.3);
+  border-radius: 24px;
+  box-shadow: inset 0 0 0 1px rgba(120, 128, 255, 0.08);
+}
+
+.browser-sidebar__header h2 {
+  margin: 0 0 0.25rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.browser-sidebar__header p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(197, 204, 255, 0.7);
+}
+
+.browser-site-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.browser-site-list li {
+  padding: 0.6rem 0.75rem;
+  border-radius: 14px;
+  background: rgba(32, 37, 70, 0.6);
+  border: 1px solid rgba(103, 109, 204, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.browser-site-list__title {
+  font-weight: 600;
+}
+
+.browser-site-list__meta {
+  font-size: 0.85rem;
+  color: rgba(197, 204, 255, 0.6);
+}
+
+.browser-sidebar__action {
+  align-self: flex-start;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  border: 1px dashed rgba(120, 128, 255, 0.65);
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.browser-main {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.browser-home__header h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.browser-home__header p {
+  margin: 0.5rem 0 0;
+  color: rgba(197, 204, 255, 0.75);
+}
+
+.browser-home__widgets {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.browser-widget {
+  padding: 1.5rem;
+  border-radius: 24px;
+  background: rgba(17, 20, 40, 0.88);
+  border: 1px solid rgba(103, 109, 204, 0.4);
+  box-shadow: 0 24px 48px rgba(6, 7, 16, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.browser-widget__header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.browser-widget__header p {
+  margin: 0.35rem 0 0;
+  font-size: 0.9rem;
+  color: rgba(197, 204, 255, 0.7);
+}
+
+.browser-widget__body {
+  min-height: 120px;
+  border-radius: 18px;
+  background: rgba(25, 29, 58, 0.65);
+  border: 1px solid rgba(120, 128, 255, 0.22);
+  padding: 1rem;
+}
+
+.browser-widget__body--grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.browser-widget__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.browser-widget__list li {
+  padding: 0.75rem 1rem;
+  border-radius: 16px;
+  background: rgba(30, 35, 66, 0.7);
+  border: 1px solid rgba(140, 148, 255, 0.25);
+}
+
+@media (max-width: 960px) {
+  .browser-layout {
+    grid-template-columns: 1fr;
+    padding: 1.5rem;
+  }
+
+  .browser-sidebar {
+    position: sticky;
+    top: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- add a browser.html entry page with chrome markup and dedicated styling
- register a browser view with resolvers and auto-detect it during boot
- document the browser shell experiment and update the changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd523e8de4832cad59950ce3167f56