### PR TITLE
Refine browser homepage widgets

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -79,9 +79,9 @@
 
           <main class="browser-main" aria-live="polite">
             <section id="browser-home" class="browser-home" aria-labelledby="browser-widget-todo-heading">
-              <section class="browser-launch" aria-label="Today's focus">
-                <section class="todo-widget" data-widget="todo" aria-labelledby="browser-widget-todo-heading">
-                  <header class="todo-widget__header">
+              <div class="browser-home__widgets">
+                <section class="browser-widget todo-widget" data-widget="todo" aria-labelledby="browser-widget-todo-heading">
+                  <header class="browser-widget__header todo-widget__header">
                     <div class="todo-widget__intro">
                       <h2 id="browser-widget-todo-heading">Today's Tasks</h2>
                       <p id="browser-widget-todo-note">Pick the moves that make today sparkle.</p>
@@ -107,7 +107,37 @@
 
                   <button id="browser-widget-todo-end" class="todo-widget__end" type="button">End Day</button>
                 </section>
-              </section>
+
+                <section
+                  class="browser-widget apps-widget"
+                  data-widget="apps"
+                  aria-labelledby="browser-widget-apps-heading"
+                >
+                  <header class="browser-widget__header">
+                    <div>
+                      <h2 id="browser-widget-apps-heading">Apps</h2>
+                      <p id="browser-widget-apps-note">Launch into any workspace in a single click.</p>
+                    </div>
+                  </header>
+                  <ul id="browser-widget-apps-list" class="apps-widget__list" aria-live="polite"></ul>
+                </section>
+
+                <section
+                  class="browser-widget bank-widget"
+                  data-widget="bank"
+                  aria-labelledby="browser-widget-bank-heading"
+                >
+                  <header class="browser-widget__header">
+                    <div>
+                      <h2 id="browser-widget-bank-heading">Bank Snapshot</h2>
+                      <p id="browser-widget-bank-note">Fresh totals piped in from BankApp.</p>
+                    </div>
+                  </header>
+                  <ul id="browser-widget-bank-stats" class="bank-widget__stats" aria-live="polite"></ul>
+                  <p id="browser-widget-bank-footnote" class="bank-widget__footnote" hidden></p>
+                  <div id="browser-widget-bank-highlights" class="bank-widget__highlights" hidden></div>
+                </section>
+              </div>
             </section>
           </main>
         </div>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 - Browser shell graduates to a multi-tab workspace: the launch page stays pinned as the first tab while apps like BankApp open in their own closable tabs and keep their state when you swap views.
 - Browser launch view trims the hero headline, keeps repeatable quick tasks visible, and adds an inline End Day button when the action list is empty for faster wrap-ups.
 - Browser homepage now launches with a focused ToDo widget, time tracker, and End Day button while shortcut, earnings, and notification surfaces stay hidden for future drops.
+- Browser homepage now features a three-card column with a simplified apps roster and a BankApp-powered cash snapshot for instant context.
 - Boot logic now respects an `?ui=` flag and the browser chrome includes a Classic Shell button so testers can bounce between shells while feature parity lands.
 - BankApp finance portal now pipes the classic dashboard totals into a bank-style header (Current balance, Net / Day, Daily +, Daily -) and mirrors the daily ledger inside the browser shell.
 - Browser shell entry experiments ship a homepage chrome with pinned sites and dedicated widgets while sharing the core game lo

--- a/docs/features/browser-shell.md
+++ b/docs/features/browser-shell.md
@@ -13,12 +13,14 @@
 - Hours available and hours spent stay visible so players can pace their day while they click through tasks.
 - Completed actions slide into a muted "Done" ledger with time-spent markers, celebrating momentum without crowding the list.
 - A dedicated End Day button sits under the checklist so players can wrap the day from the same surface they planned it on.
+- A compact bank snapshot mirrors the BankApp header so daily cashflow, net movement, and highlights are visible without opening a new tab.
+- The apps widget now reads like a login roster—each workspace is a single button with its description tucked into a tooltip for quick launches.
 
 ## Implementation Notes
-- `browser.html` still boots the shared game scripts, but the homepage markup now collapses to a single ToDo widget with a time summary and End Day control.
-- Dashboard presenters only initialize the todo widget; earnings and notification modules stay dormant until future iterations bring them back.
+- `browser.html` now lays out three uniform widgets (tasks, apps, bank) so the homepage reads as a single column of quick actions.
+- Dashboard presenters initialize todo, apps, and bank widgets—each module keeps state in sync with the shared registries while remaining lazy-loaded.
 - `todoWidget` now treats each hustle row as a full-width button that fires the action, logs completions with time data, and updates hours spent immediately.
-- `styles/browser.css` received a pared-down layout and new `.todo-widget` system so the launch screen reads like a standard productivity app in both light and dark themes.
+- `styles/browser.css` defines a reusable `.browser-widget` shell plus dedicated styling for the app roster and bank chips so every panel lines up cleanly.
 - Quick action view models provide payout, duration, and day metadata so the widget can track hours and reset completion history when a new day begins.
 
 ## Multi-Tab Workspace System

--- a/src/ui/views/browser/dashboardPresenter.js
+++ b/src/ui/views/browser/dashboardPresenter.js
@@ -1,8 +1,12 @@
 import { getElement } from '../../elements/registry.js';
 import todoWidget from './widgets/todoWidget.js';
+import appsWidget from './widgets/appsWidget.js';
+import bankWidget from './widgets/bankWidget.js';
 
 const widgetModules = {
-  todo: todoWidget
+  todo: todoWidget,
+  apps: appsWidget,
+  bank: bankWidget
 };
 
 function getWidgetMounts() {
@@ -26,9 +30,21 @@ function renderTodo(actions = {}) {
   widget?.render(actions);
 }
 
-function renderDashboard(viewModel = {}) {
+function renderApps(context = {}) {
+  const widget = ensureWidget('apps');
+  widget?.render(context);
+}
+
+function renderBank(context = {}) {
+  const widget = ensureWidget('bank');
+  widget?.render(context);
+}
+
+function renderDashboard(viewModel = {}, context = {}) {
   if (!viewModel) return;
   renderTodo(viewModel.quickActions || {});
+  renderApps(context);
+  renderBank(context);
 }
 
 export default {

--- a/src/ui/views/browser/layoutPresenter.js
+++ b/src/ui/views/browser/layoutPresenter.js
@@ -466,6 +466,11 @@ function initNavigation() {
     siteList.addEventListener('click', handleSiteClick);
   }
 
+  const homepage = getElement('homepage')?.container;
+  if (homepage) {
+    homepage.addEventListener('click', handleSiteClick);
+  }
+
   setActivePage(currentPage, { recordHistory: false, ensureTab: false });
   updateNavigationButtons();
 }

--- a/src/ui/views/browser/resolvers.js
+++ b/src/ui/views/browser/resolvers.js
@@ -40,6 +40,17 @@ const resolvers = {
       availableValue: root.getElementById('browser-widget-todo-available'),
       spentValue: root.getElementById('browser-widget-todo-spent'),
       endDayButton: root.getElementById('browser-widget-todo-end')
+    },
+    apps: {
+      container: root.querySelector('[data-widget="apps"]'),
+      list: root.getElementById('browser-widget-apps-list'),
+      note: root.getElementById('browser-widget-apps-note')
+    },
+    bank: {
+      container: root.querySelector('[data-widget="bank"]'),
+      stats: root.getElementById('browser-widget-bank-stats'),
+      footnote: root.getElementById('browser-widget-bank-footnote'),
+      highlights: root.getElementById('browser-widget-bank-highlights')
     }
   })
 };

--- a/src/ui/views/browser/widgets/appsWidget.js
+++ b/src/ui/views/browser/widgets/appsWidget.js
@@ -1,0 +1,119 @@
+import { SERVICE_PAGES } from '../config.js';
+import {
+  getLatestServiceSummaries,
+  subscribeToServiceSummaries
+} from '../cardsPresenter.js';
+
+let elements = null;
+let initialized = false;
+let latestSummaries = [];
+
+function ensureElements(widgetElements = {}) {
+  if (elements) return;
+  elements = widgetElements;
+}
+
+function getSummaryMap() {
+  return new Map(latestSummaries.map(entry => [entry?.id, entry]));
+}
+
+function isPageLocked(meta = '') {
+  return /lock/i.test(meta || '');
+}
+
+function describeTooltip(page, summary = {}) {
+  const parts = [];
+  if (page?.tagline) {
+    parts.push(page.tagline);
+  }
+  if (summary?.meta) {
+    parts.push(`Status: ${summary.meta}`);
+  }
+  return parts.join(' • ');
+}
+
+function describeAriaLabel(page, summary = {}) {
+  const parts = [page?.label || 'Workspace'];
+  if (summary?.meta) {
+    parts.push(summary.meta);
+  } else if (page?.tagline) {
+    parts.push(page.tagline);
+  }
+  return parts.join('. ');
+}
+
+function renderEmptyState() {
+  if (!elements?.list) return;
+  elements.list.innerHTML = '';
+  const empty = document.createElement('li');
+  empty.className = 'apps-widget__empty';
+  empty.textContent = 'Unlock more apps to populate this list.';
+  elements.list.appendChild(empty);
+  if (elements?.note) {
+    elements.note.textContent = 'Unlock more workspaces through upgrades and courses.';
+  }
+}
+
+function renderList() {
+  if (!elements?.list) return;
+  const summaryMap = getSummaryMap();
+  const pages = SERVICE_PAGES.filter(page => !isPageLocked(summaryMap.get(page.id)?.meta));
+
+  elements.list.innerHTML = '';
+
+  if (!pages.length) {
+    renderEmptyState();
+    return;
+  }
+
+  pages.forEach(page => {
+    const summary = summaryMap.get(page.id) || {};
+    const item = document.createElement('li');
+    item.className = 'apps-widget__item';
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'apps-widget__link';
+    button.dataset.siteTarget = page.id;
+    button.title = describeTooltip(page, summary);
+    button.setAttribute('aria-label', describeAriaLabel(page, summary));
+
+    const icon = document.createElement('span');
+    icon.className = 'apps-widget__icon';
+    icon.textContent = page.icon || '✨';
+
+    const name = document.createElement('span');
+    name.className = 'apps-widget__name';
+    name.textContent = page.label;
+
+    button.append(icon, name);
+    item.appendChild(button);
+    elements.list.appendChild(item);
+  });
+
+  if (elements?.note) {
+    elements.note.textContent = 'Hover to peek the description, click to launch instantly.';
+  }
+}
+
+function handleServiceSummaries(summaries = []) {
+  latestSummaries = Array.isArray(summaries) ? summaries.filter(entry => entry?.id) : [];
+  renderList();
+}
+
+function init(widgetElements = {}) {
+  if (initialized) return;
+  ensureElements(widgetElements);
+  initialized = true;
+  subscribeToServiceSummaries(handleServiceSummaries);
+  handleServiceSummaries(getLatestServiceSummaries());
+}
+
+function render() {
+  renderList();
+}
+
+export default {
+  init,
+  render
+};

--- a/src/ui/views/browser/widgets/bankWidget.js
+++ b/src/ui/views/browser/widgets/bankWidget.js
@@ -1,0 +1,196 @@
+import { buildFinanceModel } from '../../../cards/model.js';
+import { formatMoney } from '../../../../core/helpers.js';
+
+let elements = null;
+let initialized = false;
+
+function ensureElements(widgetElements = {}) {
+  if (elements) return;
+  elements = widgetElements;
+}
+
+function formatCurrency(amount) {
+  const numeric = Number(amount);
+  const absolute = Math.abs(Number.isFinite(numeric) ? numeric : 0);
+  const formatted = formatMoney(Math.round(absolute * 100) / 100);
+  const prefix = numeric < 0 ? '-$' : '$';
+  return `${prefix}${formatted}`;
+}
+
+function formatSignedCurrency(amount) {
+  const numeric = Number(amount);
+  if (!Number.isFinite(numeric) || numeric === 0) {
+    return '$0';
+  }
+  const absolute = Math.abs(numeric);
+  const formatted = formatMoney(Math.round(absolute * 100) / 100);
+  const sign = numeric > 0 ? '+' : '-';
+  return `${sign}$${formatted}`;
+}
+
+function decorateValue(element, tone) {
+  element.classList.remove('is-positive', 'is-negative');
+  if (tone === 'positive') {
+    element.classList.add('is-positive');
+  } else if (tone === 'negative') {
+    element.classList.add('is-negative');
+  }
+}
+
+function buildStat(label, value, tone = 'neutral') {
+  const row = document.createElement('li');
+  row.className = 'bank-widget__stat';
+
+  const name = document.createElement('span');
+  name.className = 'bank-widget__label';
+  name.textContent = label;
+
+  const amount = document.createElement('span');
+  amount.className = 'bank-widget__value';
+  amount.textContent = value;
+  decorateValue(amount, tone);
+
+  row.append(name, amount);
+  return row;
+}
+
+function renderStats(header = {}) {
+  if (!elements?.stats) return;
+  const balance = Number(header?.currentBalance ?? header?.cashOnHand ?? 0);
+  const netDaily = Number(header?.netDaily ?? 0);
+  const income = Number(header?.dailyIncome ?? 0);
+  const spend = Number(header?.dailySpend ?? 0);
+
+  const stats = [
+    buildStat('Current balance', formatCurrency(balance), 'neutral'),
+    buildStat(
+      'Net / Day',
+      formatSignedCurrency(netDaily),
+      netDaily > 0 ? 'positive' : netDaily < 0 ? 'negative' : 'neutral'
+    ),
+    buildStat('Daily +', formatCurrency(income), income > 0 ? 'positive' : 'neutral'),
+    buildStat('Daily -', formatCurrency(spend > 0 ? -spend : 0), spend > 0 ? 'negative' : 'neutral')
+  ];
+
+  elements.stats.innerHTML = '';
+  stats.forEach(stat => elements.stats.appendChild(stat));
+}
+
+function renderFootnote(header = {}) {
+  if (!elements?.footnote) return;
+  const earned = Number(header?.lifetimeEarned ?? 0);
+  const spent = Number(header?.lifetimeSpent ?? 0);
+  if (earned <= 0 && spent <= 0) {
+    elements.footnote.hidden = true;
+    elements.footnote.textContent = '';
+    return;
+  }
+  const earnedText = formatCurrency(earned);
+  const spentText = formatCurrency(spent > 0 ? -spent : 0);
+  elements.footnote.hidden = false;
+  elements.footnote.textContent = `Lifetime earned ${earnedText} • Lifetime spent ${spentText}`;
+}
+
+function createChip({ label, value, tone = 'neutral', note }) {
+  const chip = document.createElement('span');
+  chip.className = 'bank-widget__chip';
+  chip.dataset.tone = tone;
+
+  const chipLabel = document.createElement('span');
+  chipLabel.className = 'bank-widget__chip-label';
+  chipLabel.textContent = label;
+
+  const chipValue = document.createElement('span');
+  chipValue.className = 'bank-widget__chip-value';
+  chipValue.textContent = value;
+
+  chip.append(chipLabel, chipValue);
+  if (note) {
+    chip.title = note;
+  }
+  return chip;
+}
+
+function renderHighlights(header = {}) {
+  if (!elements?.highlights) return;
+  const chips = [];
+
+  if (header?.quickObligation) {
+    chips.push(
+      createChip({
+        label: header.quickObligation.label || 'Next due',
+        value: formatCurrency(header.quickObligation.amount || 0),
+        tone: 'out',
+        note: header.quickObligation.note || ''
+      })
+    );
+  }
+
+  if (header?.topEarner) {
+    chips.push(
+      createChip({
+        label: 'Top earner',
+        value: `${header.topEarner.label} • ${formatCurrency(header.topEarner.amount || 0)}`,
+        tone: 'in',
+        note: 'Highest payout logged today'
+      })
+    );
+  }
+
+  const pulse = Array.isArray(header?.pulse) ? header.pulse.slice(0, 2) : [];
+  pulse.forEach(entry => {
+    chips.push(
+      createChip({
+        label: entry.label || 'Pulse',
+        value: formatSignedCurrency(entry.direction === 'out' ? -entry.amount : entry.amount),
+        tone: entry.direction === 'out' ? 'out' : 'in',
+        note: 'Live cash pulse'
+      })
+    );
+  });
+
+  elements.highlights.innerHTML = '';
+  if (!chips.length) {
+    elements.highlights.hidden = true;
+    return;
+  }
+
+  chips.forEach(chip => elements.highlights.appendChild(chip));
+  elements.highlights.hidden = false;
+}
+
+function render(context = {}) {
+  if (!initialized) return;
+  if (!context?.state) {
+    if (elements?.stats) {
+      elements.stats.innerHTML = '';
+    }
+    if (elements?.footnote) {
+      elements.footnote.hidden = true;
+      elements.footnote.textContent = '';
+    }
+    if (elements?.highlights) {
+      elements.highlights.hidden = true;
+      elements.highlights.innerHTML = '';
+    }
+    return;
+  }
+
+  const model = buildFinanceModel(undefined, {
+    getState: () => context.state
+  });
+  renderStats(model?.header || {});
+  renderFootnote(model?.header || {});
+  renderHighlights(model?.header || {});
+}
+
+function init(widgetElements = {}) {
+  if (initialized) return;
+  ensureElements(widgetElements);
+  initialized = true;
+}
+
+export default {
+  init,
+  render
+};

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -19,6 +19,7 @@
   --browser-radius-pill: 999px;
   --browser-shadow-card: 0 18px 38px rgba(15, 23, 42, 0.08);
   --browser-shadow-soft: 0 20px 44px rgba(15, 23, 42, 0.06);
+  --browser-shadow-focus: 0 12px 30px rgba(37, 99, 235, 0.16);
 }
 
 :root[data-browser-theme="night"] {
@@ -38,6 +39,7 @@
   --browser-radius-pill: 999px;
   --browser-shadow-card: 0 24px 48px rgba(2, 6, 23, 0.6);
   --browser-shadow-soft: 0 26px 52px rgba(2, 6, 23, 0.52);
+  --browser-shadow-focus: 0 16px 38px rgba(139, 170, 255, 0.28);
 }
 
 body {
@@ -410,11 +412,18 @@ a {
 }
 
 .browser-home {
-  width: min(640px, 100%);
+  width: min(720px, 100%);
   display: flex;
   flex-direction: column;
   gap: 2rem;
   align-items: center;
+}
+
+.browser-home__widgets {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
 }
 
 .browser-home__header {
@@ -436,13 +445,7 @@ a {
   font-size: 1.05rem;
 }
 
-.browser-launch {
-  width: 100%;
-  display: flex;
-  justify-content: center;
-}
-
-.todo-widget {
+.browser-widget {
   width: 100%;
   background: var(--browser-panel);
   border: 1px solid var(--browser-panel-border);
@@ -454,12 +457,31 @@ a {
   gap: 1.5rem;
 }
 
-.todo-widget__header {
+.browser-widget__header {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
   justify-content: space-between;
   gap: 1.25rem;
+}
+
+.browser-widget__header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.browser-widget__header p {
+  margin: 0.4rem 0 0;
+  color: var(--browser-muted);
+  font-size: 0.95rem;
+}
+
+.todo-widget {
+  gap: 1.5rem;
+}
+
+.todo-widget__header {
+  width: 100%;
 }
 
 .todo-widget__intro h2 {
@@ -696,6 +718,141 @@ a {
 .todo-widget__end:focus-visible {
   outline: 2px solid var(--browser-accent);
   outline-offset: 3px;
+}
+
+.apps-widget__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.apps-widget__item {
+  margin: 0;
+}
+
+.apps-widget__link {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  border-radius: var(--browser-radius-md);
+  border: 1px solid transparent;
+  background: var(--browser-panel-elevated);
+  color: inherit;
+  font: inherit;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease;
+}
+
+.apps-widget__link:hover,
+.apps-widget__link:focus-visible {
+  border-color: var(--browser-accent);
+  box-shadow: var(--browser-shadow-focus);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.apps-widget__icon {
+  font-size: 1.4rem;
+}
+
+.apps-widget__name {
+  flex: 1;
+  font-size: 1rem;
+}
+
+.apps-widget__empty {
+  margin: 0;
+  padding: 0.5rem 0;
+  text-align: center;
+  color: var(--browser-muted);
+  font-size: 0.95rem;
+}
+
+.bank-widget__stats {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.bank-widget__stat {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.95rem 1rem;
+  border-radius: var(--browser-radius-md);
+  background: var(--browser-panel-elevated);
+  border: 1px solid var(--browser-panel-border);
+}
+
+.bank-widget__label {
+  font-size: 0.85rem;
+  color: var(--browser-subtle);
+  font-weight: 600;
+}
+
+.bank-widget__value {
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+.bank-widget__value.is-positive {
+  color: var(--browser-positive);
+}
+
+.bank-widget__value.is-negative {
+  color: var(--browser-danger);
+}
+
+.bank-widget__footnote {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.9rem;
+}
+
+.bank-widget__highlights {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.bank-widget__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 0.9rem;
+  border-radius: var(--browser-radius-pill);
+  background: var(--browser-panel-elevated);
+  border: 1px solid var(--browser-panel-border);
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
+.bank-widget__chip-label {
+  font-weight: 600;
+  color: var(--browser-subtle);
+}
+
+.bank-widget__chip-value {
+  font-weight: 700;
+}
+
+.bank-widget__chip[data-tone='out'] .bank-widget__chip-value {
+  color: var(--browser-danger);
+}
+
+.bank-widget__chip[data-tone='in'] .bank-widget__chip-value {
+  color: var(--browser-positive);
 }
 
   padding: 0.75rem 0.9rem;


### PR DESCRIPTION
## Summary
- restructure the browser homepage into a single-column trio of widgets with consistent markup
- add dedicated apps and bank widgets that reuse service summaries and finance data from BankApp
- refresh browser shell styles plus docs to capture the new launcher layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd9f9cb738832c8c370be8bd747632