### PR TITLE
Adjust apps widget arrange control layout

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -116,11 +116,6 @@
                       <p id="browser-widget-apps-note">Launch a workspace in a tap — hover to preview where it leads.</p>
                     </div>
                     <div class="apps-widget__controls">
-                      <span
-                        id="browser-widget-apps-sort-indicator"
-                        class="apps-widget__sort-indicator"
-                        hidden
-                      >Sorting mode on — drag tiles to swap!</span>
                       <button
                         id="browser-widget-apps-sort-toggle"
                         class="apps-widget__sort-toggle"

--- a/src/ui/views/browser/resolvers.js
+++ b/src/ui/views/browser/resolvers.js
@@ -142,8 +142,7 @@ const resolvers = {
       container: root.querySelector('[data-widget="apps"]'),
       list: root.getElementById('browser-widget-apps-list'),
       note: root.getElementById('browser-widget-apps-note'),
-      sortToggle: root.getElementById('browser-widget-apps-sort-toggle'),
-      sortIndicator: root.getElementById('browser-widget-apps-sort-indicator')
+      sortToggle: root.getElementById('browser-widget-apps-sort-toggle')
     },
     bank: {
       container: root.querySelector('[data-widget="bank"]'),

--- a/src/ui/views/browser/widgets/appsWidget.js
+++ b/src/ui/views/browser/widgets/appsWidget.js
@@ -177,10 +177,6 @@ function updateSortModeUI() {
       : 'Arrange the apps';
   }
 
-  if (elements?.sortIndicator) {
-    elements.sortIndicator.hidden = !(sortMode && allowSort);
-  }
-
   if (elements?.container) {
     elements.container.classList.toggle('is-sorting', sortMode && allowSort);
   }

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -579,14 +579,13 @@ a {
 .apps-widget {
   padding: 0.85rem 0.95rem 1rem;
   gap: 0.65rem;
+  position: relative;
 }
 
 .apps-widget__header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 0.75rem;
-  flex-wrap: wrap;
+  position: relative;
+  display: block;
+  padding-inline-end: 6rem;
 }
 
 .apps-widget__intro {
@@ -596,11 +595,9 @@ a {
 }
 
 .apps-widget__controls {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  flex-wrap: wrap;
-  justify-content: flex-end;
+  position: absolute;
+  top: 0;
+  right: 0;
 }
 
 .apps-widget__sort-toggle {
@@ -634,19 +631,6 @@ a {
 .apps-widget__sort-toggle:disabled {
   opacity: 0.4;
   cursor: not-allowed;
-}
-
-.apps-widget__sort-indicator {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.25rem 0.6rem;
-  border-radius: var(--browser-radius-pill);
-  background: var(--browser-accent-soft);
-  color: var(--browser-accent);
-  font-size: 0.75rem;
-  font-weight: 700;
-  white-space: nowrap;
 }
 
 .apps-widget.is-sorting .apps-widget__tile {


### PR DESCRIPTION
## Summary
- remove the sorting mode indicator copy from the browser apps widget
- anchor the arrange/done toggle in the widget header so it stays in the top-right corner
- drop unused resolver wiring for the indicator element after layout update

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68df03c6f6dc832caccdeb237f90fc37