### PR TITLE
Connect browser header button to ToDo queue

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@
 - Browser homepage ToDo widget now unifies quick actions, upgrade prompts, and enrollable study tracks in a single filtered checklist so only affordable moves surface.
 - Browser homepage ToDo widget adds a "Focus on" toggle so players can sort for top-paying hustles, fastest upgrades, or an alternating blend of both.
 - Browser homepage ToDo widget now auto-lists any upkeep or study time already consumed at daybreak inside the Done column so players see their remaining capacity at a glance.
+- Browser chrome End Day button now launches the next queued ToDo task and only offers "Next Day" once the list is clear.
 - Learnly graduates into a dedicated browser app with a course catalog, detail pages, My Courses hub, and pricing FAQ while reusing the existing education systems.
 - BlogPress brings the Personal Blog management flow into the browser shell with a table overview, detail inspector, pricing page, and one-click quality actions while reusing the existing passive-income logic.
 - VideoTube graduates the vlog asset tools into a studio-style browser app with a channel dashboard, analytics view, niche selection, and launch workflow that reuse the existing vlog economy.

--- a/docs/features/browser-home-redesign.md
+++ b/docs/features/browser-home-redesign.md
@@ -13,6 +13,7 @@
 - The ToDo widget now aggregates quick actions, asset upgrade recommendations, and enrollable study tracks into a single scrollable list. Tasks validate hour and cash requirements before rendering so the queue always reflects moves you can take right now.
 - A "Focus on" toggle lets players sort the ToDo queue for Money-first hustles, upgrade milestones, or an alternating blend of both by interleaving the two lists.
 - The ToDo widget seeds its Done column with any maintenance or study time already reserved for the current day so the schedule immediately reflects auto-funded commitments.
+- The browser chrome's End Day control now mirrors the ToDo widget: it fires the next queued task when work remains and flips to "Next Day" only after the list is clear.
 
 ## Player Impact
 - Players can scan the day's plan, finances, and workspace launchers at a glance without juggling two columns.

--- a/src/ui/views/browser/headerActionPresenter.js
+++ b/src/ui/views/browser/headerActionPresenter.js
@@ -1,0 +1,102 @@
+import { getElement } from '../../elements/registry.js';
+import todoWidget from './widgets/todoWidget.js';
+
+const state = {
+  primaryButton: null,
+  onPrimaryAction: null
+};
+
+function resolveButtons() {
+  const nodes = getElement('headerActionButtons') || {};
+  state.primaryButton = nodes.endDayButton || state.primaryButton;
+  return state;
+}
+
+function handlePrimaryClick(event) {
+  event.preventDefault();
+  const executed = todoWidget.runNextTask();
+  if (executed) {
+    return;
+  }
+  if (typeof state.onPrimaryAction === 'function') {
+    state.onPrimaryAction();
+  }
+}
+
+function bindPrimaryButton(button) {
+  if (!button) return;
+  if (button.dataset.browserActionBound === 'true') return;
+  button.addEventListener('click', handlePrimaryClick);
+  button.dataset.browserActionBound = 'true';
+}
+
+function applyAccessibilityAttributes(button, label) {
+  if (!button) return;
+  if (label) {
+    button.setAttribute('aria-label', label);
+  } else {
+    button.removeAttribute('aria-label');
+  }
+}
+
+function renderAction(model) {
+  resolveButtons();
+  const button = state.primaryButton;
+  if (!button) return;
+
+  const hasTasks = todoWidget.hasPendingTasks();
+  const nextTask = todoWidget.peekNextTask();
+  const label = hasTasks ? 'Next Task' : 'Next Day';
+  const title = hasTasks
+    ? (nextTask?.title ? `Run next: ${nextTask.title}` : 'Run the next queued task for today.')
+    : model?.button?.title || 'Wrap today when you are ready to reset the grind.';
+
+  button.textContent = label;
+  button.dataset.actionMode = hasTasks ? 'task' : (model?.button?.mode || 'end');
+
+  if (hasTasks && nextTask?.id) {
+    button.dataset.actionId = nextTask.id;
+  } else if (model?.button?.actionId) {
+    button.dataset.actionId = model.button.actionId;
+  } else {
+    delete button.dataset.actionId;
+  }
+
+  button.classList.toggle('is-recommendation', hasTasks || Boolean(model?.button?.isRecommendation));
+
+  if (title) {
+    button.title = title;
+  } else {
+    button.removeAttribute('title');
+  }
+
+  applyAccessibilityAttributes(button, title || label);
+  button.disabled = Boolean(model?.button?.disabled);
+
+  bindPrimaryButton(button);
+}
+
+function renderAutoForward() {
+  // Browser shell does not expose an auto-forward toggle in the header yet.
+}
+
+function init({ onPrimaryAction } = {}) {
+  state.onPrimaryAction = typeof onPrimaryAction === 'function' ? onPrimaryAction : null;
+  resolveButtons();
+  bindPrimaryButton(state.primaryButton);
+}
+
+function isPrimaryEnabled() {
+  resolveButtons();
+  if (!state.primaryButton) return false;
+  return !state.primaryButton.disabled;
+}
+
+const headerActionPresenter = {
+  init,
+  renderAction,
+  renderAutoForward,
+  isPrimaryEnabled
+};
+
+export default headerActionPresenter;

--- a/src/ui/views/browser/index.js
+++ b/src/ui/views/browser/index.js
@@ -3,6 +3,7 @@ import { renderDashboard as baseRenderDashboard } from '../../dashboard.js';
 import dashboardPresenter from './dashboardPresenter.js';
 import cardsPresenter from './cardsPresenter.js';
 import layoutPresenter from './layoutPresenter.js';
+import headerActionPresenter from './headerActionPresenter.js';
 
 const browserView = {
   id: 'browser',
@@ -11,7 +12,8 @@ const browserView = {
   presenters: {
     dashboard: dashboardPresenter,
     cards: cardsPresenter,
-    layout: layoutPresenter
+    layout: layoutPresenter,
+    headerAction: headerActionPresenter
   },
   renderDashboard(state, summary) {
     baseRenderDashboard(state, summary, dashboardPresenter);

--- a/src/ui/views/browser/widgets/todoWidget.js
+++ b/src/ui/views/browser/widgets/todoWidget.js
@@ -8,6 +8,7 @@ let currentDay = null;
 let lastModel = null;
 const focusModes = ['money', 'upgrades', 'balanced'];
 let focusMode = 'balanced';
+let pendingEntries = [];
 
 function bindEndDay(button) {
   if (!button || button.dataset.bound === 'true') return;
@@ -575,6 +576,7 @@ export function render(model = {}) {
   });
 
   const orderedPending = applyFocusOrdering(pending, focusMode);
+  pendingEntries = orderedPending;
 
   renderHours(model);
   updateNote(model, orderedPending.length);
@@ -588,7 +590,26 @@ export function render(model = {}) {
   renderCompleted();
 }
 
+export function hasPendingTasks() {
+  return pendingEntries.length > 0;
+}
+
+export function peekNextTask() {
+  return pendingEntries.length ? pendingEntries[0] : null;
+}
+
+export function runNextTask() {
+  const next = peekNextTask();
+  if (!next) {
+    return false;
+  }
+  return handleCompletion(next, lastModel);
+}
+
 export default {
   init,
-  render
+  render,
+  hasPendingTasks,
+  peekNextTask,
+  runNextTask
 };


### PR DESCRIPTION
## Summary
- add a browser-specific header action presenter that fires the next ToDo task and keeps the session button text between Next Task and Next Day
- expose pending-task helpers from the ToDo widget so the header presenter can inspect and run the queue
- update the browser redesign feature notes and changelog to reflect the new header behavior

## Testing
- npm test
- python -m http.server 8000 (manual smoke to load browser.html and capture screenshot)


------
https://chatgpt.com/codex/tasks/task_e_68de94726b6c832ca078c40501ab682e