### PR TITLE
Unify browser ToDo widget task sources

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,7 @@
 - BankApp’s finance dashboard now pipes every tracked dataset—obligations, pending payouts, asset ROI tables, opportunity queues, and education commitments—into the in-app layout so the browser view matches the classic shell’s depth.
 - ShopStack storefront replaces the legacy upgrades tab with a full browser app featuring category filters, product detail pages, and a My Purchases hub while reusing the original upgrade logic.
 - Retired the debug action catalog and command palette overlays to streamline the shell and remove unused maintenance paths.
-- Browser homepage ToDo widget merges quick actions and upgrade suggestions into a scrollable list so every pending move stays visible.
+- Browser homepage ToDo widget now unifies quick actions, upgrade prompts, and enrollable study tracks in a single filtered checklist so only affordable moves surface.
 - Learnly graduates into a dedicated browser app with a course catalog, detail pages, My Courses hub, and pricing FAQ while reusing the existing education systems.
 - BlogPress brings the Personal Blog management flow into the browser shell with a table overview, detail inspector, pricing page, and one-click quality actions while reusing the existing passive-income logic.
 - VideoTube graduates the vlog asset tools into a studio-style browser app with a channel dashboard, analytics view, niche selection, and launch workflow that reuse the existing vlog economy.

--- a/docs/features/browser-home-redesign.md
+++ b/docs/features/browser-home-redesign.md
@@ -10,10 +10,10 @@
 - Widget cards reuse the existing presenter modules and simply stretch to fill each grid cell. Cards share a consistent padding, border radius, and drop shadow defined in `styles/browser.css` so they feel like a matched set.
 - The apps widget reuses the existing `appsWidget` module. It now renders each workspace as a tile button with an icon, label, and optional status badge derived from the service summary metadata.
 - Navigation highlighting looks for `[data-role="browser-app-launcher"]` containers in addition to the legacy sidebar list so active pages still pulse even without the sidebar.
-- The ToDo widget now merges quick actions and asset upgrade recommendations, keeping their time costs in sync with the action queue. The list sits inside a scrollable pane so every pending task stays accessible without stretching the rest of the grid.
+- The ToDo widget now aggregates quick actions, asset upgrade recommendations, and enrollable study tracks into a single scrollable list. Tasks validate hour and cash requirements before rendering so the queue always reflects moves you can take right now.
 
 ## Player Impact
 - Players can scan the day's plan, finances, and workspace launchers at a glance without juggling two columns.
 - The tile launcher mirrors a mobile home screen, making it faster to spot ready actions or idle tabs from the status badges.
 - Responsive breakpoints ensure the layout remains legible on narrow QA windows while keeping the three-up structure on desktop.
-- Combining upgrades with quick actions in the ToDo queue helps players chain momentum moves back-to-back, and the scroll affordance means long task lists no longer crowd out neighboring widgets.
+- Combining upgrades, hustles, and study enrollments in the ToDo queue helps players chain momentum moves back-to-back. Affordability checks keep impossible options hidden while the scroll affordance means long task lists no longer crowd out neighboring widgets.

--- a/src/ui/views/browser/dashboardPresenter.js
+++ b/src/ui/views/browser/dashboardPresenter.js
@@ -20,6 +20,7 @@ function createUpgradeTodoEntries(entries = []) {
   return list.map((entry, index) => {
     const hours = Math.max(0, toNumber(entry?.durationHours, toNumber(entry?.timeCost)));
     const durationText = entry?.durationText || formatHours(hours);
+    const moneyCost = Math.max(0, toNumber(entry?.moneyCost));
     const metaParts = [entry?.subtitle, entry?.meta].filter(Boolean);
     return {
       id: entry?.id || `upgrade-${index}`,
@@ -28,27 +29,51 @@ function createUpgradeTodoEntries(entries = []) {
       onClick: typeof entry?.onClick === 'function' ? entry.onClick : null,
       durationHours: hours,
       durationText,
+      moneyCost,
       repeatable: Boolean(entry?.repeatable),
       remainingRuns: entry?.remainingRuns ?? null
     };
   });
 }
 
-function composeTodoModel(quickActions = {}, assetActions = {}) {
+function createEnrollmentTodoEntries(entries = []) {
+  const list = Array.isArray(entries) ? entries.filter(Boolean) : [];
+  return list.map((entry, index) => {
+    const hours = Math.max(0, toNumber(entry?.durationHours, toNumber(entry?.timeCost)));
+    const durationText = entry?.durationText || formatHours(hours);
+    const moneyCost = Math.max(0, toNumber(entry?.moneyCost));
+    const metaParts = [entry?.subtitle, entry?.meta].filter(Boolean);
+    return {
+      id: entry?.id || `study-${index}`,
+      title: entry?.title || 'Study Track',
+      meta: metaParts.join(' • '),
+      onClick: typeof entry?.onClick === 'function' ? entry.onClick : null,
+      durationHours: hours,
+      durationText,
+      moneyCost,
+      repeatable: Boolean(entry?.repeatable),
+      remainingRuns: entry?.remainingRuns ?? null
+    };
+  });
+}
+
+function composeTodoModel(quickActions = {}, assetActions = {}, enrollmentActions = {}) {
   const quickEntries = Array.isArray(quickActions?.entries)
     ? quickActions.entries.filter(Boolean)
     : [];
   const upgradeEntries = createUpgradeTodoEntries(assetActions?.entries);
-  const entries = [...quickEntries, ...upgradeEntries];
+  const enrollmentEntries = createEnrollmentTodoEntries(enrollmentActions?.entries);
+  const entries = [...quickEntries, ...upgradeEntries, ...enrollmentEntries];
 
   const model = { ...(quickActions || {}) };
   model.entries = entries;
   model.emptyMessage = quickActions?.emptyMessage
     || assetActions?.emptyMessage
+    || enrollmentActions?.emptyMessage
     || 'Queue a hustle or upgrade to add new tasks.';
 
-  if (quickActions?.scroller || assetActions?.scroller) {
-    model.scroller = quickActions?.scroller || assetActions?.scroller;
+  if (quickActions?.scroller || assetActions?.scroller || enrollmentActions?.scroller) {
+    model.scroller = quickActions?.scroller || assetActions?.scroller || enrollmentActions?.scroller;
   } else if (model.scroller) {
     delete model.scroller;
   }
@@ -56,8 +81,14 @@ function composeTodoModel(quickActions = {}, assetActions = {}) {
   if (model.hoursAvailable == null && assetActions?.hoursAvailable != null) {
     model.hoursAvailable = assetActions.hoursAvailable;
   }
+  if (model.hoursAvailable == null && enrollmentActions?.hoursAvailable != null) {
+    model.hoursAvailable = enrollmentActions.hoursAvailable;
+  }
   if (model.hoursSpent == null && assetActions?.hoursSpent != null) {
     model.hoursSpent = assetActions.hoursSpent;
+  }
+  if (model.hoursSpent == null && enrollmentActions?.hoursSpent != null) {
+    model.hoursSpent = enrollmentActions.hoursSpent;
   }
   if (!model.hoursAvailableLabel && model.hoursAvailable != null) {
     const available = toNumber(model.hoursAvailable);
@@ -66,6 +97,18 @@ function composeTodoModel(quickActions = {}, assetActions = {}) {
   if (!model.hoursSpentLabel && model.hoursSpent != null) {
     const spent = toNumber(model.hoursSpent);
     model.hoursSpentLabel = formatHours(Math.max(0, spent));
+  }
+
+  if (model.moneyAvailable == null) {
+    const moneySources = [
+      quickActions?.moneyAvailable,
+      assetActions?.moneyAvailable,
+      enrollmentActions?.moneyAvailable
+    ];
+    const sourced = moneySources.find(value => value != null);
+    if (sourced != null) {
+      model.moneyAvailable = sourced;
+    }
   }
 
   return model;
@@ -87,10 +130,10 @@ function ensureWidget(key) {
   return module;
 }
 
-function renderTodo(quickActions = {}, assetActions = {}) {
+function renderTodo(quickActions = {}, assetActions = {}, enrollmentActions = {}) {
   const widget = ensureWidget('todo');
   if (!widget) return;
-  const model = composeTodoModel(quickActions, assetActions);
+  const model = composeTodoModel(quickActions, assetActions, enrollmentActions);
   widget.render(model);
 }
 
@@ -106,7 +149,7 @@ function renderBank(context = {}) {
 
 function renderDashboard(viewModel = {}, context = {}) {
   if (!viewModel) return;
-  renderTodo(viewModel.quickActions || {}, viewModel.assetActions || {});
+  renderTodo(viewModel.quickActions || {}, viewModel.assetActions || {}, viewModel.studyActions || {});
   renderApps(context);
   renderBank(context);
 }


### PR DESCRIPTION
## Summary
- aggregate quick actions, asset upgrades, and enrollable study tracks into the browser ToDo widget model so it remains the single actionable queue
- filter ToDo entries by available hours and cash, and document the consolidated behavior in the homepage redesign notes and changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddd47b1fdc832cac8838e2b12e0f0a