### PR TITLE
Add alphabetical sort option to Trends Analytics

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 - Browser chrome now features a notification bell that mirrors the event log with unread badges, read tracking, and a mark-all control.
 - AboutYou rebrands the browser profile hub with upbeat copy, refreshed styling, and tighter lists that only surface owned education tracks and equipped gear.
 - Trends Intelligence Lab refreshes the browser app with analytics-style header controls, overview metrics, sparkline cards, and an expanded watchlist panel while reusing existing niche data.
+- Trends Intelligence Lab now includes a Name (A–Z) sort so players can scan niches alphabetically alongside momentum filters.
 - ServerHub launches as a cloud-inspired control center for Micro SaaS ventures with KPI hero metrics, app table + detail sidebar, upgrade shelf, and pricing tiers built on the existing SaaS backend.
 - BankApp now archives the last seven day-end ledgers and mirrors the shared activity log so the browser shell surfaces cashflow streaks without leaving the app.
 - BankApp’s finance dashboard now pipes every tracked dataset—obligations, pending payouts, asset ROI tables, opportunity queues, and education commitments—into the in-app layout so the browser view matches the classic shell’s depth.

--- a/docs/features/trends.md
+++ b/docs/features/trends.md
@@ -18,7 +18,7 @@ The Trends app now frames niche analytics like a professional SaaS dashboard. A 
 - Navigation URLs remain unchanged, keeping `/`, `/watchlist`, and `/niche/{slug}` ready for future expansion.
 
 ## Data & Logic
-- Sorting options map to highest momentum score, highest payout impact, or fastest cooling delta using the existing board metrics.
+- Sorting options map to highest momentum score, alphabetical niche names, highest payout impact, or fastest cooling delta using the existing board metrics.
 - Search operates on niche names only, ensuring no new backend lookups are required.
 - Sparkline trendlines interpolate between the stored previous and current scores when deeper history is unavailable, keeping fidelity with current data.
 - Watchlist meta counts recalculate locally so filters disable gracefully when nothing is starred.

--- a/src/ui/views/browser/components/trends.js
+++ b/src/ui/views/browser/components/trends.js
@@ -7,6 +7,7 @@ import {
 
 const SORT_OPTIONS = [
   { key: 'momentum', label: 'Highest Momentum' },
+  { key: 'name', label: 'Name (A–Z)' },
   { key: 'payout', label: 'Payout Impact' },
   { key: 'cooling', label: 'Cooling Off' }
 ];
@@ -528,6 +529,14 @@ function sortEntries(entries = []) {
       const deltaA = Number(a.popularity?.delta) || 0;
       const deltaB = Number(b.popularity?.delta) || 0;
       return deltaB - deltaA;
+    },
+    name: (a, b) => {
+      const nameA = String(a.definition?.name || '').toLowerCase();
+      const nameB = String(b.definition?.name || '').toLowerCase();
+      if (nameA !== nameB) return nameA.localeCompare(nameB);
+      const scoreA = clampScore(a.popularity?.score) || 0;
+      const scoreB = clampScore(b.popularity?.score) || 0;
+      return scoreB - scoreA;
     },
     payout: (a, b) => {
       const impactA = Number(a.trendImpact) || 0;


### PR DESCRIPTION
## Summary
- add a Name (A–Z) option to the Trends Analytics sort dropdown and implement alphabetical sorting logic
- note the new sort in the Trends feature design doc and changelog

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68df1d572968832ca953114fe88decd1