### PR TITLE
Refactor persistence into repository and migration runner

### DIFF
--- a/src/core/persistence/snapshotRepository.js
+++ b/src/core/persistence/snapshotRepository.js
@@ -1,0 +1,27 @@
+export class SnapshotRepository {
+  constructor({ storageKey, storage = globalThis?.localStorage } = {}) {
+    this.storageKey = storageKey;
+    this.storage = storage;
+  }
+
+  loadRaw() {
+    try {
+      const rawSnapshot = this.storage?.getItem(this.storageKey) ?? null;
+      if (!rawSnapshot) {
+        return { type: 'empty' };
+      }
+      return { type: 'success', value: rawSnapshot };
+    } catch (error) {
+      return { type: 'error', error };
+    }
+  }
+
+  saveRaw(rawSnapshot) {
+    try {
+      this.storage?.setItem(this.storageKey, rawSnapshot);
+      return { type: 'success' };
+    } catch (error) {
+      return { type: 'error', error };
+    }
+  }
+}

--- a/src/core/persistence/stateMigrationRunner.js
+++ b/src/core/persistence/stateMigrationRunner.js
@@ -1,0 +1,37 @@
+export class StateMigrationRunner {
+  constructor({ migrations = [] } = {}) {
+    this.migrations = Array.isArray(migrations) ? migrations : [];
+  }
+
+  get version() {
+    return this.migrations.length;
+  }
+
+  run(snapshot, context) {
+    if (!snapshot || typeof snapshot !== 'object') {
+      return context.clone(context.defaultState);
+    }
+
+    if (!this.migrations.length) {
+      return { ...snapshot };
+    }
+
+    let current = { ...snapshot };
+    const startVersion = Number.isInteger(current.version) ? current.version : 0;
+    const runnerContext = { ...context, version: this.version };
+
+    if (startVersion < this.version) {
+      for (let index = Math.max(0, startVersion); index < this.migrations.length; index += 1) {
+        const step = this.migrations[index];
+        if (typeof step !== 'function') continue;
+        current = step(current, runnerContext);
+        if (!current || typeof current !== 'object') {
+          throw new Error(`Migration at index ${index} did not return an object.`);
+        }
+      }
+    }
+
+    current.version = Math.max(this.version, startVersion);
+    return current;
+  }
+}

--- a/tests/persistence.test.js
+++ b/tests/persistence.test.js
@@ -1,6 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { StatePersistence } from '../src/core/persistence/index.js';
+import {
+  SnapshotRepository,
+  StateMigrationRunner,
+  StatePersistence
+} from '../src/core/persistence/index.js';
 
 function createPersistence({ storage, migrations = [] } = {}) {
   let state;
@@ -16,9 +20,14 @@ function createPersistence({ storage, migrations = [] } = {}) {
     version: 0
   });
 
+  const repository = new SnapshotRepository({
+    storageKey: 'test-key',
+    storage
+  });
+  const migrationRunner = new StateMigrationRunner({ migrations });
+
   const persistence = new StatePersistence({
     storageKey: 'test-key',
-    storage,
     clone,
     now: () => nowValue,
     buildDefaultState: () => baseState(),
@@ -32,8 +41,9 @@ function createPersistence({ storage, migrations = [] } = {}) {
     },
     ensureStateShape: () => {},
     getState: () => state,
-    migrations,
-    logger: { error: () => {} }
+    logger: { error: () => {} },
+    repository,
+    migrationRunner
   });
 
   return { persistence, getState: () => state, nowValue };


### PR DESCRIPTION
## Summary
- add a SnapshotRepository to isolate raw snapshot storage IO
- extract a StateMigrationRunner to manage ordered state migrations and version tracking
- refactor StatePersistence and related tests to orchestrate the new collaborators

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd99c57f08832c987fad729dd8cfd6