### PR TITLE
Redesign browser home widgets for compact shortcut grid

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -113,7 +113,7 @@
                   <header class="browser-widget__header">
                     <div>
                       <h2 id="browser-widget-apps-heading">Apps</h2>
-                      <p id="browser-widget-apps-note">Tap an icon to launch. Status badges light up when something's ready.</p>
+                      <p id="browser-widget-apps-note">Launch a workspace in a tap — hover to preview where it leads.</p>
                     </div>
                   </header>
                   <ul

--- a/src/ui/views/browser/widgets/appsWidget.js
+++ b/src/ui/views/browser/widgets/appsWidget.js
@@ -21,14 +21,24 @@ function isPageLocked(meta = '') {
   return /lock/i.test(meta || '');
 }
 
-function describeTooltip(page) {
-  return page?.tagline ? page.tagline : '';
+function describeTooltip(page, summary) {
+  const parts = [];
+  if (page?.tagline) {
+    parts.push(page.tagline);
+  }
+  if (summary?.meta) {
+    parts.push(summary.meta);
+  }
+  return parts.join(' — ');
 }
 
-function describeAriaLabel(page) {
+function describeAriaLabel(page, summary) {
   const parts = [page?.label || 'Workspace'];
   if (page?.tagline) {
     parts.push(page.tagline);
+  }
+  if (summary?.meta) {
+    parts.push(summary.meta);
   }
   return parts.join('. ');
 }
@@ -58,6 +68,7 @@ function renderList() {
   }
 
   pages.forEach(page => {
+    const summary = summaryMap.get(page.id);
     const item = document.createElement('li');
     item.className = 'apps-widget__item';
 
@@ -65,11 +76,11 @@ function renderList() {
     button.type = 'button';
     button.className = 'apps-widget__tile';
     button.dataset.siteTarget = page.id;
-    const tooltip = describeTooltip(page);
+    const tooltip = describeTooltip(page, summary);
     if (tooltip) {
       button.title = tooltip;
     }
-    button.setAttribute('aria-label', describeAriaLabel(page));
+    button.setAttribute('aria-label', describeAriaLabel(page, summary));
     button.setAttribute('aria-pressed', 'false');
 
     const icon = document.createElement('span');

--- a/src/ui/views/browser/widgets/appsWidget.js
+++ b/src/ui/views/browser/widgets/appsWidget.js
@@ -21,22 +21,13 @@ function isPageLocked(meta = '') {
   return /lock/i.test(meta || '');
 }
 
-function describeTooltip(page, summary = {}) {
-  const parts = [];
-  if (page?.tagline) {
-    parts.push(page.tagline);
-  }
-  if (summary?.meta) {
-    parts.push(`Status: ${summary.meta}`);
-  }
-  return parts.join(' • ');
+function describeTooltip(page) {
+  return page?.tagline ? page.tagline : '';
 }
 
-function describeAriaLabel(page, summary = {}) {
+function describeAriaLabel(page) {
   const parts = [page?.label || 'Workspace'];
-  if (summary?.meta) {
-    parts.push(summary.meta);
-  } else if (page?.tagline) {
+  if (page?.tagline) {
     parts.push(page.tagline);
   }
   return parts.join('. ');
@@ -67,7 +58,6 @@ function renderList() {
   }
 
   pages.forEach(page => {
-    const summary = summaryMap.get(page.id) || {};
     const item = document.createElement('li');
     item.className = 'apps-widget__item';
 
@@ -75,8 +65,11 @@ function renderList() {
     button.type = 'button';
     button.className = 'apps-widget__tile';
     button.dataset.siteTarget = page.id;
-    button.title = describeTooltip(page, summary);
-    button.setAttribute('aria-label', describeAriaLabel(page, summary));
+    const tooltip = describeTooltip(page);
+    if (tooltip) {
+      button.title = tooltip;
+    }
+    button.setAttribute('aria-label', describeAriaLabel(page));
     button.setAttribute('aria-pressed', 'false');
 
     const icon = document.createElement('span');
@@ -92,20 +85,13 @@ function renderList() {
 
     label.appendChild(name);
 
-    if (summary.meta) {
-      const badge = document.createElement('span');
-      badge.className = 'apps-widget__badge';
-      badge.textContent = summary.meta;
-      label.appendChild(badge);
-    }
-
     button.append(icon, label);
     item.appendChild(button);
     elements.list.appendChild(item);
   });
 
   if (elements?.note) {
-    elements.note.textContent = 'Hover to peek the description, click to launch instantly.';
+    elements.note.textContent = 'Hover to preview each workspace, click to launch instantly.';
   }
 }
 

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -466,28 +466,28 @@ a {
 
 .browser-stage__pane--home .browser-layout {
   max-width: 1400px;
-  padding: 2.5rem clamp(0.5rem, 2.4vw, 1.35rem) 3.25rem;
+  padding: 2.2rem clamp(0.45rem, 2.1vw, 1.2rem) 2.85rem;
 }
 
 .browser-main {
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 3rem;
+  gap: 2.6rem;
 }
 
 .browser-home {
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 2.5rem;
+  gap: 2.15rem;
 }
 
 .browser-home__widgets {
   width: 100%;
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1.6rem;
+  gap: 1.35rem;
   align-items: stretch;
 }
 
@@ -528,10 +528,10 @@ a {
   border: 1px solid var(--browser-panel-border);
   border-radius: var(--browser-radius-lg);
   box-shadow: var(--browser-shadow-soft);
-  padding: 1.35rem;
+  padding: 1.2rem;
   display: flex;
   flex-direction: column;
-  gap: 1.1rem;
+  gap: 0.95rem;
   height: 100%;
   min-height: 0;
 }
@@ -541,25 +541,25 @@ a {
   flex-wrap: wrap;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 1.25rem;
+  gap: 1.05rem;
 }
 
 .browser-widget__header h2 {
   margin: 0;
-  font-size: 1.5rem;
+  font-size: 1.35rem;
 }
 
 .browser-widget__header p {
-  margin: 0.4rem 0 0;
+  margin: 0.3rem 0 0;
   color: var(--browser-muted);
-  font-size: 0.95rem;
+  font-size: 0.88rem;
 }
 
 .todo-widget {
-  gap: 1.5rem;
+  gap: 1.3rem;
   flex: 1 1 auto;
   min-height: 0;
-  --todo-widget-row-height: 4.5rem;
+  --todo-widget-row-height: 4.1rem;
 }
 
 .todo-widget__header {
@@ -570,15 +570,15 @@ a {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.35rem;
-  font-size: 0.9rem;
+  gap: 0.3rem;
+  font-size: 0.82rem;
   color: var(--browser-muted);
 }
 
 .todo-widget__focus-label {
   font-weight: 600;
   color: var(--browser-subtle);
-  margin-right: 0.25rem;
+  margin-right: 0.2rem;
 }
 
 .todo-widget__focus-button {
@@ -586,7 +586,7 @@ a {
   background: none;
   color: inherit;
   font: inherit;
-  padding: 0.2rem 0.6rem;
+  padding: 0.18rem 0.55rem;
   border-radius: var(--browser-radius-pill);
   cursor: pointer;
   display: inline-flex;
@@ -611,34 +611,34 @@ a {
 .todo-widget__focus-separator {
   color: var(--browser-subtle);
   font-weight: 600;
-  margin: 0 0.1rem;
+  margin: 0 0.08rem;
   user-select: none;
 }
 
 .todo-widget__intro h2 {
   margin: 0;
-  font-size: 1.5rem;
+  font-size: 1.35rem;
 }
 
 .todo-widget__intro p {
-  margin: 0.4rem 0 0;
+  margin: 0.3rem 0 0;
   color: var(--browser-muted);
-  font-size: 0.95rem;
+  font-size: 0.88rem;
 }
 
 .todo-widget__hours {
   margin: 0;
   display: grid;
-  gap: 0.5rem;
-  min-width: 180px;
+  gap: 0.45rem;
+  min-width: 160px;
 }
 
 .todo-widget__hours-row {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 1rem;
-  font-size: 0.95rem;
+  gap: 0.85rem;
+  font-size: 0.88rem;
 }
 
 .todo-widget__hours-row dt {
@@ -659,7 +659,7 @@ a {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65rem;
 }
 
 .todo-widget__list-wrapper {
@@ -679,9 +679,9 @@ a {
   width: 100%;
   display: flex;
   align-items: center;
-  gap: 0.85rem;
-  padding: 0.85rem 1rem;
-  border-radius: 14px;
+  gap: 0.75rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 13px;
   border: 1px solid var(--browser-panel-border);
   background: var(--browser-panel);
   color: inherit;
@@ -708,14 +708,14 @@ a {
 }
 
 .todo-widget__checkbox {
-  width: 22px;
-  height: 22px;
+  width: 20px;
+  height: 20px;
   border-radius: 6px;
   border: 2px solid var(--browser-muted);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   font-weight: 600;
   color: transparent;
   transition: background 140ms ease, border-color 140ms ease, color 140ms ease;
@@ -729,7 +729,7 @@ a {
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
+  gap: 0.18rem;
 }
 
 .todo-widget__title {
@@ -738,7 +738,7 @@ a {
 
 .todo-widget__meta {
   color: var(--browser-muted);
-  font-size: 0.95rem;
+  font-size: 0.85rem;
 }
 
 .todo-widget__task.is-complete {
@@ -759,15 +759,15 @@ a {
 
 .todo-widget__done {
   border-top: 1px solid var(--browser-panel-border);
-  padding-top: 1rem;
+  padding-top: 0.9rem;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65rem;
 }
 
 .todo-widget__done h3 {
   margin: 0;
-  font-size: 0.95rem;
+  font-size: 0.88rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--browser-subtle);
@@ -777,12 +777,12 @@ a {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
-  padding: 0.65rem 0.75rem;
-  border-radius: 12px;
+  gap: 0.85rem;
+  padding: 0.55rem 0.7rem;
+  border-radius: 11px;
   background: rgba(148, 163, 184, 0.16);
   color: var(--browser-muted);
-  font-size: 0.95rem;
+  font-size: 0.88rem;
 }
 
 .todo-widget__done-title {
@@ -790,18 +790,18 @@ a {
 }
 
 .todo-widget__done-meta {
-  font-size: 0.9rem;
+  font-size: 0.82rem;
 }
 
 .todo-widget__empty {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
-  border-radius: 12px;
+  gap: 0.65rem;
+  padding: 0.65rem 0.9rem;
+  border-radius: 11px;
   background: rgba(148, 163, 184, 0.12);
   color: var(--browser-subtle);
-  font-size: 0.95rem;
+  font-size: 0.88rem;
 }
 
 .todo-widget__empty-text {
@@ -815,7 +815,7 @@ a {
   background: var(--browser-accent);
   border: none;
   border-radius: 10px;
-  padding: 0.5rem 0.9rem;
+  padding: 0.45rem 0.8rem;
   cursor: pointer;
   transition: background 160ms ease, transform 160ms ease;
 }
@@ -842,7 +842,7 @@ a {
   background: var(--browser-accent);
   border: none;
   border-radius: 12px;
-  padding: 0.85rem 1.6rem;
+  padding: 0.75rem 1.4rem;
   cursor: pointer;
   transition: background 160ms ease, transform 160ms ease;
 }
@@ -865,8 +865,20 @@ a {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 1.25rem;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.9rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+@media (max-width: 1024px) {
+  .apps-widget__list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 680px) {
+  .apps-widget__list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .apps-widget__item {
@@ -879,12 +891,12 @@ a {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.9rem;
-  padding: 1.35rem 1.1rem 1.25rem;
-  border-radius: 18px;
-  border: 1px solid rgba(148, 163, 184, 0.28);
+  gap: 0.7rem;
+  padding: 1.1rem 0.85rem 1rem;
+  border-radius: 16px;
+  border: 1px solid transparent;
   background: var(--browser-panel-elevated);
-  background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0));
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
   color: inherit;
   font: inherit;
   text-align: center;
@@ -894,21 +906,20 @@ a {
 }
 
 :root[data-browser-theme="night"] .apps-widget__tile {
-  border-color: rgba(139, 170, 255, 0.32);
-  background-image: linear-gradient(180deg, rgba(139, 170, 255, 0.12), rgba(139, 170, 255, 0));
+  box-shadow: 0 18px 42px rgba(2, 6, 23, 0.48);
 }
 
 .apps-widget__tile:hover,
 .apps-widget__tile:focus-visible {
   border-color: var(--browser-accent);
-  box-shadow: 0 16px 38px rgba(37, 99, 235, 0.18);
-  transform: translateY(-4px);
+  box-shadow: 0 16px 36px rgba(37, 99, 235, 0.2);
+  transform: translateY(-3px);
   outline: none;
 }
 
 .apps-widget__tile.is-active {
   border-color: var(--browser-accent);
-  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.18);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
 }
 
 .apps-widget__icon {
@@ -925,35 +936,23 @@ a {
 .apps-widget__label {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.28rem;
   align-items: center;
 }
 
 .apps-widget__name {
-  font-size: 1rem;
-  font-weight: 600;
-}
-
-.apps-widget__badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.25rem 0.65rem;
-  border-radius: var(--browser-radius-pill);
-  background: var(--browser-accent-soft);
-  color: var(--browser-accent);
-  font-size: 0.8rem;
+  font-size: 0.92rem;
   font-weight: 600;
 }
 
 .apps-widget__empty {
   margin: 0;
-  padding: 2rem 1.25rem;
-  border-radius: 18px;
+  padding: 1.6rem 1.1rem;
+  border-radius: 16px;
   border: 1px dashed rgba(148, 163, 184, 0.4);
   background: rgba(148, 163, 184, 0.08);
   color: var(--browser-muted);
-  font-size: 0.95rem;
+  font-size: 0.88rem;
   text-align: center;
   grid-column: 1 / -1;
 }
@@ -963,29 +962,29 @@ a {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 0.75rem;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.65rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
 }
 
 .bank-widget__stat {
   list-style: none;
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  padding: 0.95rem 1rem;
+  gap: 0.3rem;
+  padding: 0.85rem 0.9rem;
   border-radius: var(--browser-radius-md);
   background: var(--browser-panel-elevated);
   border: 1px solid var(--browser-panel-border);
 }
 
 .bank-widget__label {
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   color: var(--browser-subtle);
   font-weight: 600;
 }
 
 .bank-widget__value {
-  font-size: 1.2rem;
+  font-size: 1.08rem;
   font-weight: 700;
 }
 
@@ -1000,24 +999,24 @@ a {
 .bank-widget__footnote {
   margin: 0;
   color: var(--browser-muted);
-  font-size: 0.9rem;
+  font-size: 0.82rem;
 }
 
 .bank-widget__highlights {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.65rem;
 }
 
 .bank-widget__chip {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.6rem 0.9rem;
+  gap: 0.45rem;
+  padding: 0.52rem 0.82rem;
   border-radius: var(--browser-radius-pill);
   background: var(--browser-panel-elevated);
   border: 1px solid var(--browser-panel-border);
-  font-size: 0.9rem;
+  font-size: 0.84rem;
   line-height: 1;
 }
 


### PR DESCRIPTION
## Summary
- tighten homepage widget spacing and typography for a lighter browser-style layout
- convert the apps widget into a four-column shortcut grid with icon-plus-name tiles
- simplify the apps widget logic to drop status badges while keeping accessible labels

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68ded3059118832cb32cb58cd0614d01