### PR TITLE
Fix notifications dropdown selectors for dashboard view

### DIFF
--- a/src/ui/views/browser/resolvers.js
+++ b/src/ui/views/browser/resolvers.js
@@ -1,3 +1,37 @@
+function selectFirst(root, selectors = []) {
+  if (!root) return null;
+  for (const selector of selectors) {
+    if (!selector) continue;
+    const node = root.querySelector(selector);
+    if (node) {
+      return node;
+    }
+  }
+  return null;
+}
+
+function resolveNotificationContainer(root) {
+  return (
+    selectFirst(root, [
+      '[data-role="browser-notifications"]',
+      '[data-role="notifications"]',
+      '[data-notifications]',
+      '[data-component="notifications"]',
+      '#browser-notifications',
+      '#notifications',
+      '.browser-notifications',
+      '.notifications'
+    ]) || null
+  );
+}
+
+function resolveNotificationPart(root, container, selectors = []) {
+  return (
+    selectFirst(container, selectors) ||
+    selectFirst(root, selectors)
+  );
+}
+
 const resolvers = {
   browserNavigation: root => ({
     backButton: root.getElementById('browser-nav-back'),
@@ -13,16 +47,64 @@ const resolvers = {
     endDayButton: root.getElementById('browser-session-button')
   }),
   browserNotifications: root => {
-    const container = root.querySelector('[data-role="browser-notifications"]');
+    const container = resolveNotificationContainer(root);
     if (!container) return null;
     return {
       container,
-      button: container.querySelector('#browser-notifications-button'),
-      panel: container.querySelector('#browser-notifications-panel'),
-      list: container.querySelector('#browser-notifications-list'),
-      empty: container.querySelector('#browser-notifications-empty'),
-      badge: container.querySelector('#browser-notifications-badge'),
-      markAll: container.querySelector('#browser-notifications-mark-all')
+      button: resolveNotificationPart(root, container, [
+        '#browser-notifications-button',
+        '[data-role="browser-notifications-button"]',
+        '[data-role="notifications-button"]',
+        '[data-notifications-button]',
+        '[data-notification-button]',
+        '#notifications-button',
+        '.browser-notifications__trigger',
+        '.notifications__trigger'
+      ]),
+      panel: resolveNotificationPart(root, container, [
+        '#browser-notifications-panel',
+        '[data-role="browser-notifications-panel"]',
+        '[data-role="notifications-panel"]',
+        '[data-notifications-panel]',
+        '#notifications-panel',
+        '#notifications-dropdown',
+        '.browser-notifications__panel',
+        '.notifications__panel'
+      ]),
+      list: resolveNotificationPart(root, container, [
+        '#browser-notifications-list',
+        '[data-role="browser-notifications-list"]',
+        '[data-role="notifications-list"]',
+        '[data-notifications-list]',
+        '#notifications-list',
+        '.browser-notifications__list',
+        '.notifications__list'
+      ]),
+      empty: resolveNotificationPart(root, container, [
+        '#browser-notifications-empty',
+        '[data-role="browser-notifications-empty"]',
+        '[data-role="notifications-empty"]',
+        '[data-notifications-empty]',
+        '#notifications-empty',
+        '.browser-notifications__empty',
+        '.notifications__empty'
+      ]),
+      badge: resolveNotificationPart(root, container, [
+        '#browser-notifications-badge',
+        '[data-role="browser-notifications-badge"]',
+        '[data-role="notifications-badge"]',
+        '[data-notifications-badge]',
+        '#notifications-badge',
+        '.browser-notifications__badge',
+        '.notifications__badge'
+      ]),
+      markAll: resolveNotificationPart(root, container, [
+        '#browser-notifications-mark-all',
+        '[data-role="browser-notifications-mark-all"]',
+        '[data-role="notifications-mark-all"]',
+        '[data-notifications-mark-all]',
+        '#notifications-mark-all'
+      ])
     };
   },
   themeToggle: root => root.getElementById('browser-theme-toggle'),

--- a/tests/ui/browserNotificationsResolver.test.js
+++ b/tests/ui/browserNotificationsResolver.test.js
@@ -1,0 +1,33 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+import resolvers from '../../src/ui/views/browser/resolvers.js';
+
+test('browserNotifications resolver finds alternate notification markup', () => {
+  const dom = new JSDOM(`
+    <header>
+      <div data-role="notifications" class="notifications">
+        <button id="notifications-button" data-role="notifications-button" class="notifications__trigger"></button>
+        <span id="notifications-badge" data-role="notifications-badge" class="notifications__badge"></span>
+        <div id="notifications-dropdown" data-role="notifications-panel" class="notifications__panel">
+          <p id="notifications-empty" data-role="notifications-empty" class="notifications__empty"></p>
+          <ul id="notifications-list" data-role="notifications-list" class="notifications__list"></ul>
+          <button id="notifications-mark-all" data-role="notifications-mark-all"></button>
+        </div>
+      </div>
+    </header>
+  `);
+
+  const root = dom.window.document;
+  const refs = resolvers.browserNotifications(root);
+
+  assert.ok(refs, 'expected resolver to return refs');
+  assert.equal(refs.container?.getAttribute('data-role'), 'notifications');
+  assert.equal(refs.button?.id, 'notifications-button');
+  assert.equal(refs.panel?.id, 'notifications-dropdown');
+  assert.equal(refs.list?.id, 'notifications-list');
+  assert.equal(refs.empty?.id, 'notifications-empty');
+  assert.equal(refs.badge?.id, 'notifications-badge');
+  assert.equal(refs.markAll?.id, 'notifications-mark-all');
+});


### PR DESCRIPTION
## Summary
- expand the browser notifications resolver to look for the notification controls used in the new dashboard markup
- add a regression test that covers the alternate selectors so the dropdown wiring stays intact

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dec1d890cc832caded9c0b0431e79f