### PR TITLE
Adjust browser workspace spacing

### DIFF
--- a/styles/browser.css
+++ b/styles/browser.css
@@ -198,9 +198,8 @@ a {
   flex-direction: column;
   gap: 2rem;
   width: 100%;
-  max-width: 1180px;
   margin: 0 auto;
-  padding: 3rem 1.75rem 4rem;
+  padding: 0rem 1.75rem 4rem;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Summary
- remove the max-width constraint from the browser workspace pane so it can grow with the viewport
- update the workspace padding to 0rem 1.75rem 4rem to match the desired spacing

## Testing
- python3 -m http.server 8000 (loaded browser.html and confirmed layout renders)


------
https://chatgpt.com/codex/tasks/task_e_68df15f418b4832ca4bf2d91482fc483