### PR TITLE
Refine Learnly catalog navigation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,7 @@
 - Browser homepage ToDo widget now auto-lists any upkeep or study time already consumed at daybreak inside the Done column so players see their remaining capacity at a glance.
 - Browser chrome End Day button now launches the next queued ToDo task and only offers "Next Day" once the list is clear.
 - Learnly graduates into a dedicated browser app with a course catalog, detail pages, My Courses hub, and pricing FAQ while reusing the existing education systems.
+- Learnly catalog now hides completed courses, floats active enrollments to the top of My Courses, and mirrors tab switches in the workspace URL bar for clearer navigation.
 - BlogPress brings the Personal Blog management flow into the browser shell with a table overview, detail inspector, pricing page, and one-click quality actions while reusing the existing passive-income logic.
 - VideoTube graduates the vlog asset tools into a studio-style browser app with a channel dashboard, analytics view, niche selection, and launch workflow that reuse the existing vlog economy.
 - Shopily launches as the dropshipping control center with KPI hero, store table + sidebar, upgrade shelf, and pricing tier cards while reusing the established commerce backend.

--- a/docs/features/learnly.md
+++ b/docs/features/learnly.md
@@ -10,7 +10,10 @@ Reimagine the education experience inside the browser shell as a dedicated Learn
 
 ## Key Details
 - Catalog view organizes courses by skill constellations such as Writing & Storycraft, Promotion & Funnels, and Technical Skills. Badges surface the focus areas directly on each card.
+- Completed courses drop out of the catalog once you graduate so the grid always spotlights fresh study leads.
 - Course detail pages reuse existing descriptions, tuition, duration, and bonus definitions, adding sections for “What you’ll learn,” “Requirements,” and “Certificate of Completion.”
 - My Courses tab lists active and completed enrollments, displaying hours reserved per day, tuition already paid, and a drop-course confirmation that keeps tuition sunk.
+- Active enrollments float to the top of the My Courses list so the next study session is never buried beneath old certificates.
 - Pricing Info tab explains tuition, time reservation, and graduation rewards so new players understand how Learnly interacts with their schedule and income.
+- Browser navigation mirrors Learnly’s tabs, mapping the workspace URL to `/catalog`, `/my-courses`, or `/pricing` for easy orientation.
 - The module reuses the existing knowledge track registry so XP rewards, unlocks, and study progress remain in sync with backend systems.

--- a/src/ui/views/browser/apps/education.js
+++ b/src/ui/views/browser/apps/education.js
@@ -1,4 +1,5 @@
 import learnlyApp from '../components/learnly.js';
+import { setWorkspacePath } from '../layoutPresenter.js';
 import { getPageByType } from './pageLookup.js';
 
 export default function renderEducation(context = {}, definitions = [], model = {}) {
@@ -19,7 +20,13 @@ export default function renderEducation(context = {}, definitions = [], model = 
   const mount = refs.body.querySelector('[data-role="learnly-root"]');
   if (!mount) return null;
 
-  const summary = learnlyApp.render(model, { mount, page, definitions });
+  const handleRouteChange = path => {
+    setWorkspacePath(page.id, path);
+  };
+
+  const summary = learnlyApp.render(model, { mount, page, definitions, onRouteChange: handleRouteChange });
+  const path = summary?.urlPath || '';
+  setWorkspacePath(page.id, path);
   const meta = summary?.meta || 'Browse the catalog';
-  return { id: page.id, meta };
+  return { id: page.id, meta, urlPath: path };
 }


### PR DESCRIPTION
## Summary
- hide completed Learnly courses from the catalog and keep category counts in sync
- surface active enrollments at the top of My Courses and emit fake URL routes for each tab/detail state
- sync the Learnly workspace address with browser navigation helpers and document the behavior updates

## Testing
- npm test -- --watch=false *(partial run; aborted after hanging processes)*

------
https://chatgpt.com/codex/tasks/task_e_68df045d44ac832cada17d0b7004e0f1