### PR TITLE
Refocus browser launch screen on todo list

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -56,63 +56,38 @@
       <main class="browser-main" aria-live="polite">
         <section id="browser-home" class="browser-home" aria-labelledby="browser-home-heading">
           <header class="browser-home__header">
-            <div class="browser-home__headline">
-              <h1 id="browser-home-heading">Browser Homepage</h1>
-              <p id="browser-home-tagline">Your empire’s launchpad with shortcuts, streaks, and story beats.</p>
-            </div>
+            <h1 id="browser-home-heading">Launch the day</h1>
+            <p id="browser-home-tagline">Line up the next win and keep the streak rolling.</p>
           </header>
 
-          <section class="browser-home__section" aria-labelledby="browser-sites-heading">
-            <div class="browser-section-header">
-              <h2 id="browser-sites-heading">Workspace</h2>
-              <p id="browser-sites-note">Pin your go-to dashboards for lightning hops.</p>
-            </div>
-            <div class="browser-home__apps">
-              <ul id="browser-site-list" class="browser-app-grid" aria-live="polite"></ul>
-              <button id="browser-add-site" class="browser-app-button" type="button">Add site</button>
-            </div>
-          </section>
-
-          <section class="browser-home__section" aria-labelledby="browser-widgets-heading">
-            <div class="browser-section-header">
-              <h2 id="browser-widgets-heading">Pinned widgets</h2>
-              <p>Keep fast stats and actions right where you need them.</p>
-            </div>
-            <div id="browser-widget-grid" class="browser-widget-grid">
-              <section class="browser-widget-card" data-widget="todo" aria-labelledby="browser-widget-todo-heading">
-                <header class="browser-widget-card__header">
-                  <h3 id="browser-widget-todo-heading">Today's tasks</h3>
-                  <p id="browser-widget-todo-note">Line up your next wins.</p>
-                </header>
-                <div class="browser-widget-card__body">
-                  <ul id="browser-widget-todo-list" class="browser-todo-list"></ul>
-                  <div class="browser-todo-log" aria-live="polite">
-                    <h4 id="browser-widget-todo-done-heading">Done</h4>
-                    <ul id="browser-widget-todo-done" class="browser-todo-done"></ul>
+          <section class="browser-launch" aria-label="Today's focus">
+            <section class="todo-widget" data-widget="todo" aria-labelledby="browser-widget-todo-heading">
+              <header class="todo-widget__header">
+                <div class="todo-widget__intro">
+                  <h2 id="browser-widget-todo-heading">Today's Tasks</h2>
+                  <p id="browser-widget-todo-note">Pick the moves that make today sparkle.</p>
+                </div>
+                <dl class="todo-widget__hours" aria-live="polite">
+                  <div class="todo-widget__hours-row">
+                    <dt>Hours available</dt>
+                    <dd id="browser-widget-todo-available">0h</dd>
                   </div>
-                </div>
+                  <div class="todo-widget__hours-row">
+                    <dt>Hours spent</dt>
+                    <dd id="browser-widget-todo-spent">0h</dd>
+                  </div>
+                </dl>
+              </header>
+
+              <ul id="browser-widget-todo-list" class="todo-widget__list" aria-live="polite"></ul>
+
+              <section class="todo-widget__done" aria-labelledby="browser-widget-todo-done-heading">
+                <h3 id="browser-widget-todo-done-heading">Done</h3>
+                <ul id="browser-widget-todo-done" class="todo-widget__done-list"></ul>
               </section>
 
-              <section class="browser-widget-card" data-widget="earnings" aria-labelledby="browser-widget-earnings-heading">
-                <header class="browser-widget-card__header">
-                  <h3 id="browser-widget-earnings-heading">Earnings pulse</h3>
-                  <p id="browser-widget-earnings-note">Track today’s flow at a glance.</p>
-                </header>
-                <div class="browser-widget-card__body">
-                  <div id="browser-widget-earnings" class="browser-earnings-stats"></div>
-                </div>
-              </section>
-
-              <section class="browser-widget-card" data-widget="notifications" aria-labelledby="browser-widget-notifications-heading">
-                <header class="browser-widget-card__header">
-                  <h3 id="browser-widget-notifications-heading">Notifications</h3>
-                  <p id="browser-widget-notifications-note">Alerts and upgrades ready to roll.</p>
-                </header>
-                <div class="browser-widget-card__body">
-                  <ul id="browser-widget-notifications" class="browser-notification-list"></ul>
-                </div>
-              </section>
-            </div>
+              <button id="browser-widget-todo-end" class="todo-widget__end" type="button">End Day</button>
+            </section>
           </section>
         </section>
       </main>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-- Browser homepage redesign introduces a widget-driven launchpad with app shortcut grid, actionable TODO checklist, finance pulse, notifications, and a persistent light/dark toggle.
+- Browser homepage now launches with a focused ToDo widget, time tracker, and End Day button while shortcut, earnings, and notification surfaces stay hidden for future drops.
 - Boot logic now respects an `?ui=` flag and the browser chrome includes a Classic Shell button so testers can bounce between shells while feature parity lands.
 - Browser shell entry experiments ship a homepage chrome with pinned sites and dedicated widgets while sharing the core game lo
 op with the classic dashboard.

--- a/docs/features/browser-shell.md
+++ b/docs/features/browser-shell.md
@@ -2,24 +2,20 @@
 
 ## Goals
 - Provide a browser-inspired chrome for the incremental game to explore multi-surface UI experiments.
-- Highlight top-level navigation (address bar, session controls, pinned sites) as composable widgets.
 - Keep gameplay logic intact by reusing the existing state, registry, and command pipeline.
-- Shape the homepage as a launchpad with modular widgets and an app shortcut grid instead of dashboard-length feeds.
+- Establish a minimal "new tab" launch screen that spotlights today’s actionable tasks and time budget.
+- Leave room for future widgets while keeping the initial experience intentionally uncluttered.
 
 ## Player Impact
-- Players gain a high-level "homepage" where shortcuts, quick tasks, and earnings cues surface before diving into deeper dashboards.
-- The shortcut grid keeps only unlocked surfaces visible while status badges highlight available actions at a glance.
-- Session controls remain reachable in the chrome, reinforcing end-of-day and command palette actions, and a theme toggle matches lighting preference.
-- The TODO widget lets players check off actions as they trigger them, logging completions so momentum feels tangible.
-- Compact earnings and notification widgets keep money flow and upgrade alerts scannable without overwhelming the launch screen.
+- Players land on a calm launch view that feels like opening a clean browser tab—only the task list and time tracker are in view.
+- The centered ToDo widget renders every available hustle as a familiar checklist row, complete with payout and duration chips.
+- Hours available and hours spent stay visible so players can pace their day while they click through tasks.
+- Completed actions slide into a muted "Done" ledger with time-spent markers, celebrating momentum without crowding the list.
+- A dedicated End Day button sits under the checklist so players can wrap the day from the same surface they planned it on.
 
 ## Implementation Notes
-- Introduced `browser.html` as an alternate entry point that loads the existing game scripts with a new DOM skeleton.
-- Added `src/ui/views/browser/` with dedicated resolvers wired to the browser chrome, shortcut grid, theme toggle, and widget containers.
-- A standalone stylesheet (`styles/browser.css`) scopes the new visual language without touching the classic layout.
-- `src/main.js` now detects `data-ui-view` on the document body (or an `?ui=` feature flag) to pick between the classic and browser views during boot.
-- Browser presenters reuse the shared dashboard and card models to render homepage widgets plus BlogPress, VideoTube, ShopStack, and Learnly service pages inside the chrome shell.
-- Layout navigation tracks a lightweight history stack so the browser buttons, pinned sites, and address bar all stay in sync.
-- Browser chrome exposes a "Classic Shell" button so players can hop back to the legacy dashboard while the browser view matures.
-- Modular widget controllers (`todoWidget`, `earningsWidget`, `notificationsWidget`) accept data models from the dashboard presenter so new cards can slot into the grid without touching DOM glue elsewhere.
-- The homepage stylesheet now supports light and dark themes driven by a persistent toggle that updates both the shell wrapper and root theme tokens.
+- `browser.html` still boots the shared game scripts, but the homepage markup now collapses to a single ToDo widget with a time summary and End Day control.
+- Dashboard presenters only initialize the todo widget; earnings and notification modules stay dormant until future iterations bring them back.
+- `todoWidget` now treats each hustle row as a full-width button that fires the action, logs completions with time data, and updates hours spent immediately.
+- `styles/browser.css` received a pared-down layout and new `.todo-widget` system so the launch screen reads like a standard productivity app in both light and dark themes.
+- Quick action view models provide payout, duration, and day metadata so the widget can track hours and reset completion history when a new day begins.

--- a/src/ui/dashboard/model.js
+++ b/src/ui/dashboard/model.js
@@ -337,6 +337,8 @@ export function buildQuickActions(state) {
     const payout = clampNumber(hustle.payout?.amount);
     const time = clampNumber(hustle.time || hustle.action?.timeCost) || 1;
     const roi = time > 0 ? payout / time : payout;
+    const payoutText = `$${formatMoney(payout)}`;
+    const timeText = formatHours(time);
     items.push({
       id: hustle.id,
       label: hustle.name,
@@ -346,7 +348,12 @@ export function buildQuickActions(state) {
       description: `${formatMoney(payout)} payout • ${formatHours(time)}`,
       onClick: hustle.action.onClick,
       roi,
-      timeCost: time
+      timeCost: time,
+      payout,
+      payoutText,
+      durationHours: time,
+      durationText: timeText,
+      meta: `${payoutText} • ${timeText}`
     });
   }
 
@@ -730,13 +737,26 @@ function buildQuickActionModel(state = {}) {
     title: action.label,
     subtitle: action.description,
     buttonLabel: action.primaryLabel,
-    onClick: action.onClick
+    onClick: action.onClick,
+    payout: action.payout,
+    payoutText: action.payoutText,
+    durationHours: action.durationHours,
+    durationText: action.durationText,
+    meta: action.meta
   }));
+  const baseHours = clampNumber(state.baseTime) + clampNumber(state.bonusTime) + clampNumber(state.dailyBonusTime);
+  const hoursAvailable = Math.max(0, clampNumber(state.timeLeft));
+  const hoursSpent = Math.max(0, baseHours - hoursAvailable);
   return {
     entries,
     emptyMessage: 'No ready actions. Check upgrades or ventures.',
     buttonClass: 'primary',
-    defaultLabel: 'Queue'
+    defaultLabel: 'Queue',
+    hoursAvailable,
+    hoursAvailableLabel: formatHours(hoursAvailable),
+    hoursSpent,
+    hoursSpentLabel: formatHours(hoursSpent),
+    day: clampNumber(state.day)
   };
 }
 

--- a/src/ui/views/browser/dashboardPresenter.js
+++ b/src/ui/views/browser/dashboardPresenter.js
@@ -1,13 +1,9 @@
 import { getElement } from '../../elements/registry.js';
 import setText from '../../dom.js';
 import todoWidget from './widgets/todoWidget.js';
-import earningsWidget from './widgets/earningsWidget.js';
-import notificationsWidget from './widgets/notificationsWidget.js';
 
 const widgetModules = {
-  todo: todoWidget,
-  earnings: earningsWidget,
-  notifications: notificationsWidget
+  todo: todoWidget
 };
 
 function getWidgetMounts() {
@@ -26,29 +22,13 @@ function ensureWidget(key) {
   return module;
 }
 
-function resolveNotificationAction(entry) {
-  if (!entry?.action) return null;
-  if (entry.action.type === 'shell-tab') {
-    const tabId = entry.action.tabId;
-    return () => {
-      const { shellTabs = [] } = getElement('shellNavigation') || {};
-      shellTabs.find(tab => tab.id === tabId)?.click();
-    };
-  }
-  if (typeof entry.action === 'function') {
-    return () => entry.action();
-  }
-  return null;
-}
-
 function renderHomepageShell(session = {}) {
   const homepage = getElement('homepage') || {};
   if (homepage.heading) {
-    setText(homepage.heading, session.statusText || 'Browser Homepage');
+    setText(homepage.heading, 'Launch the day');
   }
   if (homepage.tagline) {
-    const money = session.moneyText || '$0';
-    setText(homepage.tagline, `Wallet humming at ${money}. Deploy those hours with style.`);
+    setText(homepage.tagline, session.statusText || 'Day 0 • 0h remaining');
   }
 }
 
@@ -57,28 +37,10 @@ function renderTodo(actions = {}) {
   widget?.render(actions);
 }
 
-function renderEarnings(headerMetrics = {}, kpis = {}) {
-  const widget = ensureWidget('earnings');
-  if (!widget) return;
-  widget.render({
-    inflow: headerMetrics.dailyPlus,
-    outflow: headerMetrics.dailyMinus,
-    net: kpis.net
-  });
-}
-
-function renderNotifications(notifications = {}) {
-  const widget = ensureWidget('notifications');
-  if (!widget) return;
-  widget.render(notifications, { resolveAction: resolveNotificationAction });
-}
-
 function renderDashboard(viewModel = {}) {
   if (!viewModel) return;
   renderHomepageShell(viewModel.session || {});
   renderTodo(viewModel.quickActions || {});
-  renderEarnings(viewModel.headerMetrics || {}, viewModel.kpis || {});
-  renderNotifications(viewModel.notifications || {});
 }
 
 export default {

--- a/src/ui/views/browser/resolvers.js
+++ b/src/ui/views/browser/resolvers.js
@@ -32,17 +32,10 @@ const resolvers = {
       list: root.getElementById('browser-widget-todo-list'),
       done: root.getElementById('browser-widget-todo-done'),
       note: root.getElementById('browser-widget-todo-note'),
-      doneHeading: root.getElementById('browser-widget-todo-done-heading')
-    },
-    earnings: {
-      container: root.querySelector('[data-widget="earnings"]'),
-      list: root.getElementById('browser-widget-earnings'),
-      note: root.getElementById('browser-widget-earnings-note')
-    },
-    notifications: {
-      container: root.querySelector('[data-widget="notifications"]'),
-      list: root.getElementById('browser-widget-notifications'),
-      note: root.getElementById('browser-widget-notifications-note')
+      doneHeading: root.getElementById('browser-widget-todo-done-heading'),
+      availableValue: root.getElementById('browser-widget-todo-available'),
+      spentValue: root.getElementById('browser-widget-todo-spent'),
+      endDayButton: root.getElementById('browser-widget-todo-end')
     }
   })
 };

--- a/src/ui/views/browser/widgets/todoWidget.js
+++ b/src/ui/views/browser/widgets/todoWidget.js
@@ -1,110 +1,203 @@
+import { formatHours } from '../../../../core/helpers.js';
+import { endDay } from '../../../../game/lifecycle.js';
+
 const completedItems = new Map();
 let elements = null;
 let initialized = false;
+let currentDay = null;
+let lastModel = null;
+
+function bindEndDay(button) {
+  if (!button || button.dataset.bound === 'true') return;
+  button.addEventListener('click', () => {
+    const handler = typeof lastModel?.onEndDay === 'function'
+      ? lastModel.onEndDay
+      : () => endDay(false);
+    handler();
+  });
+  button.dataset.bound = 'true';
+}
 
 function init(widgetElements = {}) {
   if (initialized) return;
   elements = widgetElements;
   initialized = true;
+  bindEndDay(elements?.endDayButton);
   if (elements?.doneHeading) {
     elements.doneHeading.hidden = true;
   }
 }
 
+function normalizeDay(day) {
+  const numeric = Number(day);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function resetCompletedForDay(day) {
+  const normalized = normalizeDay(day);
+  if (normalized === null) {
+    if (currentDay !== null) {
+      completedItems.clear();
+      currentDay = null;
+    }
+    return;
+  }
+  if (normalized !== currentDay) {
+    completedItems.clear();
+    currentDay = normalized;
+  }
+}
+
+function formatDuration(hours) {
+  const numeric = Number(hours);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return formatHours(0);
+  }
+  return formatHours(Math.max(0, numeric));
+}
+
 function normalizeEntries(model = {}) {
   const entries = Array.isArray(model.entries) ? model.entries : [];
   return entries
-    .map((entry, index) => ({
-      id: entry?.id ?? `todo-${index}`,
-      title: entry?.title || 'Action',
-      subtitle: entry?.subtitle || '',
-      onClick: typeof entry?.onClick === 'function' ? entry.onClick : null
-    }))
-    .filter(Boolean);
+    .map((entry, index) => {
+      const id = entry?.id ?? `todo-${index}`;
+      const durationHours = Number(entry?.durationHours ?? entry?.timeCost);
+      const normalizedDuration = Number.isFinite(durationHours) ? Math.max(0, durationHours) : 0;
+      const durationText = entry?.durationText || formatDuration(normalizedDuration);
+      const payoutText = entry?.payoutText || entry?.payoutLabel || '';
+      const meta = entry?.meta || [payoutText, durationText].filter(Boolean).join(' • ');
+      return {
+        id,
+        title: entry?.title || 'Action',
+        meta,
+        onClick: typeof entry?.onClick === 'function' ? entry.onClick : null,
+        durationHours: normalizedDuration,
+        durationText
+      };
+    })
+    .filter(entry => Boolean(entry?.id));
 }
 
-function syncCompleted(entries) {
-  const allowed = new Set(entries.map(entry => entry.id));
-  Array.from(completedItems.keys()).forEach(key => {
-    if (!allowed.has(key)) {
-      completedItems.delete(key);
-    }
-  });
+function applyImmediateTimeDelta(model, hours) {
+  if (!model || !Number.isFinite(hours) || hours <= 0) return;
+  const available = Math.max(0, Number(model.hoursAvailable) - hours);
+  const spent = Math.max(0, Number(model.hoursSpent) + hours);
+  model.hoursAvailable = available;
+  model.hoursSpent = spent;
+  model.hoursAvailableLabel = formatHours(available);
+  model.hoursSpentLabel = formatHours(spent);
+}
+
+function renderHours(model = {}) {
+  if (elements?.availableValue) {
+    const available = Number(model.hoursAvailable);
+    const label = model.hoursAvailableLabel
+      || formatHours(Number.isFinite(available) ? Math.max(0, available) : 0);
+    elements.availableValue.textContent = label || '0h';
+  }
+  if (elements?.spentValue) {
+    const spent = Number(model.hoursSpent);
+    const label = model.hoursSpentLabel
+      || formatHours(Number.isFinite(spent) ? Math.max(0, spent) : 0);
+    elements.spentValue.textContent = label || '0h';
+  }
+}
+
+function updateNote(model = {}, pendingCount = 0) {
+  if (!elements?.note) return;
+  if (pendingCount > 0) {
+    elements.note.textContent = pendingCount === 1
+      ? '1 task ready to trigger.'
+      : `${pendingCount} tasks ready to trigger.`;
+    return;
+  }
+  elements.note.textContent = model.emptyMessage || 'Queue a hustle or upgrade to add new tasks.';
 }
 
 function renderEmptyState(message) {
   if (!elements?.list) return;
   elements.list.innerHTML = '';
   const empty = document.createElement('li');
-  empty.className = 'browser-todo-empty';
+  empty.className = 'todo-widget__empty';
   empty.textContent = message || 'No quick wins queued. Check upgrades or ventures.';
   elements.list.appendChild(empty);
 }
 
-function renderPending(entries, source) {
+function handleCompletion(entry, model) {
+  if (!entry || completedItems.has(entry.id)) return;
+  completedItems.set(entry.id, {
+    id: entry.id,
+    title: entry.title,
+    durationHours: entry.durationHours,
+    durationText: entry.durationText,
+    completedAt: Date.now()
+  });
+  if (typeof entry.onClick === 'function') {
+    entry.onClick();
+  }
+  applyImmediateTimeDelta(model, entry.durationHours);
+  render(model);
+}
+
+function createTask(entry, model) {
+  const item = document.createElement('li');
+  item.className = 'todo-widget__item';
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'todo-widget__task';
+  button.setAttribute('aria-label', `${entry.title} ${entry.meta}`.trim());
+
+  const checkbox = document.createElement('span');
+  checkbox.className = 'todo-widget__checkbox';
+  checkbox.textContent = '✓';
+
+  const content = document.createElement('div');
+  content.className = 'todo-widget__content';
+
+  const title = document.createElement('span');
+  title.className = 'todo-widget__title';
+  title.textContent = entry.title;
+  content.appendChild(title);
+
+  if (entry.meta) {
+    const meta = document.createElement('span');
+    meta.className = 'todo-widget__meta';
+    meta.textContent = entry.meta;
+    content.appendChild(meta);
+  }
+
+  button.addEventListener('click', () => {
+    if (button.getAttribute('aria-disabled') === 'true') return;
+    button.setAttribute('aria-disabled', 'true');
+    button.classList.add('is-complete');
+    handleCompletion(entry, model);
+  });
+
+  button.append(checkbox, content);
+  item.appendChild(button);
+  return item;
+}
+
+function renderPending(entries, model) {
   if (!elements?.list) return;
   elements.list.innerHTML = '';
-
   entries.forEach(entry => {
-    const item = document.createElement('li');
-    item.className = 'browser-todo-item';
-
-    const checkbox = document.createElement('input');
-    checkbox.type = 'checkbox';
-    checkbox.className = 'browser-todo-checkbox';
-    checkbox.setAttribute('aria-label', entry.title);
-
-    const content = document.createElement('div');
-    content.className = 'browser-todo-content';
-
-    const label = document.createElement('span');
-    label.className = 'browser-todo-label';
-    label.textContent = entry.title;
-
-    content.appendChild(label);
-
-    if (entry.subtitle) {
-      const note = document.createElement('p');
-      note.className = 'browser-todo-note';
-      note.textContent = entry.subtitle;
-      content.appendChild(note);
-    }
-
-    checkbox.addEventListener('change', () => {
-      if (!checkbox.checked) return;
-      item.classList.add('is-completing');
-      window.setTimeout(() => {
-        completedItems.set(entry.id, {
-          id: entry.id,
-          title: entry.title,
-          subtitle: entry.subtitle,
-          completedAt: Date.now()
-        });
-        if (typeof entry.onClick === 'function') {
-          entry.onClick();
-        }
-        render(source);
-      }, 240);
-    });
-
-    item.append(checkbox, content);
-    elements.list.appendChild(item);
+    const task = createTask(entry, model);
+    elements.list.appendChild(task);
   });
 }
 
 function renderCompleted() {
   if (!elements?.done) return;
-
   const entries = Array.from(completedItems.values()).sort((a, b) => b.completedAt - a.completedAt);
   elements.done.innerHTML = '';
-
   if (elements.doneHeading) {
     elements.doneHeading.hidden = entries.length === 0;
   }
-
   if (!entries.length) {
     const placeholder = document.createElement('li');
-    placeholder.className = 'browser-todo-empty';
+    placeholder.className = 'todo-widget__empty';
     placeholder.textContent = 'Nothing checked off yet.';
     elements.done.appendChild(placeholder);
     return;
@@ -112,10 +205,18 @@ function renderCompleted() {
 
   entries.forEach(entry => {
     const item = document.createElement('li');
-    item.textContent = entry.title;
-    if (entry.subtitle) {
-      item.title = entry.subtitle;
-    }
+    item.className = 'todo-widget__done-item';
+
+    const title = document.createElement('span');
+    title.className = 'todo-widget__done-title';
+    title.textContent = entry.title;
+
+    const meta = document.createElement('span');
+    meta.className = 'todo-widget__done-meta';
+    const label = entry.durationText || formatDuration(entry.durationHours);
+    meta.textContent = `(${label})`;
+
+    item.append(title, meta);
     elements.done.appendChild(item);
   });
 }
@@ -124,18 +225,18 @@ export function render(model = {}) {
   if (!initialized) {
     init(elements || {});
   }
+  if (!elements) {
+    elements = {};
+  }
+
+  lastModel = model || {};
+  resetCompletedForDay(model.day);
 
   const entries = normalizeEntries(model);
-  syncCompleted(entries);
-
   const pending = entries.filter(entry => !completedItems.has(entry.id));
 
-  if (elements?.note) {
-    const count = pending.length;
-    elements.note.textContent = count
-      ? `${count} actionable step${count === 1 ? '' : 's'} ready.`
-      : model.emptyMessage || 'Queue a hustle or upgrade to add new tasks.';
-  }
+  renderHours(model);
+  updateNote(model, pending.length);
 
   if (!pending.length) {
     renderEmptyState(model.emptyMessage);

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -150,289 +150,204 @@ a {
   flex: 1 1 auto;
   display: flex;
   justify-content: center;
-  padding: 2.5rem 3rem 3.5rem;
+  padding: 3rem 1.75rem 4rem;
 }
 
 .browser-main {
   width: 100%;
-  max-width: 1200px;
+  max-width: 900px;
   display: flex;
   flex-direction: column;
+  align-items: center;
 }
 
 .browser-home {
+  width: min(640px, 100%);
   display: flex;
   flex-direction: column;
-  gap: 2.5rem;
+  gap: 2rem;
+  align-items: center;
 }
 
 .browser-home__header {
+  width: 100%;
   display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
+  flex-direction: column;
+  gap: 0.75rem;
+  text-align: left;
 }
 
-.browser-home__headline h1 {
+.browser-home__header h1 {
   margin: 0;
-  font-size: clamp(1.8rem, 2.4vw, 2.6rem);
+  font-size: clamp(1.8rem, 2.6vw, 2.6rem);
 }
 
-.browser-home__headline p {
-  margin: 0.45rem 0 0;
+.browser-home__header p {
+  margin: 0;
   color: var(--browser-muted);
   font-size: 1.05rem;
 }
 
-.browser-home__section {
+.browser-launch {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.todo-widget {
+  width: 100%;
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  box-shadow: var(--browser-shadow-soft);
+  padding: 1.75rem;
   display: flex;
   flex-direction: column;
-  gap: 1.4rem;
+  gap: 1.5rem;
 }
 
-.browser-section-header {
+.todo-widget__header {
   display: flex;
   flex-wrap: wrap;
-  align-items: baseline;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: 0.75rem;
+  gap: 1.25rem;
 }
 
-.browser-section-header h2 {
+.todo-widget__intro h2 {
   margin: 0;
-  font-size: 1.25rem;
+  font-size: 1.5rem;
 }
 
-.browser-section-header p {
-  margin: 0;
-  color: var(--browser-subtle);
+.todo-widget__intro p {
+  margin: 0.4rem 0 0;
+  color: var(--browser-muted);
   font-size: 0.95rem;
 }
 
-.browser-home__apps {
-  display: flex;
-  flex-direction: column;
-  gap: 1.2rem;
-}
-
-.browser-app-grid {
-  list-style: none;
+.todo-widget__hours {
   margin: 0;
-  padding: 0;
   display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 0.5rem;
+  min-width: 180px;
 }
 
-.browser-app-card,
-.browser-app-button {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 0.55rem;
-  padding: 1.1rem 1.1rem 1.2rem;
-  border-radius: var(--browser-radius);
-  border: 1px solid var(--browser-panel-border);
-  background: var(--browser-panel);
-  box-shadow: var(--browser-shadow-card);
-  text-align: left;
-  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
-}
-
-.browser-app-card:hover,
-.browser-app-button:hover {
-  transform: translateY(-2px);
-  border-color: var(--browser-accent);
-  box-shadow: 0 22px 44px rgba(37, 99, 235, 0.15);
-}
-
-.browser-app-card__icon {
-  width: 42px;
-  height: 42px;
-  border-radius: 12px;
-  background: var(--browser-accent-soft);
-  display: grid;
-  place-items: center;
-  font-size: 1.35rem;
-}
-
-.browser-app-card__header {
+.todo-widget__hours-row {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 0.5rem;
+  gap: 1rem;
+  font-size: 0.95rem;
 }
 
-.browser-app-card__title {
+.todo-widget__hours-row dt {
   margin: 0;
-  font-size: 1.1rem;
+  color: var(--browser-subtle);
+  font-weight: 600;
+}
+
+.todo-widget__hours-row dd {
+  margin: 0;
   font-weight: 700;
 }
 
-.browser-app-card__meta {
+.todo-widget__list,
+.todo-widget__done-list {
+  list-style: none;
   margin: 0;
-  font-size: 0.95rem;
-  color: var(--browser-subtle);
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
-.browser-app-card__badge {
-  display: inline-flex;
+.todo-widget__item {
+  margin: 0;
+}
+
+.todo-widget__task {
+  width: 100%;
+  display: flex;
   align-items: center;
-  padding: 0.3rem 0.55rem;
-  border-radius: 999px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  background: var(--browser-accent-soft);
-  color: var(--browser-accent);
+  gap: 0.85rem;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  border: 1px solid var(--browser-panel-border);
+  background: var(--browser-panel);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  transition: background 140ms ease, border-color 140ms ease, transform 140ms ease;
 }
 
-.browser-app-card.is-active {
+.todo-widget__task:hover,
+.todo-widget__task:focus-visible {
   border-color: var(--browser-accent);
-  box-shadow: 0 22px 46px rgba(37, 99, 235, 0.18);
+  background: var(--browser-accent-soft);
 }
 
-.browser-app-card.is-active .browser-app-card__badge {
-  background: var(--browser-accent);
-  color: #fff;
-}
-
-.browser-app-card:focus-visible,
-.browser-app-button:focus-visible {
+.todo-widget__task:focus-visible {
   outline: 2px solid var(--browser-accent);
   outline-offset: 2px;
 }
 
-.browser-app-button {
-  cursor: pointer;
-  border-style: dashed;
+.todo-widget__task[aria-disabled='true'] {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.todo-widget__checkbox {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  border: 2px solid var(--browser-muted);
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 160px;
-  color: var(--browser-accent);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: transparent;
+  transition: background 140ms ease, border-color 140ms ease, color 140ms ease;
+}
+
+.todo-widget__task:hover .todo-widget__checkbox {
+  border-color: var(--browser-accent);
+}
+
+.todo-widget__content {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.todo-widget__title {
   font-weight: 600;
 }
 
-.browser-app-button:active {
-  transform: translateY(1px);
-}
-
-.browser-widget-grid {
-  display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-}
-
-.browser-widget-card {
-  background: var(--browser-panel-elevated);
-  border-radius: var(--browser-radius-lg);
-  border: 1px solid var(--browser-panel-border);
-  box-shadow: var(--browser-shadow-soft);
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-}
-
-.browser-widget-card__header {
-  padding: 1.25rem 1.5rem 0.5rem;
-}
-
-.browser-widget-card__header h3 {
-  margin: 0;
-  font-size: 1.1rem;
-}
-
-.browser-widget-card__header p {
-  margin: 0.35rem 0 0;
-  color: var(--browser-subtle);
+.todo-widget__meta {
+  color: var(--browser-muted);
   font-size: 0.95rem;
 }
 
-.browser-widget-card__body {
-  padding: 0.5rem 1.5rem 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1.1rem;
+.todo-widget__task.is-complete {
+  background: transparent;
+  border-color: rgba(148, 163, 184, 0.3);
 }
 
-.browser-todo-list,
-.browser-todo-done {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
-}
-
-.browser-todo-content {
-  display: flex;
-  flex-direction: column;
-}
-
-.browser-todo-item {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 0.75rem;
-  align-items: center;
-  padding: 0.75rem 0.85rem;
-  border-radius: 14px;
-  border: 1px solid var(--browser-panel-border);
-  background: var(--browser-panel);
-  transition: background 140ms ease, border-color 140ms ease, transform 140ms ease;
-}
-
-.browser-todo-item:hover {
-  border-color: var(--browser-accent);
-  background: var(--browser-accent-soft);
-}
-
-.browser-todo-checkbox {
-  width: 20px;
-  height: 20px;
-  border-radius: 6px;
-  cursor: pointer;
-  accent-color: var(--browser-accent);
-}
-
-.browser-todo-label {
-  position: relative;
-  font-weight: 600;
-  color: var(--browser-text);
-  line-height: 1.4;
-}
-
-.browser-todo-label::after {
-  content: '';
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 55%;
-  height: 2px;
+.todo-widget__task.is-complete .todo-widget__checkbox {
   background: var(--browser-accent);
-  transform: scaleX(0);
-  transform-origin: left center;
-  opacity: 0;
+  border-color: var(--browser-accent);
+  color: #fff;
 }
 
-.browser-todo-item.is-completing .browser-todo-label::after {
-  animation: browser-todo-scratch 260ms ease forwards;
-}
-
-.browser-todo-item.is-complete .browser-todo-label::after {
-  transform: scaleX(1);
-  opacity: 1;
-}
-
-.browser-todo-item.is-complete .browser-todo-label {
+.todo-widget__task.is-complete .todo-widget__title {
   color: var(--browser-muted);
+  text-decoration: line-through;
 }
 
-.browser-todo-note {
-  margin: 0.25rem 0 0;
-  color: var(--browser-subtle);
-  font-size: 0.9rem;
-}
-
-.browser-todo-log {
+.todo-widget__done {
   border-top: 1px solid var(--browser-panel-border);
   padding-top: 1rem;
   display: flex;
@@ -440,7 +355,7 @@ a {
   gap: 0.75rem;
 }
 
-.browser-todo-log h4 {
+.todo-widget__done h3 {
   margin: 0;
   font-size: 0.95rem;
   text-transform: uppercase;
@@ -448,78 +363,61 @@ a {
   color: var(--browser-subtle);
 }
 
-.browser-todo-done li {
+.todo-widget__done-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
   padding: 0.65rem 0.75rem;
   border-radius: 12px;
   background: rgba(148, 163, 184, 0.16);
   color: var(--browser-muted);
+  font-size: 0.95rem;
+}
+
+.todo-widget__done-title {
+  text-decoration: line-through;
+}
+
+.todo-widget__done-meta {
   font-size: 0.9rem;
 }
 
-.browser-todo-empty {
-  padding: 0.6rem 0.75rem;
+.todo-widget__empty {
+  padding: 0.75rem 1rem;
   border-radius: 12px;
   background: rgba(148, 163, 184, 0.12);
   color: var(--browser-subtle);
-  font-size: 0.9rem;
+  font-size: 0.95rem;
 }
 
-.browser-earnings-stats {
-  margin: 0;
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+.todo-widget__end {
+  margin-top: auto;
+  align-self: flex-end;
+  font: inherit;
+  font-weight: 600;
+  color: #fff;
+  background: var(--browser-accent);
+  border: none;
+  border-radius: 12px;
+  padding: 0.85rem 1.6rem;
+  cursor: pointer;
+  transition: background 160ms ease, transform 160ms ease;
 }
 
-.browser-earnings-stat {
-  padding: 0.75rem 0.85rem;
-  border-radius: 14px;
-  border: 1px solid var(--browser-panel-border);
-  background: var(--browser-panel);
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
+.todo-widget__end:hover {
+  background: #1e4fd6;
 }
 
-.browser-earnings-stat__label {
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--browser-subtle);
+.todo-widget__end:active {
+  transform: translateY(1px);
 }
 
-.browser-earnings-stat__value {
-  font-size: 1.25rem;
-  font-weight: 700;
+.todo-widget__end:focus-visible {
+  outline: 2px solid var(--browser-accent);
+  outline-offset: 3px;
 }
 
-.browser-earnings-stat[data-tone='positive'] .browser-earnings-stat__value {
-  color: var(--browser-positive);
-}
-
-.browser-earnings-stat[data-tone='negative'] .browser-earnings-stat__value {
-  color: var(--browser-danger);
-}
-
-.browser-earnings-stat__note {
-  font-size: 0.9rem;
-  color: var(--browser-muted);
-}
-
-.browser-notification-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  max-height: 260px;
-  overflow: auto;
-}
-
-.browser-notification {
-  display: grid;
-  gap: 0.6rem;
   padding: 0.75rem 0.9rem;
   border-radius: 14px;
   border: 1px solid var(--browser-panel-border);
@@ -722,17 +620,6 @@ a {
   }
 }
 
-@keyframes browser-todo-scratch {
-  from {
-    transform: scaleX(0);
-    opacity: 0;
-  }
-  to {
-    transform: scaleX(1);
-    opacity: 1;
-  }
-}
-
 @media (max-width: 960px) {
   .browser-layout {
     padding: 1.8rem 1.4rem 2.5rem;
@@ -746,5 +633,28 @@ a {
   .browser-chrome__cluster--session {
     justify-content: flex-start;
     flex-wrap: wrap;
+  }
+
+  .browser-main {
+    align-items: stretch;
+  }
+
+  .browser-home {
+    width: 100%;
+  }
+
+  .todo-widget {
+    padding: 1.3rem;
+  }
+
+  .todo-widget__hours {
+    grid-template-columns: 1fr;
+    min-width: 0;
+  }
+
+  .todo-widget__end {
+    width: 100%;
+    align-self: stretch;
+    text-align: center;
   }
 }


### PR DESCRIPTION
## Summary
- simplify the browser homepage to a minimal ToDo widget with live hours counters and an end-of-day control
- restyle the widget to behave like a full-row checklist and enhance quick action models with payout/duration metadata
- document the streamlined launch screen in the browser shell feature note and changelog

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68dd7d02c9a4832c8d4fd45ea30c552c