### PR TITLE
Redesign browser homepage layout

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -64,19 +64,6 @@
         aria-labelledby="browser-sites-note"
       >
         <div class="browser-layout">
-          <aside class="browser-sidebar" aria-label="Workspace launcher">
-            <section class="browser-sites">
-              <header class="browser-sites__header">
-                <h2 class="browser-sites__title">Apps</h2>
-                <p id="browser-sites-note" class="browser-sites__note">
-                  Pick a workspace to launch. Status badges refresh in real time.
-                </p>
-              </header>
-              <ul id="browser-site-list" class="browser-app-list" aria-live="polite"></ul>
-              <button id="browser-add-site" class="browser-app-button" type="button">Discover more apps</button>
-            </section>
-          </aside>
-
           <main class="browser-main" aria-live="polite">
             <section id="browser-home" class="browser-home" aria-labelledby="browser-widget-todo-heading">
               <div class="browser-home__widgets">
@@ -109,20 +96,6 @@
                 </section>
 
                 <section
-                  class="browser-widget apps-widget"
-                  data-widget="apps"
-                  aria-labelledby="browser-widget-apps-heading"
-                >
-                  <header class="browser-widget__header">
-                    <div>
-                      <h2 id="browser-widget-apps-heading">Apps</h2>
-                      <p id="browser-widget-apps-note">Launch into any workspace in a single click.</p>
-                    </div>
-                  </header>
-                  <ul id="browser-widget-apps-list" class="apps-widget__list" aria-live="polite"></ul>
-                </section>
-
-                <section
                   class="browser-widget bank-widget"
                   data-widget="bank"
                   aria-labelledby="browser-widget-bank-heading"
@@ -136,6 +109,24 @@
                   <ul id="browser-widget-bank-stats" class="bank-widget__stats" aria-live="polite"></ul>
                   <p id="browser-widget-bank-footnote" class="bank-widget__footnote" hidden></p>
                   <div id="browser-widget-bank-highlights" class="bank-widget__highlights" hidden></div>
+                </section>
+                <section
+                  class="browser-widget apps-widget"
+                  data-widget="apps"
+                  aria-labelledby="browser-widget-apps-heading"
+                >
+                  <header class="browser-widget__header">
+                    <div>
+                      <h2 id="browser-widget-apps-heading">Apps</h2>
+                      <p id="browser-widget-apps-note">Tap an icon to launch. Status badges light up when something's ready.</p>
+                    </div>
+                  </header>
+                  <ul
+                    id="browser-widget-apps-list"
+                    class="apps-widget__list"
+                    aria-live="polite"
+                    data-role="browser-app-launcher"
+                  ></ul>
                 </section>
               </div>
             </section>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Browser homepage redesign removes the sidebar, aligns widgets into a responsive three-column grid, and promotes the app launcher into tile-based cards with live status badges.
 - Browser shell graduates to a multi-tab workspace: the launch page stays pinned as the first tab while apps like BankApp open in their own closable tabs and keep their state when you swap views.
 - Browser launch view trims the hero headline, keeps repeatable quick tasks visible, and adds an inline End Day button when the action list is empty for faster wrap-ups.
 - Browser homepage now launches with a focused ToDo widget, time tracker, and End Day button while shortcut, earnings, and notification surfaces stay hidden for future drops.

--- a/docs/features/browser-home-redesign.md
+++ b/docs/features/browser-home-redesign.md
@@ -1,0 +1,17 @@
+# Browser Homepage Redesign
+
+## Goals
+- Give the browser shell a centered canvas without a sidebar so focus stays on the day-to-day widgets.
+- Group homepage widgets into a consistent three-column grid that scales down gracefully on smaller screens.
+- Turn the apps list into a touch-friendly launcher with icon tiles and real-time status badges sourced from service summaries.
+
+## Implementation Notes
+- The launch stage now renders a single-column layout with `.browser-home__widgets` using CSS Grid to provide three equal columns on wide viewports, two columns on medium, and one column on narrow screens.
+- Widget cards reuse the existing presenter modules and simply stretch to fill each grid cell. Cards share a consistent padding, border radius, and drop shadow defined in `styles/browser.css` so they feel like a matched set.
+- The apps widget reuses the existing `appsWidget` module. It now renders each workspace as a tile button with an icon, label, and optional status badge derived from the service summary metadata.
+- Navigation highlighting looks for `[data-role="browser-app-launcher"]` containers in addition to the legacy sidebar list so active pages still pulse even without the sidebar.
+
+## Player Impact
+- Players can scan the day's plan, finances, and workspace launchers at a glance without juggling two columns.
+- The tile launcher mirrors a mobile home screen, making it faster to spot ready actions or idle tabs from the status badges.
+- Responsive breakpoints ensure the layout remains legible on narrow QA windows while keeping the three-up structure on desktop.

--- a/src/ui/cards/model.js
+++ b/src/ui/cards/model.js
@@ -1,0 +1,1 @@
+export * from './model/index.js';

--- a/src/ui/views/browser/layoutPresenter.js
+++ b/src/ui/views/browser/layoutPresenter.js
@@ -131,12 +131,27 @@ function getPageElement(pageId) {
 }
 
 function markActiveSite(pageId) {
+  const containers = [];
   const list = getElement('siteList');
-  if (!list) return;
-  list.querySelectorAll('button[data-site-target]').forEach(button => {
-    const isActive = button.dataset.siteTarget === pageId;
-    button.classList.toggle('is-active', isActive);
-    button.setAttribute('aria-pressed', String(isActive));
+  if (list) containers.push(list);
+
+  const homepage = getElement('homepage')?.container || null;
+  if (homepage) {
+    homepage.querySelectorAll('[data-role="browser-app-launcher"]').forEach(node => {
+      if (node instanceof HTMLElement) {
+        containers.push(node);
+      }
+    });
+  }
+
+  if (!containers.length) return;
+
+  containers.forEach(container => {
+    container.querySelectorAll('button[data-site-target]').forEach(button => {
+      const isActive = button.dataset.siteTarget === pageId;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-pressed', String(isActive));
+    });
   });
 }
 

--- a/src/ui/views/browser/widgets/appsWidget.js
+++ b/src/ui/views/browser/widgets/appsWidget.js
@@ -73,20 +73,33 @@ function renderList() {
 
     const button = document.createElement('button');
     button.type = 'button';
-    button.className = 'apps-widget__link';
+    button.className = 'apps-widget__tile';
     button.dataset.siteTarget = page.id;
     button.title = describeTooltip(page, summary);
     button.setAttribute('aria-label', describeAriaLabel(page, summary));
+    button.setAttribute('aria-pressed', 'false');
 
     const icon = document.createElement('span');
     icon.className = 'apps-widget__icon';
     icon.textContent = page.icon || '✨';
 
+    const label = document.createElement('span');
+    label.className = 'apps-widget__label';
+
     const name = document.createElement('span');
     name.className = 'apps-widget__name';
     name.textContent = page.label;
 
-    button.append(icon, name);
+    label.appendChild(name);
+
+    if (summary.meta) {
+      const badge = document.createElement('span');
+      badge.className = 'apps-widget__badge';
+      badge.textContent = summary.meta;
+      label.appendChild(badge);
+    }
+
+    button.append(icon, label);
     item.appendChild(button);
     elements.list.appendChild(item);
   });

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -269,161 +269,45 @@ a {
 
 .browser-layout {
   flex: 1 1 auto;
-  display: grid;
-  grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
-  gap: 2.75rem;
   padding: 3rem 1.75rem 4rem;
   width: 100%;
   max-width: 1180px;
   margin: 0 auto;
-}
-
-.browser-sidebar {
-  display: flex;
-  flex-direction: column;
-  gap: 1.75rem;
-  position: sticky;
-  top: 3rem;
-  align-self: flex-start;
-}
-
-.browser-sites {
-  background: var(--browser-panel);
-  border: 1px solid var(--browser-panel-border);
-  border-radius: var(--browser-radius-lg);
-  box-shadow: var(--browser-shadow-soft);
-  padding: 1.75rem 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1.35rem;
-}
-
-.browser-sites__header {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.browser-sites__title {
-  margin: 0;
-  font-size: 1.15rem;
-  font-weight: 700;
-}
-
-.browser-sites__note {
-  margin: 0;
-  color: var(--browser-muted);
-  font-size: 0.95rem;
-}
-
-.browser-app-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.85rem;
-}
-
-.browser-app-card {
-  width: 100%;
-  border: 1px solid var(--browser-panel-border);
-  border-radius: var(--browser-radius-md);
-  background: #fff;
-  padding: 1rem 1.25rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  text-align: left;
-  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
-}
-
-.browser-app-card:hover,
-.browser-app-card:focus-visible {
-  border-color: var(--browser-accent);
-  box-shadow: 0 6px 18px rgba(30, 62, 123, 0.14);
-  transform: translateY(-1px);
-  outline: none;
-}
-
-.browser-app-card.is-active {
-  border-color: var(--browser-accent);
-  box-shadow: 0 0 0 3px rgba(85, 122, 255, 0.15);
-}
-
-.browser-app-card__icon {
-  font-size: 1.5rem;
-}
-
-.browser-app-card__header {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  justify-content: space-between;
-}
-
-.browser-app-card__title {
-  font-weight: 700;
-  font-size: 1rem;
-}
-
-.browser-app-card__badge {
-  background: var(--browser-accent-soft);
-  color: var(--browser-accent);
-  border-radius: var(--browser-radius-pill);
-  padding: 0.15rem 0.6rem;
-  font-size: 0.75rem;
-  font-weight: 600;
-}
-
-.browser-app-card__meta {
-  margin: 0;
-  color: var(--browser-muted);
-  font-size: 0.9rem;
-}
-
-.browser-app-button {
-  width: 100%;
-  border: 1px dashed var(--browser-panel-border);
-  border-radius: var(--browser-radius-md);
-  padding: 0.85rem 1.1rem;
-  background: transparent;
-  color: var(--browser-accent);
-  font-weight: 600;
-  cursor: pointer;
-  transition: border-color 160ms ease, background 160ms ease, color 160ms ease;
-}
-
-.browser-app-button:hover,
-.browser-app-button:focus-visible {
-  border-color: var(--browser-accent);
-  background: var(--browser-accent-soft);
-  outline: none;
+  box-sizing: border-box;
 }
 
 .browser-main {
   width: 100%;
-  max-width: 900px;
   display: flex;
   flex-direction: column;
-  align-items: stretch;
-  gap: 0;
-  margin: 0 auto;
+  gap: 3rem;
 }
 
 .browser-home {
-  width: min(720px, 100%);
+  width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
-  align-items: center;
+  gap: 2.5rem;
 }
 
 .browser-home__widgets {
   width: 100%;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 1.75rem;
+  align-items: stretch;
+}
+
+@media (max-width: 1200px) {
+  .browser-home__widgets {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
+  .browser-home__widgets {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 .browser-home__header {
@@ -455,6 +339,7 @@ a {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  height: 100%;
 }
 
 .browser-widget__header {
@@ -724,55 +609,98 @@ a {
   list-style: none;
   margin: 0;
   padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
 }
 
 .apps-widget__item {
   margin: 0;
+  display: flex;
 }
 
-.apps-widget__link {
+.apps-widget__tile {
   width: 100%;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.85rem 1rem;
-  border-radius: var(--browser-radius-md);
-  border: 1px solid transparent;
+  gap: 0.9rem;
+  padding: 1.35rem 1.1rem 1.25rem;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
   background: var(--browser-panel-elevated);
+  background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0));
   color: inherit;
   font: inherit;
-  font-weight: 600;
-  text-align: left;
+  text-align: center;
   cursor: pointer;
-  transition: transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease;
+  position: relative;
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
 }
 
-.apps-widget__link:hover,
-.apps-widget__link:focus-visible {
+:root[data-browser-theme="night"] .apps-widget__tile {
+  border-color: rgba(139, 170, 255, 0.32);
+  background-image: linear-gradient(180deg, rgba(139, 170, 255, 0.12), rgba(139, 170, 255, 0));
+}
+
+.apps-widget__tile:hover,
+.apps-widget__tile:focus-visible {
   border-color: var(--browser-accent);
-  box-shadow: var(--browser-shadow-focus);
-  transform: translateY(-1px);
+  box-shadow: 0 16px 38px rgba(37, 99, 235, 0.18);
+  transform: translateY(-4px);
   outline: none;
 }
 
+.apps-widget__tile.is-active {
+  border-color: var(--browser-accent);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.18);
+}
+
 .apps-widget__icon {
-  font-size: 1.4rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 22px;
+  background: rgba(37, 99, 235, 0.08);
+  font-size: 1.65rem;
+}
+
+.apps-widget__label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  align-items: center;
 }
 
 .apps-widget__name {
-  flex: 1;
   font-size: 1rem;
+  font-weight: 600;
+}
+
+.apps-widget__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: var(--browser-radius-pill);
+  background: var(--browser-accent-soft);
+  color: var(--browser-accent);
+  font-size: 0.8rem;
+  font-weight: 600;
 }
 
 .apps-widget__empty {
   margin: 0;
-  padding: 0.5rem 0;
-  text-align: center;
+  padding: 2rem 1.25rem;
+  border-radius: 18px;
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  background: rgba(148, 163, 184, 0.08);
   color: var(--browser-muted);
   font-size: 0.95rem;
+  text-align: center;
+  grid-column: 1 / -1;
 }
 
 .bank-widget__stats {


### PR DESCRIPTION
## Summary
- remove the browser home sidebar and collapse the launch stage into a centered, responsive grid
- restyle the apps widget into a tile launcher with status badges while keeping existing presenters working
- document the redesign and add a cards model barrel file so tests can import shared helpers

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68dda68ab168832cb9c952c67764ea9a