### PR TITLE
Prune unused exports and redundant UI proxies

### DIFF
--- a/src/core/state.js
+++ b/src/core/state.js
@@ -151,8 +151,6 @@ class StateManager {
 
 const stateManager = new StateManager();
 
-export default stateManager;
-
 export const createEmptyDailyMetrics = (...args) => stateManager.createEmptyDailyMetrics(...args);
 export const ensureDailyMetrics = (...args) => stateManager.ensureDailyMetrics(...args);
 export const ensureMetricsHistory = (...args) => stateManager.ensureMetricsHistory(...args);

--- a/src/core/state/assets.js
+++ b/src/core/state/assets.js
@@ -161,8 +161,3 @@ export function normalizeAssetState(definition, assetState = {}, context = {}) {
   return merged;
 }
 
-export default {
-  createAssetInstance,
-  normalizeAssetInstance,
-  normalizeAssetState
-};

--- a/src/core/state/niches.js
+++ b/src/core/state/niches.js
@@ -53,8 +53,3 @@ export function ensureNicheStateShape(target, { fallbackDay = 1 } = {}) {
   nicheState.lastRollDay = Number.isFinite(storedDay) ? storedDay : fallbackDay;
 }
 
-export default {
-  ensureNicheStateShape,
-  isValidNicheId,
-  rollInitialNicheScore
-};

--- a/src/core/state/registry.js
+++ b/src/core/state/registry.js
@@ -32,11 +32,3 @@ export function getMetricDefinition(metricId) {
   return getMetricDefinitionFromService(metricId);
 }
 
-export default {
-  configureRegistry,
-  getRegistrySnapshot,
-  getHustleDefinition,
-  getAssetDefinition,
-  getUpgradeDefinition,
-  getMetricDefinition
-};

--- a/src/core/state/slices/assets.js
+++ b/src/core/state/slices/assets.js
@@ -22,7 +22,3 @@ const { ensureSlice, getSliceState } = createRegistrySliceManager({
 
 export { ensureSlice, getSliceState };
 
-export default {
-  ensureSlice,
-  getSliceState
-};

--- a/src/core/state/slices/factory.js
+++ b/src/core/state/slices/factory.js
@@ -127,6 +127,3 @@ export function createRegistrySliceManager({
   };
 }
 
-export default {
-  createRegistrySliceManager
-};

--- a/src/core/state/slices/hustles.js
+++ b/src/core/state/slices/hustles.js
@@ -24,7 +24,3 @@ const { ensureSlice, getSliceState } = createRegistrySliceManager({
 
 export { ensureSlice, getSliceState };
 
-export default {
-  ensureSlice,
-  getSliceState
-};

--- a/src/core/state/slices/progress.js
+++ b/src/core/state/slices/progress.js
@@ -13,7 +13,3 @@ const { ensureSlice, getSliceState } = createRegistrySliceManager({
 
 export { ensureSlice, getSliceState };
 
-export default {
-  ensureSlice,
-  getSliceState
-};

--- a/src/core/state/slices/upgrades.js
+++ b/src/core/state/slices/upgrades.js
@@ -60,7 +60,3 @@ const { ensureSlice, getSliceState } = createRegistrySliceManager({
 
 export { ensureSlice, getSliceState };
 
-export default {
-  ensureSlice,
-  getSliceState
-};

--- a/src/game/registryBootstrap.js
+++ b/src/game/registryBootstrap.js
@@ -34,6 +34,3 @@ export function ensureRegistryReady() {
   return readySnapshot;
 }
 
-export default {
-  ensureRegistryReady
-};

--- a/src/game/registryLoader.js
+++ b/src/game/registryLoader.js
@@ -7,4 +7,3 @@ export function loadDefaultRegistry() {
   return loadRegistry({ assets: ASSETS, hustles: HUSTLES, upgrades: UPGRADES });
 }
 
-export default { loadDefaultRegistry };

--- a/src/game/registryService.js
+++ b/src/game/registryService.js
@@ -76,15 +76,3 @@ export function getMetricDefinition(metricId) {
   return metricIndex.get(metricId) || null;
 }
 
-export default {
-  loadRegistry,
-  resetRegistry,
-  getRegistry,
-  getHustles,
-  getAssets,
-  getUpgrades,
-  getHustleDefinition,
-  getAssetDefinition,
-  getUpgradeDefinition,
-  getMetricDefinition
-};

--- a/src/ui/cards/model.js
+++ b/src/ui/cards/model.js
@@ -1,1 +1,0 @@
-export * from './model/index.js';

--- a/src/ui/layout.js
+++ b/src/ui/layout.js
@@ -1,2 +1,0 @@
-export * from './layout/index.js';
-export { default } from './layout/index.js';

--- a/src/ui/player.js
+++ b/src/ui/player.js
@@ -1,1 +1,0 @@
-export * from './player/model.js';

--- a/src/ui/skillsWidget.js
+++ b/src/ui/skillsWidget.js
@@ -1,1 +1,0 @@
-export * from './skillsWidget/model.js';

--- a/src/ui/views/browser/components/widgets.js
+++ b/src/ui/views/browser/components/widgets.js
@@ -21,7 +21,3 @@ export function createStat(label, value) {
   return stat;
 }
 
-export default {
-  createStat,
-  formatRoi
-};

--- a/tests/ui/legendToggle.test.js
+++ b/tests/ui/legendToggle.test.js
@@ -5,7 +5,7 @@ import { ensureTestDom } from '../helpers/setupDom.js';
 test('event log panel toggles visibility from dashboard shortcut', async () => {
   ensureTestDom();
 
-  const { initLayoutControls } = await import('../../src/ui/layout.js');
+  const { initLayoutControls } = await import('../../src/ui/layout/index.js');
   initLayoutControls();
 
   const trigger = document.getElementById('open-event-log');

--- a/tests/ui/update.integration.test.js
+++ b/tests/ui/update.integration.test.js
@@ -51,7 +51,7 @@ test('classic view update flow routes through cards presenter with dashboard and
   assetState.instances = [activeInstance, setupInstance];
 
   const updateModule = await import('../../src/ui/update.js');
-  const layoutModule = await import('../../src/ui/layout.js');
+  const layoutModule = await import('../../src/ui/layout/index.js');
   const classicModule = await import('../../src/ui/views/classic/index.js');
 
   layoutModule.initLayoutControls();


### PR DESCRIPTION
## Summary
- remove redundant default export wrappers across state and registry helpers now referenced solely by named exports
- delete unused UI re-export shells and update tests to import layout helpers directly
- drop unused default export object from browser widget utilities

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68deb5042a84832cb027e50faa639a84