### PR TITLE
Refactor browser workspace formatting helpers

### DIFF
--- a/src/ui/views/browser/components/blogpress.js
+++ b/src/ui/views/browser/components/blogpress.js
@@ -1,6 +1,7 @@
 import { formatHours, formatMoney } from '../../../../core/helpers.js';
 import { selectBlogpressNiche } from '../../../cards/model/index.js';
 import { performQualityAction } from '../../../../game/assets/index.js';
+import { formatCurrency as baseFormatCurrency } from '../utils/formatting.js';
 
 const VIEW_HOME = 'home';
 const VIEW_DETAIL = 'detail';
@@ -20,9 +21,8 @@ let currentMount = null;
 let currentPageMeta = null;
 let routeListener = null;
 
-function formatCurrency(amount) {
-  return `$${formatMoney(Math.max(0, Math.round(Number(amount) || 0)))}`;
-}
+const formatCurrency = amount =>
+  baseFormatCurrency(amount, { precision: 'integer', clampZero: true });
 
 function formatRange(range = {}) {
   const min = Number(range.min) || 0;

--- a/src/ui/views/browser/components/digishelf.js
+++ b/src/ui/views/browser/components/digishelf.js
@@ -4,6 +4,7 @@ import {
   selectDigishelfNiche
 } from '../../../cards/model/digishelf.js';
 import { performQualityAction } from '../../../../game/assets/index.js';
+import { formatCurrency as baseFormatCurrency } from '../utils/formatting.js';
 
 const VIEW_EBOOKS = 'ebooks';
 const VIEW_STOCK = 'stock';
@@ -42,10 +43,8 @@ function clampNumber(value) {
   return Number.isFinite(number) ? number : 0;
 }
 
-function formatCurrency(amount) {
-  const numeric = Math.max(0, Math.round(clampNumber(amount)));
-  return `$${formatMoney(numeric)}`;
-}
+const formatCurrency = amount =>
+  baseFormatCurrency(amount, { precision: 'integer', clampZero: true });
 
 function ensureState(model) {
   const ebookInstances = Array.isArray(model.ebook?.instances) ? model.ebook.instances : [];

--- a/src/ui/views/browser/components/learnly.js
+++ b/src/ui/views/browser/components/learnly.js
@@ -1,6 +1,7 @@
-import { formatDays, formatHours, formatMoney } from '../../../../core/helpers.js';
+import { formatDays, formatHours } from '../../../../core/helpers.js';
 import { describeTrackEducationBonuses } from '../../../../game/educationEffects.js';
 import { dropKnowledgeTrack } from '../../../../game/requirements.js';
+import { formatCurrency as baseFormatCurrency } from '../utils/formatting.js';
 
 const VIEW_CATALOG = 'catalog';
 const VIEW_DETAIL = 'detail';
@@ -51,10 +52,8 @@ let currentContext = {
   }
 };
 
-function formatCurrency(amount) {
-  const numeric = Math.max(0, Number(amount) || 0);
-  return `$${formatMoney(numeric)}`;
-}
+const formatCurrency = amount =>
+  baseFormatCurrency(amount, { clampZero: true });
 
 function deriveCategories(skills = []) {
   const categoryIds = new Set();

--- a/src/ui/views/browser/components/serverhub.js
+++ b/src/ui/views/browser/components/serverhub.js
@@ -1,6 +1,11 @@
-import { ensureArray, formatHours, formatMoney } from '../../../../core/helpers.js';
+import { ensureArray, formatHours } from '../../../../core/helpers.js';
 import { performQualityAction } from '../../../../game/assets/index.js';
 import { selectServerHubNiche } from '../../../cards/model/index.js';
+import {
+  formatCurrency as baseFormatCurrency,
+  formatNetCurrency as baseFormatNetCurrency,
+  formatPercent as baseFormatPercent
+} from '../utils/formatting.js';
 
 const VIEW_APPS = 'apps';
 const VIEW_UPGRADES = 'upgrades';
@@ -19,28 +24,12 @@ let currentModel = {
 let currentMount = null;
 let currentPageMeta = null;
 
-function formatCurrency(amount) {
-  const numeric = Math.max(0, Math.round(Number(amount) || 0));
-  return `$${formatMoney(numeric)}`;
-}
-
-function formatNetCurrency(amount) {
-  const numeric = Number(amount) || 0;
-  const absolute = Math.abs(numeric);
-  const formatted = `$${formatMoney(Math.round(absolute))}`;
-  return numeric >= 0 ? formatted : `-${formatted}`;
-}
-
-function formatPercent(value) {
-  if (value === null || value === undefined) {
-    return '—';
-  }
-  const numeric = Number(value);
-  if (!Number.isFinite(numeric)) return '—';
-  const percent = Math.round(numeric * 100);
-  const sign = percent > 0 ? '+' : percent < 0 ? '-' : '';
-  return `${sign}${Math.abs(percent)}%`;
-}
+const formatCurrency = amount =>
+  baseFormatCurrency(amount, { precision: 'integer', clampZero: true });
+const formatNetCurrency = amount =>
+  baseFormatNetCurrency(amount, { precision: 'integer' });
+const formatPercent = value =>
+  baseFormatPercent(value, { nullFallback: '—', signDisplay: 'always' });
 
 function ensureSelectedApp() {
   const instances = ensureArray(currentModel.instances);

--- a/src/ui/views/browser/components/shopily.js
+++ b/src/ui/views/browser/components/shopily.js
@@ -1,4 +1,9 @@
-import { ensureArray, formatHours, formatMoney } from '../../../../core/helpers.js';
+import { ensureArray, formatHours } from '../../../../core/helpers.js';
+import {
+  formatCurrency as baseFormatCurrency,
+  formatPercent as baseFormatPercent,
+  formatSignedCurrency as baseFormatSignedCurrency
+} from '../utils/formatting.js';
 import { selectShopilyNiche } from '../../../cards/model/index.js';
 import { performQualityAction } from '../../../../game/assets/index.js';
 
@@ -23,29 +28,12 @@ let currentMount = null;
 let currentPageMeta = null;
 let routeListener = null;
 
-function formatCurrency(amount) {
-  const numeric = Number(amount) || 0;
-  return `$${formatMoney(Math.max(0, Math.round(numeric)))}`;
-}
-
-function formatSignedCurrency(amount) {
-  const numeric = Number(amount) || 0;
-  const absolute = Math.abs(numeric);
-  const formatted = formatMoney(Math.round(absolute * 100) / 100);
-  const sign = numeric > 0 ? '+' : numeric < 0 ? '-' : '';
-  return `${sign}$${formatted}`;
-}
-
-function formatPercent(value) {
-  if (value === null || value === undefined) {
-    return '—';
-  }
-  const numeric = Number(value);
-  if (!Number.isFinite(numeric)) return '—';
-  const percent = Math.round(numeric * 100);
-  const sign = percent > 0 ? '+' : percent < 0 ? '-' : '';
-  return `${sign}${Math.abs(percent)}%`;
-}
+const formatCurrency = amount =>
+  baseFormatCurrency(amount, { precision: 'integer', clampZero: true });
+const formatSignedCurrency = amount =>
+  baseFormatSignedCurrency(amount, { precision: 'cent' });
+const formatPercent = value =>
+  baseFormatPercent(value, { nullFallback: '—', signDisplay: 'always' });
 
 function ensureSelectedStore() {
   const instances = Array.isArray(currentModel.instances) ? currentModel.instances : [];

--- a/src/ui/views/browser/components/trends.js
+++ b/src/ui/views/browser/components/trends.js
@@ -1,6 +1,10 @@
-import { formatMoney } from '../../../../core/helpers.js';
 import { setNicheWatchlist } from '../../../../game/assets/niches.js';
 import { navigateToWorkspace } from '../layoutPresenter.js';
+import {
+  formatCurrency as baseFormatCurrency,
+  formatPercent as baseFormatPercent,
+  formatSignedCurrency as baseFormatSignedCurrency
+} from '../utils/formatting.js';
 
 const SORT_OPTIONS = [
   { key: 'impact', label: 'Highest payout impact' },
@@ -35,27 +39,14 @@ function clampScore(value) {
   return Math.max(0, Math.min(100, Math.round(value)));
 }
 
-function formatPercent(value) {
-  if (value === null || value === undefined) return '0%';
-  const numeric = Number(value);
-  if (!Number.isFinite(numeric)) return '0%';
-  const percent = Math.round(numeric * 100);
-  const sign = percent > 0 ? '+' : percent < 0 ? '-' : '';
-  return `${sign}${Math.abs(percent)}%`;
-}
+const formatPercent = value =>
+  baseFormatPercent(value, { nullFallback: '0%', signDisplay: 'always' });
 
-function formatCurrency(amount) {
-  const numeric = Number(amount) || 0;
-  const absolute = Math.abs(Math.round(numeric * 100) / 100);
-  return `$${formatMoney(absolute)}`;
-}
+const formatCurrency = amount =>
+  baseFormatCurrency(amount, { absolute: true, precision: 'cent', signDisplay: 'never' });
 
-function formatSignedCurrency(amount) {
-  const numeric = Number(amount) || 0;
-  const absolute = Math.abs(Math.round(numeric * 100) / 100);
-  const sign = numeric > 0 ? '+' : numeric < 0 ? '-' : '';
-  return `${sign}$${formatMoney(absolute)}`;
-}
+const formatSignedCurrency = amount =>
+  baseFormatSignedCurrency(amount, { precision: 'cent' });
 
 function describeDelta(popularity = {}) {
   const raw = Number(popularity.delta);

--- a/src/ui/views/browser/components/videotube.js
+++ b/src/ui/views/browser/components/videotube.js
@@ -1,7 +1,11 @@
-import { formatHours, formatMoney } from '../../../../core/helpers.js';
+import { formatHours } from '../../../../core/helpers.js';
 import { performQualityAction } from '../../../../game/assets/index.js';
 import { setAssetInstanceName } from '../../../../game/assets/helpers.js';
 import { selectVideoTubeNiche } from '../../../cards/model/index.js';
+import {
+  formatCurrency as baseFormatCurrency,
+  formatPercent as baseFormatPercent
+} from '../utils/formatting.js';
 
 const VIEW_DASHBOARD = 'dashboard';
 const VIEW_DETAIL = 'detail';
@@ -23,14 +27,14 @@ let currentModel = {
 let currentMount = null;
 let currentPageMeta = null;
 
-function formatCurrency(amount) {
-  return `$${formatMoney(Math.max(0, Math.round(Number(amount) || 0)))}`;
-}
-
-function formatPercent(value) {
-  const numeric = Math.max(0, Math.min(1, Number(value) || 0));
-  return `${Math.round(numeric * 100)}%`;
-}
+const formatCurrency = amount =>
+  baseFormatCurrency(amount, { precision: 'integer', clampZero: true });
+const formatPercent = value =>
+  baseFormatPercent(value, {
+    clampMin: 0,
+    clampMax: 1,
+    signDisplay: 'never'
+  });
 
 function ensureSelectedVideo() {
   const instances = Array.isArray(currentModel.instances) ? currentModel.instances : [];

--- a/src/ui/views/browser/components/yournetwork.js
+++ b/src/ui/views/browser/components/yournetwork.js
@@ -1,4 +1,8 @@
-import { formatHours, formatMoney } from '../../../../core/helpers.js';
+import { formatHours } from '../../../../core/helpers.js';
+import {
+  formatCurrency as baseFormatCurrency,
+  formatSignedCurrency as baseFormatSignedCurrency
+} from '../utils/formatting.js';
 
 const AVATAR_GLYPHS = ['🌱', '🚀', '🌟', '🏆', '🪐', '💫'];
 
@@ -8,23 +12,9 @@ function clampPercent(value) {
   return Math.min(100, Math.max(0, Math.round(numeric)));
 }
 
-function formatCurrency(amount) {
-  const numeric = Number(amount) || 0;
-  const absolute = Math.abs(Math.round(numeric * 100) / 100);
-  const formatted = formatMoney(absolute);
-  const prefix = numeric < 0 ? '-$' : '$';
-  return `${prefix}${formatted}`;
-}
-
-function formatSignedCurrency(amount) {
-  const numeric = Number(amount) || 0;
-  if (numeric === 0) {
-    return '$0';
-  }
-  const absolute = Math.abs(Math.round(numeric * 100) / 100);
-  const formatted = `$${formatMoney(absolute)}`;
-  return numeric > 0 ? `+${formatted}` : `-${formatted}`;
-}
+const formatCurrency = amount => baseFormatCurrency(amount, { precision: 'cent' });
+const formatSignedCurrency = amount =>
+  baseFormatSignedCurrency(amount, { precision: 'cent' });
 
 function toTitleCase(value) {
   if (!value) return '';

--- a/src/ui/views/browser/utils/formatting.js
+++ b/src/ui/views/browser/utils/formatting.js
@@ -1,0 +1,147 @@
+import { formatMoney } from '../../../../core/helpers.js';
+
+function toNumeric(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : 0;
+}
+
+function roundValue(value, precision) {
+  switch (precision) {
+    case 'integer':
+    case 'dollar':
+      return Math.round(value);
+    case 'none':
+      return value;
+    case 'cent':
+    default:
+      return Math.round(value * 100) / 100;
+  }
+}
+
+function formatMagnitude(value, precision) {
+  const rounded = roundValue(value, precision);
+  return Math.abs(rounded);
+}
+
+function getSignPrefix(value, signDisplay) {
+  const mode = signDisplay || 'auto';
+  if (value > 0 && mode === 'always') {
+    return '+';
+  }
+  if (value < 0 && mode !== 'never') {
+    return '-';
+  }
+  return '';
+}
+
+function buildCurrency(value, options = {}) {
+  const {
+    precision = 'cent',
+    clampZero = false,
+    absolute = false,
+    signDisplay = 'auto',
+    zeroDisplay = null
+  } = options;
+
+  const baseValue = toNumeric(value);
+  const clampedValue = clampZero ? Math.max(0, baseValue) : baseValue;
+  const magnitudeSource = absolute ? baseValue : clampedValue;
+  const magnitude = formatMagnitude(magnitudeSource, precision);
+  const formatted = `$${formatMoney(magnitude)}`;
+
+  if (magnitude === 0 && zeroDisplay != null) {
+    return zeroDisplay;
+  }
+
+  const signReference = absolute && !clampZero ? baseValue : clampedValue;
+  const sign = getSignPrefix(signReference, signDisplay);
+  return `${sign}${formatted}`;
+}
+
+export function formatCurrency(value, options = {}) {
+  return buildCurrency(value, options);
+}
+
+export function formatSignedCurrency(value, options = {}) {
+  const { precision = 'cent', zeroDisplay = '$0' } = options;
+  return buildCurrency(value, {
+    ...options,
+    precision,
+    zeroDisplay,
+    absolute: true,
+    signDisplay: 'always'
+  });
+}
+
+export function formatNetCurrency(value, options = {}) {
+  const { precision = 'integer' } = options;
+  return buildCurrency(value, {
+    ...options,
+    precision,
+    absolute: true,
+    signDisplay: 'auto'
+  });
+}
+
+function formatPercentMagnitude(value, precision) {
+  if (typeof precision === 'number' && precision > 0) {
+    const factor = 10 ** precision;
+    return Math.round(value * factor) / factor;
+  }
+  return Math.round(value);
+}
+
+function toPercentString(value, precision) {
+  if (typeof precision === 'number' && precision > 0) {
+    const fixed = value.toFixed(precision);
+    return fixed.replace(/\.0+$/, '').replace(/(\.\d*?)0+$/, '$1');
+  }
+  return String(Math.round(value));
+}
+
+export function formatPercent(value, options = {}) {
+  const {
+    precision = 0,
+    clampMin = null,
+    clampMax = null,
+    nullFallback = '—',
+    zeroDisplay = null,
+    signDisplay = 'auto'
+  } = options;
+
+  if (value === null || value === undefined) {
+    return nullFallback;
+  }
+
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return nullFallback;
+  }
+
+  let clamped = numeric;
+  if (clampMin !== null && clampMin !== undefined) {
+    clamped = Math.max(clampMin, clamped);
+  }
+  if (clampMax !== null && clampMax !== undefined) {
+    clamped = Math.min(clampMax, clamped);
+  }
+
+  const percentValue = clamped * 100;
+  const rounded = formatPercentMagnitude(percentValue, precision);
+  const magnitude = Math.abs(rounded);
+
+  if (magnitude === 0 && zeroDisplay != null) {
+    return zeroDisplay;
+  }
+
+  const sign = getSignPrefix(clamped, signDisplay);
+  const formattedMagnitude = toPercentString(magnitude, precision);
+  return `${sign}${formattedMagnitude}%`;
+}
+
+export default {
+  formatCurrency,
+  formatSignedCurrency,
+  formatNetCurrency,
+  formatPercent
+};

--- a/tests/ui/views/browser/utils/formatting.test.js
+++ b/tests/ui/views/browser/utils/formatting.test.js
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  formatCurrency,
+  formatNetCurrency,
+  formatPercent,
+  formatSignedCurrency
+} from '../../../../../src/ui/views/browser/utils/formatting.js';
+
+test('formatCurrency rounds to whole dollars when requested', () => {
+  assert.equal(formatCurrency(10.6, { precision: 'integer' }), '$11');
+});
+
+test('formatCurrency clamps negative values to zero when asked', () => {
+  assert.equal(formatCurrency(-25, { clampZero: true }), '$0');
+});
+
+test('formatCurrency supports absolute formatting without a sign', () => {
+  assert.equal(
+    formatCurrency(-18.75, { absolute: true, signDisplay: 'never' }),
+    '$18.75'
+  );
+});
+
+test('formatSignedCurrency adds a plus sign for positive values', () => {
+  assert.equal(formatSignedCurrency(7.25), '+$7.25');
+});
+
+test('formatSignedCurrency uses the provided zero display option', () => {
+  assert.equal(formatSignedCurrency(0, { zeroDisplay: '—' }), '—');
+});
+
+test('formatNetCurrency omits the plus sign for positive values', () => {
+  assert.equal(formatNetCurrency(19), '$19');
+});
+
+test('formatNetCurrency preserves the negative sign for losses', () => {
+  assert.equal(formatNetCurrency(-19.4), '-$19');
+});
+
+test('formatPercent returns the fallback when the value is missing', () => {
+  assert.equal(formatPercent(null, { nullFallback: '—' }), '—');
+});
+
+test('formatPercent applies clamping and hides the sign when requested', () => {
+  assert.equal(
+    formatPercent(1.2, { clampMin: 0, clampMax: 1, signDisplay: 'never' }),
+    '100%'
+  );
+});
+
+test('formatPercent adds a plus sign for positive deltas when asked', () => {
+  assert.equal(formatPercent(0.156, { signDisplay: 'always' }), '+16%');
+});


### PR DESCRIPTION
## Summary
- add a shared browser formatting utility that covers currency, signed/net currency, and percentage helpers
- update browser workspace components to use the centralized formatter options instead of local duplicates
- add unit coverage for the formatter to document rounding, clamping, and sign behaviors

## Testing
- npm test -- tests/ui/views/browser/utils/formatting.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dedbb57f08832cbdee15d331b78216