### PR TITLE
Adjust browser home widget spacing

### DIFF
--- a/styles/browser.css
+++ b/styles/browser.css
@@ -466,6 +466,7 @@ a {
 
 .browser-stage__pane--home .browser-layout {
   --browser-home-spacing: clamp(0.75rem, 1vw + 0.4rem, 1.25rem);
+  --browser-home-widget-gap: clamp(0.75rem, 0.85vw + 0.45rem, 1.2rem);
   max-width: none;
   margin: 0;
   padding: var(--browser-home-spacing);
@@ -489,7 +490,7 @@ a {
   width: 100%;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: var(--browser-home-spacing, 1.5rem);
+  gap: var(--browser-home-widget-gap, var(--browser-home-spacing, 1.1rem));
   align-items: stretch;
   justify-items: stretch;
   margin: 0;


### PR DESCRIPTION
## Summary
- add a dedicated browser home widget gap variable
- apply the widget gap to the home widget grid so tiles have breathing room

## Testing
- Loaded `browser.html` in a local browser to confirm widget spacing


------
https://chatgpt.com/codex/tasks/task_e_68defc989254832cbcacf2fc783062b8