### PR TITLE
Add BlogPress income recap detail panel

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,7 @@
 - Learnly graduates into a dedicated browser app with a course catalog, detail pages, My Courses hub, and pricing FAQ while reusing the existing education systems.
 - Learnly catalog now hides completed courses, floats active enrollments to the top of My Courses, and mirrors tab switches in the workspace URL bar for clearer navigation.
 - BlogPress brings the Personal Blog management flow into the browser shell with a table overview, detail inspector, pricing page, and one-click quality actions while reusing the existing passive-income logic.
+- BlogPress detail view now features an Income recap panel that mirrors the classic asset card with lifetime totals, daily averages, net earnings, pending payouts, and upkeep cues.
 - VideoTube graduates the vlog asset tools into a studio-style browser app with a channel dashboard, analytics view, niche selection, and launch workflow that reuse the existing vlog economy.
 - Shopily launches as the dropshipping control center with KPI hero, store table + sidebar, upgrade shelf, and pricing tier cards while reusing the established commerce backend.
 - DigiShelf consolidates Digital E-Book Series and Stock Photo Galleries into a SaaS-style browser workspace with unified stats, detail panels, and pricing guidance while reusing the original asset logic.

--- a/docs/features/blogpress.md
+++ b/docs/features/blogpress.md
@@ -17,6 +17,7 @@ BlogPress relocates the classic Personal Blog management experience into the bro
 - **Upgrade buttons → Action panel**: quality actions (Write Post, SEO Sprint, Backlink Outreach) display with their time/cost requirements and respect usage, upgrade, and time/money gates.
 - **Niche selector → Locked selector**: niches may be chosen once; after selection the dropdown is disabled and the panel reminds players the niche is locked.
 - **Payout recap → Modifier list**: the latest income breakdown is rendered as a list with the base payout and modifiers pulled from the stored breakdown entries.
+- **Income recap → Earnings ledger**: the detail view mirrors the classic asset card by bundling daily averages, lifetime totals, spend, net results, pending payouts, and upkeep status into a dedicated panel.
 
 ## Data & Logic
 - Uses `buildBlogpressModel` to adapt `getAssetState('blog')`, quality helpers, maintenance summaries, and niche popularity into a view model shared with the Browser shell.

--- a/src/ui/cards/model/blogpress.js
+++ b/src/ui/cards/model/blogpress.js
@@ -211,6 +211,14 @@ function buildBlogInstances(definition, state) {
     const label = instanceLabel(definition, index);
     const status = describeStatus(instance, definition);
     const averagePayout = calculateAveragePayout(instance, state);
+    const lifetimeIncome = Math.max(0, clampNumber(instance.totalIncome));
+    const estimatedSpend = estimateLifetimeSpend(definition, instance, state);
+    const lifetimeNet = lifetimeIncome - estimatedSpend;
+    const createdOnDay = Math.max(0, clampNumber(instance?.createdOnDay));
+    const currentDay = Math.max(1, clampNumber(state?.day) || 1);
+    const daysActive = instance.status === 'active' && createdOnDay > 0
+      ? Math.max(1, currentDay - createdOnDay + 1)
+      : 0;
     const qualityLevel = Math.max(0, clampNumber(instance?.quality?.level));
     const qualityInfo = getQualityLevel(definition, qualityLevel);
     const milestone = buildMilestoneProgress(definition, instance);
@@ -239,10 +247,12 @@ function buildBlogInstances(definition, state) {
       status,
       latestPayout: Math.max(0, clampNumber(instance.lastIncome)),
       averagePayout,
-      lifetimeIncome: Math.max(0, clampNumber(instance.totalIncome)),
-      estimatedSpend: estimateLifetimeSpend(definition, instance, state),
+      lifetimeIncome,
+      estimatedSpend,
+      lifetimeNet,
       maintenanceFunded: Boolean(instance.maintenanceFundedToday),
       pendingIncome: Math.max(0, clampNumber(instance.pendingIncome)),
+      daysActive,
       qualityLevel,
       qualityInfo: qualityInfo || null,
       qualityRange,

--- a/src/ui/views/browser/components/blogpress.js
+++ b/src/ui/views/browser/components/blogpress.js
@@ -1,7 +1,7 @@
 import { formatHours, formatMoney } from '../../../../core/helpers.js';
 import { selectBlogpressNiche } from '../../../cards/model/index.js';
 import { performQualityAction } from '../../../../game/assets/index.js';
-import { formatCurrency as baseFormatCurrency } from '../utils/formatting.js';
+import { formatCurrency as baseFormatCurrency, formatNetCurrency } from '../utils/formatting.js';
 import { createWorkspacePathController } from '../utils/workspacePaths.js';
 
 const VIEW_HOME = 'home';
@@ -482,6 +482,84 @@ function renderQualityPanel(instance) {
   return panel;
 }
 
+function renderIncomePanel(instance) {
+  const panel = document.createElement('article');
+  panel.className = 'blogpress-panel blogpress-panel--income';
+
+  const title = document.createElement('h3');
+  title.textContent = 'Income recap';
+  panel.appendChild(title);
+
+  const stats = document.createElement('dl');
+  stats.className = 'blogpress-stats';
+
+  const entries = [
+    {
+      label: 'Daily average',
+      value:
+        instance.averagePayout > 0
+          ? formatCurrency(instance.averagePayout)
+          : instance.status?.id === 'active'
+            ? 'No earnings yet'
+            : 'Launch pending'
+    },
+    {
+      label: 'Latest payout',
+      value: instance.latestPayout > 0 ? formatCurrency(instance.latestPayout) : '—'
+    },
+    {
+      label: 'Lifetime income',
+      value: formatCurrency(instance.lifetimeIncome)
+    },
+    {
+      label: 'Lifetime spend',
+      value: formatCurrency(instance.estimatedSpend)
+    },
+    {
+      label: 'Lifetime net',
+      value: formatNetCurrency(instance.lifetimeNet || 0, { precision: 'integer', zeroDisplay: '$0' })
+    },
+    {
+      label: 'Pending payout',
+      value: instance.pendingIncome > 0 ? formatCurrency(instance.pendingIncome) : 'No payout queued'
+    }
+  ];
+
+  if (instance.daysActive > 0) {
+    const daysLabel = instance.daysActive === 1 ? '1 day' : `${instance.daysActive} days`;
+    entries.push({ label: 'Days live', value: daysLabel });
+  }
+
+  entries.forEach(entry => {
+    const dt = document.createElement('dt');
+    dt.textContent = entry.label;
+    const dd = document.createElement('dd');
+    dd.textContent = entry.value;
+    stats.append(dt, dd);
+  });
+
+  panel.appendChild(stats);
+
+  const upkeepMessage = document.createElement('p');
+  const upkeepParts = instance.maintenance?.parts || [];
+  const upkeepSummary = upkeepParts.length ? upkeepParts.join(' • ') : 'No upkeep';
+  if (instance.status?.id === 'active') {
+    if (instance.maintenanceFunded) {
+      upkeepMessage.className = 'blogpress-panel__hint';
+      upkeepMessage.textContent = `Upkeep covered today (${upkeepSummary}). Expect the payout at day end.`;
+    } else {
+      upkeepMessage.className = 'blogpress-panel__warning';
+      upkeepMessage.textContent = `Upkeep still due (${upkeepSummary}). Fund hours or cash to restart payouts.`;
+    }
+  } else {
+    upkeepMessage.className = 'blogpress-panel__hint';
+    upkeepMessage.textContent = 'Income tracking begins once launch prep wraps.';
+  }
+  panel.appendChild(upkeepMessage);
+
+  return panel;
+}
+
 function renderPayoutPanel(instance) {
   const panel = document.createElement('article');
   panel.className = 'blogpress-panel blogpress-panel--payout';
@@ -623,6 +701,7 @@ function renderDetailView(model) {
   grid.append(
     renderNichePanel(instance),
     renderQualityPanel(instance),
+    renderIncomePanel(instance),
     renderPayoutPanel(instance),
     renderActionPanel(instance),
     renderUpkeepPanel(instance)


### PR DESCRIPTION
## Summary
- add an Income recap panel to the BlogPress detail view so browser players see the same lifetime stats as the classic venture card
- expose lifetime net earnings and days-active data from the BlogPress model to power the recap metrics
- document the new panel in the BlogPress feature notes and changelog

## Testing
- npm test
- Manual verification: not run (no browser available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68df23539a9c832caa10962ae453261a