### PR TITLE
Remove workspace page headers from browser shell apps

### DIFF
--- a/src/ui/views/browser/cardsPresenter.js
+++ b/src/ui/views/browser/cardsPresenter.js
@@ -42,21 +42,13 @@ function createPageSection(page) {
   section.dataset.browserPage = page.id;
   section.id = `browser-page-${page.slug}`;
 
-  const header = document.createElement('header');
-  header.className = 'browser-page__header';
-  const title = document.createElement('h1');
-  title.textContent = page.headline;
-  const note = document.createElement('p');
-  note.textContent = page.tagline;
-  header.append(title, note);
-
   const body = document.createElement('div');
   body.className = 'browser-page__body';
 
-  section.append(header, body);
+  section.append(body);
   main.appendChild(section);
 
-  const refs = { section, header, note, body };
+  const refs = { section, body };
   pageSections.set(page.id, refs);
   return refs;
 }

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -1195,23 +1195,6 @@ a {
   animation: browser-page-refresh 320ms ease;
 }
 
-.browser-page__header {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.browser-page__header h1 {
-  margin: 0;
-  font-size: 1.45rem;
-}
-
-.browser-page__header p {
-  margin: 0;
-  color: var(--browser-muted);
-  font-size: 0.95rem;
-}
-
 .browser-card-grid {
   display: grid;
   gap: 1.35rem;


### PR DESCRIPTION
## Summary
- stop rendering the workspace header wrapper so browser apps no longer display taglines
- remove the unused `.browser-page__header` styling to match the markup update

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68df1225a424832cbfd94af2f8c7334e