### PR TITLE
Remove browser command palette button

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -30,7 +30,6 @@
       </form>
       <div class="browser-chrome__cluster browser-chrome__cluster--session" aria-label="Session controls">
         <button id="browser-home-button" class="browser-button" type="button">Home</button>
-        <button id="browser-command-button" class="browser-button" type="button">⌘K</button>
         <button
           id="browser-theme-toggle"
           class="browser-button browser-button--icon"

--- a/src/ui/views/browser/resolvers.js
+++ b/src/ui/views/browser/resolvers.js
@@ -10,7 +10,6 @@ const resolvers = {
   }),
   browserSessionControls: root => ({
     homeButton: root.getElementById('browser-home-button'),
-    commandButton: root.getElementById('browser-command-button'),
     endDayButton: root.getElementById('browser-session-button')
   }),
   themeToggle: root => root.getElementById('browser-theme-toggle'),


### PR DESCRIPTION
## Summary
- remove the command palette button from the browser shell header
- clean up the browser view resolver now that the command button is gone

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68de93eb72e8832cb28098442f8d45ce