### PR TITLE
Tighten workspace header spacing in browser apps

### DIFF
--- a/src/ui/views/browser/components/shopily.js
+++ b/src/ui/views/browser/components/shopily.js
@@ -154,7 +154,11 @@ function renderTopBar(model) {
   actions.className = 'shopily-topbar__actions';
   actions.appendChild(createLaunchButton(model.launch));
 
-  bar.append(title, nav, actions);
+  const topRow = document.createElement('div');
+  topRow.className = 'shopily-topbar__row';
+  topRow.append(title, actions);
+
+  bar.append(topRow, nav);
   return bar;
 }
 

--- a/src/ui/views/browser/components/videotube.js
+++ b/src/ui/views/browser/components/videotube.js
@@ -117,7 +117,11 @@ function renderHeader(model) {
   launchButton.addEventListener('click', () => setView(VIEW_CREATE));
   actions.appendChild(launchButton);
 
-  header.append(title, nav, actions);
+  const masthead = document.createElement('div');
+  masthead.className = 'videotube__masthead';
+  masthead.append(title, actions);
+
+  header.append(masthead, nav);
   return header;
 }
 

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -1177,8 +1177,8 @@ a {
 .browser-page {
   display: none;
   flex-direction: column;
-  gap: 1.6rem;
-  padding: 2rem;
+  gap: 1.2rem;
+  padding: 1.25rem 1.6rem 1.8rem;
   border-radius: var(--browser-radius-lg);
   border: 1px solid var(--browser-panel-border);
   background: var(--browser-panel-elevated);
@@ -1195,14 +1195,21 @@ a {
   animation: browser-page-refresh 320ms ease;
 }
 
+.browser-page__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
 .browser-page__header h1 {
   margin: 0;
-  font-size: 1.6rem;
+  font-size: 1.45rem;
 }
 
 .browser-page__header p {
-  margin: 0.35rem 0 0;
+  margin: 0;
   color: var(--browser-muted);
+  font-size: 0.95rem;
 }
 
 .browser-card-grid {
@@ -4280,34 +4287,43 @@ a {
 .videotube {
   display: flex;
   flex-direction: column;
-  gap: 1.75rem;
+  gap: 1.5rem;
 }
 
 .videotube__header {
   display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.videotube__masthead {
+  display: flex;
   flex-wrap: wrap;
-  align-items: flex-end;
+  align-items: center;
   justify-content: space-between;
-  gap: 1.25rem;
+  gap: 0.85rem;
 }
 
 .videotube__title h1 {
-  font-size: 1.75rem;
-  margin-bottom: 0.25rem;
+  margin: 0;
+  font-size: 1.55rem;
 }
 
 .videotube__title p {
   margin: 0;
-  color: var(--browser-text-subtle);
+  color: var(--browser-muted);
+  font-size: 0.95rem;
 }
 
 .videotube-tabs {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.6rem;
+  padding: 0.35rem 0;
+  border-bottom: 1px solid var(--browser-panel-border);
 }
 
 .videotube-tab {
-  padding: 0.5rem 0.9rem;
+  padding: 0.45rem 0.85rem;
   border-radius: 999px;
   border: 1px solid transparent;
   font-weight: 600;
@@ -4330,7 +4346,9 @@ a {
 }
 
 .videotube__actions {
-  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
 }
 
 .videotube-button {
@@ -4739,10 +4757,11 @@ a {
   background: rgba(19, 26, 40, 0.85);
 }
 
+
 .shopily {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.6rem;
 }
 
 .shopily-topbar {
@@ -4750,14 +4769,29 @@ a {
   border: 1px solid var(--browser-panel-border);
   border-radius: var(--browser-radius-lg);
   box-shadow: var(--browser-shadow-soft);
-  padding: 1.75rem;
-  display: grid;
-  gap: 1.25rem;
+  padding: 1.35rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.shopily-topbar__row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.shopily-topbar__title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
 }
 
 .shopily-topbar__title h1 {
-  margin: 0 0 0.35rem;
-  font-size: 1.75rem;
+  margin: 0;
+  font-size: 1.6rem;
   font-weight: 700;
 }
 
@@ -4770,7 +4804,9 @@ a {
 .shopily-nav {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.45rem;
+  padding-top: 0.55rem;
+  border-top: 1px solid var(--browser-panel-border);
 }
 
 .shopily-nav__button {
@@ -4780,7 +4816,7 @@ a {
   background: rgba(148, 163, 184, 0.12);
   color: inherit;
   font-weight: 600;
-  padding: 0.5rem 1.1rem;
+  padding: 0.45rem 1rem;
   transition: border-color 160ms ease, background 160ms ease, box-shadow 160ms ease;
 }
 
@@ -4806,8 +4842,9 @@ a {
 
 .shopily-topbar__actions {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.65rem;
   flex-wrap: wrap;
+  align-items: center;
 }
 
 .shopily-button {
@@ -5326,9 +5363,9 @@ a {
 }
 
 @media (min-width: 768px) {
-  .shopily-topbar {
-    grid-template-columns: minmax(0, 1fr) auto;
+  .shopily-topbar__row {
     align-items: center;
+    flex-wrap: nowrap;
   }
 
   .shopily-metrics {
@@ -5344,30 +5381,30 @@ a {
 .trends-app {
   display: flex;
   flex-direction: column;
-  gap: 2.4rem;
+  gap: 1.9rem;
 }
 
 .trends-app__header {
   display: grid;
-  gap: 1.5rem;
+  gap: 1rem;
   background: var(--browser-panel);
   border: 1px solid var(--browser-panel-border);
   border-radius: var(--browser-radius-lg);
-  padding: 1.6rem;
+  padding: 1.3rem 1.5rem;
   box-shadow: var(--browser-shadow-soft);
 }
 
 @media (min-width: 768px) {
   .trends-app__header {
     grid-template-columns: minmax(0, 1fr) auto;
-    align-items: end;
+    align-items: center;
   }
 }
 
 .trends-app__heading {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.25rem;
 }
 
 .trends-app__title {
@@ -5385,8 +5422,8 @@ a {
 .trends-toolbar {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
-  align-items: flex-end;
+  gap: 0.6rem;
+  align-items: center;
   justify-content: flex-end;
 }
 


### PR DESCRIPTION
## Summary
- reduce padding on browser workspace shells so headers sit closer to the chrome
- refresh VideoTube and Shopily mastheads with tighter layouts that align actions beside titles
- slim down Trends toolbar spacing to feel closer to a modern analytics header

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df0bf8fea8832c858a6d57a77d02e7