### PR TITLE
feat: add browser view presenters and widgets

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Browser shell entry experiments ship a homepage chrome with pinned sites and dedicated widgets while sharing the core game lo
 op with the classic dashboard.
+- Browser chrome now renders dashboard KPIs, quick actions, notifications, and the BlogPress/VideoTube/ShopStack/Learnly surfaces through dedicated presenters that reuse the shared models.
 - Modular UI view-model builders keep player overview, skills, header actions, and layout filters aligned while making alternate shells easy to drop in.
 - Passive asset economy has lower upkeep, clearer payout ladders, and milestone callouts so builds pay off earlier.
 - Education and hustle systems link courses to gig bonuses with celebratory progress cues and smarter scheduling buffers.

--- a/docs/features/browser-shell.md
+++ b/docs/features/browser-shell.md
@@ -15,3 +15,5 @@
 - Added `src/ui/views/browser/` with dedicated resolvers wired to the browser chrome and widget containers.
 - A standalone stylesheet (`styles/browser.css`) scopes the new visual language without touching the classic layout.
 - `src/main.js` now detects `data-ui-view` on the document body to pick between the classic and browser views during boot.
+- Browser presenters reuse the shared dashboard and card models to render homepage widgets plus BlogPress, VideoTube, ShopStack, and Learnly service pages inside the chrome shell.
+- Layout navigation tracks a lightweight history stack so the browser buttons, pinned sites, and address bar all stay in sync.

--- a/src/ui/views/browser/cardsPresenter.js
+++ b/src/ui/views/browser/cardsPresenter.js
@@ -1,0 +1,589 @@
+import { getElement } from '../../elements/registry.js';
+import { formatHours, formatMoney } from '../../../core/helpers.js';
+import { SERVICE_PAGES } from './config.js';
+import { createStat, formatRoi } from './components/widgets.js';
+
+let cachedRegistries = null;
+let cachedModels = null;
+let mainContainer = null;
+const pageSections = new Map();
+
+function getMainContainer() {
+  if (mainContainer) return mainContainer;
+  const homepage = getElement('homepage');
+  const container = homepage?.container?.parentElement || null;
+  mainContainer = container;
+  return mainContainer;
+}
+
+function createPageSection(page) {
+  const main = getMainContainer();
+  if (!main || pageSections.has(page.id)) {
+    return pageSections.get(page.id) || null;
+  }
+
+  const section = document.createElement('section');
+  section.className = 'browser-page';
+  section.dataset.browserPage = page.id;
+  section.id = `browser-page-${page.slug}`;
+
+  const header = document.createElement('header');
+  header.className = 'browser-page__header';
+  const title = document.createElement('h1');
+  title.textContent = page.headline;
+  const note = document.createElement('p');
+  note.textContent = page.tagline;
+  header.append(title, note);
+
+  const body = document.createElement('div');
+  body.className = 'browser-page__body';
+
+  section.append(header, body);
+  main.appendChild(section);
+
+  const refs = { section, header, note, body };
+  pageSections.set(page.id, refs);
+  return refs;
+}
+
+function ensurePageContent(page, builder) {
+  const refs = createPageSection(page);
+  if (!refs) return null;
+  if (typeof builder === 'function') {
+    builder(refs);
+  }
+  return refs;
+}
+
+function buildDefinitionMap(definitions = []) {
+  const map = new Map();
+  definitions.forEach(definition => {
+    if (definition?.id) {
+      map.set(definition.id, definition);
+    }
+  });
+  return map;
+}
+
+function renderHustlesPage(definitions = [], models = []) {
+  const page = SERVICE_PAGES.find(entry => entry.type === 'hustles');
+  if (!page) return null;
+
+  const refs = ensurePageContent(page, ({ body }) => {
+    if (!body.querySelector('[data-role="browser-hustle-list"]')) {
+      const list = document.createElement('div');
+      list.className = 'browser-card-grid';
+      list.dataset.role = 'browser-hustle-list';
+      body.appendChild(list);
+    }
+  });
+  if (!refs) return null;
+
+  const list = refs.body.querySelector('[data-role="browser-hustle-list"]');
+  if (!list) return null;
+  list.innerHTML = '';
+
+  const modelMap = new Map(models.map(model => [model?.id, model]));
+  let availableCount = 0;
+
+  definitions.forEach(definition => {
+    const model = modelMap.get(definition.id);
+    if (!model) return;
+
+    if (model.filters?.available) {
+      availableCount += 1;
+    }
+
+    const card = document.createElement('article');
+    card.className = 'browser-card browser-card--hustle';
+    card.dataset.hustle = model.id;
+    card.dataset.search = model.filters?.search || '';
+    card.dataset.time = String(model.metrics?.time?.value ?? 0);
+    card.dataset.payout = String(model.metrics?.payout?.value ?? 0);
+    card.dataset.roi = String(model.metrics?.roi ?? 0);
+    card.dataset.available = model.filters?.available ? 'true' : 'false';
+    if (model.filters?.limitRemaining !== null && model.filters?.limitRemaining !== undefined) {
+      card.dataset.limitRemaining = String(model.filters.limitRemaining);
+    }
+
+    const header = document.createElement('header');
+    header.className = 'browser-card__header';
+    const title = document.createElement('h2');
+    title.className = 'browser-card__title';
+    title.textContent = model.name;
+    header.appendChild(title);
+    card.appendChild(header);
+
+    if (model.description) {
+      const summary = document.createElement('p');
+      summary.className = 'browser-card__summary';
+      summary.textContent = model.description;
+      card.appendChild(summary);
+    }
+
+    const stats = document.createElement('div');
+    stats.className = 'browser-card__stats';
+    const payoutValue = model.metrics?.payout?.value ?? 0;
+    const payoutLabel = model.metrics?.payout?.label
+      || (payoutValue > 0 ? `$${formatMoney(payoutValue)}` : 'Varies');
+    stats.append(
+      createStat('Time', model.metrics?.time?.label || formatHours(model.metrics?.time?.value ?? 0)),
+      createStat('Payout', payoutLabel),
+      createStat('ROI', formatRoi(model.metrics?.roi))
+    );
+    card.appendChild(stats);
+
+    const meta = document.createElement('p');
+    meta.className = 'browser-card__meta';
+    meta.textContent = model.requirements?.summary || 'No requirements';
+    card.appendChild(meta);
+
+    if (model.limit?.summary) {
+      const limit = document.createElement('p');
+      limit.className = 'browser-card__note';
+      limit.textContent = model.limit.summary;
+      card.appendChild(limit);
+    }
+
+    const actions = document.createElement('div');
+    actions.className = 'browser-card__actions';
+    if (definition.action && model.action?.label) {
+      const queueButton = document.createElement('button');
+      queueButton.type = 'button';
+      queueButton.className = 'browser-card__button browser-card__button--primary';
+      queueButton.textContent = model.action.label;
+      queueButton.disabled = Boolean(model.action.disabled);
+      queueButton.addEventListener('click', () => {
+        if (queueButton.disabled) return;
+        definition.action.onClick?.();
+      });
+      actions.appendChild(queueButton);
+    }
+    card.appendChild(actions);
+
+    list.appendChild(card);
+  });
+
+  if (!list.children.length) {
+    const empty = document.createElement('p');
+    empty.className = 'browser-empty';
+    empty.textContent = 'Queue a hustle to see it spotlighted here.';
+    list.appendChild(empty);
+  }
+
+  return {
+    id: page.id,
+    meta: availableCount > 0 ? `${availableCount} hustle${availableCount === 1 ? '' : 's'} ready` : 'No hustles ready yet'
+  };
+}
+
+function renderAssetInstances(group, container) {
+  const wrapper = document.createElement('article');
+  wrapper.className = 'browser-card browser-card--asset-group';
+  wrapper.dataset.assetGroup = group.id;
+
+  const header = document.createElement('header');
+  header.className = 'browser-card__header';
+  const title = document.createElement('h2');
+  title.className = 'browser-card__title';
+  title.textContent = `${group.icon || '✨'} ${group.label}`.trim();
+  header.appendChild(title);
+  container.appendChild(wrapper);
+  wrapper.appendChild(header);
+
+  if (group.note) {
+    const note = document.createElement('p');
+    note.className = 'browser-card__summary';
+    note.textContent = group.note;
+    wrapper.appendChild(note);
+  }
+
+  const list = document.createElement('div');
+  list.className = 'browser-asset-list';
+  list.dataset.role = 'browser-asset-list';
+  wrapper.appendChild(list);
+
+  group.instances.forEach(instance => {
+    const item = document.createElement('div');
+    item.className = 'browser-asset';
+    item.dataset.asset = instance.id;
+    item.dataset.status = instance.status || 'setup';
+    item.dataset.risk = instance.risk || 'medium';
+    if (instance.needsMaintenance) {
+      item.dataset.needsMaintenance = 'true';
+    }
+
+    const label = document.createElement('strong');
+    label.className = 'browser-asset__title';
+    const assetName = instance.definition?.singular || instance.definition?.name || 'Venture';
+    label.textContent = `${assetName} #${instance.index + 1}`;
+
+    const status = document.createElement('span');
+    status.className = 'browser-asset__status';
+    status.textContent = instance.status === 'active' ? 'Active' : 'Setting up';
+
+    const maintenance = document.createElement('span');
+    maintenance.className = 'browser-asset__note';
+    maintenance.textContent = instance.needsMaintenance ? 'Maintenance due' : 'All clear';
+
+    item.append(label, status, maintenance);
+    list.appendChild(item);
+  });
+
+  return wrapper;
+}
+
+function renderAssetLaunchers(launchers = [], container) {
+  if (!launchers.length) return;
+  const launcherSection = document.createElement('div');
+  launcherSection.className = 'browser-launcher-grid';
+
+  launchers.forEach(entry => {
+    const card = document.createElement('article');
+    card.className = 'browser-card browser-card--launcher';
+    card.dataset.assetLauncher = entry.id;
+
+    const header = document.createElement('header');
+    header.className = 'browser-card__header';
+    const title = document.createElement('h2');
+    title.className = 'browser-card__title';
+    title.textContent = entry.name;
+    header.appendChild(title);
+    card.appendChild(header);
+
+    if (entry.summary) {
+      const summary = document.createElement('p');
+      summary.className = 'browser-card__summary';
+      summary.textContent = entry.summary;
+      card.appendChild(summary);
+    }
+
+    const stats = document.createElement('div');
+    stats.className = 'browser-card__stats';
+    stats.append(
+      createStat('Setup', `${formatHours(entry.setup?.hoursPerDay || 0)} • ${entry.setup?.days || 0} day${entry.setup?.days === 1 ? '' : 's'}`),
+      createStat('Upkeep', entry.upkeep || 'No upkeep')
+    );
+    card.appendChild(stats);
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'browser-card__button browser-card__button--primary';
+    button.textContent = entry.action?.label || 'Launch';
+    button.disabled = Boolean(entry.action?.disabled);
+    button.addEventListener('click', () => {
+      if (button.disabled) return;
+      entry.action?.onClick?.();
+    });
+
+    const actions = document.createElement('div');
+    actions.className = 'browser-card__actions';
+    actions.appendChild(button);
+    card.appendChild(actions);
+
+    launcherSection.appendChild(card);
+  });
+
+  container.appendChild(launcherSection);
+}
+
+function renderAssetsPage(definitions = [], models = {}) {
+  const page = SERVICE_PAGES.find(entry => entry.type === 'assets');
+  if (!page) return null;
+
+  const refs = ensurePageContent(page, ({ body }) => {
+    body.innerHTML = '';
+  });
+  if (!refs) return null;
+
+  const groups = Array.isArray(models.groups) ? models.groups : [];
+  const launchers = Array.isArray(models.launchers) ? models.launchers : [];
+  let activeCount = 0;
+
+  if (groups.length) {
+    const groupGrid = document.createElement('div');
+    groupGrid.className = 'browser-card-column';
+    groups.forEach(group => {
+      activeCount += group.instances.filter(instance => instance.status === 'active').length;
+      renderAssetInstances(group, groupGrid);
+    });
+    refs.body.appendChild(groupGrid);
+  }
+
+  if (launchers.length) {
+    renderAssetLaunchers(launchers, refs.body);
+  }
+
+  if (!refs.body.children.length) {
+    const empty = document.createElement('p');
+    empty.className = 'browser-empty';
+    empty.textContent = 'No ventures discovered yet. Launch your first asset to fill this feed.';
+    refs.body.appendChild(empty);
+  }
+
+  return {
+    id: page.id,
+    meta: activeCount > 0 ? `${activeCount} active venture${activeCount === 1 ? '' : 's'}` : 'No active ventures yet'
+  };
+}
+
+function renderUpgradeCard(definition, model) {
+  const card = document.createElement('article');
+  card.className = 'browser-card browser-card--upgrade';
+  card.dataset.upgrade = model.id;
+  card.dataset.ready = model.snapshot?.ready ? 'true' : 'false';
+  card.dataset.purchased = model.snapshot?.purchased ? 'true' : 'false';
+
+  const header = document.createElement('header');
+  header.className = 'browser-card__header';
+  const title = document.createElement('h2');
+  title.className = 'browser-card__title';
+  title.textContent = model.name;
+  header.appendChild(title);
+  card.appendChild(header);
+
+  if (model.description) {
+    const description = document.createElement('p');
+    description.className = 'browser-card__summary';
+    description.textContent = model.description;
+    card.appendChild(description);
+  }
+
+  const stats = document.createElement('div');
+  stats.className = 'browser-card__stats';
+  stats.append(
+    createStat('Cost', `$${formatMoney(model.cost || 0)}`),
+    createStat('Status', model.snapshot?.ready ? 'Ready to launch' : model.snapshot?.purchased ? 'Owned' : 'Locked')
+  );
+  card.appendChild(stats);
+
+  const actions = document.createElement('div');
+  actions.className = 'browser-card__actions';
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'browser-card__button browser-card__button--primary';
+  button.textContent = definition?.action?.label || 'Install';
+  const disabled = model.snapshot?.purchased || model.snapshot?.disabled;
+  button.disabled = Boolean(disabled) || !definition?.action;
+  button.addEventListener('click', () => {
+    if (button.disabled) return;
+    definition.action?.onClick?.();
+  });
+  actions.appendChild(button);
+  card.appendChild(actions);
+
+  return card;
+}
+
+function renderUpgradesPage(definitions = [], models = {}) {
+  const page = SERVICE_PAGES.find(entry => entry.type === 'upgrades');
+  if (!page) return null;
+
+  const refs = ensurePageContent(page, ({ body }) => {
+    body.innerHTML = '';
+  });
+  if (!refs) return null;
+
+  const definitionMap = buildDefinitionMap(definitions);
+  const categories = Array.isArray(models.categories) ? models.categories : [];
+  let readyCount = 0;
+
+  const grid = document.createElement('div');
+  grid.className = 'browser-card-grid';
+
+  categories.forEach(category => {
+    (category?.families || []).forEach(family => {
+      (family?.definitions || []).forEach(model => {
+        const definition = model.definition || definitionMap.get(model.id);
+        if (!definition) return;
+        if (model.snapshot?.ready) {
+          readyCount += 1;
+        }
+        const card = renderUpgradeCard(definition, model);
+        grid.appendChild(card);
+      });
+    });
+  });
+
+  if (!grid.children.length) {
+    const empty = document.createElement('p');
+    empty.className = 'browser-empty';
+    empty.textContent = 'No upgrades visible yet. Meet a prerequisite or stack more cash to unlock new toys.';
+    refs.body.appendChild(empty);
+  } else {
+    refs.body.appendChild(grid);
+  }
+
+  return {
+    id: page.id,
+    meta: readyCount > 0 ? `${readyCount} upgrade${readyCount === 1 ? '' : 's'} ready` : 'Browse upgrades for upcoming boosts'
+  };
+}
+
+function renderStudyCard(track) {
+  const card = document.createElement('article');
+  card.className = 'browser-card browser-card--study';
+  card.dataset.track = track.id;
+  card.dataset.completed = track.progress?.completed ? 'true' : 'false';
+
+  const header = document.createElement('header');
+  header.className = 'browser-card__header';
+  const title = document.createElement('h2');
+  title.className = 'browser-card__title';
+  title.textContent = track.name;
+  header.appendChild(title);
+  card.appendChild(header);
+
+  if (track.summary) {
+    const summary = document.createElement('p');
+    summary.className = 'browser-card__summary';
+    summary.textContent = track.summary;
+    card.appendChild(summary);
+  }
+
+  const stats = document.createElement('div');
+  stats.className = 'browser-card__stats';
+  const dailyHours = Number(track.hoursPerDay) || 0;
+  stats.append(
+    createStat('Daily time', formatHours(dailyHours)),
+    createStat('Duration', `${track.days || 0} day${track.days === 1 ? '' : 's'}`),
+    createStat('Progress', `${track.progress?.daysCompleted ?? 0}/${track.progress?.totalDays ?? track.days}`)
+  );
+  card.appendChild(stats);
+
+  if (track.description) {
+    const detail = document.createElement('p');
+    detail.className = 'browser-card__note';
+    detail.textContent = track.description;
+    card.appendChild(detail);
+  }
+
+  const actions = document.createElement('div');
+  actions.className = 'browser-card__actions';
+  if (track.action?.label) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'browser-card__button browser-card__button--primary';
+    button.textContent = track.action.label;
+    button.disabled = Boolean(track.action.disabled);
+    button.addEventListener('click', () => {
+      if (button.disabled) return;
+      track.action?.onClick?.();
+    });
+    actions.appendChild(button);
+  }
+  card.appendChild(actions);
+
+  return card;
+}
+
+function renderEducationPage(definitions = [], models = {}) {
+  const page = SERVICE_PAGES.find(entry => entry.type === 'education');
+  if (!page) return null;
+
+  const refs = ensurePageContent(page, ({ body }) => {
+    body.innerHTML = '';
+  });
+  if (!refs) return null;
+
+  const tracks = Array.isArray(models.tracks) ? models.tracks : [];
+  const grid = document.createElement('div');
+  grid.className = 'browser-card-grid';
+  let activeCount = 0;
+
+  tracks.forEach(track => {
+    if (track.progress?.enrolled && !track.progress?.completed) {
+      activeCount += 1;
+    }
+    grid.appendChild(renderStudyCard(track));
+  });
+
+  if (!tracks.length) {
+    const empty = document.createElement('p');
+    empty.className = 'browser-empty';
+    empty.textContent = 'Enroll in a course to light up this study hall.';
+    refs.body.appendChild(empty);
+  } else {
+    refs.body.appendChild(grid);
+  }
+
+  return {
+    id: page.id,
+    meta: activeCount > 0 ? `${activeCount} active track${activeCount === 1 ? '' : 's'}` : 'No tracks running yet'
+  };
+}
+
+function renderSiteList(summaries = []) {
+  const list = getElement('siteList');
+  if (!list) return;
+  list.innerHTML = '';
+
+  SERVICE_PAGES.forEach(page => {
+    const summary = summaries.find(entry => entry?.id === page.id) || {};
+    const li = document.createElement('li');
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'browser-site-list__button';
+    button.dataset.siteTarget = page.id;
+
+    const title = document.createElement('span');
+    title.className = 'browser-site-list__title';
+    title.textContent = page.label;
+
+    const meta = document.createElement('span');
+    meta.className = 'browser-site-list__meta';
+    meta.textContent = summary.meta || page.tagline;
+
+    button.append(title, meta);
+    li.appendChild(button);
+    list.appendChild(li);
+  });
+
+  const note = getElement('siteListNote');
+  if (note) {
+    note.textContent = 'Pinned surfaces show quick health for each corner of your empire.';
+  }
+}
+
+function renderServices(registries = {}, models = {}) {
+  cachedRegistries = registries;
+  cachedModels = models;
+
+  const summaries = [];
+  const hustleSummary = renderHustlesPage(registries.hustles, models.hustles);
+  if (hustleSummary) summaries.push(hustleSummary);
+  const assetSummary = renderAssetsPage(registries.assets, models.assets);
+  if (assetSummary) summaries.push(assetSummary);
+  const upgradeSummary = renderUpgradesPage(registries.upgrades, models.upgrades);
+  if (upgradeSummary) summaries.push(upgradeSummary);
+  const educationSummary = renderEducationPage(registries.education, models.education);
+  if (educationSummary) summaries.push(educationSummary);
+
+  renderSiteList(summaries);
+}
+
+function renderAll(payload = {}) {
+  const { registries = {}, models = {} } = payload;
+  renderServices(registries, models);
+}
+
+function update(payload = {}) {
+  renderAll(payload);
+}
+
+function updateCard() {
+  if (!cachedRegistries || !cachedModels) return;
+  renderServices(cachedRegistries, cachedModels);
+}
+
+function refreshUpgradeSections() {
+  updateCard();
+}
+
+export default {
+  renderAll,
+  update,
+  updateCard,
+  refreshUpgradeSections
+};

--- a/src/ui/views/browser/components/widgets.js
+++ b/src/ui/views/browser/components/widgets.js
@@ -1,0 +1,95 @@
+import { formatMoney } from '../../../../core/helpers.js';
+
+function createElement(tag, className, text) {
+  const element = document.createElement(tag);
+  if (className) {
+    element.className = className;
+  }
+  if (typeof text === 'string') {
+    element.textContent = text;
+  }
+  return element;
+}
+
+export function createMetricTile({ icon, label, value, note }) {
+  const tile = createElement('article', 'browser-focus-metric');
+
+  const header = createElement('header', 'browser-focus-metric__header');
+  const iconSpan = createElement('span', 'browser-focus-metric__icon', icon || '✨');
+  const title = createElement('span', 'browser-focus-metric__label', label || 'Metric');
+  header.append(iconSpan, title);
+
+  const valueEl = createElement('span', 'browser-focus-metric__value', value || '—');
+  const noteEl = createElement('span', 'browser-focus-metric__note', note || '');
+
+  tile.append(header, valueEl, noteEl);
+  return tile;
+}
+
+export function createShortcutButton(entry) {
+  const button = createElement('button', 'browser-shortcut');
+  button.type = 'button';
+  button.textContent = entry?.title || 'Action';
+  if (entry?.buttonLabel && entry.buttonLabel !== entry.title) {
+    button.dataset.actionLabel = entry.buttonLabel;
+  }
+  if (entry?.subtitle) {
+    button.title = entry.subtitle;
+  }
+  button.disabled = Boolean(entry?.disabled);
+  if (typeof entry?.onClick === 'function') {
+    button.addEventListener('click', () => {
+      if (button.disabled) return;
+      entry.onClick();
+    });
+  }
+  return button;
+}
+
+export function createNotificationItem(entry, resolveAction) {
+  const item = createElement('li', 'browser-update');
+
+  const header = createElement('div', 'browser-update__info');
+  const title = createElement('strong', 'browser-update__title', entry?.label || 'Update');
+  const message = createElement('span', 'browser-update__message', entry?.message || '');
+  header.append(title, message);
+
+  const actionWrapper = createElement('div', 'browser-update__actions');
+  const button = createElement('button', 'browser-update__button');
+  button.type = 'button';
+  button.textContent = entry?.action?.label || 'Open';
+  const handler = resolveAction?.(entry);
+  if (handler) {
+    button.addEventListener('click', handler);
+  } else {
+    button.disabled = true;
+  }
+
+  actionWrapper.append(button);
+  item.append(header, actionWrapper);
+  return item;
+}
+
+export function formatRoi(roi) {
+  const numeric = Number(roi);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return '—';
+  }
+  return `$${formatMoney(numeric)} / h`;
+}
+
+export function createStat(label, value) {
+  const stat = createElement('div', 'browser-card__stat');
+  const labelEl = createElement('span', 'browser-card__stat-label', label || 'Stat');
+  const valueEl = createElement('span', 'browser-card__stat-value', value || '—');
+  stat.append(labelEl, valueEl);
+  return stat;
+}
+
+export default {
+  createMetricTile,
+  createShortcutButton,
+  createNotificationItem,
+  createStat,
+  formatRoi
+};

--- a/src/ui/views/browser/config.js
+++ b/src/ui/views/browser/config.js
@@ -1,0 +1,64 @@
+export const HOMEPAGE_ID = 'home';
+
+export const SERVICE_PAGES = [
+  {
+    id: 'blogpress',
+    slug: 'blogpress',
+    label: 'BlogPress',
+    headline: 'BlogPress Creator Hub',
+    tagline: 'Queue hustles, stack ROI, and keep your streak sizzling.',
+    type: 'hustles'
+  },
+  {
+    id: 'videotube',
+    slug: 'videotube',
+    label: 'VideoTube',
+    headline: 'VideoTube Venture Studio',
+    tagline: 'Survey every venture, fund upkeep, and celebrate new launches.',
+    type: 'assets'
+  },
+  {
+    id: 'shopstack',
+    slug: 'shopstack',
+    label: 'ShopStack',
+    headline: 'ShopStack Upgrade Arcade',
+    tagline: 'Install power-ups, clear prerequisites, and line up the next spike.',
+    type: 'upgrades'
+  },
+  {
+    id: 'learnly',
+    slug: 'learnly',
+    label: 'Learnly',
+    headline: 'Learnly Study Hall',
+    tagline: 'Stay sharp with daily study loops and celebratory completions.',
+    type: 'education'
+  }
+];
+
+export function findPageById(pageId) {
+  if (pageId === HOMEPAGE_ID) {
+    return {
+      id: HOMEPAGE_ID,
+      slug: 'home',
+      label: 'Homepage',
+      headline: 'Mission Control',
+      tagline: 'Your empire’s launchpad with shortcuts, streaks, and story beats.',
+      type: 'home'
+    };
+  }
+
+  return SERVICE_PAGES.find(page => page.id === pageId) || null;
+}
+
+export function findPageBySlug(slug) {
+  const normalized = String(slug || '').trim().toLowerCase();
+  if (!normalized) return null;
+  if (normalized === 'home' || normalized === HOMEPAGE_ID) {
+    return findPageById(HOMEPAGE_ID);
+  }
+  return SERVICE_PAGES.find(page => page.slug === normalized || page.label.toLowerCase() === normalized) || null;
+}
+
+export function listAllPages() {
+  return [findPageById(HOMEPAGE_ID), ...SERVICE_PAGES];
+}

--- a/src/ui/views/browser/dashboardPresenter.js
+++ b/src/ui/views/browser/dashboardPresenter.js
@@ -1,0 +1,135 @@
+import { getElement } from '../../elements/registry.js';
+import setText from '../../dom.js';
+import {
+  createMetricTile,
+  createShortcutButton,
+  createNotificationItem
+} from './components/widgets.js';
+
+const FOCUS_METRICS = [
+  { key: 'dailyPlus', label: 'Daily inflow', icon: '💸', source: 'header' },
+  { key: 'dailyMinus', label: 'Daily outflow', icon: '💳', source: 'header' },
+  { key: 'timeAvailable', label: 'Hours ready', icon: '⏱️', source: 'header' },
+  { key: 'net', label: 'Net momentum', icon: '📈', source: 'kpis' }
+];
+
+function resolveNotificationAction(entry) {
+  if (!entry?.action) return null;
+  if (entry.action.type === 'shell-tab') {
+    const tabId = entry.action.tabId;
+    return () => {
+      const { shellTabs = [] } = getElement('shellNavigation') || {};
+      shellTabs.find(tab => tab.id === tabId)?.click();
+    };
+  }
+  if (typeof entry.action === 'function') {
+    return () => entry.action();
+  }
+  return null;
+}
+
+function renderFocusWidget(headerMetrics = {}, kpis = {}) {
+  const widgets = getElement('homepageWidgets') || {};
+  const focus = widgets.focus || {};
+  const container = focus.container;
+  if (!container) return;
+  container.innerHTML = '';
+
+  const notes = [];
+
+  FOCUS_METRICS.forEach(entry => {
+    const target = entry.source === 'kpis' ? kpis?.[entry.key] : headerMetrics?.[entry.key];
+    if (!target) return;
+    const tile = createMetricTile({
+      icon: entry.icon,
+      label: entry.label,
+      value: target.value || '—',
+      note: target.note || ''
+    });
+    if (target.note) {
+      notes.push(target.note);
+    }
+    container.appendChild(tile);
+  });
+
+  if (focus.note) {
+    const summary = notes.filter(Boolean).slice(0, 2).join(' • ');
+    setText(focus.note, summary || 'Cashflow and time updates refresh with every loop tick.');
+  }
+}
+
+function renderShortcuts(quickActions = {}) {
+  const widgets = getElement('homepageWidgets') || {};
+  const shortcuts = widgets.shortcuts || {};
+  const container = shortcuts.container;
+  if (!container) return;
+
+  container.innerHTML = '';
+  const entries = Array.isArray(quickActions.entries) ? quickActions.entries.filter(Boolean) : [];
+
+  if (!entries.length) {
+    if (shortcuts.note) {
+      setText(shortcuts.note, quickActions.emptyMessage || 'No quick plays ready. Check upgrades or ventures.');
+    }
+    return;
+  }
+
+  entries.slice(0, 6).forEach(entry => {
+    const button = createShortcutButton(entry);
+    container.appendChild(button);
+  });
+
+  if (shortcuts.note) {
+    const label = quickActions.defaultLabel || 'Queue';
+    const copy = `Tap a shortcut to ${label.toLowerCase()} it instantly.`;
+    setText(shortcuts.note, copy);
+  }
+}
+
+function renderUpdates(notifications = {}) {
+  const widgets = getElement('homepageWidgets') || {};
+  const updates = widgets.updates || {};
+  const list = updates.list;
+  if (!list) return;
+  list.innerHTML = '';
+
+  const entries = Array.isArray(notifications.entries) ? notifications.entries.filter(Boolean) : [];
+  if (!entries.length) {
+    if (updates.note) {
+      setText(updates.note, notifications.emptyMessage || 'All quiet for now. Keep the empire buzzing.');
+    }
+    return;
+  }
+
+  entries.slice(0, 4).forEach(entry => {
+    const item = createNotificationItem(entry, resolveNotificationAction);
+    list.appendChild(item);
+  });
+
+  if (updates.note) {
+    setText(updates.note, 'Latest signals from upkeep, upgrades, and the queue.');
+  }
+}
+
+function renderHomepageShell(session = {}) {
+  const homepage = getElement('homepage') || {};
+  if (homepage.heading) {
+    setText(homepage.heading, session.statusText || 'Browser Homepage');
+  }
+  if (homepage.tagline) {
+    const money = session.moneyText || '$0';
+    setText(homepage.tagline, `Wallet humming at ${money}. Deploy those hours with style.`);
+  }
+}
+
+function renderDashboard(viewModel = {}) {
+  if (!viewModel) return;
+  renderHomepageShell(viewModel.session || {});
+  renderFocusWidget(viewModel.headerMetrics || {}, viewModel.kpis || {});
+  renderShortcuts(viewModel.quickActions || {});
+  renderUpdates(viewModel.notifications || {});
+}
+
+export default {
+  renderDashboard
+};

--- a/src/ui/views/browser/index.js
+++ b/src/ui/views/browser/index.js
@@ -1,10 +1,21 @@
 import resolvers from './resolvers.js';
+import { renderDashboard as baseRenderDashboard } from '../../dashboard.js';
+import dashboardPresenter from './dashboardPresenter.js';
+import cardsPresenter from './cardsPresenter.js';
+import layoutPresenter from './layoutPresenter.js';
 
 const browserView = {
   id: 'browser',
   name: 'Browser Chrome',
   resolvers,
-  presenters: {}
+  presenters: {
+    dashboard: dashboardPresenter,
+    cards: cardsPresenter,
+    layout: layoutPresenter
+  },
+  renderDashboard(state, summary) {
+    baseRenderDashboard(state, summary, dashboardPresenter);
+  }
 };
 
 export default browserView;

--- a/src/ui/views/browser/layoutPresenter.js
+++ b/src/ui/views/browser/layoutPresenter.js
@@ -1,0 +1,285 @@
+import { getElement } from '../../elements/registry.js';
+import { HOMEPAGE_ID, findPageById, findPageBySlug } from './config.js';
+
+let currentPage = HOMEPAGE_ID;
+const historyStack = [];
+const futureStack = [];
+let navigationRefs = null;
+let sessionControls = null;
+
+function getNavigationRefs() {
+  if (!navigationRefs) {
+    navigationRefs = getElement('browserNavigation') || {};
+  }
+  return navigationRefs;
+}
+
+function getSessionControls() {
+  if (!sessionControls) {
+    sessionControls = getElement('browserSessionControls') || {};
+  }
+  return sessionControls;
+}
+
+function getHomepageElement() {
+  return getElement('homepage')?.container || null;
+}
+
+function getPageElement(pageId) {
+  if (pageId === HOMEPAGE_ID) {
+    return getHomepageElement();
+  }
+  return document.querySelector(`[data-browser-page="${pageId}"]`);
+}
+
+function listPageSections() {
+  return Array.from(document.querySelectorAll('[data-browser-page]'));
+}
+
+function markActiveSite(pageId) {
+  const list = getElement('siteList');
+  if (!list) return;
+  list.querySelectorAll('button[data-site-target]').forEach(button => {
+    const isActive = button.dataset.siteTarget === pageId;
+    button.classList.toggle('is-active', isActive);
+    button.setAttribute('aria-pressed', String(isActive));
+  });
+}
+
+function updateAddressBar(page) {
+  const address = getElement('browserAddress') || {};
+  const input = address.input;
+  if (!input) return;
+  const slug = page?.slug || 'home';
+  const url = `https://hustle.city/${slug === 'home' ? '' : slug}`;
+  input.value = url;
+}
+
+function updateNavigationButtons() {
+  const { backButton, forwardButton } = getNavigationRefs();
+  if (backButton) {
+    backButton.disabled = historyStack.length === 0;
+  }
+  if (forwardButton) {
+    forwardButton.disabled = futureStack.length === 0;
+  }
+}
+
+function revealPage(pageId, { focus = false } = {}) {
+  const homepage = getHomepageElement();
+  if (homepage) {
+    const isHome = pageId === HOMEPAGE_ID;
+    homepage.hidden = !isHome;
+    homepage.classList.toggle('is-active', isHome);
+  }
+
+  listPageSections().forEach(section => {
+    const isActive = section.dataset.browserPage === pageId;
+    section.hidden = !isActive;
+    section.classList.toggle('is-active', isActive);
+  });
+
+  const target = getPageElement(pageId);
+  if (target && focus) {
+    target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+}
+
+function setActivePage(targetId, { recordHistory = true, focus = false } = {}) {
+  const resolved = findPageById(targetId) || findPageBySlug(targetId) || findPageById(HOMEPAGE_ID);
+  const pageId = resolved?.id || HOMEPAGE_ID;
+  const element = getPageElement(pageId);
+  if (!element) return;
+
+  if (recordHistory && currentPage !== pageId) {
+    historyStack.push(currentPage);
+    futureStack.length = 0;
+  }
+
+  currentPage = pageId;
+  revealPage(pageId, { focus });
+  markActiveSite(pageId);
+  updateAddressBar(resolved);
+  updateNavigationButtons();
+}
+
+function navigateBack() {
+  if (!historyStack.length) return;
+  const previous = historyStack.pop();
+  futureStack.push(currentPage);
+  setActivePage(previous, { recordHistory: false, focus: true });
+}
+
+function navigateForward() {
+  if (!futureStack.length) return;
+  const next = futureStack.pop();
+  historyStack.push(currentPage);
+  setActivePage(next, { recordHistory: false, focus: true });
+}
+
+function refreshActivePage() {
+  const { refreshButton } = getNavigationRefs();
+  const target = getPageElement(currentPage);
+  if (refreshButton) {
+    refreshButton.classList.add('is-spinning');
+    window.setTimeout(() => refreshButton.classList.remove('is-spinning'), 420);
+  }
+  if (target) {
+    target.classList.add('is-refreshing');
+    window.setTimeout(() => target.classList.remove('is-refreshing'), 420);
+  }
+}
+
+function handleSiteClick(event) {
+  const button = event.target.closest('button[data-site-target]');
+  if (!button) return;
+  event.preventDefault();
+  setActivePage(button.dataset.siteTarget || HOMEPAGE_ID);
+}
+
+function handleAddressSubmit(event) {
+  event.preventDefault();
+  const address = getElement('browserAddress') || {};
+  const input = address.input;
+  if (!input) return;
+  const value = String(input.value || '').trim();
+  const path = value.replace(/^https?:\/\/[^/]+\//iu, '').replace(/\s+/g, '').replace(/\/+$/, '');
+  const destination = findPageBySlug(path);
+  if (destination) {
+    setActivePage(destination.id);
+  } else {
+    updateAddressBar(findPageById(currentPage));
+  }
+}
+
+function initNavigation() {
+  const { backButton, forwardButton, refreshButton } = getNavigationRefs();
+  if (backButton) {
+    backButton.addEventListener('click', navigateBack);
+  }
+  if (forwardButton) {
+    forwardButton.addEventListener('click', navigateForward);
+  }
+  if (refreshButton) {
+    refreshButton.addEventListener('click', refreshActivePage);
+  }
+
+  const controls = getSessionControls();
+  if (controls?.homeButton) {
+    controls.homeButton.addEventListener('click', () => setActivePage(HOMEPAGE_ID));
+  }
+
+  const address = getElement('browserAddress') || {};
+  if (address.form) {
+    address.form.addEventListener('submit', handleAddressSubmit);
+  }
+
+  const siteList = getElement('siteList');
+  if (siteList) {
+    siteList.addEventListener('click', handleSiteClick);
+  }
+
+  setActivePage(currentPage, { recordHistory: false });
+  updateNavigationButtons();
+}
+
+function applyHustleFilters(model = {}) {
+  const list = document.querySelector('[data-role="browser-hustle-list"]');
+  if (!list) return;
+  const cards = Array.from(list.querySelectorAll('[data-hustle]'));
+  const cardMap = new Map(cards.map(card => [card.dataset.hustle, card]));
+  const fragment = document.createDocumentFragment();
+  const orderedIds = Array.isArray(model.orderedIds) ? model.orderedIds : [];
+  const hiddenSet = new Set(Array.isArray(model.hiddenIds) ? model.hiddenIds : []);
+
+  orderedIds.forEach(id => {
+    const card = cardMap.get(id);
+    if (!card) return;
+    card.hidden = hiddenSet.has(id);
+    fragment.appendChild(card);
+    cardMap.delete(id);
+    hiddenSet.delete(id);
+  });
+
+  cardMap.forEach((card, id) => {
+    const hidden = hiddenSet.has(id);
+    card.hidden = hidden;
+    fragment.appendChild(card);
+  });
+
+  list.appendChild(fragment);
+}
+
+function applyAssetFilters(model = {}) {
+  const hiddenSet = new Set(Array.isArray(model.hiddenIds) ? model.hiddenIds : []);
+  const visibleSet = new Set(Array.isArray(model.visibleIds) ? model.visibleIds : []);
+  const instances = document.querySelectorAll('[data-role="browser-asset-list"] [data-asset], .browser-asset-list [data-asset]');
+  instances.forEach(node => {
+    const id = node.dataset.asset;
+    if (!id) return;
+    if (hiddenSet.has(id)) {
+      node.hidden = true;
+      return;
+    }
+    if (visibleSet.size && !visibleSet.has(id)) {
+      node.hidden = true;
+      return;
+    }
+    node.hidden = false;
+  });
+}
+
+function applyUpgradeFilters(model = {}) {
+  const hiddenSet = new Set(Array.isArray(model.hiddenIds) ? model.hiddenIds : []);
+  const visibleSet = new Set(Array.isArray(model.visibleIds) ? model.visibleIds : []);
+  document.querySelectorAll('[data-upgrade]').forEach(card => {
+    const id = card.dataset.upgrade;
+    if (!id) return;
+    if (hiddenSet.has(id)) {
+      card.hidden = true;
+      return;
+    }
+    if (visibleSet.size && !visibleSet.has(id)) {
+      card.hidden = true;
+      return;
+    }
+    card.hidden = false;
+  });
+}
+
+function applyStudyFilters(model = {}) {
+  const hiddenSet = new Set(Array.isArray(model.hiddenIds) ? model.hiddenIds : []);
+  const visibleSet = new Set(Array.isArray(model.visibleIds) ? model.visibleIds : []);
+  document.querySelectorAll('[data-track]').forEach(card => {
+    const id = card.dataset.track;
+    if (!id) return;
+    if (hiddenSet.has(id)) {
+      card.hidden = true;
+      return;
+    }
+    if (visibleSet.size && !visibleSet.has(id)) {
+      card.hidden = true;
+      return;
+    }
+    card.hidden = false;
+  });
+}
+
+function initControls() {
+  initNavigation();
+}
+
+function applyFilters(model = {}) {
+  if (!model) return;
+  applyHustleFilters(model.hustles);
+  applyAssetFilters(model.assets);
+  applyUpgradeFilters(model.upgrades);
+  applyStudyFilters(model.study);
+}
+
+const layoutPresenter = {
+  initControls,
+  applyFilters
+};
+
+export default layoutPresenter;

--- a/src/ui/views/browser/resolvers.js
+++ b/src/ui/views/browser/resolvers.js
@@ -13,6 +13,10 @@ const resolvers = {
     commandButton: root.getElementById('browser-command-button'),
     endDayButton: root.getElementById('browser-session-button')
   }),
+  headerActionButtons: root => ({
+    endDayButton: root.getElementById('browser-session-button'),
+    autoForwardButton: null
+  }),
   siteList: root => root.getElementById('browser-site-list'),
   siteListNote: root => root.getElementById('browser-sites-note'),
   addSiteButton: root => root.getElementById('browser-add-site'),

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -231,6 +231,326 @@ body {
   border: 1px solid rgba(140, 148, 255, 0.25);
 }
 
+.browser-focus-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 1rem;
+  border-radius: 18px;
+  background: rgba(21, 24, 46, 0.85);
+  border: 1px solid rgba(124, 132, 255, 0.28);
+  box-shadow: inset 0 0 0 1px rgba(120, 128, 255, 0.08);
+}
+
+.browser-focus-metric__header {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-weight: 600;
+  color: rgba(214, 220, 255, 0.9);
+}
+
+.browser-focus-metric__icon {
+  font-size: 1.2rem;
+}
+
+.browser-focus-metric__value {
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.browser-focus-metric__note {
+  font-size: 0.85rem;
+  color: rgba(197, 204, 255, 0.7);
+}
+
+.browser-shortcut {
+  padding: 0.75rem 0.9rem;
+  border-radius: 14px;
+  border: 1px solid rgba(123, 136, 255, 0.4);
+  background: rgba(30, 35, 66, 0.65);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: transform 140ms ease, background 140ms ease;
+}
+
+.browser-shortcut:hover {
+  background: rgba(108, 118, 255, 0.5);
+  transform: translateY(-1px);
+}
+
+.browser-shortcut:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.browser-update {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 16px;
+  background: rgba(23, 26, 49, 0.8);
+  border: 1px solid rgba(133, 140, 255, 0.28);
+}
+
+.browser-update__info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.browser-update__title {
+  font-weight: 600;
+}
+
+.browser-update__message {
+  font-size: 0.85rem;
+  color: rgba(197, 204, 255, 0.75);
+}
+
+.browser-update__button {
+  padding: 0.45rem 0.9rem;
+  border-radius: 12px;
+  border: 1px solid rgba(140, 148, 255, 0.4);
+  background: rgba(44, 49, 88, 0.9);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.browser-update__button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.browser-page {
+  display: none;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem;
+  border-radius: 28px;
+  background: rgba(14, 16, 30, 0.82);
+  border: 1px solid rgba(96, 104, 214, 0.28);
+  box-shadow: 0 24px 64px rgba(4, 5, 14, 0.55);
+}
+
+.browser-page.is-active {
+  display: flex;
+}
+
+.browser-page__header h1 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.browser-page__header p {
+  margin: 0.4rem 0 0;
+  color: rgba(197, 204, 255, 0.7);
+}
+
+.browser-card-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.browser-card-column {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.browser-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.25rem;
+  border-radius: 22px;
+  background: rgba(22, 25, 46, 0.92);
+  border: 1px solid rgba(118, 128, 255, 0.32);
+  box-shadow: 0 18px 42px rgba(5, 6, 16, 0.45);
+}
+
+.browser-card__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.browser-card__title {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.browser-card__summary {
+  margin: 0;
+  color: rgba(204, 210, 255, 0.82);
+}
+
+.browser-card__stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.browser-card__stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.6rem 0.8rem;
+  border-radius: 14px;
+  background: rgba(32, 36, 66, 0.7);
+}
+
+.browser-card__stat-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(186, 194, 255, 0.65);
+}
+
+.browser-card__stat-value {
+  font-weight: 600;
+}
+
+.browser-card__meta {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(197, 204, 255, 0.7);
+}
+
+.browser-card__note {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(197, 204, 255, 0.55);
+}
+
+.browser-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.browser-card__button {
+  padding: 0.6rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(118, 128, 255, 0.45);
+  background: rgba(47, 53, 94, 0.9);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 120ms ease, background 120ms ease;
+}
+
+.browser-card__button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  background: rgba(118, 128, 255, 0.55);
+}
+
+.browser-card__button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.browser-card__button--primary {
+  background: linear-gradient(135deg, #ff7adf 0%, #7b8bff 100%);
+  border: none;
+  color: #0f1015;
+  font-weight: 700;
+}
+
+.browser-empty {
+  margin: 0;
+  padding: 1.25rem;
+  border-radius: 18px;
+  background: rgba(24, 27, 48, 0.8);
+  border: 1px dashed rgba(132, 140, 255, 0.35);
+  color: rgba(197, 204, 255, 0.7);
+  text-align: center;
+}
+
+.browser-asset-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.browser-asset {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 14px;
+  background: rgba(31, 35, 62, 0.8);
+  border: 1px solid rgba(126, 134, 255, 0.3);
+}
+
+.browser-asset__title {
+  font-weight: 600;
+}
+
+.browser-asset__status {
+  font-size: 0.85rem;
+  color: rgba(197, 204, 255, 0.7);
+}
+
+.browser-asset__note {
+  font-size: 0.8rem;
+  color: rgba(255, 196, 132, 0.85);
+}
+
+.browser-launcher-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.browser-site-list__button {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: 14px;
+  border: 1px solid rgba(103, 109, 204, 0.35);
+  background: rgba(32, 37, 70, 0.6);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: background 140ms ease, transform 140ms ease;
+}
+
+.browser-site-list__button.is-active {
+  background: rgba(102, 112, 255, 0.45);
+  transform: translateY(-1px);
+}
+
+.browser-site-list__button:focus-visible {
+  outline: 2px solid rgba(140, 148, 255, 0.75);
+  outline-offset: 2px;
+}
+
+.browser-page.is-refreshing {
+  box-shadow: 0 24px 64px rgba(20, 40, 140, 0.55);
+}
+
+.browser-button.is-spinning {
+  animation: browser-spin 0.42s linear;
+}
+
+@keyframes browser-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 @media (max-width: 960px) {
   .browser-layout {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- add browser dashboard, cards, and layout presenters so the browser chrome consumes shared models
- render BlogPress, VideoTube, ShopStack, and Learnly service pages plus homepage widgets with new browser components and styles
- extend browser resolvers/configuration to drive navigation controls and share the end-of-day action

## Testing
- npm test

## Manual Testing
- not run (no browser available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd54e098f8832cb1f89a3eff232169