### PR TITLE
Add confirmation dialogs before launching browser resources

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@
 - Shopily’s upgrades tab now mirrors a mobile top-up catalog with ShopStack-grade detail panels while the Fulfillment Automation Suite, Global Supply Mesh, and White-Label Alliance migrate out of ShopStack into the dedicated commerce app.
 - Browser chrome now features a notification bell that mirrors the event log with unread badges, read tracking, and a mark-all control.
 - AboutYou rebrands the browser profile hub with upbeat copy, refreshed styling, and tighter lists that only surface owned education tracks and equipped gear.
+- Browser shell app launchers now ask for confirmation before spinning up new blogs, SaaS apps, galleries, or e-book series, highlighting setup time, upfront spend, and daily upkeep before the action fires.
 - Trends Intelligence Lab refreshes the browser app with analytics-style header controls, overview metrics, sparkline cards, and an expanded watchlist panel while reusing existing niche data.
 - Trends Intelligence Lab now includes a Name (A–Z) sort so players can scan niches alphabetically alongside momentum filters.
 - Trends analytics now archive a rolling seven-day highlight recap in local storage and surface it in the dashboard for fast comparisons across days.

--- a/docs/features/browser-shell.md
+++ b/docs/features/browser-shell.md
@@ -22,6 +22,7 @@
 - `todoWidget` now treats each hustle row as a full-width button that fires the action, logs completions with time data, and updates hours spent immediately.
 - `styles/browser.css` defines a reusable `.browser-widget` shell plus dedicated styling for the app roster and bank chips so every panel lines up cleanly.
 - Quick action view models provide payout, duration, and day metadata so the widget can track hours and reset completion history when a new day begins.
+- App launchers surface a confirmation dialog before creating new resources, summarizing setup time, upfront cash, and ongoing upkeep pulled from the underlying asset definitions.
 
 ## Multi-Tab Workspace System
 - A dedicated tab bar now sits beneath the chrome, rendering the launch view and each opened app as tabs with icons, titles, and close controls.

--- a/src/ui/views/browser/components/serverhub.js
+++ b/src/ui/views/browser/components/serverhub.js
@@ -38,6 +38,52 @@ const ACTION_CONSOLE_ORDER = [
   { id: 'deployEdgeNodes', label: 'Deploy Edge Nodes' }
 ];
 
+function formatSetupSummary(setup = {}) {
+  const days = Number(setup.days) || 0;
+  const hoursPerDay = Number(setup.hoursPerDay) || 0;
+  const cost = Number(setup.cost) || 0;
+  const parts = [];
+  if (days > 0) {
+    parts.push(`${days} day${days === 1 ? '' : 's'}`);
+  }
+  if (hoursPerDay > 0) {
+    parts.push(`${formatHours(hoursPerDay)} per day`);
+  }
+  if (cost > 0) {
+    parts.push(`${formatCurrency(cost)} upfront`);
+  }
+  return parts.length ? parts.join(' • ') : 'Instant setup';
+}
+
+function formatUpkeepSummary(upkeep = {}) {
+  const hours = Number(upkeep.hours) || 0;
+  const cost = Number(upkeep.cost) || 0;
+  const parts = [];
+  if (hours > 0) {
+    parts.push(`${formatHours(hours)} per day`);
+  }
+  if (cost > 0) {
+    parts.push(`${formatCurrency(cost)} per day`);
+  }
+  return parts.length ? parts.join(' • ') : 'No upkeep required';
+}
+
+function confirmLaunchWithDetails(definition = {}) {
+  if (typeof window === 'undefined' || typeof window.confirm !== 'function') {
+    return true;
+  }
+  const resourceName = definition.singular || definition.name || 'app';
+  const setupSummary = formatSetupSummary(definition.setup);
+  const upkeepSummary = formatUpkeepSummary(definition.maintenance);
+  const message = [
+    `Ready to deploy the ${resourceName}?`,
+    `Setup commitment: ${setupSummary}.`,
+    `Daily upkeep: ${upkeepSummary}.`,
+    'Launch now?'
+  ].join('\n');
+  return window.confirm(message);
+}
+
 function ensureSelectedApp() {
   const instances = ensureArray(currentModel.instances);
   if (!instances.length) {
@@ -70,6 +116,9 @@ function getSelectedApp() {
 function handleLaunch() {
   const launch = currentModel.launch;
   if (!launch || launch.disabled) {
+    return;
+  }
+  if (!confirmLaunchWithDetails(currentModel.definition)) {
     return;
   }
   launch.onClick?.();


### PR DESCRIPTION
## Summary
- add confirmation dialogs to BlogPress, ServerHub, and DigiShelf launches that recap setup commitments and upkeep costs before firing the asset action
- document the new launch confirmation flow in the browser shell feature notes and changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dff1073220832caf20fa701c6b09fc