### PR TITLE
Add drag-to-arrange mode for homepage apps widget

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -110,10 +110,24 @@
                   data-widget="apps"
                   aria-labelledby="browser-widget-apps-heading"
                 >
-                  <header class="browser-widget__header">
-                    <div>
+                  <header class="browser-widget__header apps-widget__header">
+                    <div class="apps-widget__intro">
                       <h2 id="browser-widget-apps-heading">Apps</h2>
                       <p id="browser-widget-apps-note">Launch a workspace in a tap — hover to preview where it leads.</p>
+                    </div>
+                    <div class="apps-widget__controls">
+                      <span
+                        id="browser-widget-apps-sort-indicator"
+                        class="apps-widget__sort-indicator"
+                        hidden
+                      >Sorting mode on — drag tiles to swap!</span>
+                      <button
+                        id="browser-widget-apps-sort-toggle"
+                        class="apps-widget__sort-toggle"
+                        type="button"
+                        aria-pressed="false"
+                        title="Arrange the apps"
+                      >Arrange</button>
                     </div>
                   </header>
                   <ul

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Browser homepage apps widget now includes an Arrange mode so players can drag tiles to swap spots, highlight favorites, and keep the order between sessions.
 - Asset Arcade workspace retired from the browser prototype and hidden from the homepage launcher while we explore refreshed asset flows.
 - Browser chrome now features a notification bell that mirrors the event log with unread badges, read tracking, and a mark-all control.
 - YourNetwork joins the browser apps lineup with a LinkedIn-inspired profile that showcases skills, study progress, equipment, portfolio highlights, and career metrics in one celebratory view.

--- a/docs/features/browser-home-redesign.md
+++ b/docs/features/browser-home-redesign.md
@@ -4,11 +4,13 @@
 - Give the browser shell a centered canvas without a sidebar so focus stays on the day-to-day widgets.
 - Group homepage widgets into a consistent three-column grid that scales down gracefully on smaller screens.
 - Turn the apps list into a touch-friendly launcher with icon tiles and real-time status badges sourced from service summaries.
+- Give players light personalization by letting them rearrange the apps list to match their hustle priorities.
 
 ## Implementation Notes
 - The launch stage now renders a single-column layout with `.browser-home__widgets` using CSS Grid to provide three equal columns on wide viewports, two columns on medium, and one column on narrow screens.
 - Widget cards reuse the existing presenter modules and simply stretch to fill each grid cell. Cards share a consistent padding, border radius, and drop shadow defined in `styles/browser.css` so they feel like a matched set.
 - The apps widget reuses the existing `appsWidget` module. It now renders each workspace as a tile button with an icon, label, and optional status badge derived from the service summary metadata.
+- A compact "Arrange" toggle in the apps widget header activates drag-and-drop sorting. Tiles swap positions on drop and the custom order is stored in local storage so it persists between sessions.
 - Navigation highlighting looks for `[data-role="browser-app-launcher"]` containers in addition to the legacy sidebar list so active pages still pulse even without the sidebar.
 - The ToDo widget now aggregates quick actions, asset upgrade recommendations, and enrollable study tracks into a single scrollable list. Tasks validate hour and cash requirements before rendering so the queue always reflects moves you can take right now.
 - A "Focus on" toggle lets players sort the ToDo queue for Money-first hustles, upgrade milestones, or an alternating blend of both by interleaving the two lists.
@@ -18,6 +20,7 @@
 ## Player Impact
 - Players can scan the day's plan, finances, and workspace launchers at a glance without juggling two columns.
 - The tile launcher mirrors a mobile home screen, making it faster to spot ready actions or idle tabs from the status badges.
+- Drag-sorting lets players surface their favorite workspaces in the first row so the homepage always reflects their current plan.
 - Responsive breakpoints ensure the layout remains legible on narrow QA windows while keeping the three-up structure on desktop.
 - Combining upgrades, hustles, and study enrollments in the ToDo queue helps players chain momentum moves back-to-back. Affordability checks keep impossible options hidden while the scroll affordance means long task lists no longer crowd out neighboring widgets.
 - Focus controls surface the next best hustle, the nearest upgrade, or an alternating rhythm so players can align the day’s plan with their current goals.

--- a/src/ui/views/browser/resolvers.js
+++ b/src/ui/views/browser/resolvers.js
@@ -141,7 +141,9 @@ const resolvers = {
     apps: {
       container: root.querySelector('[data-widget="apps"]'),
       list: root.getElementById('browser-widget-apps-list'),
-      note: root.getElementById('browser-widget-apps-note')
+      note: root.getElementById('browser-widget-apps-note'),
+      sortToggle: root.getElementById('browser-widget-apps-sort-toggle'),
+      sortIndicator: root.getElementById('browser-widget-apps-sort-indicator')
     },
     bank: {
       container: root.querySelector('[data-widget="bank"]'),

--- a/src/ui/views/browser/widgets/appsWidget.js
+++ b/src/ui/views/browser/widgets/appsWidget.js
@@ -4,13 +4,32 @@ import {
   subscribeToServiceSummaries
 } from '../cardsPresenter.js';
 
+const STORAGE_KEY = 'browser.apps.order';
+const DEFAULT_NOTE = 'Hover to preview each workspace, click to launch instantly.';
+const EMPTY_NOTE = 'Unlock more workspaces through upgrades and courses.';
+const SORT_NOTE = 'Sorting mode active — drag tiles to swap their spots.';
+
 let elements = null;
 let initialized = false;
 let latestSummaries = [];
+let customOrder = [];
+let currentPages = [];
+let sortMode = false;
+let dragSourceId = null;
 
 function ensureElements(widgetElements = {}) {
   if (elements) return;
   elements = widgetElements;
+  elements?.sortToggle?.addEventListener('click', handleSortToggle);
+  if (elements?.list) {
+    elements.list.addEventListener('click', handleListClick, { capture: true });
+    elements.list.addEventListener('dragstart', handleDragStart);
+    elements.list.addEventListener('dragenter', handleDragEnter);
+    elements.list.addEventListener('dragover', handleDragOver);
+    elements.list.addEventListener('dragleave', handleDragLeave);
+    elements.list.addEventListener('drop', handleDrop);
+    elements.list.addEventListener('dragend', handleDragEnd);
+  }
 }
 
 function getSummaryMap() {
@@ -51,8 +70,236 @@ function renderEmptyState() {
   empty.textContent = 'Unlock more apps to populate this list.';
   elements.list.appendChild(empty);
   if (elements?.note) {
-    elements.note.textContent = 'Unlock more workspaces through upgrades and courses.';
+    elements.note.textContent = EMPTY_NOTE;
   }
+}
+
+function getStorage() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    return window.localStorage || null;
+  } catch (error) {
+    return null;
+  }
+}
+
+function loadSortOrder() {
+  const storage = getStorage();
+  if (!storage) return;
+  try {
+    const stored = JSON.parse(storage.getItem(STORAGE_KEY));
+    if (Array.isArray(stored)) {
+      customOrder = stored.filter(id => typeof id === 'string' && id);
+    }
+  } catch (error) {
+    customOrder = [];
+  }
+}
+
+function persistSortOrder(order = customOrder) {
+  const storage = getStorage();
+  if (!storage) return;
+  try {
+    if (Array.isArray(order) && order.length) {
+      storage.setItem(STORAGE_KEY, JSON.stringify(order));
+    } else {
+      storage.removeItem(STORAGE_KEY);
+    }
+  } catch (error) {
+    // Ignore persistence errors to keep the widget responsive.
+  }
+}
+
+function getOrderedIds(availableIds = []) {
+  const uniqueIds = Array.from(new Set(availableIds.filter(Boolean)));
+  if (!uniqueIds.length) return [];
+  const stored = Array.isArray(customOrder) ? customOrder : [];
+  const filtered = stored.filter(id => uniqueIds.includes(id));
+  const missing = uniqueIds.filter(id => !filtered.includes(id));
+  return [...filtered, ...missing];
+}
+
+function getOrderedPages(pages = []) {
+  const map = new Map();
+  pages.forEach(page => {
+    if (page?.id) {
+      map.set(page.id, page);
+    }
+  });
+  const orderedIds = getOrderedIds(pages.map(page => page?.id));
+  return orderedIds.map(id => map.get(id)).filter(Boolean);
+}
+
+function canSort() {
+  return currentPages.length > 1;
+}
+
+function clearDragState() {
+  dragSourceId = null;
+  if (!elements?.list) return;
+  elements.list.querySelectorAll('.apps-widget__tile').forEach(tile => {
+    tile.classList.remove('is-dragging');
+    tile.classList.remove('is-drop-target');
+  });
+}
+
+function updateDraggableState() {
+  if (!elements?.list) return;
+  const allowSort = sortMode && canSort();
+  elements.list.querySelectorAll('.apps-widget__tile').forEach(tile => {
+    tile.draggable = allowSort;
+    if (allowSort) {
+      tile.setAttribute('aria-disabled', 'true');
+    } else {
+      tile.removeAttribute('aria-disabled');
+    }
+  });
+  if (!allowSort) {
+    clearDragState();
+  }
+}
+
+function updateSortModeUI() {
+  const hasPages = currentPages.length > 0;
+  const allowSort = hasPages && canSort();
+  if (!allowSort && sortMode) {
+    sortMode = false;
+  }
+
+  if (elements?.sortToggle) {
+    elements.sortToggle.disabled = !allowSort;
+    elements.sortToggle.setAttribute('aria-pressed', String(sortMode && allowSort));
+    elements.sortToggle.textContent = sortMode && allowSort ? 'Done' : 'Arrange';
+    elements.sortToggle.title = sortMode && allowSort
+      ? 'Finish arranging your apps'
+      : 'Arrange the apps';
+  }
+
+  if (elements?.sortIndicator) {
+    elements.sortIndicator.hidden = !(sortMode && allowSort);
+  }
+
+  if (elements?.container) {
+    elements.container.classList.toggle('is-sorting', sortMode && allowSort);
+  }
+
+  if (elements?.note) {
+    if (!hasPages) {
+      elements.note.textContent = EMPTY_NOTE;
+    } else if (sortMode && allowSort) {
+      elements.note.textContent = SORT_NOTE;
+    } else {
+      elements.note.textContent = DEFAULT_NOTE;
+    }
+  }
+
+  updateDraggableState();
+}
+
+function setSortMode(active) {
+  const allowSort = canSort();
+  const nextState = active && allowSort;
+  if (sortMode === nextState) {
+    updateSortModeUI();
+    return;
+  }
+  sortMode = nextState;
+  if (!sortMode) {
+    clearDragState();
+  }
+  updateSortModeUI();
+}
+
+function handleSortToggle() {
+  setSortMode(!sortMode);
+}
+
+function handleListClick(event) {
+  if (!sortMode || !elements?.list) return;
+  const button = event.target.closest('button[data-site-target]');
+  if (!button || !elements.list.contains(button)) return;
+  event.preventDefault();
+  event.stopImmediatePropagation();
+}
+
+function handleDragStart(event) {
+  if (!sortMode) {
+    event.preventDefault();
+    return;
+  }
+  const tile = event.target.closest('.apps-widget__tile');
+  if (!tile || !elements?.list?.contains(tile)) return;
+  const siteId = tile.dataset.siteTarget;
+  if (!siteId) return;
+  dragSourceId = siteId;
+  tile.classList.add('is-dragging');
+  if (event.dataTransfer) {
+    event.dataTransfer.effectAllowed = 'move';
+    event.dataTransfer.setData('text/plain', siteId);
+  }
+}
+
+function handleDragEnter(event) {
+  if (!sortMode) return;
+  const tile = event.target.closest('.apps-widget__tile');
+  if (!tile || !elements?.list?.contains(tile)) return;
+  const siteId = tile.dataset.siteTarget;
+  if (!siteId || siteId === dragSourceId) return;
+  tile.classList.add('is-drop-target');
+}
+
+function handleDragOver(event) {
+  if (!sortMode) return;
+  const tile = event.target.closest('.apps-widget__tile');
+  if (!tile || !elements?.list?.contains(tile)) return;
+  const siteId = tile.dataset.siteTarget;
+  if (!siteId || siteId === dragSourceId) return;
+  event.preventDefault();
+  if (event.dataTransfer) {
+    event.dataTransfer.dropEffect = 'move';
+  }
+}
+
+function handleDragLeave(event) {
+  if (!sortMode) return;
+  const tile = event.target.closest('.apps-widget__tile');
+  if (!tile || !elements?.list?.contains(tile)) return;
+  const siteId = tile.dataset.siteTarget;
+  if (!siteId || siteId === dragSourceId) return;
+  tile.classList.remove('is-drop-target');
+}
+
+function swapOrder(sourceId, targetId) {
+  if (!sourceId || !targetId || sourceId === targetId) return;
+  const availableIds = getOrderedIds(currentPages.map(page => page?.id));
+  const sourceIndex = availableIds.indexOf(sourceId);
+  const targetIndex = availableIds.indexOf(targetId);
+  if (sourceIndex < 0 || targetIndex < 0) return;
+  const nextOrder = availableIds.slice();
+  nextOrder[sourceIndex] = targetId;
+  nextOrder[targetIndex] = sourceId;
+  customOrder = nextOrder;
+  persistSortOrder(customOrder);
+  renderList();
+}
+
+function handleDrop(event) {
+  if (!sortMode) return;
+  const tile = event.target.closest('.apps-widget__tile');
+  if (!tile || !elements?.list?.contains(tile)) return;
+  event.preventDefault();
+  const targetId = tile.dataset.siteTarget;
+  if (!targetId || targetId === dragSourceId) {
+    clearDragState();
+    return;
+  }
+  swapOrder(dragSourceId, targetId);
+}
+
+function handleDragEnd() {
+  clearDragState();
 }
 
 function renderList() {
@@ -61,13 +308,28 @@ function renderList() {
   const pages = SERVICE_PAGES.filter(page => !isPageLocked(summaryMap.get(page.id)?.meta));
 
   elements.list.innerHTML = '';
+  clearDragState();
+  currentPages = [];
 
   if (!pages.length) {
     renderEmptyState();
+    updateSortModeUI();
     return;
   }
 
-  pages.forEach(page => {
+  const orderedPages = getOrderedPages(pages);
+  currentPages = orderedPages;
+  const previousOrder = Array.isArray(customOrder) ? customOrder : [];
+  const nextOrder = orderedPages.map(page => page?.id).filter(Boolean);
+  const orderChanged =
+    nextOrder.length !== previousOrder.length
+    || nextOrder.some((id, index) => id !== previousOrder[index]);
+  customOrder = nextOrder;
+  if (orderChanged) {
+    persistSortOrder(customOrder);
+  }
+
+  orderedPages.forEach(page => {
     const summary = summaryMap.get(page.id);
     const item = document.createElement('li');
     item.className = 'apps-widget__item';
@@ -101,9 +363,7 @@ function renderList() {
     elements.list.appendChild(item);
   });
 
-  if (elements?.note) {
-    elements.note.textContent = 'Hover to preview each workspace, click to launch instantly.';
-  }
+  updateSortModeUI();
 }
 
 function handleServiceSummaries(summaries = []) {
@@ -114,6 +374,7 @@ function handleServiceSummaries(summaries = []) {
 function init(widgetElements = {}) {
   if (initialized) return;
   ensureElements(widgetElements);
+  loadSortOrder();
   initialized = true;
   subscribeToServiceSummaries(handleServiceSummaries);
   handleServiceSummaries(getLatestServiceSummaries());

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -581,6 +581,93 @@ a {
   gap: 0.65rem;
 }
 
+.apps-widget__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.apps-widget__intro {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.apps-widget__controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.apps-widget__sort-toggle {
+  border: 1px solid var(--browser-panel-border);
+  background: var(--browser-panel-elevated);
+  color: var(--browser-subtle);
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.28rem 0.65rem;
+  border-radius: var(--browser-radius-pill);
+  cursor: pointer;
+  transition: color 140ms ease, background-color 140ms ease, border-color 140ms ease, box-shadow 140ms ease;
+}
+
+.apps-widget__sort-toggle:hover,
+.apps-widget__sort-toggle:focus-visible {
+  color: var(--browser-accent);
+  border-color: var(--browser-accent);
+  background: var(--browser-accent-soft);
+  outline: none;
+}
+
+.apps-widget__sort-toggle[aria-pressed="true"] {
+  color: var(--browser-accent);
+  border-color: var(--browser-accent);
+  background: rgba(37, 99, 235, 0.12);
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.18);
+}
+
+.apps-widget__sort-toggle:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.apps-widget__sort-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.6rem;
+  border-radius: var(--browser-radius-pill);
+  background: var(--browser-accent-soft);
+  color: var(--browser-accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.apps-widget.is-sorting .apps-widget__tile {
+  cursor: grab;
+  user-select: none;
+}
+
+.apps-widget.is-sorting .apps-widget__tile:active {
+  cursor: grabbing;
+}
+
+.apps-widget__tile.is-dragging {
+  opacity: 0.85;
+  box-shadow: 0 12px 34px rgba(37, 99, 235, 0.28);
+}
+
+.apps-widget__tile.is-drop-target {
+  border-color: var(--browser-accent);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.22);
+}
+
 .todo-widget {
   gap: 1.3rem;
   flex: 1 1 auto;


### PR DESCRIPTION
## Summary
- add an Arrange toggle to the homepage Apps widget so tiles can be dragged to swap positions and the custom order persists
- style the widget header with a sorting indicator and grab cursor feedback while sorting is active
- document the new arrangement mode in the browser homepage design notes and changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df00d6abb4832c8475da669c6d6f3d