### PR TITLE
Refocus TimoDoro task log on completed work

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- TimoDoro Task Log now spotlights completed work only, grouping hustle hours into Hustles, Education, Upkeep, and Upgrades with hour-focused summaries.
 - TimoDoro productivity hub joins the browser app roster, remixing the ToDo queue, upkeep logs, and daily summary stats into a dedicated focus workspace.
 - Browser homepage apps widget now includes an Arrange mode so players can drag tiles to swap spots, highlight favorites, and keep the order between sessions.
 - Asset Arcade workspace retired from the browser prototype and hidden from the homepage launcher while we explore refreshed asset flows.

--- a/docs/features/timodoro.md
+++ b/docs/features/timodoro.md
@@ -2,16 +2,16 @@
 
 ## Goals
 - Give browser players a dedicated productivity workspace that pulls in the existing ToDo queue, upkeep logs, and daily summary metrics without inventing new systems.
-- Present a calm, two-column layout that highlights what’s finished, what’s queued, and how much time plus payout headroom remains for the day.
+- Present a calm, two-column layout that highlights what’s finished and how much time plus payout headroom remains for the day.
 - Establish a lightweight pattern for future focus tools that remix shared state into purpose-built dashboards.
 
 ## Player Impact
 - Players can launch the TimoDoro app to review remaining hustle hours, today’s logged time, and earnings in one glance instead of hopping between widgets.
-- The Task Log mirrors the ToDo widget’s pending entries alongside completed work summaries, so the browser tab feels like a full time-tracking companion.
+- The Task Log now celebrates completed hustle blocks, splitting them into Hustles, Education, Upkeep, and Upgrades so players instantly see where their hours landed.
 - Maintenance and study sessions surface automatically, reminding players about assistant-driven upkeep that already consumed hours or will trigger later.
 
 ## Implementation Notes
-- `src/ui/views/browser/apps/timodoro.js` composes the ToDo models (`buildQuickActionModel`, `buildAssetActionModel`, `buildStudyEnrollmentActionModel`) with the existing daily summary selectors to render pending queues, completed work, recurring upkeep, and headline stats.
+- `src/ui/views/browser/apps/timodoro.js` composes the ToDo models (`buildQuickActionModel`, `buildAssetActionModel`, `buildStudyEnrollmentActionModel`) with the existing daily summary selectors to render grouped completions, recurring upkeep, and headline stats.
 - The browser config in `src/ui/views/browser/config.js` now registers TimoDoro as a top-level service page, while `cardsPresenter.js` lists it so the workspace launcher and tab system can open it like other apps.
 - Fresh layout rules in `styles/browser.css` define the two-column grid, task list styling, and summary panels, borrowing the shared browser card components for consistency.
 

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -1351,6 +1351,26 @@ a {
   font-size: 1.05rem;
 }
 
+.timodoro-section__groups {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.timodoro-subsection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.timodoro-subsection__title {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--browser-muted-strong, var(--browser-muted));
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+}
+
 .timodoro-list {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
## Summary
- refocus the TimoDoro Task Log on completed work, grouping entries into Hustles, Education, Upkeep, and Upgrades with hour-only details
- add browser styles to support the new grouped layout in the task card
- update the TimoDoro feature notes and changelog to document the dashboard changes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfe5c12cc0832ca3ee4466fd2e50fe