### PR TITLE
Revamp browser home widget layout spacing

### DIFF
--- a/styles/browser.css
+++ b/styles/browser.css
@@ -466,7 +466,7 @@ a {
 
 .browser-stage__pane--home .browser-layout {
   max-width: 1400px;
-  padding: 2.2rem clamp(0.45rem, 2.1vw, 1.2rem) 2.85rem;
+  padding: 3rem clamp(0.85rem, 2.1vw, 1.6rem) 3.4rem;
 }
 
 .browser-main {
@@ -480,15 +480,18 @@ a {
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 2.15rem;
+  gap: 1.8rem;
 }
 
 .browser-home__widgets {
   width: 100%;
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1.35rem;
+  gap: 1.75rem;
   align-items: stretch;
+  justify-content: center;
+  margin: 0 auto;
+  max-width: min(100%, 1180px);
 }
 
 @media (max-width: 1200px) {
@@ -528,10 +531,10 @@ a {
   border: 1px solid var(--browser-panel-border);
   border-radius: var(--browser-radius-lg);
   box-shadow: var(--browser-shadow-soft);
-  padding: 1.2rem;
+  padding: 1.1rem 1.2rem;
   display: flex;
   flex-direction: column;
-  gap: 0.95rem;
+  gap: 0.8rem;
   height: 100%;
   min-height: 0;
 }
@@ -541,18 +544,35 @@ a {
   flex-wrap: wrap;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 1.05rem;
+  gap: 0.75rem;
+  text-align: left;
 }
 
 .browser-widget__header h2 {
   margin: 0;
-  font-size: 1.35rem;
+  font-size: 1.15rem;
+  font-weight: 700;
 }
 
 .browser-widget__header p {
-  margin: 0.3rem 0 0;
+  margin: 0.2rem 0 0;
   color: var(--browser-muted);
-  font-size: 0.88rem;
+  font-size: 0.85rem;
+}
+
+.todo-widget,
+.bank-widget {
+  padding: 0.95rem 1.15rem 1.2rem;
+}
+
+.todo-widget .browser-widget__header,
+.bank-widget .browser-widget__header {
+  gap: 0.65rem;
+}
+
+.apps-widget {
+  padding: 0.85rem 0.95rem 1rem;
+  gap: 0.65rem;
 }
 
 .todo-widget {
@@ -865,7 +885,7 @@ a {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 0.9rem;
+  gap: 0.75rem;
   grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
@@ -891,8 +911,8 @@ a {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.7rem;
-  padding: 1.1rem 0.85rem 1rem;
+  gap: 0.55rem;
+  padding: 0.9rem 0.75rem 0.9rem;
   border-radius: 16px;
   border: 1px solid transparent;
   background: var(--browser-panel-elevated);
@@ -934,9 +954,9 @@ a {
 }
 
 .apps-widget__label {
-  display: flex;
+  display: inline-flex;
   flex-direction: column;
-  gap: 0.28rem;
+  gap: 0.18rem;
   align-items: center;
 }
 


### PR DESCRIPTION
## Summary
- center the browser home widget grid with expanded canvas padding
- slim widget headers, card padding, and apps grid spacing for a dashboard look
- tighten todo and bank widget padding for better alignment without altering content

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ded90e5bf4832c9fc3ac6ee1903fce