### PR TITLE
Add VideoTube studio workspace to browser shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Online Hustle Simulator is a browser-based incremental game about orchestrating 
 - **Browser Tabs** – The browser shell keeps the launch view pinned as the first tab while apps like BankApp open in their own closable tabs so you can bounce between workspaces without losing state.
 - **BankApp** – The browser shell’s SSO grid now includes a dedicated BankApp tile that opens a finance dashboard with current balance, Net / Day, Daily +, Daily -, and the classic ledger presented in a bank-flavored layout.
 - **BlogPress** – A faux CMS that lists every Personal Blog in a table, opens detail panels with payout recaps and niche controls, and offers a pricing page explaining setup costs, upkeep, quality ladders, and blog-specific upgrades—all powered by the original blog economy.
+- **VideoTube** – A studio-style vlog command center that lists every channel with payouts, quality, and niche badges, opens analytics-rich detail views, and walks you through naming, niching, and launching new videos while the original vlog backend runs the show.
 - **ShopStack** – A dedicated storefront app that pulls the entire upgrade catalog into category chips and card tiles. Players can search by name, filter by lane, open e-commerce style detail pages with requirement checklists, and review a My Purchases tab that highlights upkeep and purchase dates—all while the original upgrade backend handles costs and effects.
 - **Event Log Controls** – The log dock keeps its running commentary but now includes a summary/detailed toggle when you want a lighter feed during long sessions.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 - Browser homepage ToDo widget merges quick actions and upgrade suggestions into a scrollable list so every pending move stays visible.
 - Learnly graduates into a dedicated browser app with a course catalog, detail pages, My Courses hub, and pricing FAQ while reusing the existing education systems.
 - BlogPress brings the Personal Blog management flow into the browser shell with a table overview, detail inspector, pricing page, and one-click quality actions while reusing the existing passive-income logic.
+- VideoTube graduates the vlog asset tools into a studio-style browser app with a channel dashboard, analytics view, niche selection, and launch workflow that reuse the existing vlog economy.
 - Browser homepage redesign removes the sidebar, aligns widgets into a responsive three-column grid, and promotes the app launcher into tile-based cards with live status badges.
 - Browser shell graduates to a multi-tab workspace: the launch page stays pinned as the first tab while apps like BankApp open in their own closable tabs and keep their state when you swap views.
 - Browser launch view trims the hero headline, keeps repeatable quick tasks visible, and adds an inline End Day button when the action list is empty for faster wrap-ups.

--- a/docs/features/videotube.md
+++ b/docs/features/videotube.md
@@ -1,0 +1,17 @@
+# VideoTube Studio
+
+## Goal
+VideoTube transforms the original vlog asset interface into a full browser workspace that mirrors the vibe of pro creator dashboards. Players can now manage every vlog channel from one stage, inspect earnings and quality milestones, and launch new videos without dipping back into the classic shell.
+
+## Player Impact
+- **Channel dashboard** – Lists every vlog instance with daily payout, lifetime earnings, niche badge, and quick quality action buttons.
+- **Detail inspector** – Surfaces quality progress, payout breakdowns, ROI insights, and lets players trigger any vlog quality action with clear cost/time previews.
+- **Creation flow** – Guides players through naming a video, selecting a niche, and confirming setup/upkeep costs before launching the vlog asset.
+- **Analytics tab** – Highlights top earning videos and niche performance so players can steer their strategy.
+- **Niche + naming tools** – Players can lock a niche from the detail view and rename channels to keep branding consistent.
+
+## Tuning Notes
+- Channel stats summarize lifetime and daily earnings plus average milestone momentum. This keeps expectations aligned with vlog payouts.
+- Quick actions respect the existing daily limits/time costs and route through the existing `performQualityAction` API.
+- Launch flow uses the existing asset action, then applies the chosen title/niche with `setAssetInstanceName` and `assignInstanceToNiche` to preserve backend behaviour.
+- Analytics uses live lifetime and latest payout data—no extra history was stored to avoid persistence churn.

--- a/src/game/assets/index.js
+++ b/src/game/assets/index.js
@@ -3,7 +3,8 @@ import { allocateAssetMaintenance, closeOutDay } from './lifecycle.js';
 import {
   getIncomeRangeForDisplay,
   calculateAssetSalePrice,
-  sellAssetInstance
+  sellAssetInstance,
+  setAssetInstanceName
 } from './helpers.js';
 import {
   performQualityAction,
@@ -33,6 +34,7 @@ export {
   getQualityTracks,
   sellAssetInstance,
   calculateAssetSalePrice,
+  setAssetInstanceName,
   assignInstanceToNiche,
   getAssignableNicheSummaries,
   getInstanceNicheEffect,

--- a/src/ui/cards/collectionService.js
+++ b/src/ui/cards/collectionService.js
@@ -4,7 +4,8 @@ import {
   buildBlogpressModel,
   buildEducationModels,
   buildHustleModels,
-  buildUpgradeModels
+  buildUpgradeModels,
+  buildVideoTubeModel
 } from './model/index.js';
 
 let cachedRegistries = null;
@@ -47,7 +48,8 @@ function buildModels(registries) {
     education: buildEducationModels(registries.education),
     assets: buildAssetModels(registries.assets),
     upgrades: buildUpgradeModels(registries.upgrades),
-    blogpress: buildBlogpressModel(registries.assets, registries.upgrades)
+    blogpress: buildBlogpressModel(registries.assets, registries.upgrades),
+    videotube: buildVideoTubeModel(registries.assets)
   };
 }
 

--- a/src/ui/cards/model/index.js
+++ b/src/ui/cards/model/index.js
@@ -34,3 +34,4 @@ export {
 } from '../utils.js';
 
 export { default as buildBlogpressModel, selectNiche as selectBlogpressNiche } from './blogpress.js';
+export { default as buildVideoTubeModel, selectNiche as selectVideoTubeNiche } from './videotube.js';

--- a/src/ui/cards/model/videotube.js
+++ b/src/ui/cards/model/videotube.js
@@ -1,0 +1,436 @@
+import { ensureArray, formatHours, formatMoney } from '../../../core/helpers.js';
+import { getAssetState, getState } from '../../../core/state.js';
+import { instanceLabel, formatMaintenanceSummary } from '../../../game/assets/helpers.js';
+import {
+  assignInstanceToNiche,
+  getAssignableNicheSummaries,
+  getInstanceNicheInfo
+} from '../../../game/assets/niches.js';
+import {
+  canPerformQualityAction,
+  getInstanceQualityRange,
+  getNextQualityLevel,
+  getQualityActionAvailability,
+  getQualityActionUsage,
+  getQualityActions,
+  getQualityLevel,
+  getQualityTracks
+} from '../../../game/assets/quality.js';
+import { setAssetInstanceName } from '../../../game/assets/helpers.js';
+import { describeAssetLaunchAvailability } from './assets.js';
+
+function clampNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function formatCurrency(amount) {
+  return `$${formatMoney(Math.max(0, Math.round(Number(amount) || 0)))}`;
+}
+
+function buildMilestoneProgress(definition, instance) {
+  const quality = instance?.quality || {};
+  const level = Math.max(0, clampNumber(quality.level));
+  const nextLevel = getNextQualityLevel(definition, level);
+  const tracks = getQualityTracks(definition);
+  const progress = quality.progress || {};
+
+  if (!nextLevel?.requirements) {
+    return {
+      level,
+      percent: 1,
+      summary: 'Maxed out — production is at peak polish.',
+      nextLevel: null,
+      steps: []
+    };
+  }
+
+  let totalGoal = 0;
+  let totalCurrent = 0;
+  const steps = [];
+
+  Object.entries(nextLevel.requirements).forEach(([key, rawGoal]) => {
+    const goal = Math.max(0, clampNumber(rawGoal));
+    if (goal <= 0) return;
+    const current = Math.max(0, clampNumber(progress?.[key]));
+    const capped = Math.min(current, goal);
+    totalGoal += goal;
+    totalCurrent += capped;
+    const track = tracks?.[key] || {};
+    const label = track.shortLabel || track.label || key;
+    steps.push({
+      key,
+      label,
+      current: capped,
+      goal
+    });
+  });
+
+  const percent = totalGoal > 0 ? Math.min(1, totalCurrent / totalGoal) : 1;
+  const summary = steps.length
+    ? steps.map(step => `${step.current}/${step.goal} ${step.label}`).join(' • ')
+    : 'No requirements — milestone ready to fire.';
+
+  return {
+    level,
+    percent,
+    summary,
+    nextLevel,
+    steps
+  };
+}
+
+function buildActionSnapshot(definition, instance, action, state) {
+  const timeCost = Math.max(0, clampNumber(action.time));
+  const moneyCost = Math.max(0, clampNumber(action.cost));
+  const usage = getQualityActionUsage(definition, instance, action);
+  const availability = getQualityActionAvailability(definition, instance, action, state);
+  const unlocked = Boolean(availability?.unlocked);
+  const canRun = canPerformQualityAction(definition, instance, action, state);
+  let disabledReason = '';
+  const tracks = getQualityTracks(definition);
+  const track = action.progressKey ? tracks?.[action.progressKey] : null;
+  const rawAmount = typeof action.progressAmount === 'function'
+    ? action.progressAmount({ definition, instance })
+    : Number(action.progressAmount);
+  const effectAmount = Number.isFinite(rawAmount) && rawAmount !== 0 ? rawAmount : 1;
+  const effect = track
+    ? `+${effectAmount} ${track.shortLabel || track.label}`
+    : 'Boosts quality momentum';
+
+  if (instance.status !== 'active') {
+    const remaining = Math.max(0, clampNumber(instance.daysRemaining));
+    disabledReason = remaining > 0
+      ? `Launch wraps in ${remaining} day${remaining === 1 ? '' : 's'}`
+      : 'Launch finishing up soon';
+  } else if (!unlocked) {
+    disabledReason = availability?.reason || 'Requires an upgrade first.';
+  } else if (usage.remainingUses <= 0) {
+    disabledReason = 'Daily limit hit — try again tomorrow.';
+  } else if (timeCost > 0 && state.timeLeft < timeCost) {
+    disabledReason = `Need ${formatHours(timeCost)} free.`;
+  } else if (moneyCost > 0 && state.money < moneyCost) {
+    disabledReason = `Need $${formatMoney(moneyCost)} on hand.`;
+  }
+
+  return {
+    id: action.id,
+    label: action.label || 'Quality push',
+    time: timeCost,
+    cost: moneyCost,
+    available: canRun,
+    unlocked,
+    usage,
+    disabledReason,
+    skills: action.skills || [],
+    description: action.description || '',
+    effect
+  };
+}
+
+function calculateAveragePayout(instance, state) {
+  if (!instance || instance.status !== 'active') {
+    return 0;
+  }
+  const totalIncome = Math.max(0, clampNumber(instance.totalIncome));
+  const createdOnDay = Math.max(1, clampNumber(instance.createdOnDay) || 1);
+  const currentDay = Math.max(1, clampNumber(state?.day) || 1);
+  const daysActive = Math.max(1, currentDay - createdOnDay + 1);
+  if (totalIncome <= 0) {
+    return 0;
+  }
+  return totalIncome / daysActive;
+}
+
+function describeStatus(instance, definition) {
+  const status = instance?.status === 'active' ? 'active' : 'setup';
+  if (status === 'active') {
+    return { id: 'active', label: 'Active' };
+  }
+  const totalDays = Math.max(0, clampNumber(definition?.setup?.days));
+  const completed = Math.max(0, clampNumber(instance?.daysCompleted));
+  const progress = totalDays > 0 ? Math.min(1, completed / totalDays) : 0;
+  return {
+    id: 'setup',
+    label: `Setup ${completed}/${totalDays} days`,
+    remaining: Math.max(0, clampNumber(instance?.daysRemaining)),
+    progress
+  };
+}
+
+function estimateLifetimeSpend(definition, instance, state) {
+  const setupCost = Math.max(0, clampNumber(definition?.setup?.cost));
+  const upkeepCost = Math.max(0, clampNumber(definition?.maintenance?.cost));
+  if (upkeepCost <= 0) {
+    return setupCost;
+  }
+  const createdOnDay = Math.max(1, clampNumber(instance?.createdOnDay) || 1);
+  const currentDay = Math.max(1, clampNumber(state?.day) || 1);
+  const elapsedDays = Math.max(0, currentDay - createdOnDay + 1);
+  return setupCost + upkeepCost * elapsedDays;
+}
+
+function buildPayoutBreakdown(instance) {
+  const breakdown = instance?.lastIncomeBreakdown;
+  const entries = ensureArray(breakdown?.entries).map(entry => ({
+    id: entry?.id || entry?.label || 'modifier',
+    label: entry?.label || 'Modifier',
+    amount: Math.max(0, clampNumber(entry?.amount)),
+    percent: Number.isFinite(Number(entry?.percent)) ? Number(entry.percent) : null,
+    type: entry?.type || 'modifier'
+  }));
+  const total = Math.max(0, clampNumber(breakdown?.total || instance?.lastIncome));
+  return { entries, total };
+}
+
+function mapNicheOptions(definition, state) {
+  return ensureArray(getAssignableNicheSummaries(definition, state))
+    .map(entry => ({
+      id: entry?.definition?.id || '',
+      name: entry?.definition?.name || entry?.definition?.id || '',
+      summary: entry?.popularity?.summary || '',
+      label: entry?.popularity?.label || '',
+      multiplier: entry?.popularity?.multiplier || 1,
+      score: clampNumber(entry?.popularity?.score),
+      delta: Number.isFinite(Number(entry?.popularity?.delta))
+        ? Number(entry.popularity.delta)
+        : null
+    }))
+    .filter(option => option.id && option.name);
+}
+
+function computeRoi(lifetimeIncome, lifetimeSpend) {
+  const income = Math.max(0, clampNumber(lifetimeIncome));
+  const spend = Math.max(0, clampNumber(lifetimeSpend));
+  if (spend <= 0) return null;
+  return (income - spend) / spend;
+}
+
+function buildVideoInstances(definition, state) {
+  const assetState = getAssetState('vlog', state) || { instances: [] };
+  const instances = ensureArray(assetState.instances);
+  const actions = getQualityActions(definition);
+  const maintenance = formatMaintenanceSummary(definition);
+  const nicheOptions = mapNicheOptions(definition, state);
+
+  return instances.map((instance, index) => {
+    const fallbackLabel = instanceLabel(definition, index);
+    const customName = typeof instance.customName === 'string' && instance.customName.trim()
+      ? instance.customName.trim()
+      : '';
+    const label = customName || fallbackLabel;
+    const status = describeStatus(instance, definition);
+    const averagePayout = calculateAveragePayout(instance, state);
+    const qualityLevel = Math.max(0, clampNumber(instance?.quality?.level));
+    const qualityInfo = getQualityLevel(definition, qualityLevel);
+    const milestone = buildMilestoneProgress(definition, instance);
+    const qualityRange = getInstanceQualityRange(definition, instance);
+    const payoutBreakdown = buildPayoutBreakdown(instance);
+    const actionSnapshots = actions.map(action => buildActionSnapshot(definition, instance, action, state));
+    const quickAction = actionSnapshots.find(entry => entry.available) || actionSnapshots[0] || null;
+    const nicheInfo = getInstanceNicheInfo(instance, state);
+    const niche = nicheInfo
+      ? {
+          id: nicheInfo.definition?.id || '',
+          name: nicheInfo.definition?.name || nicheInfo.definition?.id || '',
+          summary: nicheInfo.popularity?.summary || '',
+          label: nicheInfo.popularity?.label || '',
+          multiplier: nicheInfo.popularity?.multiplier || 1,
+          score: clampNumber(nicheInfo.popularity?.score),
+          delta: Number.isFinite(Number(nicheInfo.popularity?.delta))
+            ? Number(nicheInfo.popularity.delta)
+            : null
+        }
+      : null;
+
+    const lifetimeIncome = Math.max(0, clampNumber(instance.totalIncome));
+    const lifetimeSpend = estimateLifetimeSpend(definition, instance, state);
+
+    return {
+      id: instance.id,
+      label,
+      fallbackLabel,
+      customName,
+      status,
+      latestPayout: Math.max(0, clampNumber(instance.lastIncome)),
+      averagePayout,
+      lifetimeIncome,
+      lifetimeSpend,
+      roi: computeRoi(lifetimeIncome, lifetimeSpend),
+      estimatedSpend: lifetimeSpend,
+      maintenanceFunded: Boolean(instance.maintenanceFundedToday),
+      pendingIncome: Math.max(0, clampNumber(instance.pendingIncome)),
+      qualityLevel,
+      qualityInfo: qualityInfo || null,
+      qualityRange,
+      milestone,
+      payoutBreakdown,
+      actions: actionSnapshots,
+      quickAction,
+      niche,
+      nicheLocked: Boolean(instance.nicheId),
+      nicheOptions,
+      maintenance,
+      definition,
+      instance
+    };
+  });
+}
+
+function buildSummary(instances = []) {
+  const total = instances.length;
+  const active = instances.filter(entry => entry.status?.id === 'active').length;
+  const setup = total - active;
+  let meta = '';
+  if (active > 0) {
+    meta = `${active} video${active === 1 ? '' : 's'} live`;
+  } else if (setup > 0) {
+    meta = 'Launch prep underway';
+  } else {
+    meta = 'Launch your first video';
+  }
+  return { total, active, setup, meta };
+}
+
+function buildStats(instances = []) {
+  if (!instances.length) {
+    return {
+      lifetime: 0,
+      daily: 0,
+      active: 0,
+      averageQuality: 0,
+      milestonePercent: 0
+    };
+  }
+
+  const lifetime = instances.reduce((sum, entry) => sum + (Number(entry.lifetimeIncome) || 0), 0);
+  const daily = instances.reduce((sum, entry) => sum + (Number(entry.latestPayout) || 0), 0);
+  const active = instances.filter(entry => entry.status?.id === 'active').length;
+  const milestonePercent = instances.reduce((sum, entry) => sum + (Number(entry.milestone?.percent) || 0), 0) / instances.length;
+  const maxLevel = instances.reduce((max, entry) => Math.max(max, Number(entry.definition?.quality?.levels?.length || 6) - 1), 0);
+  const avgQualityRaw = instances.reduce((sum, entry) => sum + (Number(entry.qualityLevel) || 0), 0) / instances.length;
+  const averageQuality = maxLevel > 0 ? Math.min(1, avgQualityRaw / maxLevel) : 0;
+
+  return {
+    lifetime,
+    daily,
+    active,
+    averageQuality,
+    milestonePercent
+  };
+}
+
+function buildAnalytics(instances = []) {
+  const byVideo = instances
+    .map(entry => ({
+      id: entry.id,
+      label: entry.label,
+      lifetime: entry.lifetimeIncome,
+      latest: entry.latestPayout,
+      average: entry.averagePayout,
+      roi: entry.roi,
+      niche: entry.niche?.name || 'No niche',
+      quality: entry.qualityLevel
+    }))
+    .sort((a, b) => b.lifetime - a.lifetime);
+
+  const nicheMap = new Map();
+  byVideo.forEach(entry => {
+    const key = entry.niche || 'No niche';
+    const existing = nicheMap.get(key) || { niche: key, lifetime: 0, daily: 0 };
+    existing.lifetime += entry.lifetime;
+    existing.daily += entry.latest;
+    nicheMap.set(key, existing);
+  });
+
+  return {
+    videos: byVideo,
+    niches: Array.from(nicheMap.values()).sort((a, b) => b.lifetime - a.lifetime)
+  };
+}
+
+function startVideoInstance(definition, options = {}, state = getState()) {
+  if (!definition?.action?.onClick) return null;
+  const before = new Set(
+    ensureArray(getAssetState('vlog', state)?.instances).map(instance => instance?.id).filter(Boolean)
+  );
+
+  definition.action.onClick();
+
+  const assetState = getAssetState('vlog');
+  const afterInstances = ensureArray(assetState?.instances);
+  const newInstance = afterInstances.find(instance => instance && !before.has(instance.id));
+  if (!newInstance) {
+    return null;
+  }
+
+  const name = typeof options.name === 'string' ? options.name.trim() : '';
+  if (name) {
+    setAssetInstanceName('vlog', newInstance.id, name);
+  }
+  if (options.nicheId) {
+    assignInstanceToNiche('vlog', newInstance.id, options.nicheId);
+  }
+
+  return newInstance.id;
+}
+
+export default function buildVideoTubeModel(assetDefinitions = [], state = getState()) {
+  const definition = ensureArray(assetDefinitions).find(entry => entry?.id === 'vlog') || null;
+  if (!definition) {
+    return {
+      definition: null,
+      instances: [],
+      summary: { total: 0, active: 0, setup: 0, meta: 'VideoTube locked' },
+      stats: { lifetime: 0, daily: 0, active: 0, averageQuality: 0, milestonePercent: 0 },
+      analytics: { videos: [], niches: [] },
+      launch: null
+    };
+  }
+
+  const instances = buildVideoInstances(definition, state);
+  const summary = buildSummary(instances);
+  const stats = buildStats(instances);
+  const analytics = buildAnalytics(instances);
+  const availability = describeAssetLaunchAvailability(definition, state);
+  const launchAction = definition.action || null;
+  const defaultName = `Video #${instances.length + 1}`;
+  const nicheOptions = mapNicheOptions(definition, state);
+
+  const launch = launchAction
+    ? {
+        label: typeof launchAction.label === 'function' ? launchAction.label(state) : launchAction.label,
+        disabled: typeof launchAction.disabled === 'function'
+          ? launchAction.disabled(state)
+          : Boolean(launchAction.disabled),
+        availability,
+        setup: definition.setup || {},
+        maintenance: definition.maintenance || {},
+        defaultName,
+        nicheOptions,
+        create: options => startVideoInstance(definition, options, state)
+      }
+    : {
+        label: 'Launch Video',
+        disabled: availability.disabled,
+        availability,
+        setup: definition.setup || {},
+        maintenance: definition.maintenance || {},
+        defaultName,
+        nicheOptions,
+        create: () => null
+      };
+
+  return {
+    definition,
+    instances,
+    summary,
+    stats,
+    analytics,
+    launch
+  };
+}
+
+export function selectNiche(assetId, instanceId, nicheId) {
+  return assignInstanceToNiche(assetId, instanceId, nicheId);
+}

--- a/src/ui/views/browser/cardsPresenter.js
+++ b/src/ui/views/browser/cardsPresenter.js
@@ -4,6 +4,7 @@ import { SERVICE_PAGES } from './config.js';
 import { buildFinanceModel } from '../../cards/model/index.js';
 import { createStat, formatRoi } from './components/widgets.js';
 import blogpressApp from './components/blogpress.js';
+import videotubeApp from './components/videotube.js';
 import learnlyApp from './components/learnly.js';
 import shopstackApp from './components/shopstack.js';
 
@@ -343,6 +344,28 @@ function renderAssetsPage(definitions = [], models = {}) {
     id: page.id,
     meta: activeCount > 0 ? `${activeCount} active venture${activeCount === 1 ? '' : 's'}` : 'No active ventures yet'
   };
+}
+
+function renderVideoTubePage(definitions = [], model = {}) {
+  const page = SERVICE_PAGES.find(entry => entry.type === 'videotube');
+  if (!page) return null;
+
+  const refs = ensurePageContent(page, ({ body }) => {
+    if (!body.querySelector('[data-role="videotube-root"]')) {
+      body.innerHTML = '';
+      const wrapper = document.createElement('div');
+      wrapper.dataset.role = 'videotube-root';
+      body.appendChild(wrapper);
+    }
+  });
+  if (!refs) return null;
+
+  const mount = refs.body.querySelector('[data-role="videotube-root"]');
+  if (!mount) return null;
+
+  const summary = videotubeApp.render(model, { mount, page, definitions });
+  const meta = summary?.meta || model?.summary?.meta || 'Launch your first video';
+  return { id: page.id, meta };
 }
 
 function renderBlogpressPage(definitions = [], model = {}) {
@@ -1068,6 +1091,8 @@ function renderServices(registries = {}, models = {}) {
   if (hustleSummary) summaries.push(hustleSummary);
   const assetSummary = renderAssetsPage(registries.assets, models.assets);
   if (assetSummary) summaries.push(assetSummary);
+  const videotubeSummary = renderVideoTubePage(registries.assets, models.videotube);
+  if (videotubeSummary) summaries.push(videotubeSummary);
   const blogpressSummary = renderBlogpressPage(registries.assets, models.blogpress);
   if (blogpressSummary) summaries.push(blogpressSummary);
   const upgradeSummary = renderUpgradesPage(registries.upgrades, models.upgrades);

--- a/src/ui/views/browser/components/videotube.js
+++ b/src/ui/views/browser/components/videotube.js
@@ -1,0 +1,776 @@
+import { formatHours, formatMoney } from '../../../../core/helpers.js';
+import { performQualityAction } from '../../../../game/assets/index.js';
+import { setAssetInstanceName } from '../../../../game/assets/helpers.js';
+import { selectVideoTubeNiche } from '../../../cards/model/index.js';
+
+const VIEW_DASHBOARD = 'dashboard';
+const VIEW_DETAIL = 'detail';
+const VIEW_CREATE = 'create';
+const VIEW_ANALYTICS = 'analytics';
+
+let currentState = {
+  view: VIEW_DASHBOARD,
+  selectedVideoId: null
+};
+let currentModel = {
+  definition: null,
+  instances: [],
+  summary: {},
+  stats: {},
+  analytics: {},
+  launch: null
+};
+let currentMount = null;
+let currentPageMeta = null;
+
+function formatCurrency(amount) {
+  return `$${formatMoney(Math.max(0, Math.round(Number(amount) || 0)))}`;
+}
+
+function formatPercent(value) {
+  const numeric = Math.max(0, Math.min(1, Number(value) || 0));
+  return `${Math.round(numeric * 100)}%`;
+}
+
+function ensureSelectedVideo() {
+  const instances = Array.isArray(currentModel.instances) ? currentModel.instances : [];
+  if (!instances.length) {
+    currentState.selectedVideoId = null;
+    if (currentState.view === VIEW_DETAIL) {
+      currentState.view = VIEW_DASHBOARD;
+    }
+    return;
+  }
+  const active = instances.find(entry => entry.status?.id === 'active');
+  const fallback = instances[0];
+  const target = instances.find(entry => entry.id === currentState.selectedVideoId);
+  currentState.selectedVideoId = (target || active || fallback)?.id || fallback.id;
+}
+
+function setView(view, options = {}) {
+  const nextView = view || VIEW_DASHBOARD;
+  if (nextView === VIEW_DETAIL && options.videoId) {
+    currentState.selectedVideoId = options.videoId;
+  }
+  currentState.view = nextView;
+  ensureSelectedVideo();
+  render(currentModel, { mount: currentMount, page: currentPageMeta });
+}
+
+function handleQuickAction(instanceId, actionId) {
+  if (!instanceId || !actionId) return;
+  performQualityAction('vlog', instanceId, actionId);
+}
+
+function handleNicheSelect(instanceId, value) {
+  if (!instanceId) return;
+  selectVideoTubeNiche('vlog', instanceId, value);
+}
+
+function handleRename(instanceId, value) {
+  if (!instanceId) return;
+  setAssetInstanceName('vlog', instanceId, value || '');
+}
+
+function createNavButton(label, view) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'videotube-tab';
+  button.dataset.view = view;
+  button.textContent = label;
+  button.addEventListener('click', () => {
+    setView(view);
+  });
+  return button;
+}
+
+function renderHeader(model) {
+  const header = document.createElement('header');
+  header.className = 'videotube__header';
+
+  const title = document.createElement('div');
+  title.className = 'videotube__title';
+  const heading = document.createElement('h1');
+  heading.textContent = 'VideoTube Studio';
+  const note = document.createElement('p');
+  note.textContent = 'Manage uploads, hype premieres, and celebrate every payout.';
+  title.append(heading, note);
+
+  const nav = document.createElement('nav');
+  nav.className = 'videotube-tabs';
+  nav.append(
+    createNavButton('Dashboard', VIEW_DASHBOARD),
+    createNavButton('Video Details', VIEW_DETAIL),
+    createNavButton('Channel Analytics', VIEW_ANALYTICS)
+  );
+
+  const actions = document.createElement('div');
+  actions.className = 'videotube__actions';
+  const launchButton = document.createElement('button');
+  launchButton.type = 'button';
+  launchButton.className = 'videotube-button videotube-button--primary';
+  launchButton.textContent = 'Create New Video';
+  launchButton.addEventListener('click', () => setView(VIEW_CREATE));
+  actions.appendChild(launchButton);
+
+  header.append(title, nav, actions);
+  return header;
+}
+
+function renderStatsBar(model) {
+  const stats = model.stats || {};
+  const bar = document.createElement('div');
+  bar.className = 'videotube-stats';
+
+  const lifetime = document.createElement('article');
+  lifetime.className = 'videotube-stats__card';
+  lifetime.innerHTML = `<span>Total earned</span><strong>${formatCurrency(stats.lifetime)}</strong>`;
+
+  const daily = document.createElement('article');
+  daily.className = 'videotube-stats__card';
+  daily.innerHTML = `<span>Daily payout</span><strong>${formatCurrency(stats.daily)}</strong>`;
+
+  const active = document.createElement('article');
+  active.className = 'videotube-stats__card';
+  active.innerHTML = `<span>Active uploads</span><strong>${stats.active || 0}</strong>`;
+
+  const momentum = document.createElement('article');
+  momentum.className = 'videotube-stats__card';
+  momentum.innerHTML = `<span>Milestone progress</span><strong>${formatPercent(stats.milestonePercent)}</strong>`;
+
+  bar.append(lifetime, daily, active, momentum);
+  return bar;
+}
+
+function renderQualityCell(video) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'videotube-quality';
+
+  const level = document.createElement('span');
+  level.className = 'videotube-quality__level';
+  level.textContent = `Q${video.qualityLevel}`;
+
+  const bar = document.createElement('div');
+  bar.className = 'videotube-quality__bar';
+  const fill = document.createElement('div');
+  fill.className = 'videotube-quality__fill';
+  fill.style.setProperty('--videotube-quality', String((video.milestone?.percent || 0) * 100));
+  bar.appendChild(fill);
+
+  const summary = document.createElement('span');
+  summary.className = 'videotube-quality__summary';
+  summary.textContent = video.milestone?.summary || 'No milestone data yet';
+
+  wrapper.append(level, bar, summary);
+  return wrapper;
+}
+
+function renderNicheBadge(video) {
+  const badge = document.createElement('span');
+  badge.className = 'videotube-niche';
+  if (video.niche) {
+    badge.textContent = video.niche.name;
+    badge.dataset.tone = video.niche.label?.toLowerCase() || 'steady';
+    if (video.niche.label) {
+      badge.title = `${video.niche.label} • ${video.niche.summary}`;
+    }
+  } else {
+    badge.textContent = 'No niche yet';
+    badge.dataset.tone = 'idle';
+  }
+  return badge;
+}
+
+function renderDashboardTable(model) {
+  const instances = Array.isArray(model.instances) ? model.instances : [];
+  const table = document.createElement('table');
+  table.className = 'videotube-table';
+
+  const thead = document.createElement('thead');
+  const headRow = document.createElement('tr');
+  ['Video', 'Latest payout', 'Lifetime', 'Quality', 'Niche', 'Quick action'].forEach(label => {
+    const th = document.createElement('th');
+    th.textContent = label;
+    headRow.appendChild(th);
+  });
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+  instances.forEach(video => {
+    const row = document.createElement('tr');
+    row.dataset.videoId = video.id;
+    if (video.id === currentState.selectedVideoId) {
+      row.classList.add('is-selected');
+    }
+
+    row.addEventListener('click', () => {
+      setView(VIEW_DETAIL, { videoId: video.id });
+    });
+
+    const nameCell = document.createElement('td');
+    nameCell.className = 'videotube-table__cell--label';
+    const name = document.createElement('strong');
+    name.textContent = video.label;
+    const status = document.createElement('span');
+    status.className = 'videotube-status';
+    status.textContent = video.status?.label || '';
+    nameCell.append(name, status);
+
+    const latestCell = document.createElement('td');
+    latestCell.textContent = formatCurrency(video.latestPayout);
+
+    const lifetimeCell = document.createElement('td');
+    lifetimeCell.textContent = formatCurrency(video.lifetimeIncome);
+
+    const qualityCell = document.createElement('td');
+    qualityCell.appendChild(renderQualityCell(video));
+
+    const nicheCell = document.createElement('td');
+    nicheCell.appendChild(renderNicheBadge(video));
+
+    const actionCell = document.createElement('td');
+    actionCell.className = 'videotube-table__cell--actions';
+    if (video.quickAction) {
+      const actionButton = document.createElement('button');
+      actionButton.type = 'button';
+      actionButton.className = 'videotube-button videotube-button--ghost';
+      actionButton.textContent = video.quickAction.label;
+      actionButton.disabled = !video.quickAction.available;
+      actionButton.title = video.quickAction.available
+        ? `${video.quickAction.effect} • ${formatHours(video.quickAction.time)} • ${formatCurrency(video.quickAction.cost)}`
+        : video.quickAction.disabledReason || 'Locked';
+      actionButton.addEventListener('click', event => {
+        event.stopPropagation();
+        if (actionButton.disabled) return;
+        handleQuickAction(video.id, video.quickAction.id);
+      });
+      actionCell.appendChild(actionButton);
+    } else {
+      actionCell.textContent = 'No actions';
+    }
+
+    row.append(nameCell, latestCell, lifetimeCell, qualityCell, nicheCell, actionCell);
+    tbody.appendChild(row);
+  });
+
+  if (!tbody.children.length) {
+    const emptyRow = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 6;
+    cell.className = 'videotube-table__empty';
+    cell.textContent = 'No videos yet. Launch your first upload to start cashing in.';
+    emptyRow.appendChild(cell);
+    tbody.appendChild(emptyRow);
+  }
+
+  table.appendChild(tbody);
+  return table;
+}
+
+function renderDashboardView(model) {
+  const container = document.createElement('section');
+  container.className = 'videotube-view videotube-view--dashboard';
+  container.appendChild(renderStatsBar(model));
+  container.appendChild(renderDashboardTable(model));
+  return container;
+}
+
+function renderNicheSection(video) {
+  const panel = document.createElement('section');
+  panel.className = 'videotube-panel';
+  const title = document.createElement('h3');
+  title.textContent = 'Niche focus';
+  panel.appendChild(title);
+
+  if (video.nicheLocked && video.niche) {
+    const badge = renderNicheBadge(video);
+    badge.classList.add('videotube-niche--large');
+    panel.appendChild(badge);
+    const summary = document.createElement('p');
+    summary.className = 'videotube-panel__note';
+    summary.textContent = `${video.niche.label || 'Steady'} demand • ${video.niche.summary}`;
+    panel.appendChild(summary);
+  } else {
+    const description = document.createElement('p');
+    description.className = 'videotube-panel__note';
+    description.textContent = 'Lock a niche once to boost payouts. Choose wisely — it sticks after launch!';
+    panel.appendChild(description);
+
+    const field = document.createElement('label');
+    field.className = 'videotube-field';
+    field.textContent = 'Select niche';
+    const select = document.createElement('select');
+    select.className = 'videotube-select';
+    const emptyOption = document.createElement('option');
+    emptyOption.value = '';
+    emptyOption.textContent = 'Pick a niche';
+    select.appendChild(emptyOption);
+    video.nicheOptions.forEach(option => {
+      const opt = document.createElement('option');
+      opt.value = option.id;
+      opt.textContent = `${option.name} • ${option.label || ''}`.trim();
+      opt.title = option.summary || '';
+      select.appendChild(opt);
+    });
+    select.addEventListener('change', () => {
+      if (!select.value) return;
+      handleNicheSelect(video.id, select.value);
+    });
+    field.appendChild(select);
+    panel.appendChild(field);
+  }
+
+  return panel;
+}
+
+function renderRenameForm(video) {
+  const form = document.createElement('form');
+  form.className = 'videotube-rename';
+  form.addEventListener('submit', event => {
+    event.preventDefault();
+    const input = form.querySelector('input');
+    handleRename(video.id, input.value);
+  });
+
+  const label = document.createElement('label');
+  label.textContent = 'Video title';
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.maxLength = 60;
+  input.className = 'videotube-input';
+  input.placeholder = video.fallbackLabel;
+  input.value = video.customName || '';
+
+  const submit = document.createElement('button');
+  submit.type = 'submit';
+  submit.className = 'videotube-button videotube-button--secondary';
+  submit.textContent = 'Save title';
+
+  form.append(label, input, submit);
+  return form;
+}
+
+function renderVideoStats(video) {
+  const stats = document.createElement('dl');
+  stats.className = 'videotube-stats-grid';
+
+  const entries = [
+    { label: 'Latest payout', value: formatCurrency(video.latestPayout) },
+    { label: 'Daily average', value: formatCurrency(video.averagePayout) },
+    { label: 'Lifetime earned', value: formatCurrency(video.lifetimeIncome) },
+    {
+      label: 'ROI',
+      value:
+        typeof video.roi === 'number'
+          ? `${video.roi >= 0 ? '+' : ''}${Math.round(video.roi * 100)}%`
+          : 'N/A'
+    }
+  ];
+
+  entries.forEach(entry => {
+    const dt = document.createElement('dt');
+    dt.textContent = entry.label;
+    const dd = document.createElement('dd');
+    dd.textContent = entry.value;
+    stats.append(dt, dd);
+  });
+
+  return stats;
+}
+
+function renderQualityPanel(video) {
+  const panel = document.createElement('section');
+  panel.className = 'videotube-panel';
+  const title = document.createElement('h3');
+  title.textContent = 'Quality momentum';
+  panel.appendChild(title);
+
+  const level = document.createElement('p');
+  level.className = 'videotube-panel__lead';
+  level.textContent = `Quality ${video.qualityLevel} • ${video.qualityInfo?.name || 'Growing audience'}`;
+  panel.appendChild(level);
+
+  const progress = document.createElement('div');
+  progress.className = 'videotube-progress';
+  const progressFill = document.createElement('div');
+  progressFill.className = 'videotube-progress__fill';
+  progressFill.style.setProperty('--videotube-progress', String((video.milestone?.percent || 0) * 100));
+  progress.appendChild(progressFill);
+  panel.appendChild(progress);
+
+  if (video.milestone?.summary) {
+    const summary = document.createElement('p');
+    summary.className = 'videotube-panel__note';
+    summary.textContent = `${video.milestone.summary} • next: ${video.milestone?.nextLevel?.name || 'Maxed out'}`;
+    panel.appendChild(summary);
+  }
+
+  if (video.milestone?.steps?.length) {
+    const list = document.createElement('ul');
+    list.className = 'videotube-list';
+    video.milestone.steps.forEach(step => {
+      const item = document.createElement('li');
+      item.textContent = `${step.current}/${step.goal} ${step.label}`;
+      list.appendChild(item);
+    });
+    panel.appendChild(list);
+  }
+
+  return panel;
+}
+
+function renderPayoutPanel(video) {
+  const panel = document.createElement('section');
+  panel.className = 'videotube-panel';
+  const title = document.createElement('h3');
+  title.textContent = 'Latest payout breakdown';
+  panel.appendChild(title);
+
+  if (!video.payoutBreakdown?.entries?.length) {
+    const empty = document.createElement('p');
+    empty.className = 'videotube-panel__note';
+    empty.textContent = 'No payout history yet — run a day to gather data.';
+    panel.appendChild(empty);
+    return panel;
+  }
+
+  const total = document.createElement('p');
+  total.className = 'videotube-panel__lead';
+  total.textContent = `Total ${formatCurrency(video.payoutBreakdown.total)}`;
+  panel.appendChild(total);
+
+  const list = document.createElement('ul');
+  list.className = 'videotube-list videotube-list--payout';
+  video.payoutBreakdown.entries.forEach(entry => {
+    const item = document.createElement('li');
+    const label = document.createElement('span');
+    label.textContent = entry.label;
+    const value = document.createElement('span');
+    value.textContent = `${entry.percent ? `${Math.round(entry.percent * 100)}% • ` : ''}${formatCurrency(entry.amount)}`;
+    item.append(label, value);
+    list.appendChild(item);
+  });
+  panel.appendChild(list);
+
+  return panel;
+}
+
+function renderActionsPanel(video) {
+  const panel = document.createElement('section');
+  panel.className = 'videotube-panel';
+  const title = document.createElement('h3');
+  title.textContent = 'Quality actions';
+  panel.appendChild(title);
+
+  if (!Array.isArray(video.actions) || !video.actions.length) {
+    const empty = document.createElement('p');
+    empty.className = 'videotube-panel__note';
+    empty.textContent = 'No actions unlocked yet. Discover upgrades to expand your toolkit.';
+    panel.appendChild(empty);
+    return panel;
+  }
+
+  const list = document.createElement('ul');
+  list.className = 'videotube-action-list';
+
+  video.actions.forEach(action => {
+    const item = document.createElement('li');
+    item.className = 'videotube-action';
+
+    const label = document.createElement('div');
+    label.className = 'videotube-action__label';
+    label.textContent = action.label;
+
+    const meta = document.createElement('div');
+    meta.className = 'videotube-action__meta';
+    const costParts = [
+      action.time > 0 ? `${formatHours(action.time)}` : 'Instant',
+      action.cost > 0 ? formatCurrency(action.cost) : 'Free'
+    ];
+    meta.textContent = `${action.effect} • ${costParts.join(' • ')}`;
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'videotube-button videotube-button--primary';
+    button.textContent = 'Run action';
+    button.disabled = !action.available;
+    button.title = action.available ? '' : action.disabledReason || 'Unavailable';
+    button.addEventListener('click', () => {
+      if (button.disabled) return;
+      handleQuickAction(video.id, action.id);
+    });
+
+    item.append(label, meta, button);
+    list.appendChild(item);
+  });
+
+  panel.appendChild(list);
+  return panel;
+}
+
+function renderDetailView(model) {
+  const container = document.createElement('section');
+  container.className = 'videotube-view videotube-view--detail';
+
+  const instances = Array.isArray(model.instances) ? model.instances : [];
+  const video = instances.find(entry => entry.id === currentState.selectedVideoId);
+  if (!video) {
+    const empty = document.createElement('p');
+    empty.className = 'videotube-empty';
+    empty.textContent = 'Select a video from the dashboard to inspect analytics.';
+    container.appendChild(empty);
+    return container;
+  }
+
+  const header = document.createElement('div');
+  header.className = 'videotube-detail__header';
+  const title = document.createElement('h2');
+  title.textContent = video.label;
+  header.appendChild(title);
+  header.appendChild(renderRenameForm(video));
+  container.appendChild(header);
+
+  container.appendChild(renderVideoStats(video));
+
+  const grid = document.createElement('div');
+  grid.className = 'videotube-detail-grid';
+  grid.append(
+    renderQualityPanel(video),
+    renderPayoutPanel(video),
+    renderActionsPanel(video),
+    renderNicheSection(video)
+  );
+  container.appendChild(grid);
+
+  return container;
+}
+
+function renderCreateView(model) {
+  const container = document.createElement('section');
+  container.className = 'videotube-view videotube-view--create';
+
+  const card = document.createElement('article');
+  card.className = 'videotube-create';
+
+  const title = document.createElement('h2');
+  title.textContent = 'Spin up a new video';
+  card.appendChild(title);
+
+  const launch = model.launch || {};
+  const setup = launch.setup || {};
+  const maintenance = launch.maintenance || {};
+
+  const summary = document.createElement('p');
+  summary.className = 'videotube-panel__note';
+  summary.textContent = `${setup.days || 0} day launch • ${formatHours(setup.hoursPerDay || 0)} each day • ${formatCurrency(setup.cost || 0)} upfront.`;
+  card.appendChild(summary);
+
+  const upkeep = document.createElement('p');
+  upkeep.className = 'videotube-panel__note';
+  upkeep.textContent = `Upkeep: ${formatHours(maintenance.hours || 0)} • ${formatCurrency(maintenance.cost || 0)} daily`;
+  card.appendChild(upkeep);
+
+  const form = document.createElement('form');
+  form.className = 'videotube-create__form';
+  form.addEventListener('submit', event => {
+    event.preventDefault();
+    if (!launch.create) return;
+    const nameInput = form.querySelector('[name="video-name"]');
+    const nicheInput = form.querySelector('[name="video-niche"]');
+    const newId = launch.create({
+      name: nameInput.value || launch.defaultName,
+      nicheId: nicheInput.value || null
+    });
+    if (newId) {
+      currentState.selectedVideoId = newId;
+      setView(VIEW_DETAIL, { videoId: newId });
+    }
+  });
+
+  const nameField = document.createElement('label');
+  nameField.className = 'videotube-field';
+  nameField.textContent = 'Video title';
+  const nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameInput.name = 'video-name';
+  nameInput.maxLength = 60;
+  nameInput.className = 'videotube-input';
+  nameInput.value = launch.defaultName || '';
+  nameField.appendChild(nameInput);
+  form.appendChild(nameField);
+
+  const nicheField = document.createElement('label');
+  nicheField.className = 'videotube-field';
+  nicheField.textContent = 'Pick a niche';
+  const nicheSelect = document.createElement('select');
+  nicheSelect.name = 'video-niche';
+  nicheSelect.className = 'videotube-select';
+  const blank = document.createElement('option');
+  blank.value = '';
+  blank.textContent = 'No niche yet';
+  nicheSelect.appendChild(blank);
+  (launch.nicheOptions || []).forEach(option => {
+    const opt = document.createElement('option');
+    opt.value = option.id;
+    opt.textContent = `${option.name} • ${option.label || ''}`.trim();
+    nicheSelect.appendChild(opt);
+  });
+  nicheField.appendChild(nicheSelect);
+  form.appendChild(nicheField);
+
+  const submit = document.createElement('button');
+  submit.type = 'submit';
+  submit.className = 'videotube-button videotube-button--primary';
+  submit.textContent = launch.label || 'Launch video';
+  submit.disabled = launch.disabled || launch.availability?.disabled;
+  form.appendChild(submit);
+
+  if (launch.availability?.reasons?.length) {
+    const list = document.createElement('ul');
+    list.className = 'videotube-requirements';
+    launch.availability.reasons.forEach(reason => {
+      const item = document.createElement('li');
+      item.textContent = reason;
+      list.appendChild(item);
+    });
+    card.appendChild(list);
+  }
+
+  card.appendChild(form);
+
+  const hint = document.createElement('p');
+  hint.className = 'videotube-panel__hint';
+  hint.textContent = 'Costs pull instantly. Niche locks after launch, so preview heat before committing!';
+  card.appendChild(hint);
+
+  container.appendChild(card);
+  return container;
+}
+
+function renderAnalyticsView(model) {
+  const container = document.createElement('section');
+  container.className = 'videotube-view videotube-view--analytics';
+
+  const analytics = model.analytics || { videos: [], niches: [] };
+
+  const grid = document.createElement('div');
+  grid.className = 'videotube-analytics';
+
+  const videoCard = document.createElement('article');
+  videoCard.className = 'videotube-panel';
+  const videoTitle = document.createElement('h3');
+  videoTitle.textContent = 'Top earners';
+  videoCard.appendChild(videoTitle);
+  if (analytics.videos?.length) {
+    const list = document.createElement('ul');
+    list.className = 'videotube-list';
+    analytics.videos.slice(0, 5).forEach(entry => {
+      const item = document.createElement('li');
+      item.innerHTML = `<strong>${entry.label}</strong><span>${formatCurrency(entry.lifetime)} lifetime • ${formatCurrency(entry.latest)} daily</span>`;
+      list.appendChild(item);
+    });
+    videoCard.appendChild(list);
+  } else {
+    const empty = document.createElement('p');
+    empty.className = 'videotube-panel__note';
+    empty.textContent = 'No earning history yet. Launch a video to start tracking analytics.';
+    videoCard.appendChild(empty);
+  }
+
+  const nicheCard = document.createElement('article');
+  nicheCard.className = 'videotube-panel';
+  const nicheTitle = document.createElement('h3');
+  nicheTitle.textContent = 'Niche breakdown';
+  nicheCard.appendChild(nicheTitle);
+  if (analytics.niches?.length) {
+    const list = document.createElement('ul');
+    list.className = 'videotube-list';
+    analytics.niches.slice(0, 5).forEach(entry => {
+      const item = document.createElement('li');
+      item.innerHTML = `<strong>${entry.niche}</strong><span>${formatCurrency(entry.lifetime)} lifetime • ${formatCurrency(entry.daily)} daily</span>`;
+      list.appendChild(item);
+    });
+    nicheCard.appendChild(list);
+  } else {
+    const empty = document.createElement('p');
+    empty.className = 'videotube-panel__note';
+    empty.textContent = 'No niche data yet. Assign niches to start ranking performance.';
+    nicheCard.appendChild(empty);
+  }
+
+  grid.append(videoCard, nicheCard);
+  container.appendChild(grid);
+  return container;
+}
+
+function renderLockedState() {
+  const container = document.createElement('section');
+  container.className = 'videotube-view videotube-view--locked';
+  const message = document.createElement('p');
+  message.className = 'videotube-empty';
+  message.textContent = 'VideoTube unlocks once the Vlog blueprint is discovered.';
+  container.appendChild(message);
+  return container;
+}
+
+function renderCurrentView(model) {
+  switch (currentState.view) {
+    case VIEW_DETAIL:
+      return renderDetailView(model);
+    case VIEW_CREATE:
+      return renderCreateView(model);
+    case VIEW_ANALYTICS:
+      return renderAnalyticsView(model);
+    case VIEW_DASHBOARD:
+    default:
+      return renderDashboardView(model);
+  }
+}
+
+function updateActiveTab(root) {
+  const tabs = root.querySelectorAll('.videotube-tab');
+  tabs.forEach(tab => {
+    if (tab.dataset.view === currentState.view) {
+      tab.classList.add('is-active');
+    } else {
+      tab.classList.remove('is-active');
+    }
+  });
+}
+
+export function render(model = {}, context = {}) {
+  currentModel = model || {};
+  if (context.mount) {
+    currentMount = context.mount;
+  }
+  if (context.page) {
+    currentPageMeta = context.page;
+  }
+  if (!currentMount) {
+    return currentModel.summary || {};
+  }
+
+  if (!currentModel.definition) {
+    currentMount.innerHTML = '';
+    currentMount.appendChild(renderLockedState());
+    return currentModel.summary || {};
+  }
+
+  ensureSelectedVideo();
+
+  currentMount.innerHTML = '';
+  const root = document.createElement('div');
+  root.className = 'videotube';
+  root.appendChild(renderHeader(currentModel));
+  const view = renderCurrentView(currentModel);
+  root.appendChild(view);
+  currentMount.appendChild(root);
+  updateActiveTab(root);
+
+  return currentModel.summary || {};
+}
+
+export default {
+  render
+};

--- a/src/ui/views/browser/config.js
+++ b/src/ui/views/browser/config.js
@@ -26,7 +26,7 @@ export const SERVICE_PAGES = [
     headline: 'VideoTube Venture Studio',
     tagline: 'Schedule drops, review analytics, and amplify fans.',
     icon: '📺',
-    type: 'assets'
+    type: 'videotube'
   },
   {
     id: 'blogpress',

--- a/src/ui/views/browser/config.js
+++ b/src/ui/views/browser/config.js
@@ -20,6 +20,15 @@ export const SERVICE_PAGES = [
     type: 'hustles'
   },
   {
+    id: 'assets',
+    slug: 'assets',
+    label: 'Asset Arcade',
+    headline: 'Asset Arcade Command Deck',
+    tagline: 'Tend ebooks, SaaS, and evergreen earners in one upbeat hub.',
+    icon: '💼',
+    type: 'assets'
+  },
+  {
     id: 'videotube',
     slug: 'videotube',
     label: 'VideoTube',

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -3019,3 +3019,466 @@ a {
     max-height: none;
   }
 }
+
+/* VideoTube styles */
+.videotube {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.videotube__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1.25rem;
+}
+
+.videotube__title h1 {
+  font-size: 1.75rem;
+  margin-bottom: 0.25rem;
+}
+
+.videotube__title p {
+  margin: 0;
+  color: var(--browser-text-subtle);
+}
+
+.videotube-tabs {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.videotube-tab {
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-weight: 600;
+  background: var(--browser-surface-muted);
+  color: var(--browser-text-subtle);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.videotube-tab:hover,
+.videotube-tab:focus-visible {
+  border-color: var(--browser-border-strong);
+  color: var(--browser-text-strong);
+}
+
+.videotube-tab.is-active {
+  background: var(--browser-primary-surface);
+  color: var(--browser-primary-text);
+  border-color: transparent;
+}
+
+.videotube__actions {
+  margin-left: auto;
+}
+
+.videotube-button {
+  border-radius: 0.65rem;
+  padding: 0.55rem 1.1rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.videotube-button--primary {
+  background: var(--browser-primary-surface);
+  color: var(--browser-primary-text);
+  box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.08);
+}
+
+.videotube-button--primary:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 0.5rem 1.2rem rgba(0, 0, 0, 0.1);
+}
+
+.videotube-button--secondary {
+  background: transparent;
+  color: var(--browser-text-strong);
+  border-color: var(--browser-border-strong);
+}
+
+.videotube-button--ghost {
+  background: transparent;
+  color: var(--browser-text-strong);
+  border-color: var(--browser-border-muted);
+}
+
+.videotube-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.videotube-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+.videotube-stats__card {
+  background: var(--browser-surface-muted);
+  border-radius: 1rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.videotube-stats__card span {
+  font-size: 0.8rem;
+  color: var(--browser-text-subtle);
+}
+
+.videotube-stats__card strong {
+  font-size: 1.15rem;
+  color: var(--browser-text-strong);
+}
+
+.videotube-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  background: var(--browser-surface-base);
+  border-radius: 1rem;
+  overflow: hidden;
+}
+
+.videotube-table th,
+.videotube-table td {
+  padding: 0.9rem 1rem;
+  text-align: left;
+}
+
+.videotube-table thead th {
+  background: var(--browser-surface-muted);
+  font-size: 0.85rem;
+  color: var(--browser-text-subtle);
+}
+
+.videotube-table tbody tr {
+  border-bottom: 1px solid var(--browser-border-muted);
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.videotube-table tbody tr:hover {
+  background: var(--browser-surface-muted);
+}
+
+.videotube-table tbody tr.is-selected {
+  background: var(--browser-primary-surface-transparent, rgba(73, 94, 255, 0.08));
+}
+
+.videotube-table__cell--label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.videotube-status {
+  font-size: 0.75rem;
+  color: var(--browser-text-subtle);
+}
+
+.videotube-table__cell--actions {
+  text-align: right;
+}
+
+.videotube-table__empty {
+  text-align: center;
+  padding: 2.5rem 1rem;
+  color: var(--browser-text-subtle);
+}
+
+.videotube-quality {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.videotube-quality__level {
+  font-weight: 700;
+  color: var(--browser-text-strong);
+}
+
+.videotube-quality__bar {
+  position: relative;
+  background: var(--browser-border-muted);
+  height: 0.4rem;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.videotube-quality__fill {
+  position: absolute;
+  inset: 0;
+  width: calc(var(--videotube-quality, 0) * 1%);
+  background: linear-gradient(90deg, var(--browser-primary-surface), var(--browser-accent-surface));
+}
+
+.videotube-quality__summary {
+  font-size: 0.75rem;
+  color: var(--browser-text-subtle);
+}
+
+.videotube-niche {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  background: var(--browser-surface-muted);
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--browser-text-strong);
+}
+
+.videotube-niche[data-tone*='blazing'] {
+  background: rgba(255, 94, 132, 0.15);
+  color: #ff3b6b;
+}
+
+.videotube-niche[data-tone*='surging'],
+.videotube-niche[data-tone*='warm'] {
+  background: rgba(255, 165, 0, 0.15);
+  color: #ff7a00;
+}
+
+.videotube-niche[data-tone*='cool'],
+.videotube-niche[data-tone*='cold'] {
+  background: rgba(66, 153, 225, 0.18);
+  color: #2b6cb0;
+}
+
+.videotube-niche--large {
+  font-size: 1rem;
+}
+
+.videotube-view {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.videotube-panel {
+  background: var(--browser-surface-base);
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.06);
+}
+
+.videotube-panel h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.videotube-panel__lead {
+  font-weight: 600;
+  margin: 0;
+}
+
+.videotube-panel__note,
+.videotube-panel__hint {
+  margin: 0;
+  color: var(--browser-text-subtle);
+  font-size: 0.85rem;
+}
+
+.videotube-panel__hint {
+  font-style: italic;
+}
+
+.videotube-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.videotube-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.85rem;
+}
+
+.videotube-list--payout li {
+  font-variant-numeric: tabular-nums;
+}
+
+.videotube-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.videotube-input,
+.videotube-select {
+  border-radius: 0.65rem;
+  border: 1px solid var(--browser-border-muted);
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
+  background: var(--browser-surface-base);
+  color: var(--browser-text-strong);
+}
+
+.videotube-action-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.videotube-action {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.videotube-action__label {
+  font-weight: 600;
+}
+
+.videotube-action__meta {
+  grid-column: 1 / 2;
+  font-size: 0.8rem;
+  color: var(--browser-text-subtle);
+}
+
+.videotube-progress {
+  position: relative;
+  height: 0.6rem;
+  background: var(--browser-border-muted);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.videotube-progress__fill {
+  position: absolute;
+  inset: 0;
+  width: calc(var(--videotube-progress, 0) * 1%);
+  background: linear-gradient(90deg, var(--browser-primary-surface), var(--browser-accent-surface));
+}
+
+.videotube-detail__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.videotube-detail__header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.videotube-rename {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.videotube-rename label {
+  display: none;
+}
+
+.videotube-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+.videotube-stats-grid dt {
+  font-size: 0.8rem;
+  color: var(--browser-text-subtle);
+}
+
+.videotube-stats-grid dd {
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.videotube-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
+}
+
+.videotube-empty {
+  margin: 0;
+  padding: 2rem;
+  text-align: center;
+  background: var(--browser-surface-muted);
+  border-radius: 1rem;
+  color: var(--browser-text-subtle);
+}
+
+.videotube-create {
+  background: var(--browser-surface-base);
+  border-radius: 1.5rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 14px 48px rgba(15, 23, 42, 0.08);
+}
+
+.videotube-create__form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.videotube-requirements {
+  list-style: disc;
+  margin: 0 0 0 1rem;
+  color: var(--browser-text-subtle);
+  font-size: 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.videotube-analytics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
+}
+
+.videotube-view--locked {
+  align-items: center;
+}
+
+:root[data-browser-theme="night"] .videotube-table thead th {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+:root[data-browser-theme="night"] .videotube-stats__card {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+:root[data-browser-theme="night"] .videotube-table tbody tr:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+:root[data-browser-theme="night"] .videotube-panel {
+  background: rgba(19, 26, 40, 0.85);
+}


### PR DESCRIPTION
## Summary
- add a VideoTube workspace with dashboard, detail, analytics, and creation flows for vlog assets
- support custom vlog naming while wiring the new model and presenter into the browser shell
- style the VideoTube experience and document the feature in the changelog and README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddc4ae6d90832c92b50521c7a00416