### PR TITLE
Swap Shopily and ShopStack icons

### DIFF
--- a/src/ui/views/browser/config.js
+++ b/src/ui/views/browser/config.js
@@ -79,7 +79,7 @@ export const SERVICE_PAGES = [
     label: 'Shopily',
     headline: 'Shopily Storefront Studio',
     tagline: 'Launch dropshipping brands, monitor ROI, and trigger upgrades.',
-    icon: '🛒',
+    icon: '🛍️',
     type: 'shopily'
   },
   {
@@ -97,7 +97,7 @@ export const SERVICE_PAGES = [
     label: 'ShopStack',
     headline: 'ShopStack Upgrade Arcade',
     tagline: 'Install upgrades, stock products, and plan the next spike.',
-    icon: '🛍️',
+    icon: '🛒',
     type: 'upgrades'
   },
   {


### PR DESCRIPTION
## Summary
- swap the Shopily and ShopStack icons in the browser apps widget configuration so each app shows its correct symbol

## Testing
- python -m http.server 8000 (manual)

------
https://chatgpt.com/codex/tasks/task_e_68dff04788c0832c8820518442cf1389