### PR TITLE
Refactor workspace routing with shared controller

### DIFF
--- a/src/ui/views/browser/components/blogpress.js
+++ b/src/ui/views/browser/components/blogpress.js
@@ -816,7 +816,9 @@ export function render(model = {}, context = {}) {
   if (context.page) {
     currentPageMeta = context.page;
   }
-  workspacePathController.setListener(context.onRouteChange);
+  if (typeof context.onRouteChange === 'function') {
+    workspacePathController.setListener(context.onRouteChange);
+  }
   ensureSelectedBlog();
   workspacePathController.sync();
 

--- a/src/ui/views/browser/components/learnly.js
+++ b/src/ui/views/browser/components/learnly.js
@@ -817,7 +817,9 @@ function deriveWorkspacePath() {
 
 function render(model, { mount, definitions = [], onRouteChange } = {}) {
   currentMount = mount || currentMount;
-  workspacePathController.setListener(onRouteChange);
+  if (typeof onRouteChange === 'function') {
+    workspacePathController.setListener(onRouteChange);
+  }
   currentContext = buildContext(model, definitions);
   if (currentState.view === VIEW_DETAIL) {
     ensureSelectedCourse();

--- a/src/ui/views/browser/components/shopily.js
+++ b/src/ui/views/browser/components/shopily.js
@@ -872,7 +872,9 @@ function render(model, { mount, page, onRouteChange } = {}) {
   currentModel = model || currentModel;
   currentMount = mount || currentMount;
   currentPageMeta = page || currentPageMeta;
-  workspacePathController.setListener(onRouteChange);
+  if (typeof onRouteChange === 'function') {
+    workspacePathController.setListener(onRouteChange);
+  }
   ensureSelectedStore();
   renderApp();
   const urlPath = workspacePathController.getPath();

--- a/src/ui/views/browser/utils/workspacePaths.js
+++ b/src/ui/views/browser/utils/workspacePaths.js
@@ -1,0 +1,40 @@
+export function createWorkspacePathController({ derivePath }) {
+  if (typeof derivePath !== 'function') {
+    throw new TypeError('derivePath must be a function');
+  }
+
+  let lastPath = undefined;
+  let listener = null;
+
+  function setListener(fn) {
+    listener = typeof fn === 'function' ? fn : null;
+  }
+
+  function sync(options = {}) {
+    const { force = false } = options;
+    const nextPath = derivePath();
+    const changed = nextPath !== lastPath;
+    if ((force || changed) && listener) {
+      listener(nextPath);
+    }
+    lastPath = nextPath;
+    return nextPath;
+  }
+
+  function getPath() {
+    if (lastPath === undefined) {
+      lastPath = derivePath();
+    }
+    return lastPath;
+  }
+
+  return {
+    setListener,
+    sync,
+    getPath
+  };
+}
+
+export default {
+  createWorkspacePathController
+};


### PR DESCRIPTION
## Summary
- add a shared workspace path controller utility for browser workspaces
- refactor the BlogPress, Shopily, and Learnly components to sync URL paths through the controller
- reuse the controller for summary returns so wrappers keep receiving meta and urlPath values

## Testing
- npm test
- Manual verification in browser shell: opened BlogPress, Shopily, and Learnly workspaces; switched between tabs/views, selected entries, and confirmed the fake address bar updated without redundant setWorkspacePath calls

------
https://chatgpt.com/codex/tasks/task_e_68df08f958e4832c88992269e51511ee