### PR TITLE
Ensure browser todo widget lists all upgrade actions

### DIFF
--- a/src/ui/views/browser/dashboardPresenter.js
+++ b/src/ui/views/browser/dashboardPresenter.js
@@ -29,7 +29,8 @@ function createUpgradeTodoEntries(entries = []) {
       durationHours: hours,
       durationText,
       repeatable: Boolean(entry?.repeatable),
-      remainingRuns: entry?.remainingRuns ?? null
+      remainingRuns: entry?.remainingRuns ?? null,
+      ignoreAvailableHours: true
     };
   });
 }

--- a/src/ui/views/browser/widgets/todoWidget.js
+++ b/src/ui/views/browser/widgets/todoWidget.js
@@ -116,6 +116,7 @@ function normalizeEntries(model = {}) {
       const hasRemaining = Number.isFinite(rawRemaining);
       const remainingRuns = hasRemaining ? Math.max(0, rawRemaining) : null;
       const repeatable = Boolean(entry?.repeatable) || (hasRemaining && remainingRuns > 1);
+      const ignoreAvailableHours = entry?.ignoreAvailableHours === true;
       return {
         id,
         title: entry?.title || 'Action',
@@ -124,7 +125,8 @@ function normalizeEntries(model = {}) {
         durationHours: normalizedDuration,
         durationText,
         repeatable,
-        remainingRuns
+        remainingRuns,
+        ignoreAvailableHours
       };
     })
     .filter(entry => Boolean(entry?.id));
@@ -371,9 +373,11 @@ export function render(model = {}) {
     const hasRunsLeft = remainingRuns === null || remainingRuns > 0;
     if (!hasRunsLeft) return false;
 
-    const canAfford = Number.isFinite(availableHours)
-      ? entry.durationHours <= availableHours
-      : true;
+    const enforceHours = entry.ignoreAvailableHours !== true;
+    let canAfford = true;
+    if (enforceHours && Number.isFinite(availableHours)) {
+      canAfford = entry.durationHours <= availableHours;
+    }
     if (!canAfford) return false;
 
     if (!completion) return true;


### PR DESCRIPTION
## Summary
- mark asset upgrade entries to ignore hour availability when composing the browser todo widget
- carry the ignore flag through todo normalization so upgrade tasks remain visible even when hours are low

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddcef73868832cafd5b6c5a5ce4541