### PR TITLE
Refine browser launch tasks and empty state

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -54,12 +54,7 @@
 
     <div class="browser-layout">
       <main class="browser-main" aria-live="polite">
-        <section id="browser-home" class="browser-home" aria-labelledby="browser-home-heading">
-          <header class="browser-home__header">
-            <h1 id="browser-home-heading">Launch the day</h1>
-            <p id="browser-home-tagline">Line up the next win and keep the streak rolling.</p>
-          </header>
-
+        <section id="browser-home" class="browser-home" aria-labelledby="browser-widget-todo-heading">
           <section class="browser-launch" aria-label="Today's focus">
             <section class="todo-widget" data-widget="todo" aria-labelledby="browser-widget-todo-heading">
               <header class="todo-widget__header">

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Browser launch view trims the hero headline, keeps repeatable quick tasks visible, and adds an inline End Day button when the action list is empty for faster wrap-ups.
 - Browser homepage now launches with a focused ToDo widget, time tracker, and End Day button while shortcut, earnings, and notification surfaces stay hidden for future drops.
 - Boot logic now respects an `?ui=` flag and the browser chrome includes a Classic Shell button so testers can bounce between shells while feature parity lands.
 - Browser shell entry experiments ship a homepage chrome with pinned sites and dedicated widgets while sharing the core game lo

--- a/src/ui/dashboard/model.js
+++ b/src/ui/dashboard/model.js
@@ -330,6 +330,12 @@ export function buildQuickActions(state) {
   for (const hustle of getHustles()) {
     if (hustle?.tag?.type === 'study') continue;
     if (!hustle?.action?.onClick) continue;
+    const usage = typeof hustle.getDailyUsage === 'function' ? hustle.getDailyUsage(state) : null;
+    const remainingRuns = Number.isFinite(usage?.remaining)
+      ? Math.max(0, usage.remaining)
+      : Infinity;
+    const usageLimit = usage?.limit;
+    const repeatable = remainingRuns > 0 && (!Number.isFinite(usageLimit) || usageLimit !== 1);
     const disabled = typeof hustle.action.disabled === 'function'
       ? hustle.action.disabled(state)
       : Boolean(hustle.action.disabled);
@@ -353,7 +359,9 @@ export function buildQuickActions(state) {
       payoutText,
       durationHours: time,
       durationText: timeText,
-      meta: `${payoutText} • ${timeText}`
+      meta: `${payoutText} • ${timeText}`,
+      repeatable,
+      remainingRuns
     });
   }
 

--- a/src/ui/views/browser/dashboardPresenter.js
+++ b/src/ui/views/browser/dashboardPresenter.js
@@ -1,5 +1,4 @@
 import { getElement } from '../../elements/registry.js';
-import setText from '../../dom.js';
 import todoWidget from './widgets/todoWidget.js';
 
 const widgetModules = {
@@ -22,16 +21,6 @@ function ensureWidget(key) {
   return module;
 }
 
-function renderHomepageShell(session = {}) {
-  const homepage = getElement('homepage') || {};
-  if (homepage.heading) {
-    setText(homepage.heading, 'Launch the day');
-  }
-  if (homepage.tagline) {
-    setText(homepage.tagline, session.statusText || 'Day 0 • 0h remaining');
-  }
-}
-
 function renderTodo(actions = {}) {
   const widget = ensureWidget('todo');
   widget?.render(actions);
@@ -39,7 +28,6 @@ function renderTodo(actions = {}) {
 
 function renderDashboard(viewModel = {}) {
   if (!viewModel) return;
-  renderHomepageShell(viewModel.session || {});
   renderTodo(viewModel.quickActions || {});
 }
 

--- a/src/ui/views/browser/resolvers.js
+++ b/src/ui/views/browser/resolvers.js
@@ -22,9 +22,7 @@ const resolvers = {
   siteListNote: root => root.getElementById('browser-sites-note'),
   addSiteButton: root => root.getElementById('browser-add-site'),
   homepage: root => ({
-    container: root.getElementById('browser-home'),
-    heading: root.getElementById('browser-home-heading'),
-    tagline: root.getElementById('browser-home-tagline')
+    container: root.getElementById('browser-home')
   }),
   homepageWidgets: root => ({
     todo: {

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -384,11 +384,43 @@ a {
 }
 
 .todo-widget__empty {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
   padding: 0.75rem 1rem;
   border-radius: 12px;
   background: rgba(148, 163, 184, 0.12);
   color: var(--browser-subtle);
   font-size: 0.95rem;
+}
+
+.todo-widget__empty-text {
+  flex: 1;
+}
+
+.todo-widget__empty-action {
+  font: inherit;
+  font-weight: 600;
+  color: #fff;
+  background: var(--browser-accent);
+  border: none;
+  border-radius: 10px;
+  padding: 0.5rem 0.9rem;
+  cursor: pointer;
+  transition: background 160ms ease, transform 160ms ease;
+}
+
+.todo-widget__empty-action:hover {
+  background: #1e4fd6;
+}
+
+.todo-widget__empty-action:active {
+  transform: translateY(1px);
+}
+
+.todo-widget__empty-action:focus-visible {
+  outline: 2px solid var(--browser-accent);
+  outline-offset: 3px;
 }
 
 .todo-widget__end {


### PR DESCRIPTION
## Summary
- remove the launch hero heading from the browser homepage and retarget its section labelling
- surface an inline End Day control in the empty quick action state with supporting styles
- keep repeatable quick tasks visible by carrying repeat metadata into the browser todo widget

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd8232b248832caf87b47f22814eb7