### PR TITLE
Adjust browser home widget layout

### DIFF
--- a/styles/browser.css
+++ b/styles/browser.css
@@ -466,9 +466,10 @@ a {
 
 .browser-stage__pane--home .browser-layout {
   --browser-home-spacing: clamp(0.75rem, 1vw + 0.4rem, 1.25rem);
+  --browser-home-gutter: clamp(0.75rem, 0.9vw + 0.35rem, 1.05rem);
   max-width: none;
   margin: 0;
-  padding: var(--browser-home-spacing);
+  padding: var(--browser-home-gutter);
 }
 
 .browser-main {
@@ -488,8 +489,8 @@ a {
 .browser-home__widgets {
   width: 100%;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: var(--browser-home-spacing, 1.5rem);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--browser-home-gutter, var(--browser-home-spacing, 1.5rem));
   align-items: stretch;
   justify-items: stretch;
   margin: 0;
@@ -497,7 +498,7 @@ a {
 
 @media (max-width: 1200px) {
   .browser-home__widgets {
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 


### PR DESCRIPTION
## Summary
- switch the home widgets grid to a fixed three-column desktop layout with responsive fallbacks
- introduce a dedicated gutter variable to synchronize layout padding and widget spacing

## Testing
- Reloaded browser.html in local browser (manual)


------
https://chatgpt.com/codex/tasks/task_e_68defa4a8d04832c86fa4600a3e05dbe