### PR TITLE
Modularize browser layout subsystems

### DIFF
--- a/src/ui/views/browser/layout/navigation.js
+++ b/src/ui/views/browser/layout/navigation.js
@@ -1,0 +1,153 @@
+import { HOMEPAGE_ID } from '../config.js';
+
+function removeFromArray(array, value) {
+  const index = array.indexOf(value);
+  if (index !== -1) {
+    array.splice(index, 1);
+  }
+}
+
+export function createNavigationController({ homepageId = HOMEPAGE_ID } = {}) {
+  let currentPage = homepageId;
+  const historyStack = [];
+  const futureStack = [];
+
+  function getCurrentPage() {
+    return currentPage;
+  }
+
+  function handleNavigation(pageId, { recordHistory = true } = {}) {
+    if (!pageId) return currentPage;
+    if (recordHistory && currentPage !== pageId) {
+      historyStack.push(currentPage);
+      futureStack.length = 0;
+    }
+    currentPage = pageId;
+    return currentPage;
+  }
+
+  function navigateBack(onNavigate) {
+    if (!historyStack.length) return false;
+    const previous = historyStack.pop();
+    futureStack.push(currentPage);
+    if (typeof onNavigate === 'function') {
+      onNavigate(previous);
+    }
+    return true;
+  }
+
+  function navigateForward(onNavigate) {
+    if (!futureStack.length) return false;
+    const next = futureStack.pop();
+    historyStack.push(currentPage);
+    if (typeof onNavigate === 'function') {
+      onNavigate(next);
+    }
+    return true;
+  }
+
+  function purge(pageId) {
+    if (!pageId) return;
+    removeFromArray(historyStack, pageId);
+    removeFromArray(futureStack, pageId);
+    if (currentPage === pageId) {
+      currentPage = homepageId;
+    }
+  }
+
+  function parseAddressValue(value) {
+    const raw = String(value || '').trim();
+    if (!raw) return null;
+
+    const pattern = /^(?:https?:\/\/)?([^/]+)(?:\/(.*))?$/i;
+    const match = pattern.exec(raw);
+    if (!match) return null;
+
+    const host = match[1].toLowerCase();
+    const remainder = String(match[2] || '')
+      .trim()
+      .split(/[?#]/, 1)[0]
+      .replace(/^\/+|\/+$/g, '');
+
+    if (host === 'hustle.city') {
+      if (!remainder) {
+        return { pageId: homepageId };
+      }
+      const [slug] = remainder.split('/');
+      return { slug };
+    }
+
+    if (host.endsWith('.hub')) {
+      const workspace = host.slice(0, -4);
+      return { slug: workspace, path: remainder };
+    }
+
+    if (!host.includes('.')) {
+      return { slug: host };
+    }
+
+    return null;
+  }
+
+  function updateButtons({ backButton, forwardButton } = {}) {
+    if (backButton) {
+      backButton.disabled = historyStack.length === 0;
+    }
+    if (forwardButton) {
+      forwardButton.disabled = futureStack.length === 0;
+    }
+  }
+
+  function createAddressSubmitHandler({
+    getValue,
+    setValue,
+    onNavigate,
+    findPageById,
+    findPageBySlug,
+    formatAddress
+  }) {
+    return event => {
+      event.preventDefault();
+      const inputValue = typeof getValue === 'function' ? getValue() : '';
+      const target = parseAddressValue(inputValue);
+      if (!target) {
+        const current = findPageById?.(currentPage);
+        if (current && typeof setValue === 'function' && typeof formatAddress === 'function') {
+          setValue(formatAddress(current));
+        }
+        return;
+      }
+
+      if (target.pageId) {
+        onNavigate?.(target.pageId);
+        return;
+      }
+
+      const destination = target.slug ? findPageBySlug?.(target.slug) : null;
+      if (destination) {
+        onNavigate?.(destination.id, target);
+        return;
+      }
+
+      const current = findPageById?.(currentPage);
+      if (current && typeof setValue === 'function' && typeof formatAddress === 'function') {
+        setValue(formatAddress(current));
+      }
+    };
+  }
+
+  return {
+    getCurrentPage,
+    handleNavigation,
+    navigateBack,
+    navigateForward,
+    purge,
+    parseAddressValue,
+    updateButtons,
+    createAddressSubmitHandler
+  };
+}
+
+const navigation = { createNavigationController };
+
+export default navigation;

--- a/src/ui/views/browser/layout/tabs.js
+++ b/src/ui/views/browser/layout/tabs.js
@@ -1,0 +1,188 @@
+import { getElement } from '../../../elements/registry.js';
+import { HOMEPAGE_ID, findPageById } from '../config.js';
+
+const openTabs = new Set([HOMEPAGE_ID]);
+const tabOrder = [HOMEPAGE_ID];
+const activationHistory = [HOMEPAGE_ID];
+let activeTab = HOMEPAGE_ID;
+let tabRefs = null;
+
+function removeFromArray(list, value) {
+  const index = list.indexOf(value);
+  if (index !== -1) {
+    list.splice(index, 1);
+  }
+}
+
+function getTabRefs() {
+  if (!tabRefs) {
+    tabRefs = getElement('browserTabs') || {};
+  }
+  return tabRefs;
+}
+
+function ensureTab(pageId) {
+  if (!pageId || openTabs.has(pageId)) {
+    return false;
+  }
+  openTabs.add(pageId);
+  tabOrder.push(pageId);
+  return true;
+}
+
+function recordActivation(pageId) {
+  removeFromArray(activationHistory, pageId);
+  activationHistory.push(pageId);
+}
+
+function getFallbackTab(closedId) {
+  for (let index = activationHistory.length - 1; index >= 0; index -= 1) {
+    const candidate = activationHistory[index];
+    if (candidate && candidate !== closedId && openTabs.has(candidate)) {
+      return candidate;
+    }
+  }
+  return HOMEPAGE_ID;
+}
+
+function renderTabs() {
+  const { list } = getTabRefs();
+  if (!list) return;
+
+  list.innerHTML = '';
+
+  tabOrder.forEach(pageId => {
+    if (!openTabs.has(pageId)) return;
+    const page = findPageById(pageId);
+    if (!page) return;
+
+    const item = document.createElement('li');
+    item.className = 'browser-tab';
+    item.dataset.tab = pageId;
+    if (pageId === activeTab) {
+      item.classList.add('is-active');
+    }
+
+    const tabButton = document.createElement('button');
+    tabButton.type = 'button';
+    tabButton.className = 'browser-tab__button';
+    tabButton.dataset.tabTarget = pageId;
+    tabButton.setAttribute('role', 'tab');
+    tabButton.setAttribute('aria-selected', pageId === activeTab ? 'true' : 'false');
+    const panelId =
+      pageId === HOMEPAGE_ID ? 'browser-launch-stage' : `browser-page-${page.slug || page.id}`;
+    tabButton.setAttribute('aria-controls', panelId);
+    tabButton.tabIndex = pageId === activeTab ? 0 : -1;
+
+    const icon = document.createElement('span');
+    icon.className = 'browser-tab__icon';
+    icon.textContent = page.icon || '✨';
+
+    const label = document.createElement('span');
+    label.className = 'browser-tab__label';
+    label.textContent = page.label || page.name || 'Workspace';
+
+    tabButton.append(icon, label);
+    item.appendChild(tabButton);
+
+    if (pageId !== HOMEPAGE_ID) {
+      const close = document.createElement('button');
+      close.type = 'button';
+      close.className = 'browser-tab__close';
+      close.dataset.tabClose = pageId;
+      close.setAttribute('aria-label', `Close ${page.label || page.name || 'workspace'} tab`);
+      close.textContent = '×';
+      item.appendChild(close);
+    }
+
+    list.appendChild(item);
+  });
+}
+
+function initTabControls({ onSelectTab, onCloseTab } = {}) {
+  const { list } = getTabRefs();
+  if (list) {
+    list.addEventListener('click', event => {
+      const closeTarget = event.target.closest('[data-tab-close]');
+      if (closeTarget) {
+        event.preventDefault();
+        onCloseTab?.(closeTarget.dataset.tabClose);
+        return;
+      }
+
+      const tabTarget = event.target.closest('[data-tab-target]');
+      if (tabTarget) {
+        event.preventDefault();
+        onSelectTab?.(tabTarget.dataset.tabTarget);
+      }
+    });
+  }
+  renderTabs();
+}
+
+function openTab(pageId) {
+  const added = ensureTab(pageId);
+  if (added) {
+    renderTabs();
+  }
+  return added;
+}
+
+function closeTab(pageId) {
+  if (pageId === HOMEPAGE_ID || !openTabs.has(pageId)) {
+    return { closed: false, wasActive: false, fallbackId: null };
+  }
+
+  openTabs.delete(pageId);
+  removeFromArray(tabOrder, pageId);
+  removeFromArray(activationHistory, pageId);
+
+  const wasActive = activeTab === pageId;
+  const fallbackId = wasActive ? getFallbackTab(pageId) : null;
+
+  renderTabs();
+
+  return { closed: true, wasActive, fallbackId };
+}
+
+function setActiveTab(pageId) {
+  if (!openTabs.has(pageId)) {
+    return false;
+  }
+  activeTab = pageId;
+  recordActivation(pageId);
+  renderTabs();
+  return true;
+}
+
+function isOpen(pageId) {
+  return openTabs.has(pageId);
+}
+
+function getActiveTab() {
+  return activeTab;
+}
+
+const tabControls = {
+  initTabControls,
+  openTab,
+  closeTab,
+  setActiveTab,
+  isOpen,
+  getActiveTab,
+  getFallbackTab,
+  renderTabs
+};
+
+export {
+  initTabControls,
+  openTab,
+  closeTab,
+  setActiveTab,
+  isOpen,
+  getActiveTab,
+  getFallbackTab,
+  renderTabs
+};
+
+export default tabControls;

--- a/src/ui/views/browser/layout/theme.js
+++ b/src/ui/views/browser/layout/theme.js
@@ -1,0 +1,97 @@
+import { getElement } from '../../../elements/registry.js';
+
+const THEME_STORAGE_KEY = 'browser-theme';
+let themeToggleRef = null;
+let currentTheme = 'day';
+
+function getThemeToggle() {
+  if (!themeToggleRef) {
+    themeToggleRef = getElement('themeToggle');
+  }
+  return themeToggleRef;
+}
+
+function getShellElement() {
+  return document.querySelector('.browser-shell');
+}
+
+function loadThemePreference() {
+  try {
+    return window.localStorage.getItem(THEME_STORAGE_KEY);
+  } catch (error) {
+    return null;
+  }
+}
+
+function saveThemePreference(theme) {
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch (error) {
+    // ignore storage errors to keep the UI responsive
+  }
+}
+
+function updateToggleState(theme) {
+  const toggle = getThemeToggle();
+  if (!toggle) return;
+
+  const isNight = theme === 'night';
+  toggle.setAttribute('aria-pressed', String(isNight));
+  toggle.dataset.mode = theme;
+  toggle.title = isNight ? 'Switch to light mode' : 'Switch to dark mode';
+
+  const icon = toggle.querySelector('.browser-theme-toggle__icon');
+  if (icon) {
+    icon.textContent = isNight ? '🌜' : '🌞';
+  }
+
+  const label = toggle.querySelector('.browser-theme-toggle__label');
+  if (label) {
+    label.textContent = isNight ? 'Dark' : 'Light';
+  }
+}
+
+function applyTheme(theme) {
+  const targetTheme = theme === 'night' ? 'night' : 'day';
+  currentTheme = targetTheme;
+
+  const shell = getShellElement();
+  if (shell) {
+    shell.dataset.theme = targetTheme;
+  }
+
+  if (document?.documentElement) {
+    document.documentElement.setAttribute('data-browser-theme', targetTheme);
+  }
+
+  updateToggleState(targetTheme);
+}
+
+function toggleTheme() {
+  const next = currentTheme === 'day' ? 'night' : 'day';
+  applyTheme(next);
+  saveThemePreference(next);
+}
+
+function initThemeControls() {
+  const stored = loadThemePreference();
+  const initial = stored || getShellElement()?.dataset.theme || 'day';
+  applyTheme(initial);
+
+  const toggle = getThemeToggle();
+  if (!toggle) return;
+  toggle.addEventListener('click', toggleTheme);
+}
+
+function getCurrentTheme() {
+  return currentTheme;
+}
+
+const themeControls = {
+  initThemeControls,
+  applyTheme,
+  getCurrentTheme
+};
+
+export { initThemeControls, applyTheme, getCurrentTheme };
+export default themeControls;

--- a/src/ui/views/browser/layout/workspaces.js
+++ b/src/ui/views/browser/layout/workspaces.js
@@ -1,0 +1,107 @@
+import { getElement } from '../../../elements/registry.js';
+import { HOMEPAGE_ID } from '../config.js';
+
+let launchStageRef = null;
+let workspaceHostRef = null;
+
+function getLaunchStage() {
+  if (!launchStageRef) {
+    launchStageRef = getElement('launchStage') || null;
+  }
+  return launchStageRef;
+}
+
+function getWorkspaceHost() {
+  if (!workspaceHostRef) {
+    workspaceHostRef = getElement('workspaceHost') || null;
+  }
+  return workspaceHostRef;
+}
+
+function getHomepageElement() {
+  return getElement('homepage')?.container || null;
+}
+
+function normalizeWorkspacePath(path = '') {
+  return String(path || '')
+    .trim()
+    .split(/[?#]/, 1)[0]
+    .replace(/^\/+|\/+$/g, '');
+}
+
+function getWorkspaceElement(pageId) {
+  if (pageId === HOMEPAGE_ID) {
+    return getLaunchStage() || getHomepageElement();
+  }
+  const host = getWorkspaceHost();
+  if (!host) return null;
+  return host.querySelector(`[data-browser-page="${pageId}"]`);
+}
+
+function getWorkspacePath(pageId) {
+  const element = getWorkspaceElement(pageId);
+  if (!element) return '';
+  return normalizeWorkspacePath(element.dataset.browserPath || '');
+}
+
+function setWorkspacePath(pageId, path) {
+  const element = getWorkspaceElement(pageId);
+  if (!element) return;
+  const normalized = normalizeWorkspacePath(path);
+  if (normalized) {
+    element.dataset.browserPath = normalized;
+  } else {
+    delete element.dataset.browserPath;
+  }
+}
+
+function getWorkspaceDomain(page) {
+  if (!page) return 'workspace';
+  const source = page.domain || page.id || page.slug || page.label || 'workspace';
+  const cleaned = String(source)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '');
+  return cleaned || 'workspace';
+}
+
+function buildWorkspaceUrl(page) {
+  if (!page || page.id === HOMEPAGE_ID) {
+    return 'https://hustle.city/';
+  }
+  const domain = `${getWorkspaceDomain(page)}.hub`;
+  const path = getWorkspacePath(page.id);
+  const suffix = path ? `/${path}` : '/';
+  return `https://${domain}${suffix}`;
+}
+
+function resetWorkspaceRefs() {
+  launchStageRef = null;
+  workspaceHostRef = null;
+}
+
+const workspaceRoutes = {
+  getLaunchStage,
+  getWorkspaceHost,
+  getHomepageElement,
+  getWorkspaceElement,
+  getWorkspacePath,
+  setWorkspacePath,
+  normalizeWorkspacePath,
+  buildWorkspaceUrl,
+  resetWorkspaceRefs
+};
+
+export {
+  getLaunchStage,
+  getWorkspaceHost,
+  getHomepageElement,
+  getWorkspaceElement,
+  getWorkspacePath,
+  setWorkspacePath,
+  normalizeWorkspacePath,
+  buildWorkspaceUrl,
+  resetWorkspaceRefs
+};
+
+export default workspaceRoutes;

--- a/tests/ui/views/browser/layout/navigation.test.js
+++ b/tests/ui/views/browser/layout/navigation.test.js
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createNavigationController } from '../../../../../src/ui/views/browser/layout/navigation.js';
+
+const HOMEPAGE_ID = 'home';
+
+function createStubEvent() {
+  return {
+    preventDefault() {}
+  };
+}
+
+test('navigation controller tracks history and back/forward flows', () => {
+  const controller = createNavigationController({ homepageId: HOMEPAGE_ID });
+
+  assert.equal(controller.getCurrentPage(), HOMEPAGE_ID);
+
+  controller.handleNavigation('alpha');
+  controller.handleNavigation('beta');
+
+  let target = null;
+  controller.navigateBack(pageId => {
+    target = pageId;
+  });
+  assert.equal(target, 'alpha', 'back should yield previous page');
+  controller.handleNavigation(target, { recordHistory: false });
+  assert.equal(controller.getCurrentPage(), 'alpha');
+
+  target = null;
+  controller.navigateBack(pageId => {
+    target = pageId;
+  });
+  assert.equal(target, HOMEPAGE_ID, 'back reaches homepage');
+  controller.handleNavigation(target, { recordHistory: false });
+  assert.equal(controller.getCurrentPage(), HOMEPAGE_ID);
+
+  target = null;
+  controller.navigateForward(pageId => {
+    target = pageId;
+  });
+  assert.equal(target, 'alpha', 'forward returns to last visited page');
+  controller.handleNavigation(target, { recordHistory: false });
+  assert.equal(controller.getCurrentPage(), 'alpha');
+
+  controller.handleNavigation('gamma');
+  controller.purge('alpha');
+  controller.navigateBack(pageId => {
+    target = pageId;
+  });
+  assert.equal(target, HOMEPAGE_ID, 'purged page is removed from history');
+});
+
+test('address handler parses urls and resets to current page', () => {
+  const controller = createNavigationController({ homepageId: HOMEPAGE_ID });
+  const calls = [];
+  const captured = [];
+  const handler = controller.createAddressSubmitHandler({
+    getValue: () => captured.at(-1) ?? 'https://alpha.hub/quests',
+    setValue: value => {
+      captured.push(value);
+    },
+    onNavigate: pageId => {
+      calls.push(pageId);
+    },
+    findPageById: id => (id === HOMEPAGE_ID ? { id: HOMEPAGE_ID } : null),
+    findPageBySlug: slug => (slug === 'alpha' ? { id: 'alpha', slug } : null),
+    formatAddress: page => `formatted:${page.id}`
+  });
+
+  handler(createStubEvent());
+  assert.deepEqual(calls, ['alpha'], 'slug navigation invokes callback');
+
+  captured.push('https://unknown.example.com/path');
+  handler(createStubEvent());
+  assert.equal(
+    captured.at(-1),
+    'formatted:home',
+    'invalid addresses reset to the current workspace URL'
+  );
+});

--- a/tests/ui/views/browser/layout/theme.test.js
+++ b/tests/ui/views/browser/layout/theme.test.js
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+import { initElementRegistry } from '../../../../../src/ui/elements/registry.js';
+import {
+  initThemeControls,
+  getCurrentTheme
+} from '../../../../../src/ui/views/browser/layout/theme.js';
+
+test('initThemeControls applies stored preference and toggles themes', async t => {
+  const dom = new JSDOM(`
+    <div class="browser-shell" data-theme="day">
+      <button id="theme-toggle" type="button" data-mode="day" aria-pressed="false">
+        <span class="browser-theme-toggle__icon"></span>
+        <span class="browser-theme-toggle__label"></span>
+      </button>
+    </div>
+  `, { url: 'https://hustle.city/' });
+
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  dom.window.localStorage.setItem('browser-theme', 'night');
+
+  initElementRegistry(dom.window.document, {
+    themeToggle: root => root.getElementById('theme-toggle')
+  });
+
+  t.after(() => {
+    dom.window.close();
+    delete globalThis.window;
+    delete globalThis.document;
+  });
+
+  initThemeControls();
+
+  assert.equal(getCurrentTheme(), 'night', 'stored preference should be applied');
+  assert.equal(
+    dom.window.document.documentElement.getAttribute('data-browser-theme'),
+    'night',
+    'document theme attribute should match stored preference'
+  );
+  const shell = dom.window.document.querySelector('.browser-shell');
+  assert.equal(shell.dataset.theme, 'night', 'shell element receives stored theme');
+
+  const toggle = dom.window.document.getElementById('theme-toggle');
+  toggle.dispatchEvent(new dom.window.Event('click', { bubbles: true }));
+
+  assert.equal(getCurrentTheme(), 'day', 'clicking the toggle flips the theme');
+  assert.equal(
+    dom.window.document.documentElement.getAttribute('data-browser-theme'),
+    'day',
+    'document theme updates after toggle'
+  );
+  assert.equal(dom.window.localStorage.getItem('browser-theme'), 'day');
+});


### PR DESCRIPTION
## Summary
- modularize theme, navigation, tab, and workspace helpers into dedicated layout modules
- refactor the browser layout presenter to orchestrate the new modules without changing its public API
- add unit tests that cover navigation history handling and theme toggling behaviours

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dedbb8b3e0832cbebe04893102e4b7