### PR TITLE
Adjust browser home widget layout

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -67,6 +67,24 @@
           <main class="browser-main" aria-live="polite">
             <section id="browser-home" class="browser-home" aria-labelledby="browser-widget-todo-heading">
               <div class="browser-home__widgets">
+                <section
+                  class="browser-widget apps-widget"
+                  data-widget="apps"
+                  aria-labelledby="browser-widget-apps-heading"
+                >
+                  <header class="browser-widget__header">
+                    <div>
+                      <h2 id="browser-widget-apps-heading">Apps</h2>
+                      <p id="browser-widget-apps-note">Tap an icon to launch. Status badges light up when something's ready.</p>
+                    </div>
+                  </header>
+                  <ul
+                    id="browser-widget-apps-list"
+                    class="apps-widget__list"
+                    aria-live="polite"
+                    data-role="browser-app-launcher"
+                  ></ul>
+                </section>
                 <section class="browser-widget todo-widget" data-widget="todo" aria-labelledby="browser-widget-todo-heading">
                   <header class="browser-widget__header todo-widget__header">
                     <div class="todo-widget__intro">
@@ -109,24 +127,6 @@
                   <ul id="browser-widget-bank-stats" class="bank-widget__stats" aria-live="polite"></ul>
                   <p id="browser-widget-bank-footnote" class="bank-widget__footnote" hidden></p>
                   <div id="browser-widget-bank-highlights" class="bank-widget__highlights" hidden></div>
-                </section>
-                <section
-                  class="browser-widget apps-widget"
-                  data-widget="apps"
-                  aria-labelledby="browser-widget-apps-heading"
-                >
-                  <header class="browser-widget__header">
-                    <div>
-                      <h2 id="browser-widget-apps-heading">Apps</h2>
-                      <p id="browser-widget-apps-note">Tap an icon to launch. Status badges light up when something's ready.</p>
-                    </div>
-                  </header>
-                  <ul
-                    id="browser-widget-apps-list"
-                    class="apps-widget__list"
-                    aria-live="polite"
-                    data-role="browser-app-launcher"
-                  ></ul>
                 </section>
               </div>
             </section>

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -276,6 +276,11 @@ a {
   box-sizing: border-box;
 }
 
+.browser-stage__pane--home .browser-layout {
+  max-width: 1400px;
+  padding: 2.5rem clamp(0.75rem, 3vw, 1.5rem) 3.25rem;
+}
+
 .browser-main {
   width: 100%;
   display: flex;
@@ -294,7 +299,7 @@ a {
   width: 100%;
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1.75rem;
+  gap: 1.25rem;
   align-items: stretch;
 }
 
@@ -335,10 +340,10 @@ a {
   border: 1px solid var(--browser-panel-border);
   border-radius: var(--browser-radius-lg);
   box-shadow: var(--browser-shadow-soft);
-  padding: 1.75rem;
+  padding: 1.2rem;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.05rem;
   height: 100%;
 }
 


### PR DESCRIPTION
## Summary
- reorder the browser home widgets so the Apps launcher leads the grid
- expand the home layout width and tighten spacing so cards fill more of the browser stage
- trim widget padding to reduce card height while keeping existing content structure

## Testing
- npm test
- Manual: Loaded browser.html via local HTTP server and verified widget spacing and sizing


------
https://chatgpt.com/codex/tasks/task_e_68ddaa66f280832c898c512b5c2883e9