### PR TITLE
Remove workspace hero headers except Shopily

### DIFF
--- a/src/ui/views/browser/cardsPresenter.js
+++ b/src/ui/views/browser/cardsPresenter.js
@@ -42,18 +42,24 @@ function createPageSection(page) {
   section.dataset.browserPage = page.id;
   section.id = `browser-page-${page.slug}`;
 
-  const header = document.createElement('header');
-  header.className = 'browser-page__header';
-  const title = document.createElement('h1');
-  title.textContent = page.headline;
-  const note = document.createElement('p');
-  note.textContent = page.tagline;
-  header.append(title, note);
+  const shouldShowHeader = page.id === 'shopily';
+  let header = null;
+  let note = null;
+  if (shouldShowHeader) {
+    header = document.createElement('header');
+    header.className = 'browser-page__header';
+    const title = document.createElement('h1');
+    title.textContent = page.headline;
+    note = document.createElement('p');
+    note.textContent = page.tagline;
+    header.append(title, note);
+    section.appendChild(header);
+  }
 
   const body = document.createElement('div');
   body.className = 'browser-page__body';
 
-  section.append(header, body);
+  section.appendChild(body);
   main.appendChild(section);
 
   const refs = { section, header, note, body };


### PR DESCRIPTION
## Summary
- skip rendering the generic workspace header and tagline for all browser pages except Shopily to declutter the dashboards

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df0f66de24832c9beed2da567f3c2b