### PR TITLE
Auto-read passive notifications and remove welcome back alert

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Passive income and upgrade completion notifications now arrive pre-read, and the welcome-back alert no longer appears so the tray only spotlights actionable events.
 - Random event engine now tracks multi-day boosts and setbacks for assets and niches, including the vlog’s viral streak migrating onto the shared system.
 - TimoDoro Task Log now spotlights completed work only, grouping hustle hours into Hustles, Education, Upkeep, and Upgrades with hour-focused summaries.
 - TimoDoro productivity hub joins the browser app roster, remixing the ToDo queue, upkeep logs, and daily summary stats into a dedicated focus workspace.

--- a/docs/features/browser-notifications.md
+++ b/docs/features/browser-notifications.md
@@ -16,3 +16,4 @@
 - The browser notifications presenter renders the dropdown, updates the unread badge, and reuses the shared event log model for formatting.
 - `markLogEntryRead` and `markAllLogEntriesRead` helpers live in `src/core/log.js` and trigger UI refreshes when state changes.
 - Styling lives in `styles/browser.css` alongside other browser chrome rules, using the accent palette for unread indicators.
+- Logs generated for passive income ticks and completed upgrades are auto-marked as read so routine upkeep doesn't inflate the unread count.

--- a/src/core/log.js
+++ b/src/core/log.js
@@ -6,15 +6,22 @@ import { getActiveView } from '../ui/viewManager.js';
 import { saveState } from './storage.js';
 import classicLogPresenter from '../ui/views/classic/logPresenter.js';
 
+const AUTO_READ_TYPES = new Set(['passive', 'upgrade']);
+
+function shouldAutoRead(type) {
+  return typeof type === 'string' && AUTO_READ_TYPES.has(type);
+}
+
 export function addLog(message, type = 'info') {
   const state = getState();
   if (!state) return;
+  const normalizedType = typeof type === 'string' && type ? type : 'info';
   const entry = {
     id: createId(),
     timestamp: Date.now(),
     message,
-    type,
-    read: false
+    type: normalizedType,
+    read: shouldAutoRead(normalizedType)
   };
   state.log.push(entry);
   if (state.log.length > MAX_LOG_ENTRIES) {

--- a/src/main.js
+++ b/src/main.js
@@ -14,9 +14,7 @@ const initialView = resolveInitialView(document);
 setActiveView(initialView, document);
 const { returning, lastSaved } = loadState({
   onFirstLoad: () =>
-    addLog('Welcome to Online Hustle Simulator! Time to make that side cash.', 'info'),
-  onReturning: () =>
-    addLog('Welcome back! Your hustles kept buzzing while you were away.', 'info')
+    addLog('Welcome to Online Hustle Simulator! Time to make that side cash.', 'info')
 });
 if (returning) {
   handleOfflineProgress(lastSaved);


### PR DESCRIPTION
## Summary
- mark passive income and upgrade completion log entries as read on creation so the dashboard badge only reflects actionable alerts
- stop emitting the returning-player "welcome back" notification during startup
- document the notification tweaks in the browser notifications design notes and changelog

## Testing
- npm test
- Manual testing: not run (headless environment)


------
https://chatgpt.com/codex/tasks/task_e_68dff021d5b0832c8d04eb1b663d08da