### PR TITLE
Rebrand BlogPress references to DownWork

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,7 +8,7 @@
 - BankApp finance portal now pipes the classic dashboard totals into a bank-style header (Current balance, Net / Day, Daily +, Daily -) and mirrors the daily ledger inside the browser shell.
 - Browser shell entry experiments ship a homepage chrome with pinned sites and dedicated widgets while sharing the core game lo
 op with the classic dashboard.
-- Browser chrome now renders dashboard KPIs, quick actions, notifications, and the BlogPress/VideoTube/ShopStack/Learnly surfaces through dedicated presenters that reuse the shared models.
+- Browser chrome now renders dashboard KPIs, quick actions, notifications, and the DownWork/VideoTube/ShopStack/Learnly surfaces through dedicated presenters that reuse the shared models.
 - Modular UI view-model builders keep player overview, skills, header actions, and layout filters aligned while making alternate shells easy to drop in.
 - Passive asset economy has lower upkeep, clearer payout ladders, and milestone callouts so builds pay off earlier.
 - Education and hustle systems link courses to gig bonuses with celebratory progress cues and smarter scheduling buffers.

--- a/src/ui/views/browser/config.js
+++ b/src/ui/views/browser/config.js
@@ -11,11 +11,11 @@ export const SERVICE_PAGES = [
     type: 'finance'
   },
   {
-    id: 'blogpress',
-    slug: 'blogpress',
-    label: 'BlogPress',
-    headline: 'BlogPress Creator Hub',
-    tagline: 'Publish posts, tweak monetization, and celebrate streaks.',
+    id: 'downwork',
+    slug: 'downwork',
+    label: 'DownWork',
+    headline: 'DownWork Hustle Exchange',
+    tagline: 'Match with online gigs, pitch your services, and celebrate new wins.',
     icon: '📝',
     type: 'hustles'
   },


### PR DESCRIPTION
## Summary
- rename the browser shell service entry from BlogPress to DownWork with a refreshed headline and tagline for online gig discovery
- update the changelog entry to reference DownWork alongside the other browser surfaces

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dda05f6ec0832c91914cd991981c68