### PR TITLE
Add TimoDoro productivity workspace to browser shell

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- TimoDoro productivity hub joins the browser app roster, remixing the ToDo queue, upkeep logs, and daily summary stats into a dedicated focus workspace.
 - Browser homepage apps widget now includes an Arrange mode so players can drag tiles to swap spots, highlight favorites, and keep the order between sessions.
 - Asset Arcade workspace retired from the browser prototype and hidden from the homepage launcher while we explore refreshed asset flows.
 - Browser chrome now features a notification bell that mirrors the event log with unread badges, read tracking, and a mark-all control.

--- a/docs/features/timodoro.md
+++ b/docs/features/timodoro.md
@@ -1,0 +1,21 @@
+# TimoDoro Productivity Hub
+
+## Goals
+- Give browser players a dedicated productivity workspace that pulls in the existing ToDo queue, upkeep logs, and daily summary metrics without inventing new systems.
+- Present a calm, two-column layout that highlights what’s finished, what’s queued, and how much time plus payout headroom remains for the day.
+- Establish a lightweight pattern for future focus tools that remix shared state into purpose-built dashboards.
+
+## Player Impact
+- Players can launch the TimoDoro app to review remaining hustle hours, today’s logged time, and earnings in one glance instead of hopping between widgets.
+- The Task Log mirrors the ToDo widget’s pending entries alongside completed work summaries, so the browser tab feels like a full time-tracking companion.
+- Maintenance and study sessions surface automatically, reminding players about assistant-driven upkeep that already consumed hours or will trigger later.
+
+## Implementation Notes
+- `src/ui/views/browser/apps/timodoro.js` composes the ToDo models (`buildQuickActionModel`, `buildAssetActionModel`, `buildStudyEnrollmentActionModel`) with the existing daily summary selectors to render pending queues, completed work, recurring upkeep, and headline stats.
+- The browser config in `src/ui/views/browser/config.js` now registers TimoDoro as a top-level service page, while `cardsPresenter.js` lists it so the workspace launcher and tab system can open it like other apps.
+- Fresh layout rules in `styles/browser.css` define the two-column grid, task list styling, and summary panels, borrowing the shared browser card components for consistency.
+
+## Future Work
+- Add historical filters so players can compare today’s effort with prior days and celebrate streaks.
+- Pipe in assistant prompts that explain why certain upkeep tasks triggered (e.g., payroll, equipment) to deepen transparency.
+- Explore lightweight inline controls for marking maintenance as delegated or rescheduling study sessions without leaving the hub.

--- a/src/ui/dashboard/model.js
+++ b/src/ui/dashboard/model.js
@@ -282,6 +282,8 @@ export function buildDashboardViewModel(state, summary = {}) {
   };
 }
 
+export { buildQuickActionModel, buildAssetActionModel, buildStudyEnrollmentActionModel };
+
 export default {
   buildDashboardViewModel,
   buildDailySummaries,

--- a/src/ui/views/browser/apps/timodoro.js
+++ b/src/ui/views/browser/apps/timodoro.js
@@ -1,0 +1,457 @@
+import { formatHours, formatMoney } from '../../../../core/helpers.js';
+import { getState } from '../../../../core/state.js';
+import { computeDailySummary } from '../../../../game/summary.js';
+import {
+  buildQuickActionModel,
+  buildAssetActionModel,
+  buildStudyEnrollmentActionModel
+} from '../../../dashboard/model.js';
+import { buildSummaryPresentations } from '../../../dashboard/formatters.js';
+import { composeTodoModel, createAutoCompletedEntries } from '../dashboardPresenter.js';
+import { getPageByType } from './pageLookup.js';
+import { createStat } from '../components/widgets.js';
+
+let elements = null;
+
+function formatCurrency(amount) {
+  const numeric = Number(amount);
+  if (!Number.isFinite(numeric) || Math.abs(numeric) < 1e-4) {
+    return '$0';
+  }
+  const absolute = Math.abs(numeric);
+  const formatted = formatMoney(Math.round(absolute * 100) / 100);
+  const prefix = numeric < 0 ? '-$' : '$';
+  return `${prefix}${formatted}`;
+}
+
+function computeTimeCap(state = {}) {
+  const base = Number(state?.baseTime) || 0;
+  const bonus = Number(state?.bonusTime) || 0;
+  const daily = Number(state?.dailyBonusTime) || 0;
+  return Math.max(0, base + bonus + daily);
+}
+
+function createCard(title, summary) {
+  const card = document.createElement('article');
+  card.className = 'browser-card timodoro-card';
+
+  const header = document.createElement('header');
+  header.className = 'browser-card__header';
+
+  const heading = document.createElement('h2');
+  heading.className = 'browser-card__title';
+  heading.textContent = title;
+  header.appendChild(heading);
+
+  if (summary) {
+    const description = document.createElement('p');
+    description.className = 'browser-card__summary';
+    description.textContent = summary;
+    header.appendChild(description);
+  }
+
+  card.appendChild(header);
+  return card;
+}
+
+function ensureElements(body) {
+  if (!body) return null;
+  let root = body.querySelector('[data-role="timodoro-root"]');
+  if (!root) {
+    body.innerHTML = '';
+
+    root = document.createElement('div');
+    root.className = 'timodoro';
+    root.dataset.role = 'timodoro-root';
+
+    const header = document.createElement('header');
+    header.className = 'timodoro__header';
+
+    const title = document.createElement('h1');
+    title.className = 'timodoro__title';
+    title.textContent = 'TimoDoro';
+
+    const subtitle = document.createElement('p');
+    subtitle.className = 'timodoro__subtitle';
+    subtitle.textContent = 'Track your hustle hours and assistant work.';
+
+    header.append(title, subtitle);
+
+    const grid = document.createElement('div');
+    grid.className = 'timodoro__grid';
+
+    const taskColumn = document.createElement('div');
+    taskColumn.className = 'timodoro__column timodoro__column--tasks';
+
+    const summaryColumn = document.createElement('div');
+    summaryColumn.className = 'timodoro__column timodoro__column--summary';
+
+    const taskCard = createCard('Task Log', 'See what’s finished and what’s waiting.');
+
+    const pendingSection = document.createElement('section');
+    pendingSection.className = 'timodoro-section';
+    const pendingHeading = document.createElement('h3');
+    pendingHeading.className = 'timodoro-section__title';
+    pendingHeading.textContent = 'Pending tasks';
+    const pendingList = document.createElement('ul');
+    pendingList.className = 'timodoro-list timodoro-list--tasks';
+    pendingList.dataset.role = 'timodoro-pending';
+    pendingSection.append(pendingHeading, pendingList);
+
+    const completedSection = document.createElement('section');
+    completedSection.className = 'timodoro-section';
+    const completedHeading = document.createElement('h3');
+    completedHeading.className = 'timodoro-section__title';
+    completedHeading.textContent = 'Completed today';
+    const completedList = document.createElement('ul');
+    completedList.className = 'timodoro-list timodoro-list--tasks';
+    completedList.dataset.role = 'timodoro-completed';
+    completedSection.append(completedHeading, completedList);
+
+    taskCard.append(pendingSection, completedSection);
+
+    const recurringCard = createCard('Recurring / Assistant Work', 'Upkeep, maintenance, and study sessions auto-logged for you.');
+    const recurringList = document.createElement('ul');
+    recurringList.className = 'timodoro-list timodoro-list--tasks';
+    recurringList.dataset.role = 'timodoro-recurring';
+    recurringCard.appendChild(recurringList);
+
+    taskColumn.append(taskCard, recurringCard);
+
+    const snapshotCard = createCard('Today’s Snapshot', 'Where your hustle hours landed.');
+    const stats = document.createElement('div');
+    stats.className = 'browser-card__stats';
+    const availableStat = createStat('Hours available', '0h');
+    const availableValue = availableStat.querySelector('.browser-card__stat-value');
+    const spentStat = createStat('Hours spent', '0h');
+    const spentValue = spentStat.querySelector('.browser-card__stat-value');
+    if (availableValue) {
+      availableValue.dataset.role = 'timodoro-hours-available';
+    }
+    if (spentValue) {
+      spentValue.dataset.role = 'timodoro-hours-spent';
+    }
+    stats.append(availableStat, spentStat);
+
+    const breakdownList = document.createElement('ul');
+    breakdownList.className = 'timodoro-list timodoro-list--breakdown';
+    breakdownList.dataset.role = 'timodoro-breakdown';
+
+    snapshotCard.append(stats, breakdownList);
+
+    const summaryCard = createCard('Summary Stats', 'Totals for today’s push.');
+    const summaryList = document.createElement('ul');
+    summaryList.className = 'timodoro-list timodoro-list--stats';
+    summaryList.dataset.role = 'timodoro-stats';
+    summaryCard.appendChild(summaryList);
+
+    summaryColumn.append(snapshotCard, summaryCard);
+
+    grid.append(taskColumn, summaryColumn);
+    root.append(header, grid);
+    body.appendChild(root);
+
+    elements = {
+      root,
+      pendingList,
+      completedList,
+      recurringList,
+      breakdownList,
+      summaryList,
+      availableValue,
+      spentValue
+    };
+    return elements;
+  }
+
+  elements = {
+    root,
+    pendingList: root.querySelector('[data-role="timodoro-pending"]'),
+    completedList: root.querySelector('[data-role="timodoro-completed"]'),
+    recurringList: root.querySelector('[data-role="timodoro-recurring"]'),
+    breakdownList: root.querySelector('[data-role="timodoro-breakdown"]'),
+    summaryList: root.querySelector('[data-role="timodoro-stats"]'),
+    availableValue: root.querySelector('[data-role="timodoro-hours-available"]'),
+    spentValue: root.querySelector('[data-role="timodoro-hours-spent"]')
+  };
+  return elements;
+}
+
+function renderList(list, entries, emptyText) {
+  if (!list) return;
+  list.innerHTML = '';
+  if (!entries.length) {
+    const empty = document.createElement('li');
+    empty.className = 'timodoro-list__empty';
+    empty.textContent = emptyText;
+    list.appendChild(empty);
+    return;
+  }
+
+  entries.forEach(entry => {
+    const item = document.createElement('li');
+    item.className = 'timodoro-list__item';
+
+    const name = document.createElement('span');
+    name.className = 'timodoro-list__name';
+    name.textContent = entry.name;
+
+    const meta = document.createElement('span');
+    meta.className = 'timodoro-list__meta';
+    meta.textContent = entry.detail;
+
+    item.append(name, meta);
+    list.appendChild(item);
+  });
+}
+
+function renderBreakdown(list, entries) {
+  if (!list) return;
+  list.innerHTML = '';
+  if (!entries.length) {
+    const empty = document.createElement('li');
+    empty.className = 'timodoro-breakdown__empty';
+    empty.textContent = 'No hours tracked yet.';
+    list.appendChild(empty);
+    return;
+  }
+
+  entries.forEach(entry => {
+    const item = document.createElement('li');
+    item.className = 'timodoro-breakdown__item';
+
+    const label = document.createElement('span');
+    label.className = 'timodoro-breakdown__label';
+    label.textContent = entry.label;
+
+    const value = document.createElement('span');
+    value.className = 'timodoro-breakdown__value';
+    value.textContent = entry.value;
+
+    item.append(label, value);
+    list.appendChild(item);
+  });
+}
+
+function renderSummaryStats(list, entries) {
+  if (!list) return;
+  list.innerHTML = '';
+  entries.forEach(entry => {
+    const item = document.createElement('li');
+    item.className = 'timodoro-stats__item';
+
+    const label = document.createElement('span');
+    label.className = 'timodoro-stats__label';
+    label.textContent = entry.label;
+
+    const value = document.createElement('span');
+    value.className = 'timodoro-stats__value';
+    value.textContent = entry.value;
+
+    item.append(label, value);
+
+    if (entry.note) {
+      const note = document.createElement('span');
+      note.className = 'timodoro-stats__note';
+      note.textContent = entry.note;
+      item.appendChild(note);
+    }
+
+    list.appendChild(item);
+  });
+}
+
+function buildPendingEntries(model = {}) {
+  const entries = Array.isArray(model.entries) ? model.entries : [];
+  const availableHours = Number.isFinite(model.hoursAvailable)
+    ? Math.max(0, model.hoursAvailable)
+    : Infinity;
+  const availableMoney = Number.isFinite(model.moneyAvailable)
+    ? Math.max(0, model.moneyAvailable)
+    : Infinity;
+
+  return entries
+    .filter(entry => {
+      const duration = Number(entry?.durationHours);
+      const moneyCost = Number(entry?.moneyCost);
+      const remainingRuns = entry?.remainingRuns;
+      const hasRuns = remainingRuns == null || remainingRuns > 0;
+      if (!hasRuns) return false;
+      const fitsTime = !Number.isFinite(availableHours) || !Number.isFinite(duration)
+        ? true
+        : duration <= availableHours;
+      if (!fitsTime) return false;
+      const cost = Number.isFinite(moneyCost) ? moneyCost : 0;
+      const fitsMoney = !Number.isFinite(availableMoney) || cost <= availableMoney;
+      return fitsMoney;
+    })
+    .map(entry => {
+      const durationText = entry?.durationText || formatHours(Number(entry?.durationHours) || 0);
+      const payout = Number(entry?.payout);
+      const payoutLabel = Number.isFinite(payout) && payout > 0
+        ? `${formatCurrency(payout)}`
+        : (entry?.payoutText || entry?.meta || '—');
+      const detailParts = [durationText];
+      if (payoutLabel) {
+        detailParts.push(payoutLabel);
+      }
+      return {
+        name: entry?.title || 'Task',
+        detail: detailParts.join(' • ')
+      };
+    });
+}
+
+function buildCompletedEntries(summary = {}) {
+  const presentations = buildSummaryPresentations(summary);
+  const timeEntries = Array.isArray(presentations.timeEntries) ? presentations.timeEntries : [];
+  const earningsEntries = Array.isArray(presentations.earningsEntries) ? presentations.earningsEntries : [];
+  const payoutMap = new Map(earningsEntries.map(entry => [entry?.key, entry?.amount]));
+
+  return timeEntries
+    .filter(entry => entry && entry.category !== 'maintenance' && entry.category !== 'study')
+    .map(entry => {
+      const payout = payoutMap.get(entry.key) || 0;
+      const payoutLabel = payout > 0 ? formatCurrency(payout) : '$0';
+      return {
+        name: entry.label,
+        detail: `${formatHours(entry.hours)} • ${payoutLabel}`
+      };
+    });
+}
+
+function buildRecurringEntries(summary = {}) {
+  const presentations = buildSummaryPresentations(summary);
+  const timeEntries = Array.isArray(presentations.timeEntries) ? presentations.timeEntries : [];
+  const studyEntries = Array.isArray(presentations.studyEntries) ? presentations.studyEntries : [];
+
+  const maintenance = timeEntries
+    .filter(entry => entry && entry.category === 'maintenance')
+    .map(entry => ({
+      name: entry.label,
+      detail: `${formatHours(entry.hours)} logged today • Maintenance`
+    }));
+
+  const study = studyEntries.map(entry => ({
+    name: entry.label,
+    detail: entry.value
+  }));
+
+  return [...maintenance, ...study];
+}
+
+function buildSummaryEntries(summary = {}, todoModel = {}, state = {}) {
+  const totalHours = Math.max(0, Number(summary?.totalTime) || 0);
+  const activeEarnings = Math.max(0, Number(summary?.activeEarnings) || 0);
+  const passiveEarnings = Math.max(0, Number(summary?.passiveEarnings) || 0);
+  const totalEarnings = Math.max(0, Number(summary?.totalEarnings) || 0);
+  const timeCap = computeTimeCap(state);
+  const hoursAvailable = Number.isFinite(todoModel?.hoursAvailable)
+    ? Math.max(0, todoModel.hoursAvailable)
+    : Math.max(0, Number(state?.timeLeft) || 0);
+  const hoursSpent = Math.max(0, timeCap - hoursAvailable);
+  const percentUsed = timeCap > 0 ? Math.min(100, Math.round((hoursSpent / timeCap) * 100)) : 0;
+
+  return [
+    {
+      label: 'Hours logged',
+      value: formatHours(totalHours),
+      note: totalHours > 0 ? 'Across all workstreams today.' : 'No focus hours logged yet.'
+    },
+    {
+      label: 'Earnings today',
+      value: formatCurrency(totalEarnings),
+      note: totalEarnings > 0
+        ? `${formatCurrency(activeEarnings)} active • ${formatCurrency(passiveEarnings)} passive`
+        : 'Ship a gig to see cash roll in.'
+    },
+    {
+      label: 'Time used',
+      value: `${percentUsed}%`,
+      note: timeCap > 0
+        ? `${formatHours(hoursSpent)} of ${formatHours(timeCap)} booked.`
+        : 'Daily cap not set yet.'
+    }
+  ];
+}
+
+function buildBreakdown(summary = {}, todoModel = {}, state = {}) {
+  const totalHours = Math.max(0, Number(summary?.totalTime) || 0);
+  const maintenance = Math.max(0, Number(summary?.maintenanceHours) || 0);
+  const active = Math.max(0, totalHours - maintenance);
+  const hoursAvailable = Number.isFinite(todoModel?.hoursAvailable)
+    ? Math.max(0, todoModel.hoursAvailable)
+    : Math.max(0, Number(state?.timeLeft) || 0);
+
+  return [
+    { label: 'Active work', value: formatHours(active) },
+    { label: 'Upkeep & care', value: formatHours(maintenance) },
+    { label: 'Hours remaining', value: formatHours(hoursAvailable) }
+  ];
+}
+
+function buildMeta(summary = {}, completed = []) {
+  const totalHours = Math.max(0, Number(summary?.totalTime) || 0);
+  const totalEarnings = Math.max(0, Number(summary?.totalEarnings) || 0);
+  const taskCount = completed.length;
+  const parts = [];
+  if (taskCount > 0) {
+    parts.push(`${taskCount} task${taskCount === 1 ? '' : 's'} logged`);
+  }
+  if (totalHours > 0) {
+    parts.push(`${formatHours(totalHours)} logged`);
+  }
+  if (totalEarnings > 0) {
+    parts.push(`${formatCurrency(totalEarnings)} earned`);
+  }
+  return parts.length ? parts.join(' • ') : 'No hustle data yet.';
+}
+
+export default function renderTimodoro(context = {}) {
+  const page = getPageByType('timodoro');
+  if (!page) return null;
+
+  const refs = context.ensurePageContent?.(page, ({ body }) => {
+    ensureElements(body);
+  });
+  if (!refs) return null;
+
+  const dom = ensureElements(refs.body);
+  if (!dom) return null;
+
+  const state = getState() || {};
+  const summary = computeDailySummary(state);
+
+  const quickActions = buildQuickActionModel(state);
+  const assetActions = buildAssetActionModel(state);
+  const studyActions = buildStudyEnrollmentActionModel(state);
+  const autoEntries = createAutoCompletedEntries(summary);
+  const todoModel = composeTodoModel(quickActions, assetActions, studyActions, autoEntries);
+
+  const pendingEntries = buildPendingEntries(todoModel);
+  const completedEntries = buildCompletedEntries(summary);
+  const recurringEntries = buildRecurringEntries(summary);
+  const summaryEntries = buildSummaryEntries(summary, todoModel, state);
+  const breakdownEntries = buildBreakdown(summary, todoModel, state);
+
+  if (dom.availableValue) {
+    const availableLabel = todoModel?.hoursAvailableLabel
+      || formatHours(Number(todoModel?.hoursAvailable) || Number(state?.timeLeft) || 0);
+    dom.availableValue.textContent = availableLabel;
+  }
+  if (dom.spentValue) {
+    const hoursSpent = Number.isFinite(todoModel?.hoursSpent)
+      ? Math.max(0, todoModel.hoursSpent)
+      : Math.max(0, computeTimeCap(state) - (Number(state?.timeLeft) || 0));
+    dom.spentValue.textContent = formatHours(hoursSpent);
+  }
+
+  renderBreakdown(dom.breakdownList, breakdownEntries);
+  renderList(dom.pendingList, pendingEntries, 'Queue a hustle or upgrade to add new tasks.');
+  renderList(dom.completedList, completedEntries, 'Nothing checked off yet.');
+  renderList(dom.recurringList, recurringEntries, 'No upkeep logged yet. Assistants will report here.');
+  renderSummaryStats(dom.summaryList, summaryEntries);
+
+  const meta = buildMeta(summary, completedEntries);
+  return { id: page.id, meta };
+}

--- a/src/ui/views/browser/cardsPresenter.js
+++ b/src/ui/views/browser/cardsPresenter.js
@@ -12,6 +12,7 @@ import renderServerHub from './apps/serverhub.js';
 import renderUpgrades from './apps/upgrades.js';
 import renderEducation from './apps/education.js';
 import renderFinance from './apps/finance.js';
+import renderTimodoro from './apps/timodoro.js';
 import {
   cachePayload,
   getCachedPayload,
@@ -146,7 +147,8 @@ export const APP_RENDERERS = [
     renderUpgrades(context, registries.upgrades || [], models.upgrades || {}),
   (context, registries = {}, models = {}) =>
     renderEducation(context, registries.education || [], models.education || {}),
-  (context, registries = {}, models = {}) => renderFinance(context, registries, models)
+  (context, registries = {}, models = {}) => renderFinance(context, registries, models),
+  (context, registries = {}, models = {}) => renderTimodoro(context, registries, models)
 ];
 
 function collectSummaries(context, registries = {}, models = {}) {

--- a/src/ui/views/browser/config.js
+++ b/src/ui/views/browser/config.js
@@ -11,6 +11,15 @@ export const SERVICE_PAGES = [
     type: 'finance'
   },
   {
+    id: 'timodoro',
+    slug: 'timodoro',
+    label: 'TimoDoro',
+    headline: 'TimoDoro Productivity Hub',
+    tagline: 'Track your hustle hours and assistant work.',
+    icon: '⏱️',
+    type: 'timodoro'
+  },
+  {
     id: 'aboutyou',
     slug: 'about-you',
     label: 'AboutYou',

--- a/src/ui/views/browser/dashboardPresenter.js
+++ b/src/ui/views/browser/dashboardPresenter.js
@@ -65,7 +65,7 @@ function createEnrollmentTodoEntries(entries = []) {
   });
 }
 
-function composeTodoModel(
+export function composeTodoModel(
   quickActions = {},
   assetActions = {},
   enrollmentActions = {},
@@ -137,7 +137,7 @@ function composeTodoModel(
   return model;
 }
 
-function createAutoCompletedEntries(summary = {}) {
+export function createAutoCompletedEntries(summary = {}) {
   const entries = Array.isArray(summary?.timeBreakdown) ? summary.timeBreakdown : [];
   return entries
     .map((entry, index) => {

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -1305,6 +1305,162 @@ a {
   box-shadow: var(--browser-shadow-card);
 }
 
+.timodoro {
+  display: flex;
+  flex-direction: column;
+  gap: 1.8rem;
+}
+
+.timodoro__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.timodoro__title {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.timodoro__subtitle {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.95rem;
+}
+
+.timodoro__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1.15fr);
+}
+
+.timodoro__column {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.timodoro-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.timodoro-section__title {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.timodoro-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.timodoro-list__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid var(--browser-panel-border);
+  background: var(--browser-panel-elevated);
+}
+
+.timodoro-list__name {
+  font-weight: 600;
+}
+
+.timodoro-list__meta {
+  color: var(--browser-muted);
+  font-size: 0.9rem;
+}
+
+.timodoro-list__empty {
+  margin: 0;
+  padding: 0.85rem 0.9rem;
+  border-radius: 12px;
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  background: rgba(148, 163, 184, 0.08);
+  color: var(--browser-muted);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.timodoro-list--breakdown {
+  gap: 0.65rem;
+}
+
+.timodoro-breakdown__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 0.6rem 0.1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.timodoro-breakdown__item:last-child {
+  border-bottom: none;
+}
+
+.timodoro-breakdown__label {
+  color: var(--browser-muted);
+  font-size: 0.92rem;
+}
+
+.timodoro-breakdown__value {
+  font-weight: 600;
+}
+
+.timodoro-breakdown__empty {
+  margin: 0;
+  padding: 0.85rem 0.9rem;
+  border-radius: 12px;
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  background: rgba(148, 163, 184, 0.08);
+  color: var(--browser-muted);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.timodoro-stats__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.75rem 0.1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.timodoro-stats__item:last-child {
+  border-bottom: none;
+}
+
+.timodoro-stats__label {
+  font-size: 0.9rem;
+  color: var(--browser-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.timodoro-stats__value {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.timodoro-stats__note {
+  font-size: 0.88rem;
+  color: var(--browser-subtle);
+}
+
+@media (max-width: 960px) {
+  .timodoro__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 .bankapp-summary {
   display: grid;
   gap: 1rem;

--- a/tests/ui/views/browser/cardsPresenter.test.js
+++ b/tests/ui/views/browser/cardsPresenter.test.js
@@ -55,7 +55,8 @@ test('cardsPresenter dispatches to app modules and publishes summaries', async t
     { id: 'blogpress', meta: 'Blog ready' },
     { id: 'shopstack', meta: 'Upgrades ready' },
     { id: 'learnly', meta: 'Education ready' },
-    { id: 'bankapp', meta: 'Bank ready' }
+    { id: 'bankapp', meta: 'Bank ready' },
+    { id: 'timodoro', meta: 'Productivity ready' }
   ];
 
   const callCounts = new Array(APP_RENDERERS.length).fill(0);


### PR DESCRIPTION
## Summary
- register a new TimoDoro workspace in the browser config and card presenter and implement the dedicated view
- reuse existing ToDo, upkeep, and daily summary builders to populate snapshot, task log, and recurring maintenance cards
- style the workspace layout, extend regression coverage, and document the feature in the changelog and feature notes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df1fcee164832ca331da1f7dc63ae3