### PR TITLE
Refine VideoTube Studio navigation and metrics layout

### DIFF
--- a/src/ui/views/browser/config.js
+++ b/src/ui/views/browser/config.js
@@ -59,8 +59,8 @@ export const SERVICE_PAGES = [
     id: 'videotube',
     slug: 'videotube',
     label: 'VideoTube',
-    headline: 'VideoTube Venture Studio',
-    tagline: 'Schedule drops, review analytics, and amplify fans.',
+    headline: 'VideoTube Studio',
+    tagline: 'Manage uploads, hype premieres, and celebrate every payout.',
     icon: '📺',
     type: 'videotube'
   },

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -4209,57 +4209,62 @@ a {
 .videotube {
   display: flex;
   flex-direction: column;
-  gap: 1.75rem;
+  gap: 1.25rem;
 }
 
 .videotube__header {
   display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 1.25rem;
-}
-
-.videotube__title h1 {
-  font-size: 1.75rem;
-  margin-bottom: 0.25rem;
-}
-
-.videotube__title p {
-  margin: 0;
-  color: var(--browser-text-subtle);
+  flex-direction: column;
+  gap: 0.65rem;
+  align-items: flex-start;
 }
 
 .videotube-tabs {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.35rem;
+  width: 100%;
+  border-bottom: 1px solid var(--browser-border-muted);
+  padding-bottom: 0.25rem;
 }
 
 .videotube-tab {
-  padding: 0.5rem 0.9rem;
-  border-radius: 999px;
-  border: 1px solid transparent;
+  position: relative;
+  padding: 0.5rem 0.8rem;
+  border: none;
+  border-radius: 0.75rem 0.75rem 0 0;
   font-weight: 600;
-  background: var(--browser-surface-muted);
+  background: none;
   color: var(--browser-text-subtle);
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  transition: color 0.2s ease;
 }
 
 .videotube-tab:hover,
 .videotube-tab:focus-visible {
-  border-color: var(--browser-border-strong);
   color: var(--browser-text-strong);
 }
 
 .videotube-tab.is-active {
-  background: var(--browser-primary-surface);
-  color: var(--browser-primary-text);
-  border-color: transparent;
+  color: var(--browser-text-strong);
 }
 
-.videotube__actions {
-  margin-left: auto;
+.videotube-tab::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -0.3rem;
+  height: 0.25rem;
+  border-radius: 999px;
+  background: transparent;
+  transition: background 0.2s ease;
+}
+
+.videotube-tab.is-active::after {
+  background: var(--browser-primary-surface);
 }
 
 .videotube-button {
@@ -4303,26 +4308,26 @@ a {
 
 .videotube-stats {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 0.75rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.65rem;
 }
 
 .videotube-stats__card {
   background: var(--browser-surface-muted);
-  border-radius: 1rem;
-  padding: 1rem;
+  border-radius: 0.9rem;
+  padding: 0.9rem;
   display: flex;
   flex-direction: column;
-  gap: 0.3rem;
+  gap: 0.25rem;
 }
 
 .videotube-stats__card span {
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   color: var(--browser-text-subtle);
 }
 
 .videotube-stats__card strong {
-  font-size: 1.15rem;
+  font-size: 1.05rem;
   color: var(--browser-text-strong);
 }
 
@@ -4449,7 +4454,7 @@ a {
 .videotube-view {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.25rem;
 }
 
 .videotube-panel {


### PR DESCRIPTION
## Summary
- streamline the VideoTube Studio header copy and navigation by aligning the page metadata with the new tagline and rendering a compact tab bar with history-backed routes
- refactor the studio component to drive internal navigation via pushState-compatible URLs, update tab accessibility, and collapse redundant markup
- restyle the KPI cards and navigation to a single-row layout that mirrors YouTube Studio tiles while tightening vertical rhythm around the video table

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df03408340832cada5f96ac78ea6c8