### PR TITLE
Add registry bootstrap helper and update tests

### DIFF
--- a/src/game/registryBootstrap.js
+++ b/src/game/registryBootstrap.js
@@ -1,0 +1,39 @@
+import { loadDefaultRegistry } from './registryLoader.js';
+import { getRegistry } from './registryService.js';
+import { configureRegistry, getRegistrySnapshot } from '../core/state/registry.js';
+
+let isRegistryReady = false;
+let readySnapshot = null;
+
+function registryLoaded() {
+  try {
+    getRegistry();
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+export function ensureRegistryReady() {
+  if (isRegistryReady) {
+    if (registryLoaded()) {
+      return readySnapshot;
+    }
+
+    isRegistryReady = false;
+    readySnapshot = null;
+  }
+
+  if (!registryLoaded()) {
+    loadDefaultRegistry();
+  }
+
+  configureRegistry();
+  readySnapshot = getRegistrySnapshot();
+  isRegistryReady = true;
+  return readySnapshot;
+}
+
+export default {
+  ensureRegistryReady
+};

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,4 @@
 import { addLog, renderLog } from './core/log.js';
-import { configureRegistry } from './core/state/registry.js';
 import { loadState, saveState } from './core/storage.js';
 import { renderCards, updateUI } from './ui/update.js';
 import { initLayoutControls } from './ui/layout/index.js';
@@ -10,7 +9,7 @@ import { initHeaderActionControls } from './ui/headerAction/index.js';
 import { setActiveView } from './ui/viewManager.js';
 import classicView from './ui/views/classic/index.js';
 import browserView from './ui/views/browser/index.js';
-import { loadDefaultRegistry } from './game/registryLoader.js';
+import { ensureRegistryReady } from './game/registryBootstrap.js';
 
 function resolveViewFromFlag(rootDocument) {
   if (typeof window === 'undefined' || typeof URLSearchParams !== 'function') {
@@ -53,8 +52,7 @@ function resolveInitialView(rootDocument = typeof document !== 'undefined' ? doc
   return classicView;
 }
 
-loadDefaultRegistry();
-configureRegistry();
+ensureRegistryReady();
 const initialView = resolveInitialView(document);
 setActiveView(initialView, document);
 const { returning, lastSaved } = loadState({

--- a/src/ui/cards/collectionService.js
+++ b/src/ui/cards/collectionService.js
@@ -1,6 +1,4 @@
-import { configureRegistry } from '../../core/state/registry.js';
-import { getRegistry } from '../../game/registryService.js';
-import { loadDefaultRegistry } from '../../game/registryLoader.js';
+import { ensureRegistryReady } from '../../game/registryBootstrap.js';
 import {
   buildAssetModels,
   buildEducationModels,
@@ -23,22 +21,8 @@ function updateSnapshot(snapshot) {
 }
 
 function ensureRegistrySnapshot() {
-  try {
-    const snapshot = getRegistry();
-    return updateSnapshot(snapshot);
-  } catch (error) {
-    const message = typeof error?.message === 'string' ? error.message : '';
-    const registryMissing = message.includes('Registry definitions have not been loaded');
-
-    if (!registryMissing) {
-      throw error;
-    }
-
-    loadDefaultRegistry();
-    configureRegistry();
-    const snapshot = getRegistry();
-    return updateSnapshot(snapshot);
-  }
+  const snapshot = ensureRegistryReady();
+  return updateSnapshot(snapshot);
 }
 
 function buildRegistries() {

--- a/tests/education.test.js
+++ b/tests/education.test.js
@@ -14,16 +14,12 @@ test('renderCardCollections synthesizes models when omitted', async () => {
   }
 
   const stateModule = await import('../src/core/state.js');
-  const registryModule = await import('../src/core/state/registry.js');
   const registryService = await import('../src/game/registryService.js');
-  const { loadDefaultRegistry } = await import('../src/game/registryLoader.js');
+  const { ensureRegistryReady } = await import('../src/game/registryBootstrap.js');
   const { initializeState } = stateModule;
-  const { configureRegistry } = registryModule;
 
   registryService.resetRegistry();
-  loadDefaultRegistry();
-  configureRegistry();
-  const registry = registryService.getRegistry();
+  const registry = ensureRegistryReady();
   initializeState();
 
   const viewManager = await import('../src/ui/viewManager.js');
@@ -69,16 +65,12 @@ test('education tracks reflect canonical study data', async () => {
   queueCap.textContent = '';
 
   const stateModule = await import('../src/core/state.js');
-  const registryModule = await import('../src/core/state/registry.js');
   const { initializeState, getState } = stateModule;
-  const { configureRegistry } = registryModule;
 
   const registryService = await import('../src/game/registryService.js');
-  const { loadDefaultRegistry } = await import('../src/game/registryLoader.js');
+  const { ensureRegistryReady } = await import('../src/game/registryBootstrap.js');
   registryService.resetRegistry();
-  loadDefaultRegistry();
-  configureRegistry();
-  const registry = registryService.getRegistry();
+  const registry = ensureRegistryReady();
   initializeState();
 
   const requirements = await import('../src/game/requirements.js');
@@ -135,16 +127,12 @@ test('completed study tracks celebrate progress and skills', async () => {
   queueCap.textContent = '';
 
   const stateModule = await import('../src/core/state.js');
-  const registryModule = await import('../src/core/state/registry.js');
   const { initializeState, getState } = stateModule;
-  const { configureRegistry } = registryModule;
 
   const registryService = await import('../src/game/registryService.js');
-  const { loadDefaultRegistry } = await import('../src/game/registryLoader.js');
+  const { ensureRegistryReady } = await import('../src/game/registryBootstrap.js');
   registryService.resetRegistry();
-  loadDefaultRegistry();
-  configureRegistry();
-  const registry = registryService.getRegistry();
+  const registry = ensureRegistryReady();
   initializeState();
 
   const requirements = await import('../src/game/requirements.js');

--- a/tests/gameLifecycle.test.js
+++ b/tests/gameLifecycle.test.js
@@ -13,7 +13,7 @@ const upgradesModule = await import('../src/game/upgrades.js');
 const requirementsModule = await import('../src/game/requirements.js');
 
 const { buildDefaultState, initializeState, getState, getAssetState, getUpgradeState } = stateModule;
-const { configureRegistry, getAssetDefinition } = registryModule;
+const { getAssetDefinition } = registryModule;
 const { createAssetInstance } = assetStateModule;
 const { allocateAssetMaintenance, closeOutDay, ASSETS, getIncomeRangeForDisplay } = assetsModule;
 const { HUSTLES } = hustlesModule;
@@ -26,10 +26,10 @@ const {
   getKnowledgeProgress
 } = requirementsModule;
 const registryService = await import('../src/game/registryService.js');
+const { ensureRegistryReady } = await import('../src/game/registryBootstrap.js');
 
 registryService.resetRegistry();
-registryService.loadRegistry({ assets: ASSETS, hustles: HUSTLES, upgrades: UPGRADES });
-configureRegistry();
+ensureRegistryReady();
 
 const resetState = () => initializeState(buildDefaultState());
 

--- a/tests/helpers/gameTestHarness.js
+++ b/tests/helpers/gameTestHarness.js
@@ -26,16 +26,12 @@ export async function getGameTestHarness() {
   const viewManagerModule = await import('../../src/ui/viewManager.js');
   const classicViewModule = await import('../../src/ui/views/classic/index.js');
   const registryService = await import('../../src/game/registryService.js');
+  const { ensureRegistryReady } = await import('../../src/game/registryBootstrap.js');
 
   viewManagerModule.setActiveView(classicViewModule.default, document);
 
   registryService.resetRegistry();
-  registryService.loadRegistry({
-    assets: assetsModule.ASSETS,
-    hustles: hustlesModule.HUSTLES,
-    upgrades: upgradesModule.UPGRADES
-  });
-  registryModule.configureRegistry();
+  ensureRegistryReady();
 
   const elements = {
     get money() {

--- a/tests/registryConsistency.test.js
+++ b/tests/registryConsistency.test.js
@@ -15,6 +15,7 @@ import {
   getRegistry,
   getMetricDefinition
 } from '../src/game/registryService.js';
+import { ensureRegistryReady } from '../src/game/registryBootstrap.js';
 import {
   buildHustleModels,
   buildAssetModels,
@@ -57,6 +58,20 @@ function createSampleDefinitions() {
     ]
   };
 }
+
+test('ensureRegistryReady hydrates and caches the shared snapshot', t => {
+  resetRegistry();
+  t.after(() => {
+    resetRegistry();
+  });
+
+  const snapshot = ensureRegistryReady();
+  assert.equal(snapshot, getRegistry(), 'ensure helper should return registry service snapshot');
+  assert.equal(snapshot, getRegistrySnapshot(), 'state snapshot should match service snapshot');
+
+  const secondCall = ensureRegistryReady();
+  assert.equal(secondCall, snapshot, 'subsequent calls should reuse the cached snapshot');
+});
 
 test('registry service and state share canonical definitions', t => {
   resetRegistry();

--- a/tests/schema.test.js
+++ b/tests/schema.test.js
@@ -4,14 +4,13 @@ import { ensureTestDom } from './helpers/setupDom.js';
 
 ensureTestDom();
 
-const { configureRegistry, getAssetDefinition, getHustleDefinition } = await import('../src/core/state/registry.js');
+const { getAssetDefinition, getHustleDefinition } = await import('../src/core/state/registry.js');
 const registryService = await import('../src/game/registryService.js');
-const { loadDefaultRegistry } = await import('../src/game/registryLoader.js');
+const { ensureRegistryReady } = await import('../src/game/registryBootstrap.js');
 
 function ensureConfigured() {
   registryService.resetRegistry();
-  loadDefaultRegistry();
-  configureRegistry();
+  ensureRegistryReady();
 }
 
 test('hustle definitions expose canonical metric identifiers', () => {

--- a/tests/summary.test.js
+++ b/tests/summary.test.js
@@ -5,9 +5,8 @@ import { ensureTestDom } from './helpers/setupDom.js';
 ensureTestDom();
 
 const { initializeState } = await import('../src/core/state.js');
-const { configureRegistry } = await import('../src/core/state/registry.js');
 const registryService = await import('../src/game/registryService.js');
-const { loadDefaultRegistry } = await import('../src/game/registryLoader.js');
+const { ensureRegistryReady } = await import('../src/game/registryBootstrap.js');
 const {
   recordCostContribution,
   recordPayoutContribution,
@@ -24,8 +23,7 @@ const {
 
 test('daily summary aggregates metrics into category totals', () => {
   registryService.resetRegistry();
-  loadDefaultRegistry();
-  configureRegistry();
+  ensureRegistryReady();
   const state = initializeState();
   resetDailyMetrics(state);
 
@@ -89,8 +87,7 @@ test('daily summary aggregates metrics into category totals', () => {
 
 test('daily summary attaches definition references for canonical metrics', () => {
   registryService.resetRegistry();
-  loadDefaultRegistry();
-  configureRegistry();
+  ensureRegistryReady();
   const state = initializeState();
   resetDailyMetrics(state);
 
@@ -133,8 +130,7 @@ test('daily summary attaches definition references for canonical metrics', () =>
 
 test('raw selectors return numeric breakdown entries', () => {
   registryService.resetRegistry();
-  loadDefaultRegistry();
-  configureRegistry();
+  ensureRegistryReady();
   const state = initializeState();
   resetDailyMetrics(state);
 
@@ -193,8 +189,7 @@ test('raw selectors return numeric breakdown entries', () => {
 
 test('lifetime totals accumulate alongside daily metrics', () => {
   registryService.resetRegistry();
-  loadDefaultRegistry();
-  configureRegistry();
+  ensureRegistryReady();
   const state = initializeState();
   resetDailyMetrics(state);
 

--- a/tests/ui/dashboardModel.test.js
+++ b/tests/ui/dashboardModel.test.js
@@ -3,13 +3,11 @@ import assert from 'node:assert/strict';
 import { buildDashboardViewModel } from '../../src/ui/dashboard/model.js';
 import { buildDefaultState } from '../../src/core/state.js';
 import { getAssets, resetRegistry } from '../../src/game/registryService.js';
-import { loadDefaultRegistry } from '../../src/game/registryLoader.js';
-import { configureRegistry } from '../../src/core/state/registry.js';
+import { ensureRegistryReady } from '../../src/game/registryBootstrap.js';
 
 test.before(() => {
   resetRegistry();
-  loadDefaultRegistry();
-  configureRegistry();
+  ensureRegistryReady();
 });
 
 function createSummary(overrides = {}) {


### PR DESCRIPTION
## Summary
- add a registry bootstrap helper that loads default definitions and configures the state once
- replace manual registry setup in the bootstrap and UI layers with the new helper
- refresh test harnesses to rely on the helper and add coverage for its caching behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd7c3d7ffc832ca5e4fd3f053b0bfc