### PR TITLE
Add event-log driven notifications to browser shell

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -40,13 +40,52 @@
           <span class="browser-theme-toggle__icon" aria-hidden="true">🌞</span>
           <span class="browser-theme-toggle__label">Light</span>
         </button>
-        <a
-          id="browser-classic-link"
-          class="browser-button"
-          href="index.html"
-          role="button"
-          title="Pop back to the classic dashboard shell"
-        >Classic Shell</a>
+        <div class="browser-notifications" data-role="browser-notifications">
+          <button
+            id="browser-notifications-button"
+            class="browser-button browser-button--icon browser-notifications__trigger"
+            type="button"
+            aria-haspopup="true"
+            aria-expanded="false"
+            title="View notifications"
+          >
+            <span class="browser-notifications__icon" aria-hidden="true">🔔</span>
+            <span class="browser-visually-hidden">Notifications</span>
+            <span
+              id="browser-notifications-badge"
+              class="browser-notifications__badge"
+              aria-hidden="true"
+              hidden
+            >0</span>
+          </button>
+          <div
+            id="browser-notifications-panel"
+            class="browser-notifications__panel"
+            role="region"
+            aria-label="Notifications"
+            hidden
+          >
+            <div class="browser-notifications__header">
+              <p class="browser-notifications__title">Notifications</p>
+              <button
+                id="browser-notifications-mark-all"
+                class="browser-button browser-button--text"
+                type="button"
+              >
+                Mark all as read
+              </button>
+            </div>
+            <p
+              id="browser-notifications-empty"
+              class="browser-notifications__empty"
+              hidden
+            ></p>
+            <ul
+              id="browser-notifications-list"
+              class="browser-notifications__list"
+            ></ul>
+          </div>
+        </div>
         <button id="browser-session-button" class="browser-button browser-button--primary" type="button">End Day</button>
       </div>
     </header>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Browser chrome now features a notification bell that mirrors the event log with unread badges, read tracking, and a mark-all control.
 - YourNetwork joins the browser apps lineup with a LinkedIn-inspired profile that showcases skills, study progress, equipment, portfolio highlights, and career metrics in one celebratory view.
 - Trends Intelligence Lab replaces the classic analytics tab with a standalone browser app featuring a daily outlook ticker, refreshed momentum cards, and a dedicated watchlist while reusing existing niche data.
 - ServerHub launches as a cloud-inspired control center for Micro SaaS ventures with KPI hero metrics, app table + detail sidebar, upgrade shelf, and pricing tiers built on the existing SaaS backend.

--- a/docs/features/browser-notifications.md
+++ b/docs/features/browser-notifications.md
@@ -1,0 +1,18 @@
+# Browser Notifications Center
+
+## Goals
+- Surface the event log inside the browser chrome so players can review recent activity without opening a separate panel.
+- Track unread status per entry so new events stand out with a badge and can be cleared intentionally.
+- Offer lightweight controls (dropdown, mark all) that feel native to modern notification trays.
+
+## Player Impact
+- A bell icon in the browser header now shows a badge with the count of unread log entries.
+- Clicking the bell opens a dropdown listing the full event log with timestamps and type labels; unread items are highlighted.
+- Players can mark individual entries read by tapping them or clear the entire list with "Mark all as read".
+- Read state persists with the save data so the badge only reflects new events that appeared since the last check.
+
+## Implementation Notes
+- Each log entry in `state.log` now includes a `read` flag; legacy saves are normalized on load.
+- The browser notifications presenter renders the dropdown, updates the unread badge, and reuses the shared event log model for formatting.
+- `markLogEntryRead` and `markAllLogEntriesRead` helpers live in `src/core/log.js` and trigger UI refreshes when state changes.
+- Styling lives in `styles/browser.css` alongside other browser chrome rules, using the accent palette for unread indicators.

--- a/src/core/log.js
+++ b/src/core/log.js
@@ -12,13 +12,43 @@ export function addLog(message, type = 'info') {
     id: createId(),
     timestamp: Date.now(),
     message,
-    type
+    type,
+    read: false
   };
   state.log.push(entry);
   if (state.log.length > MAX_LOG_ENTRIES) {
     state.log.splice(0, state.log.length - MAX_LOG_ENTRIES);
   }
   renderLog();
+}
+
+export function markLogEntryRead(entryId) {
+  if (!entryId) return false;
+  const state = getState();
+  if (!state || !Array.isArray(state.log)) return false;
+  const entry = state.log.find(item => item?.id === entryId);
+  if (!entry || entry.read === true) {
+    return false;
+  }
+  entry.read = true;
+  renderLog();
+  return true;
+}
+
+export function markAllLogEntriesRead() {
+  const state = getState();
+  if (!state || !Array.isArray(state.log)) return 0;
+  let updated = 0;
+  state.log.forEach(entry => {
+    if (entry && entry.read !== true) {
+      entry.read = true;
+      updated += 1;
+    }
+  });
+  if (updated > 0) {
+    renderLog();
+  }
+  return updated;
 }
 
 export function renderLog() {

--- a/src/core/log.js
+++ b/src/core/log.js
@@ -3,6 +3,7 @@ import { createId } from './helpers.js';
 import { getState } from './state.js';
 import { buildLogModel } from '../ui/log/model.js';
 import { getActiveView } from '../ui/viewManager.js';
+import { saveState } from './storage.js';
 import classicLogPresenter from '../ui/views/classic/logPresenter.js';
 
 export function addLog(message, type = 'info') {
@@ -31,6 +32,7 @@ export function markLogEntryRead(entryId) {
     return false;
   }
   entry.read = true;
+  saveState();
   renderLog();
   return true;
 }
@@ -46,6 +48,7 @@ export function markAllLogEntriesRead() {
     }
   });
   if (updated > 0) {
+    saveState();
     renderLog();
   }
   return updated;

--- a/src/ui/log/model.js
+++ b/src/ui/log/model.js
@@ -16,7 +16,8 @@ function formatLogEntry(entry) {
     type: entry.type || 'info',
     message: String(entry.message ?? ''),
     timestamp: timestamp,
-    timeLabel: date ? date.toLocaleTimeString([], TIME_FORMAT_OPTIONS) : ''
+    timeLabel: date ? date.toLocaleTimeString([], TIME_FORMAT_OPTIONS) : '',
+    read: entry.read === true
   };
 }
 

--- a/src/ui/views/browser/dashboardPresenter.js
+++ b/src/ui/views/browser/dashboardPresenter.js
@@ -3,6 +3,7 @@ import { formatHours } from '../../../core/helpers.js';
 import todoWidget from './widgets/todoWidget.js';
 import appsWidget from './widgets/appsWidget.js';
 import bankWidget from './widgets/bankWidget.js';
+import notificationsPresenter from './notificationsPresenter.js';
 
 const widgetModules = {
   todo: todoWidget,
@@ -206,6 +207,7 @@ function renderBank(context = {}) {
 
 function renderDashboard(viewModel = {}, context = {}) {
   if (!viewModel) return;
+  notificationsPresenter.render(viewModel.eventLog || {});
   renderTodo(
     viewModel.quickActions || {},
     viewModel.assetActions || {},

--- a/src/ui/views/browser/notificationsPresenter.js
+++ b/src/ui/views/browser/notificationsPresenter.js
@@ -15,7 +15,8 @@ const presenterState = {
   entries: [],
   emptyMessage: '',
   outsideHandler: null,
-  keydownHandler: null
+  keydownHandler: null,
+  initialized: false
 };
 
 function getRefs() {
@@ -27,7 +28,8 @@ function attachDocumentListeners() {
     presenterState.outsideHandler = event => {
       if (!presenterState.isOpen) return;
       const { container } = getRefs();
-      if (!container || container.contains(event.target)) {
+      const target = event.target;
+      if (!container || (target instanceof Node && container.contains(target))) {
         return;
       }
       togglePanel(false);
@@ -43,13 +45,13 @@ function attachDocumentListeners() {
     };
   }
 
-  document.addEventListener('pointerdown', presenterState.outsideHandler);
+  document.addEventListener('click', presenterState.outsideHandler, true);
   document.addEventListener('keydown', presenterState.keydownHandler);
 }
 
 function detachDocumentListeners() {
   if (presenterState.outsideHandler) {
-    document.removeEventListener('pointerdown', presenterState.outsideHandler);
+    document.removeEventListener('click', presenterState.outsideHandler, true);
   }
   if (presenterState.keydownHandler) {
     document.removeEventListener('keydown', presenterState.keydownHandler);
@@ -87,6 +89,18 @@ function closePanel() {
   }
   presenterState.isOpen = false;
   detachDocumentListeners();
+}
+
+function ensurePanelHiddenByDefault() {
+  if (presenterState.initialized) return;
+  const { panel, button } = getRefs();
+  if (panel) {
+    panel.hidden = true;
+  }
+  if (button) {
+    button.setAttribute('aria-expanded', 'false');
+  }
+  presenterState.initialized = true;
 }
 
 function togglePanel(force) {
@@ -248,6 +262,8 @@ function render(model = {}) {
     closePanel();
     return;
   }
+
+  ensurePanelHiddenByDefault();
 
   bindControls();
 

--- a/src/ui/views/browser/notificationsPresenter.js
+++ b/src/ui/views/browser/notificationsPresenter.js
@@ -104,6 +104,10 @@ function formatTypeLabel(type) {
   return TYPE_LABELS[normalized] || normalized.replace(/\b\w/g, char => char.toUpperCase());
 }
 
+function getUnreadEntries(entries = []) {
+  return entries.filter(entry => entry && entry.read !== true);
+}
+
 function renderBadge(entries = []) {
   const { badge, button } = getRefs();
   if (!badge || !button) return;
@@ -124,7 +128,8 @@ function renderBadge(entries = []) {
 function renderEmptyState(entries = [], emptyMessage = '') {
   const { empty } = getRefs();
   if (!empty) return;
-  if (!entries.length) {
+  const unread = getUnreadEntries(entries);
+  if (!unread.length) {
     empty.hidden = false;
     empty.textContent = emptyMessage || 'You are all caught up.';
   } else {
@@ -193,15 +198,16 @@ function createEntryButton(entry) {
 function renderList(entries = []) {
   const { list } = getRefs();
   if (!list) return;
+  const unreadEntries = getUnreadEntries(entries);
   list.innerHTML = '';
-  entries.forEach(entry => {
+  unreadEntries.forEach(entry => {
     if (!entry) return;
     const item = document.createElement('li');
     const button = createEntryButton(entry);
     item.appendChild(button);
     list.appendChild(item);
   });
-  list.hidden = entries.length === 0;
+  list.hidden = unreadEntries.length === 0;
 }
 
 function refreshFromState() {

--- a/src/ui/views/browser/resolvers.js
+++ b/src/ui/views/browser/resolvers.js
@@ -12,6 +12,19 @@ const resolvers = {
     homeButton: root.getElementById('browser-home-button'),
     endDayButton: root.getElementById('browser-session-button')
   }),
+  browserNotifications: root => {
+    const container = root.querySelector('[data-role="browser-notifications"]');
+    if (!container) return null;
+    return {
+      container,
+      button: container.querySelector('#browser-notifications-button'),
+      panel: container.querySelector('#browser-notifications-panel'),
+      list: container.querySelector('#browser-notifications-list'),
+      empty: container.querySelector('#browser-notifications-empty'),
+      badge: container.querySelector('#browser-notifications-badge'),
+      markAll: container.querySelector('#browser-notifications-mark-all')
+    };
+  },
   themeToggle: root => root.getElementById('browser-theme-toggle'),
   browserTabs: root => ({
     container: root.getElementById('browser-tab-bar'),

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -42,6 +42,18 @@
   --browser-shadow-focus: 0 16px 38px rgba(139, 170, 255, 0.28);
 }
 
+.browser-visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 body {
   margin: 0;
   min-height: 100vh;
@@ -198,6 +210,158 @@ a {
   gap: 0.5rem;
 }
 
+.browser-notifications {
+  position: relative;
+  display: flex;
+}
+
+.browser-notifications__trigger {
+  position: relative;
+}
+
+.browser-notifications__icon {
+  font-size: 1.1rem;
+}
+
+.browser-notifications__badge {
+  position: absolute;
+  top: 0.15rem;
+  right: 0.15rem;
+  min-width: 1.15rem;
+  height: 1.15rem;
+  padding: 0 0.35rem;
+  border-radius: var(--browser-radius-pill);
+  background: var(--browser-danger);
+  color: #fff;
+  font-size: 0.68rem;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 0 0 2px var(--browser-panel);
+}
+
+.browser-notifications__panel {
+  position: absolute;
+  top: calc(100% + 0.75rem);
+  right: 0;
+  width: min(380px, 90vw);
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-md);
+  box-shadow: var(--browser-shadow-soft);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  z-index: 40;
+}
+
+.browser-notifications__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.browser-notifications__title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.browser-notifications__empty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--browser-muted);
+}
+
+.browser-notifications__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  max-height: 18rem;
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+.browser-notifications__item {
+  width: 100%;
+  border: 1px solid transparent;
+  background: transparent;
+  color: inherit;
+  padding: 0.7rem 0.85rem;
+  border-radius: var(--browser-radius-md);
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 0.6rem;
+  row-gap: 0.35rem;
+  align-items: start;
+  text-align: left;
+  cursor: pointer;
+  transition: background 150ms ease, border-color 150ms ease, transform 150ms ease;
+}
+
+.browser-notifications__item:hover,
+.browser-notifications__item:focus-visible {
+  background: var(--browser-accent-soft);
+  border-color: var(--browser-accent);
+  outline: none;
+}
+
+.browser-notifications__item:active {
+  transform: translateY(1px);
+}
+
+.browser-notifications__item.is-unread {
+  border-color: var(--browser-accent);
+  background: rgba(37, 99, 235, 0.12);
+}
+
+:root[data-browser-theme="night"] .browser-notifications__item.is-unread {
+  background: rgba(139, 170, 255, 0.18);
+}
+
+.browser-notifications__message {
+  grid-column: 2;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+.browser-notifications__meta {
+  grid-column: 2;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--browser-muted);
+}
+
+.browser-notifications__indicator {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: var(--browser-accent);
+  align-self: start;
+  margin-top: 0.2rem;
+  transition: transform 150ms ease, opacity 150ms ease;
+}
+
+.browser-notifications__indicator.is-hidden {
+  opacity: 0;
+  transform: scale(0);
+}
+
+.browser-notifications__meta-label {
+  text-transform: uppercase;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  font-size: 0.7rem;
+}
+
 .browser-address {
   display: grid;
   grid-template-columns: min-content 1fr;
@@ -260,6 +424,26 @@ a {
 
 .browser-button--icon {
   padding: 0.45rem 0.65rem;
+}
+
+.browser-button--text {
+  padding: 0.2rem 0.4rem;
+  background: transparent;
+  border: none;
+  color: var(--browser-accent);
+  font-weight: 600;
+}
+
+.browser-button--text:hover,
+.browser-button--text:focus-visible {
+  background: var(--browser-accent-soft);
+  border: none;
+  outline: none;
+  color: var(--browser-accent);
+}
+
+.browser-button--text:active {
+  transform: none;
 }
 
 .browser-theme-toggle__label {

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -283,7 +283,7 @@ a {
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
-  max-height: 18rem;
+  max-height: calc(18rem * 1.3);
   overflow-y: auto;
   scrollbar-width: thin;
 }


### PR DESCRIPTION
## Summary
- replace the classic shell link with a notification bell that opens a dropdown populated from the event log
- persist read/unread state on log entries and expose helpers plus a browser presenter to manage the notification tray
- style the new notification UI and document the feature in the changelog and feature notes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68deb0833d64832c950cf1ee7fbb7105