### PR TITLE
Ensure browser workspace launches scroll from top

### DIFF
--- a/src/ui/views/browser/layoutPresenter.js
+++ b/src/ui/views/browser/layoutPresenter.js
@@ -24,6 +24,29 @@ let sessionControls = null;
 
 const navigationController = createNavigationController({ homepageId: HOMEPAGE_ID });
 
+function scrollViewportToTop({ smooth = false } = {}) {
+  if (typeof window === 'undefined') return;
+  const behavior = smooth ? 'smooth' : 'auto';
+  if (typeof window.scrollTo === 'function') {
+    try {
+      window.scrollTo({ top: 0, behavior });
+      return;
+    } catch (error) {
+      window.scrollTo(0, 0);
+      return;
+    }
+  }
+
+  if (typeof document !== 'undefined') {
+    if (document.documentElement) {
+      document.documentElement.scrollTop = 0;
+    }
+    if (document.body) {
+      document.body.scrollTop = 0;
+    }
+  }
+}
+
 function getNavigationRefs() {
   if (!navigationRefs) {
     navigationRefs = getElement('browserNavigation') || {};
@@ -64,9 +87,6 @@ function revealPage(pageId, { focus = false } = {}) {
   if (homepageContent) {
     homepageContent.hidden = !isHome;
     homepageContent.classList.toggle('is-active', isHome);
-    if (isHome && focus) {
-      homepageContent.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
   }
 
   if (workspaceHost) {
@@ -74,10 +94,11 @@ function revealPage(pageId, { focus = false } = {}) {
       const active = section.dataset.browserPage === pageId;
       section.hidden = !active;
       section.classList.toggle('is-active', active);
-      if (active && focus) {
-        section.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      }
     });
+  }
+
+  if (focus) {
+    scrollViewportToTop({ smooth: true });
   }
 }
 


### PR DESCRIPTION
## Summary
- add a viewport scroll helper to the browser layout presenter
- scroll the window to the top when focusing the homepage or an app workspace
- stop using section-level scrollIntoView that could center random components

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df0e896fc0832cbe41170b4e72d63e