### PR TITLE
Remove unused model builder registry reset helpers

### DIFF
--- a/src/ui/cards/modelBuilderRegistry.js
+++ b/src/ui/cards/modelBuilderRegistry.js
@@ -20,10 +20,6 @@ function registerModelBuilder(key, builder, { isDefault = false } = {}) {
   return () => builders.delete(normalizedKey);
 }
 
-function unregisterModelBuilder(key) {
-  builders.delete(key);
-}
-
 function getModelBuilderEntries() {
   return Array.from(builders.entries());
 }
@@ -34,11 +30,6 @@ function buildModelMap(registries, context = {}) {
     models[key] = builder(registries, context);
   });
   return models;
-}
-
-function resetModelBuilders() {
-  builders.clear();
-  defaultsRegistered = false;
 }
 
 function hasRegisteredBuilders() {
@@ -57,10 +48,8 @@ function ensureDefaultBuilders(registerDefaults) {
 
 export {
   registerModelBuilder,
-  unregisterModelBuilder,
   getModelBuilderEntries,
   buildModelMap,
-  resetModelBuilders,
   hasRegisteredBuilders,
   ensureDefaultBuilders
 };


### PR DESCRIPTION
## Summary
- remove unused unregisterModelBuilder and resetModelBuilders helpers from the card model builder registry to simplify the API
- retain ensureDefaultBuilders for collection initialization without changing consuming modules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ded2477fd4832c9f105a873cb2c7f6