### PR TITLE
Add registry-driven UI view resolution

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -7,50 +7,8 @@ import { resetTick, startGameLoop } from './game/loop.js';
 import { handleOfflineProgress } from './game/offline.js';
 import { initHeaderActionControls } from './ui/headerAction/index.js';
 import { setActiveView } from './ui/viewManager.js';
-import classicView from './ui/views/classic/index.js';
-import browserView from './ui/views/browser/index.js';
+import { resolveInitialView } from './ui/views/registry.js';
 import { ensureRegistryReady } from './game/registryBootstrap.js';
-
-function resolveViewFromFlag(rootDocument) {
-  if (typeof window === 'undefined' || typeof URLSearchParams !== 'function') {
-    return null;
-  }
-
-  let requestedId = null;
-  try {
-    const params = new URLSearchParams(window.location.search);
-    requestedId = params.get('ui') || params.get('view') || params.get('shell');
-  } catch (error) {
-    requestedId = null;
-  }
-
-  if (!requestedId) {
-    return null;
-  }
-
-  const normalizedId = requestedId.toLowerCase();
-  if (normalizedId === browserView.id && rootDocument?.getElementById('browser-home')) {
-    return browserView;
-  }
-  if (normalizedId === classicView.id && rootDocument?.getElementById('tab-dashboard')) {
-    return classicView;
-  }
-
-  return null;
-}
-
-function resolveInitialView(rootDocument = typeof document !== 'undefined' ? document : null) {
-  const flagView = resolveViewFromFlag(rootDocument);
-  if (flagView) {
-    return flagView;
-  }
-
-  const viewId = rootDocument?.body?.dataset?.uiView;
-  if (viewId === browserView.id && rootDocument?.getElementById('browser-home')) {
-    return browserView;
-  }
-  return classicView;
-}
 
 ensureRegistryReady();
 const initialView = resolveInitialView(document);

--- a/src/ui/views/registry.js
+++ b/src/ui/views/registry.js
@@ -1,0 +1,136 @@
+import classicView from './classic/index.js';
+import browserView from './browser/index.js';
+
+const registeredViews = [];
+
+function normalizeId(id) {
+  return typeof id === 'string' ? id.trim().toLowerCase() : null;
+}
+
+function ensureGuardFn(guard) {
+  if (typeof guard === 'function') {
+    return guard;
+  }
+  return () => true;
+}
+
+export function registerView(view, { guard } = {}) {
+  if (!view || !view.id) {
+    throw new Error('Cannot register a view without an id.');
+  }
+
+  const id = normalizeId(view.id);
+  const entry = {
+    id,
+    view,
+    guard: ensureGuardFn(guard),
+    presenters: view.presenters ?? {}
+  };
+
+  const existingIndex = registeredViews.findIndex(item => item.id === id);
+  if (existingIndex >= 0) {
+    registeredViews.splice(existingIndex, 1, entry);
+  } else {
+    registeredViews.push(entry);
+  }
+
+  return entry;
+}
+
+export function unregisterView(id) {
+  const normalizedId = normalizeId(id);
+  if (!normalizedId) {
+    return null;
+  }
+
+  const index = registeredViews.findIndex(item => item.id === normalizedId);
+  if (index === -1) {
+    return null;
+  }
+
+  const [removed] = registeredViews.splice(index, 1);
+  return removed;
+}
+
+export function getRegisteredViews() {
+  return registeredViews.map(entry => ({ ...entry }));
+}
+
+function findEntryById(id) {
+  const normalizedId = normalizeId(id);
+  if (!normalizedId) {
+    return null;
+  }
+
+  return registeredViews.find(entry => entry.id === normalizedId) ?? null;
+}
+
+function canActivate(entry, rootDocument) {
+  try {
+    return !entry?.guard || entry.guard(rootDocument);
+  } catch (error) {
+    return false;
+  }
+}
+
+function resolveViewFromFlag(rootDocument) {
+  if (typeof window === 'undefined' || typeof URLSearchParams !== 'function') {
+    return null;
+  }
+
+  let requestedId = null;
+  try {
+    const params = new URLSearchParams(window.location.search);
+    requestedId = params.get('ui') || params.get('view') || params.get('shell');
+  } catch (error) {
+    requestedId = null;
+  }
+
+  if (!requestedId) {
+    return null;
+  }
+
+  const entry = findEntryById(requestedId);
+  if (entry && canActivate(entry, rootDocument)) {
+    return entry.view;
+  }
+
+  return null;
+}
+
+export function resolveInitialView(
+  rootDocument = typeof document !== 'undefined' ? document : null
+) {
+  const flagView = resolveViewFromFlag(rootDocument);
+  if (flagView) {
+    return flagView;
+  }
+
+  const datasetViewId = rootDocument?.body?.dataset?.uiView;
+  const datasetEntry = findEntryById(datasetViewId);
+  if (datasetEntry && canActivate(datasetEntry, rootDocument)) {
+    return datasetEntry.view;
+  }
+
+  const firstAvailable = registeredViews.find(entry => canActivate(entry, rootDocument));
+  if (firstAvailable) {
+    return firstAvailable.view;
+  }
+
+  return registeredViews[0]?.view ?? null;
+}
+
+registerView(classicView, {
+  guard: root => Boolean(root?.getElementById('tab-dashboard'))
+});
+
+registerView(browserView, {
+  guard: root => Boolean(root?.getElementById('browser-home'))
+});
+
+export default {
+  registerView,
+  unregisterView,
+  getRegisteredViews,
+  resolveInitialView
+};

--- a/tests/ui/views/registry.test.js
+++ b/tests/ui/views/registry.test.js
@@ -1,0 +1,86 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+import {
+  getRegisteredViews,
+  registerView,
+  unregisterView,
+  resolveInitialView
+} from '../../../src/ui/views/registry.js';
+
+function withDom(html, options = {}) {
+  const dom = new JSDOM(html, options);
+  const previousWindow = global.window;
+  const previousDocument = global.document;
+
+  global.window = dom.window;
+  global.document = dom.window.document;
+
+  return {
+    dom,
+    restore() {
+      dom.window.close();
+      if (previousWindow === undefined) {
+        delete global.window;
+      } else {
+        global.window = previousWindow;
+      }
+
+      if (previousDocument === undefined) {
+        delete global.document;
+      } else {
+        global.document = previousDocument;
+      }
+    }
+  };
+}
+
+test('registry exposes built-in views with guards and presenters', () => {
+  const entries = getRegisteredViews();
+  const ids = entries.map(entry => entry.id);
+
+  assert.ok(ids.includes('classic'));
+  assert.ok(ids.includes('browser'));
+
+  for (const entry of entries) {
+    assert.equal(typeof entry.guard, 'function');
+    assert.equal(typeof entry.presenters, 'object');
+  }
+});
+
+test('resolveInitialView picks a flagged view when guard passes', t => {
+  const { dom, restore } = withDom(
+    '<!DOCTYPE html><html><body><div id="browser-home"></div></body></html>',
+    { url: 'https://example.com/?ui=browser' }
+  );
+
+  t.after(restore);
+
+  const resolved = resolveInitialView(dom.window.document);
+  assert.equal(resolved?.id, 'browser');
+});
+
+test('newly registered views can be resolved without entry point changes', t => {
+  const futureView = {
+    id: 'future',
+    presenters: { layout: () => {} }
+  };
+
+  const { dom, restore } = withDom(
+    '<!DOCTYPE html><html><body data-ui-view="future"><div id="future-shell"></div></body></html>',
+    { url: 'https://example.com/' }
+  );
+
+  registerView(futureView, {
+    guard: root => Boolean(root?.getElementById('future-shell'))
+  });
+
+  t.after(() => {
+    unregisterView('future');
+    restore();
+  });
+
+  const resolved = resolveInitialView(dom.window.document);
+  assert.equal(resolved, futureView);
+});


### PR DESCRIPTION
## Summary
- add a shared UI view registry that records ids, presenters, and DOM guards
- move initial view selection to the registry to support additional shells
- cover the new registry behavior with tests that register custom views

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd82704b8c832cac6ae8cc5202ced1