### PR TITLE
Refactor persistence pipeline and modularize UI builders

### DIFF
--- a/src/core/persistence/result.js
+++ b/src/core/persistence/result.js
@@ -1,0 +1,121 @@
+const RESULT_STATUS = {
+  SUCCESS: 'success',
+  ERROR: 'error',
+  EMPTY: 'empty'
+};
+
+function isResultLike(value) {
+  return value && typeof value === 'object' && typeof value.type === 'string';
+}
+
+function wrap(status, { value = undefined, error: capturedError = undefined } = {}) {
+  const result = {
+    type: status,
+    value,
+    error: capturedError,
+    get isSuccess() {
+      return this.type === RESULT_STATUS.SUCCESS;
+    },
+    get isError() {
+      return this.type === RESULT_STATUS.ERROR;
+    },
+    get isEmpty() {
+      return this.type === RESULT_STATUS.EMPTY;
+    },
+    map(mapper) {
+      if (!this.isSuccess) {
+        return this;
+      }
+      try {
+        return success(mapper(this.value));
+      } catch (err) {
+        return error(err);
+      }
+    },
+    chain(mapper) {
+      if (!this.isSuccess) {
+        return this;
+      }
+      try {
+        const next = mapper(this.value);
+        return from(next);
+      } catch (err) {
+        return error(err);
+      }
+    },
+    mapError(mapper) {
+      if (!this.isError) {
+        return this;
+      }
+      try {
+        return error(mapper(this.error));
+      } catch (err) {
+        return error(err);
+      }
+    },
+    tap(sideEffect) {
+      if (this.isSuccess && typeof sideEffect === 'function') {
+        sideEffect(this.value);
+      }
+      return this;
+    },
+    tapError(sideEffect) {
+      if (this.isError && typeof sideEffect === 'function') {
+        sideEffect(this.error);
+      }
+      return this;
+    },
+    orElse(fallback) {
+      return this.isSuccess ? this : from(fallback(this));
+    },
+    getOrElse(fallbackValue) {
+      return this.isSuccess ? this.value : fallbackValue;
+    }
+  };
+
+  return result;
+}
+
+function success(value) {
+  return wrap(RESULT_STATUS.SUCCESS, { value });
+}
+
+function empty() {
+  return wrap(RESULT_STATUS.EMPTY);
+}
+
+function error(err) {
+  return wrap(RESULT_STATUS.ERROR, { error: err });
+}
+
+function from(resultLike) {
+  if (resultLike === undefined) {
+    return error(new Error('Result mapper returned undefined'));
+  }
+
+  if (isResultLike(resultLike)) {
+    if (typeof resultLike.map === 'function' && typeof resultLike.chain === 'function') {
+      return resultLike;
+    }
+    const status = resultLike.type;
+    if (status === RESULT_STATUS.SUCCESS) {
+      return success(resultLike.value);
+    }
+    if (status === RESULT_STATUS.EMPTY) {
+      return empty();
+    }
+    return error(resultLike.error);
+  }
+
+  return success(resultLike);
+}
+
+function tryCatch(fn) {
+  try {
+    return success(fn());
+  } catch (err) {
+    return error(err);
+  }
+}
+
+export { RESULT_STATUS, success, error, empty, from, tryCatch };

--- a/src/ui/cards/collectionService.js
+++ b/src/ui/cards/collectionService.js
@@ -1,16 +1,6 @@
 import { ensureRegistryReady } from '../../game/registryBootstrap.js';
-import {
-  buildAssetModels,
-  buildDigishelfModel,
-  buildBlogpressModel,
-  buildShopilyModel,
-  buildServerHubModel,
-  buildEducationModels,
-  buildHustleModels,
-  buildUpgradeModels,
-  buildVideoTubeModel,
-  buildTrendsModel
-} from './model/index.js';
+import './model/index.js';
+import { buildModelMap } from './modelBuilderRegistry.js';
 
 let cachedRegistries = null;
 let cachedModels = null;
@@ -47,18 +37,7 @@ function buildRegistries() {
 }
 
 function buildModels(registries) {
-  return {
-    hustles: buildHustleModels(registries.hustles),
-    education: buildEducationModels(registries.education),
-    assets: buildAssetModels(registries.assets),
-    digishelf: buildDigishelfModel(registries.assets),
-    shopily: buildShopilyModel(registries.assets, registries.upgrades),
-    serverhub: buildServerHubModel(registries.assets, registries.upgrades),
-    upgrades: buildUpgradeModels(registries.upgrades),
-    blogpress: buildBlogpressModel(registries.assets, registries.upgrades),
-    videotube: buildVideoTubeModel(registries.assets),
-    trends: buildTrendsModel()
-  };
+  return buildModelMap(registries);
 }
 
 function getCollections() {

--- a/src/ui/cards/model/blogpress.js
+++ b/src/ui/cards/model/blogpress.js
@@ -17,6 +17,7 @@ import {
   getQualityTracks
 } from '../../../game/assets/quality.js';
 import { describeAssetLaunchAvailability } from './assets.js';
+import { registerModelBuilder } from '../modelBuilderRegistry.js';
 
 function clampNumber(value) {
   const number = Number(value);
@@ -350,3 +351,9 @@ export default function buildBlogpressModel(assetDefinitions = [], upgradeDefini
 export function selectNiche(assetId, instanceId, nicheId) {
   return assignInstanceToNiche(assetId, instanceId, nicheId);
 }
+
+registerModelBuilder(
+  'blogpress',
+  (registries = {}, context = {}) =>
+    buildBlogpressModel(registries.assets ?? [], registries.upgrades ?? [], context.state)
+);

--- a/src/ui/cards/model/digishelf.js
+++ b/src/ui/cards/model/digishelf.js
@@ -17,6 +17,7 @@ import {
   getQualityTracks
 } from '../../../game/assets/quality.js';
 import { describeAssetLaunchAvailability } from './assets.js';
+import { registerModelBuilder } from '../modelBuilderRegistry.js';
 
 const QUICK_ACTION_MAP = {
   ebook: ['writeChapter'],
@@ -420,4 +421,8 @@ export function getQuickActionIds(assetId) {
 export function selectDigishelfNiche(assetId, instanceId, nicheId) {
   return assignInstanceToNiche(assetId, instanceId, nicheId);
 }
+
+registerModelBuilder('digishelf', (registries = {}, context = {}) =>
+  buildDigishelfModel(registries.assets ?? [], context.state)
+);
 

--- a/src/ui/cards/model/index.js
+++ b/src/ui/cards/model/index.js
@@ -1,15 +1,11 @@
-export {
-  default as buildAssetModels,
+import buildAssetModels, {
   getAssetGroupLabel,
   getAssetGroupId,
   getAssetGroupNote,
   describeAssetLaunchAvailability
 } from './assets.js';
-
-export { default as buildHustleModels } from './hustles.js';
-
-export {
-  default as buildUpgradeModels,
+import buildHustleModels from './hustles.js';
+import buildUpgradeModels, {
   getUpgradeCategory,
   getUpgradeFamily,
   getCategoryCopy,
@@ -18,31 +14,81 @@ export {
   getUpgradeSnapshot,
   describeUpgradeStatus
 } from './upgrades.js';
-
-export {
-  default as buildEducationModels,
-  buildSkillRewards,
-  resolveTrack
-} from './education.js';
-
-export { default as buildFinanceModel } from './finance.js';
-
-export {
+import buildEducationModels, { buildSkillRewards, resolveTrack } from './education.js';
+import buildFinanceModel from './finance.js';
+import {
   formatLabelFromKey,
   describeAssetCardSummary,
   formatInstanceUpkeep
 } from '../utils.js';
-
-export { default as buildBlogpressModel, selectNiche as selectBlogpressNiche } from './blogpress.js';
-export { default as buildVideoTubeModel, selectNiche as selectVideoTubeNiche } from './videotube.js';
-export {
-  default as buildDigishelfModel,
+import buildBlogpressModel, { selectNiche as selectBlogpressNiche } from './blogpress.js';
+import buildVideoTubeModel, { selectNiche as selectVideoTubeNiche } from './videotube.js';
+import buildDigishelfModel, {
   selectDigishelfNiche,
   getQuickActionIds as getDigishelfQuickActionIds
 } from './digishelf.js';
-export { default as buildShopilyModel, selectNiche as selectShopilyNiche } from './shopily.js';
-export { default as buildTrendsModel } from './trends.js';
+import buildShopilyModel, { selectNiche as selectShopilyNiche } from './shopily.js';
+import buildTrendsModel from './trends.js';
+import buildServerHubModel, { selectServerHubNiche } from './serverhub.js';
+import { ensureDefaultBuilders, registerModelBuilder } from '../modelBuilderRegistry.js';
+
+function registerDefaultCardBuilders() {
+  registerModelBuilder(
+    'hustles',
+    registries => buildHustleModels(registries.hustles),
+    { isDefault: true }
+  );
+  registerModelBuilder(
+    'education',
+    registries => buildEducationModels(registries.education),
+    { isDefault: true }
+  );
+  registerModelBuilder(
+    'assets',
+    registries => buildAssetModels(registries.assets),
+    { isDefault: true }
+  );
+  registerModelBuilder(
+    'upgrades',
+    registries => buildUpgradeModels(registries.upgrades),
+    { isDefault: true }
+  );
+}
+
+ensureDefaultBuilders(registerDefaultCardBuilders);
+
 export {
-  default as buildServerHubModel,
+  buildAssetModels,
+  getAssetGroupLabel,
+  getAssetGroupId,
+  getAssetGroupNote,
+  describeAssetLaunchAvailability,
+  buildHustleModels,
+  buildUpgradeModels,
+  getUpgradeCategory,
+  getUpgradeFamily,
+  getCategoryCopy,
+  getFamilyCopy,
+  buildUpgradeCategories,
+  getUpgradeSnapshot,
+  describeUpgradeStatus,
+  buildEducationModels,
+  buildSkillRewards,
+  resolveTrack,
+  buildFinanceModel,
+  formatLabelFromKey,
+  describeAssetCardSummary,
+  formatInstanceUpkeep,
+  buildBlogpressModel,
+  selectBlogpressNiche,
+  buildVideoTubeModel,
+  selectVideoTubeNiche,
+  buildDigishelfModel,
+  selectDigishelfNiche,
+  getDigishelfQuickActionIds,
+  buildShopilyModel,
+  selectShopilyNiche,
+  buildTrendsModel,
+  buildServerHubModel,
   selectServerHubNiche
-} from './serverhub.js';
+};

--- a/src/ui/cards/model/serverhub.js
+++ b/src/ui/cards/model/serverhub.js
@@ -17,6 +17,7 @@ import {
   getQualityTracks
 } from '../../../game/assets/quality.js';
 import { describeAssetLaunchAvailability } from './assets.js';
+import { registerModelBuilder } from '../modelBuilderRegistry.js';
 import { getUpgradeSnapshot, describeUpgradeStatus } from './upgrades.js';
 
 function clampNumber(value) {
@@ -445,3 +446,9 @@ export default function buildServerHubModel(assetDefinitions = [], upgradeDefini
 export function selectServerHubNiche(assetId, instanceId, nicheId) {
   return assignInstanceToNiche(assetId, instanceId, nicheId);
 }
+
+registerModelBuilder(
+  'serverhub',
+  (registries = {}, context = {}) =>
+    buildServerHubModel(registries.assets ?? [], registries.upgrades ?? [], context.state)
+);

--- a/src/ui/cards/model/shopily.js
+++ b/src/ui/cards/model/shopily.js
@@ -22,6 +22,7 @@ import {
 } from '../../../game/assets/quality.js';
 import { getUpgradeSnapshot, describeUpgradeStatus } from './upgrades.js';
 import { describeAssetLaunchAvailability } from './assets.js';
+import { registerModelBuilder } from '../modelBuilderRegistry.js';
 
 function clampNumber(value) {
   const number = Number(value);
@@ -424,3 +425,9 @@ export default function buildShopilyModel(assetDefinitions = [], upgradeDefiniti
 export function selectNiche(assetId, instanceId, nicheId) {
   return assignInstanceToNiche(assetId, instanceId, nicheId);
 }
+
+registerModelBuilder(
+  'shopily',
+  (registries = {}, context = {}) =>
+    buildShopilyModel(registries.assets ?? [], registries.upgrades ?? [], context.state)
+);

--- a/src/ui/cards/model/trends.js
+++ b/src/ui/cards/model/trends.js
@@ -1,5 +1,6 @@
 import { getState } from '../../../core/state.js';
 import { buildNicheViewModel } from '../../dashboard/model.js';
+import { registerModelBuilder } from '../modelBuilderRegistry.js';
 
 const DEFAULT_MODEL = {
   highlights: {
@@ -26,3 +27,5 @@ export default function buildTrendsModel(state = getState()) {
   }
   return DEFAULT_MODEL;
 }
+
+registerModelBuilder('trends', (registries = {}, context = {}) => buildTrendsModel(context.state));

--- a/src/ui/cards/model/videotube.js
+++ b/src/ui/cards/model/videotube.js
@@ -18,6 +18,7 @@ import {
 } from '../../../game/assets/quality.js';
 import { setAssetInstanceName } from '../../../game/assets/helpers.js';
 import { describeAssetLaunchAvailability } from './assets.js';
+import { registerModelBuilder } from '../modelBuilderRegistry.js';
 
 function clampNumber(value) {
   const number = Number(value);
@@ -434,3 +435,9 @@ export default function buildVideoTubeModel(assetDefinitions = [], state = getSt
 export function selectNiche(assetId, instanceId, nicheId) {
   return assignInstanceToNiche(assetId, instanceId, nicheId);
 }
+
+registerModelBuilder(
+  'videotube',
+  (registries = {}, context = {}) =>
+    buildVideoTubeModel(registries.assets ?? [], context.state)
+);

--- a/src/ui/cards/modelBuilderRegistry.js
+++ b/src/ui/cards/modelBuilderRegistry.js
@@ -1,0 +1,66 @@
+const builders = new Map();
+let defaultsRegistered = false;
+
+function normalizeKey(key) {
+  if (!key || typeof key !== 'string') {
+    throw new Error('Model builder key must be a non-empty string.');
+  }
+  return key;
+}
+
+function registerModelBuilder(key, builder, { isDefault = false } = {}) {
+  const normalizedKey = normalizeKey(key);
+  if (typeof builder !== 'function') {
+    throw new Error(`Model builder for "${normalizedKey}" must be a function.`);
+  }
+  builders.set(normalizedKey, builder);
+  if (isDefault) {
+    defaultsRegistered = true;
+  }
+  return () => builders.delete(normalizedKey);
+}
+
+function unregisterModelBuilder(key) {
+  builders.delete(key);
+}
+
+function getModelBuilderEntries() {
+  return Array.from(builders.entries());
+}
+
+function buildModelMap(registries, context = {}) {
+  const models = {};
+  getModelBuilderEntries().forEach(([key, builder]) => {
+    models[key] = builder(registries, context);
+  });
+  return models;
+}
+
+function resetModelBuilders() {
+  builders.clear();
+  defaultsRegistered = false;
+}
+
+function hasRegisteredBuilders() {
+  return builders.size > 0;
+}
+
+function ensureDefaultBuilders(registerDefaults) {
+  if (defaultsRegistered) {
+    return;
+  }
+  if (typeof registerDefaults === 'function') {
+    registerDefaults();
+  }
+  defaultsRegistered = true;
+}
+
+export {
+  registerModelBuilder,
+  unregisterModelBuilder,
+  getModelBuilderEntries,
+  buildModelMap,
+  resetModelBuilders,
+  hasRegisteredBuilders,
+  ensureDefaultBuilders
+};

--- a/src/ui/layout/preferenceAdapters.js
+++ b/src/ui/layout/preferenceAdapters.js
@@ -1,0 +1,113 @@
+const adapters = new Map();
+let defaultsRegistered = false;
+
+function validateAdapter(adapter) {
+  if (!adapter || typeof adapter !== 'object') {
+    throw new Error('Preference adapter must be an object.');
+  }
+  const { section, elementKey, read } = adapter;
+  if (!section || typeof section !== 'string') {
+    throw new Error('Preference adapter requires a string "section" key.');
+  }
+  if (!elementKey || typeof elementKey !== 'string') {
+    throw new Error(`Preference adapter "${section}" requires an elementKey.`);
+  }
+  if (typeof read !== 'function') {
+    throw new Error(`Preference adapter "${section}" requires a read function.`);
+  }
+}
+
+function registerPreferenceAdapter(adapter, { isDefault = false } = {}) {
+  validateAdapter(adapter);
+  adapters.set(adapter.section, adapter);
+  if (isDefault) {
+    defaultsRegistered = true;
+  }
+  return () => {
+    if (adapters.get(adapter.section) === adapter) {
+      adapters.delete(adapter.section);
+    }
+  };
+}
+
+function getPreferenceAdapters() {
+  return Array.from(adapters.values());
+}
+
+function resetPreferenceAdapters() {
+  adapters.clear();
+  defaultsRegistered = false;
+}
+
+const DEFAULT_ADAPTERS = [
+  {
+    section: 'hustles',
+    elementKey: 'hustleControls',
+    read(elementLookup = {}) {
+      const { hustleAvailableToggle, hustleSort, hustleSearch } = elementLookup;
+      if (!hustleAvailableToggle && !hustleSort && !hustleSearch) {
+        return null;
+      }
+      return {
+        availableOnly: Boolean(hustleAvailableToggle?.checked),
+        sort: hustleSort?.value,
+        query: hustleSearch?.value ?? ''
+      };
+    }
+  },
+  {
+    section: 'assets',
+    elementKey: 'assetFilters',
+    read(elementLookup = {}) {
+      const { activeOnly, maintenance, lowRisk } = elementLookup;
+      if (!activeOnly && !maintenance && !lowRisk) {
+        return null;
+      }
+      return {
+        activeOnly: Boolean(activeOnly?.checked),
+        maintenanceOnly: Boolean(maintenance?.checked),
+        hideHighRisk: Boolean(lowRisk?.checked)
+      };
+    }
+  },
+  {
+    section: 'upgrades',
+    elementKey: 'upgradeFilters',
+    read(elementLookup = {}) {
+      const { unlocked } = elementLookup;
+      if (!unlocked) {
+        return null;
+      }
+      return { readyOnly: unlocked.checked !== false };
+    }
+  },
+  {
+    section: 'study',
+    elementKey: 'studyFilters',
+    read(elementLookup = {}) {
+      const { activeOnly, hideComplete } = elementLookup;
+      if (!activeOnly && !hideComplete) {
+        return null;
+      }
+      return {
+        activeOnly: Boolean(activeOnly?.checked),
+        hideComplete: Boolean(hideComplete?.checked)
+      };
+    }
+  }
+];
+
+function ensureDefaultPreferenceAdapters() {
+  if (defaultsRegistered) {
+    return;
+  }
+  DEFAULT_ADAPTERS.forEach(adapter => registerPreferenceAdapter(adapter, { isDefault: true }));
+  defaultsRegistered = true;
+}
+
+export {
+  registerPreferenceAdapter,
+  getPreferenceAdapters,
+  resetPreferenceAdapters,
+  ensureDefaultPreferenceAdapters
+};

--- a/tests/ui/cardsModel.test.js
+++ b/tests/ui/cardsModel.test.js
@@ -5,6 +5,8 @@ import {
   buildUpgradeModels,
   buildEducationModels
 } from '../../src/ui/cards/model/index.js';
+import { buildModelMap, registerModelBuilder } from '../../src/ui/cards/modelBuilderRegistry.js';
+import { ensureRegistryReady } from '../../src/game/registryBootstrap.js';
 
 test('buildHustleModels mirrors availability filters', () => {
   const hustles = [
@@ -158,4 +160,27 @@ test('buildEducationModels summarises study queue totals', () => {
   assert.equal(models.queue.totalHours, 2);
   assert.equal(models.queue.totalLabel.includes('Total ETA'), true);
   assert.equal(models.queue.capLabel, 'Daily cap: 8h');
+});
+
+test('model builder registry composes registered card models', () => {
+  const registries = {
+    hustles: [],
+    education: [],
+    assets: [],
+    upgrades: []
+  };
+
+  const dispose = registerModelBuilder('customCard', () => ({ id: 'customCard', label: 'Custom' }));
+
+  try {
+    ensureRegistryReady();
+    const models = buildModelMap(registries);
+    assert.ok(models.hustles, 'expected default hustle models to be present');
+    assert.ok(models.education, 'expected default education models to be present');
+    assert.ok(models.assets, 'expected default asset models to be present');
+    assert.ok(models.upgrades, 'expected default upgrade models to be present');
+    assert.deepEqual(models.customCard, { id: 'customCard', label: 'Custom' });
+  } finally {
+    dispose();
+  }
 });

--- a/tests/ui/layout/LayoutController.test.js
+++ b/tests/ui/layout/LayoutController.test.js
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { LayoutController } from '../../../src/ui/layout/LayoutController.js';
+import {
+  resetPreferenceAdapters,
+  getPreferenceAdapters,
+  ensureDefaultPreferenceAdapters
+} from '../../../src/ui/layout/preferenceAdapters.js';
+
+test('syncPreferencesFromDom delegates to registered adapters', () => {
+  const updates = [];
+  const elements = {
+    alpha: { toggle: { checked: true } },
+    beta: {}
+  };
+
+  const controller = new LayoutController({
+    getElement: key => elements[key] || {},
+    buildLayoutModel: () => ({}),
+    getLayoutPreferences: () => ({}),
+    updateLayoutPreferences: (section, patch) => {
+      updates.push({ section, patch });
+    },
+    preferenceAdapters: [
+      {
+        section: 'alpha',
+        elementKey: 'alpha',
+        read(lookup) {
+          if (!lookup.toggle) return null;
+          return { enabled: Boolean(lookup.toggle.checked) };
+        }
+      },
+      {
+        section: 'beta',
+        elementKey: 'beta',
+        read() {
+          return null;
+        }
+      }
+    ],
+    logger: { error: () => {} }
+  });
+
+  controller.syncPreferencesFromDom();
+
+  assert.equal(updates.length, 1);
+  assert.deepEqual(updates[0], {
+    section: 'alpha',
+    patch: { enabled: true }
+  });
+});
+
+test('init ensures default preference adapters are registered', () => {
+  resetPreferenceAdapters();
+
+  const controller = new LayoutController({
+    getElement: () => ({}),
+    buildLayoutModel: () => ({}),
+    getLayoutPreferences: () => ({}),
+    updateLayoutPreferences: () => {},
+    logger: { error: () => {} }
+  });
+
+  controller.init();
+
+  const sections = getPreferenceAdapters().map(adapter => adapter.section);
+  assert.ok(sections.includes('hustles'));
+  assert.ok(sections.includes('assets'));
+  assert.ok(sections.includes('upgrades'));
+  assert.ok(sections.includes('study'));
+
+  ensureDefaultPreferenceAdapters();
+});


### PR DESCRIPTION
## Summary
- introduce a reusable Result helper and rework the persistence load pipeline to compose snapshot stages
- create a card model builder registry and have specialized builders register themselves for collection assembly
- add layout preference adapters plus targeted tests for the new registry and adapter flows

## Testing
- `npm test`
- Manual smoke test (not run - environment limitation)


------
https://chatgpt.com/codex/tasks/task_e_68deab15aba4832cbbad6add8262be84