### PR TITLE
Add feature flag view selection and classic shell navigation

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -31,6 +31,13 @@
       <div class="browser-chrome__cluster" aria-label="Session controls">
         <button id="browser-home-button" class="browser-button" type="button">Home</button>
         <button id="browser-command-button" class="browser-button" type="button">⌘K</button>
+        <a
+          id="browser-classic-link"
+          class="browser-button"
+          href="index.html"
+          role="button"
+          title="Pop back to the classic dashboard shell"
+        >Classic Shell</a>
         <button id="browser-session-button" class="browser-button browser-button--primary" type="button">End Day</button>
       </div>
     </header>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Boot logic now respects an `?ui=` flag and the browser chrome includes a Classic Shell button so testers can bounce between shells while feature parity lands.
 - Browser shell entry experiments ship a homepage chrome with pinned sites and dedicated widgets while sharing the core game lo
 op with the classic dashboard.
 - Browser chrome now renders dashboard KPIs, quick actions, notifications, and the BlogPress/VideoTube/ShopStack/Learnly surfaces through dedicated presenters that reuse the shared models.

--- a/docs/features/browser-shell.md
+++ b/docs/features/browser-shell.md
@@ -14,6 +14,7 @@
 - Introduced `browser.html` as an alternate entry point that loads the existing game scripts with a new DOM skeleton.
 - Added `src/ui/views/browser/` with dedicated resolvers wired to the browser chrome and widget containers.
 - A standalone stylesheet (`styles/browser.css`) scopes the new visual language without touching the classic layout.
-- `src/main.js` now detects `data-ui-view` on the document body to pick between the classic and browser views during boot.
+- `src/main.js` now detects `data-ui-view` on the document body (or an `?ui=` feature flag) to pick between the classic and browser views during boot.
 - Browser presenters reuse the shared dashboard and card models to render homepage widgets plus BlogPress, VideoTube, ShopStack, and Learnly service pages inside the chrome shell.
 - Layout navigation tracks a lightweight history stack so the browser buttons, pinned sites, and address bar all stay in sync.
+- Browser chrome exposes a "Classic Shell" button so players can hop back to the legacy dashboard while the browser view matures.

--- a/src/main.js
+++ b/src/main.js
@@ -12,9 +12,42 @@ import classicView from './ui/views/classic/index.js';
 import browserView from './ui/views/browser/index.js';
 import { loadDefaultRegistry } from './game/registryLoader.js';
 
+function resolveViewFromFlag(rootDocument) {
+  if (typeof window === 'undefined' || typeof URLSearchParams !== 'function') {
+    return null;
+  }
+
+  let requestedId = null;
+  try {
+    const params = new URLSearchParams(window.location.search);
+    requestedId = params.get('ui') || params.get('view') || params.get('shell');
+  } catch (error) {
+    requestedId = null;
+  }
+
+  if (!requestedId) {
+    return null;
+  }
+
+  const normalizedId = requestedId.toLowerCase();
+  if (normalizedId === browserView.id && rootDocument?.getElementById('browser-home')) {
+    return browserView;
+  }
+  if (normalizedId === classicView.id && rootDocument?.getElementById('tab-dashboard')) {
+    return classicView;
+  }
+
+  return null;
+}
+
 function resolveInitialView(rootDocument = typeof document !== 'undefined' ? document : null) {
+  const flagView = resolveViewFromFlag(rootDocument);
+  if (flagView) {
+    return flagView;
+  }
+
   const viewId = rootDocument?.body?.dataset?.uiView;
-  if (viewId === browserView.id) {
+  if (viewId === browserView.id && rootDocument?.getElementById('browser-home')) {
     return browserView;
   }
   return classicView;

--- a/src/ui/headerAction/index.js
+++ b/src/ui/headerAction/index.js
@@ -31,10 +31,28 @@ const autoForwardState = {
 };
 
 let activeRecommendation = null;
+let presenterRef = null;
+let activeViewId = null;
+
+function refreshPresenterState() {
+  const view = getActiveView();
+  const nextViewId = view?.id || null;
+  if (nextViewId !== activeViewId) {
+    activeViewId = nextViewId;
+    presenterRef = null;
+  }
+}
 
 function getPresenter() {
-  const presenter = getActiveView()?.presenters?.headerAction;
-  return presenter || classicHeaderActionPresenter;
+  refreshPresenterState();
+  const view = getActiveView();
+  if (view?.presenters?.headerAction) {
+    return view.presenters.headerAction;
+  }
+  if (!view) {
+    return classicHeaderActionPresenter;
+  }
+  return null;
 }
 
 function getNextMode(current) {
@@ -91,11 +109,15 @@ function cycleAutoForward() {
 }
 
 export function initHeaderActionControls() {
+  refreshPresenterState();
   const presenter = getPresenter();
-  presenter?.init?.({
-    onPrimaryAction: handlePrimaryAction,
-    onAutoForwardToggle: cycleAutoForward
-  });
+  if (presenter && presenter !== presenterRef) {
+    presenter?.init?.({
+      onPrimaryAction: handlePrimaryAction,
+      onAutoForwardToggle: cycleAutoForward
+    });
+    presenterRef = presenter;
+  }
   applyAutoForwardState('paused');
 }
 

--- a/src/ui/layout/index.js
+++ b/src/ui/layout/index.js
@@ -7,6 +7,7 @@ let activePanelController = null;
 let currentCardModels = null;
 let layoutPresenterInitialized = false;
 let presenterRef = null;
+let activeViewId = null;
 
 function syncPreferencesFromDom() {
   const hustleControls = getElement('hustleControls') || {};
@@ -53,9 +54,25 @@ function emitLayoutEvent(name) {
   }
 }
 
+function refreshPresenterState() {
+  const view = getActiveView();
+  const nextViewId = view?.id || null;
+  if (nextViewId !== activeViewId) {
+    layoutPresenterInitialized = false;
+    presenterRef = null;
+    activeViewId = nextViewId;
+  }
+}
+
 function getPresenter() {
-  const presenter = getActiveView()?.presenters?.layout;
-  return presenter || classicLayoutPresenter;
+  const view = getActiveView();
+  if (view?.presenters?.layout) {
+    return view.presenters.layout;
+  }
+  if (!view) {
+    return classicLayoutPresenter;
+  }
+  return null;
 }
 
 function setupTabs() {
@@ -243,6 +260,7 @@ function setupKpiShortcuts() {
 }
 
 function initializeLayoutPresenter() {
+  refreshPresenterState();
   const presenter = getPresenter();
   if (!presenter?.initControls) {
     return;


### PR DESCRIPTION
## Summary
- allow bootstrapping the browser shell when the document advertises matching markup or an `?ui=` flag
- reset layout/header presenters when the active view changes so browser shells avoid classic-only assumptions
- expose a Classic Shell link in the browser chrome and document the fallback navigation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd5bba92c0832c9563bc1d745fdec1