### PR TITLE
Expose Learnly boosters for Automation Course purchase

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,7 @@
 - Browser homepage ToDo widget now auto-lists any upkeep or study time already consumed at daybreak inside the Done column so players see their remaining capacity at a glance.
 - Browser chrome End Day button now launches the next queued ToDo task and only offers "Next Day" once the list is clear.
 - Learnly graduates into a dedicated browser app with a course catalog, detail pages, My Courses hub, and pricing FAQ while reusing the existing education systems.
+- Learnly introduces a Boosters tab that surfaces Automation Course and other education add-ons for one-click purchase within the academy.
 - Learnly catalog now hides completed courses, floats active enrollments to the top of My Courses, and mirrors tab switches in the workspace URL bar for clearer navigation.
 - BlogPress brings the Personal Blog management flow into the browser shell with a table overview, detail inspector, pricing page, and one-click quality actions while reusing the existing passive-income logic.
 - VideoTube graduates the vlog asset tools into a studio-style browser app with a channel dashboard, analytics view, niche selection, and launch workflow that reuse the existing vlog economy.

--- a/docs/features/blogpress.md
+++ b/docs/features/blogpress.md
@@ -23,7 +23,7 @@ BlogPress relocates the classic Personal Blog management experience into the bro
 - Quick actions rely on `canPerformQualityAction`, `getQualityActionUsage`, and `performQualityAction` so availability, limits, and costs match the classic flow.
 - Niche selection calls through to `assignInstanceToNiche` but the UI only presents the dropdown when the instance is still unassigned.
 - Blueprint availability messages and disable reasons reuse `describeAssetLaunchAvailability` so timing/cash requirements stay consistent.
-- Pricing cards list every quality level from the definition and upgrades whose `affects.assets` target blogs (Automation Course, Editorial Pipeline Suite, etc.).
+- Pricing cards list every quality level from the definition and upgrades whose `affects.assets` target blogs (Automation Course now routes to Learnly’s Boosters tab for purchase, alongside Editorial Pipeline Suite, etc.).
 
 ## UI Notes
 - Navigation mirrors the browser shell approach: “My Blogs”, “Pricing”, and “Blueprints” tabs sit inside the header with a persistent “Spin up new blog” CTA.

--- a/src/game/upgrades/definitions/index.js
+++ b/src/game/upgrades/definitions/index.js
@@ -785,6 +785,7 @@ export const UPGRADE_DEFINITIONS = [
     name: 'Automation Course',
     tag: { label: 'Boost', type: 'boost' },
     description: 'Unlocks smarter blogging tools, boosting blog income by +50%.',
+    surface: 'learnly',
     category: 'tech',
     family: 'workflow',
     cost: 260,

--- a/src/ui/cards.js
+++ b/src/ui/cards.js
@@ -35,7 +35,9 @@ function synthesizeModels(baseModels = {}, registries = {}, force = false) {
     generated = true;
   }
   if (force || !Array.isArray(models.education)) {
-    models.education = buildEducationModels(registries.education);
+    models.education = buildEducationModels(registries.education, {
+      upgradeDefinitions: registries.upgrades
+    });
     generated = true;
   }
   if (force || typeof models.assets !== 'object' || models.assets === null) {

--- a/src/ui/cards/model/index.js
+++ b/src/ui/cards/model/index.js
@@ -14,7 +14,7 @@ import buildUpgradeModels, {
   getUpgradeSnapshot,
   describeUpgradeStatus
 } from './upgrades.js';
-import buildEducationModels, { buildSkillRewards, resolveTrack } from './education.js';
+import buildEducationModels, { buildLearnlyAddons, buildSkillRewards, resolveTrack } from './education.js';
 import buildFinanceModel from './finance/index.js';
 import {
   formatLabelFromKey,
@@ -40,7 +40,9 @@ function registerDefaultCardBuilders() {
   );
   registerModelBuilder(
     'education',
-    registries => buildEducationModels(registries.education),
+    registries => buildEducationModels(registries.education, {
+      upgradeDefinitions: registries.upgrades
+    }),
     { isDefault: true }
   );
   registerModelBuilder(
@@ -73,6 +75,7 @@ export {
   getUpgradeSnapshot,
   describeUpgradeStatus,
   buildEducationModels,
+  buildLearnlyAddons,
   buildSkillRewards,
   resolveTrack,
   buildFinanceModel,

--- a/tests/ui/views/browser/learnly/addons.test.js
+++ b/tests/ui/views/browser/learnly/addons.test.js
@@ -1,0 +1,100 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+import learnlyApp from '../../../../../src/ui/views/browser/components/learnly.js';
+
+function setupDom() {
+  const dom = new JSDOM('<div id="root"></div>', { pretendToBeVisual: true });
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  return dom;
+}
+
+test('Learnly boosters render add-ons with purchase states', async t => {
+  const dom = setupDom();
+  t.after(() => {
+    dom.window.close();
+    delete globalThis.window;
+    delete globalThis.document;
+  });
+
+  const mount = document.getElementById('root');
+  const clickSpy = { count: 0 };
+
+  const model = {
+    tracks: [],
+    addons: [
+      {
+        id: 'automationCourse',
+        name: 'Automation Course',
+        description: 'Boost blog payouts by automating repetitive publishing.',
+        cost: 260,
+        tag: { label: 'Boost', type: 'boost' },
+        snapshot: {
+          cost: 260,
+          affordable: true,
+          disabled: false,
+          purchased: false,
+          ready: true
+        },
+        action: {
+          label: 'Study Up',
+          disabled: false,
+          onClick: () => {
+            clickSpy.count += 1;
+          }
+        }
+      },
+      {
+        id: 'ownedBooster',
+        name: 'Owned Booster',
+        description: 'Already active add-on.',
+        cost: 0,
+        snapshot: {
+          cost: 0,
+          affordable: true,
+          disabled: false,
+          purchased: true,
+          ready: false
+        },
+        action: {
+          label: 'Owned',
+          disabled: true,
+          onClick: () => {
+            throw new Error('owned booster should not invoke action');
+          }
+        }
+      }
+    ],
+    queue: { entries: [], totalHours: 0, totalLabel: '', capHours: 0, capLabel: '' }
+  };
+
+  learnlyApp.render(model, { mount, page: { id: 'learnly' }, definitions: [], onRouteChange: () => {} });
+
+  const boosterTab = Array.from(mount.querySelectorAll('.learnly-tab')).find(button =>
+    button.textContent.includes('Boosters')
+  );
+  assert.ok(boosterTab, 'expected Boosters tab to render');
+  boosterTab.click();
+
+  const addonCards = mount.querySelectorAll('.learnly-card--addon');
+  assert.equal(addonCards.length, 2, 'expected two booster cards to render');
+
+  const [readyCard, ownedCard] = addonCards;
+  const readyStatus = readyCard.querySelectorAll('.learnly-card__stats dd')[1]?.textContent;
+  assert.equal(readyStatus, 'Ready to launch', 'ready booster should announce readiness');
+
+  const purchaseButton = readyCard.querySelector('.learnly-button');
+  assert.ok(purchaseButton, 'ready booster should have a purchase button');
+  assert.equal(purchaseButton.disabled, false, 'ready booster button should be enabled');
+  purchaseButton.click();
+  assert.equal(clickSpy.count, 1, 'purchase handler should run when clicking ready booster');
+
+  const ownedStatus = ownedCard.querySelectorAll('.learnly-card__stats dd')[1]?.textContent;
+  assert.equal(ownedStatus, 'Owned and active', 'owned booster should display owned status');
+
+  const ownedButton = ownedCard.querySelector('.learnly-button');
+  assert.ok(ownedButton, 'owned booster should render button');
+  assert.equal(ownedButton.disabled, true, 'owned booster button should be disabled');
+  assert.match(ownedButton.textContent, /Owned/i, 'owned booster button should read Owned');
+});


### PR DESCRIPTION
## Summary
- tag the Automation Course upgrade for Learnly and surface boosters from the education model with upgrade snapshots
- extend the Learnly app with a Boosters tab, hero metric, and purchase buttons that call upgrade actions
- add browser UI coverage for booster states and document the Learnly flow in the BlogPress feature notes and changelog

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68df20f4c434832cb021a11b8c1b2b98