### PR TITLE
Fix auto-read logic for payout notifications

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-- Passive income and upgrade completion notifications now arrive pre-read, and the welcome-back alert no longer appears so the tray only spotlights actionable events.
+- Passive income, hustle payouts, and upgrade completion notifications now arrive pre-read, and the welcome-back alert no longer appears so the tray only spotlights actionable events.
 - Random event engine now tracks multi-day boosts and setbacks for assets and niches, including the vlog’s viral streak migrating onto the shared system.
 - TimoDoro Task Log now spotlights completed work only, grouping hustle hours into Hustles, Education, Upkeep, and Upgrades with hour-focused summaries.
 - TimoDoro productivity hub joins the browser app roster, remixing the ToDo queue, upkeep logs, and daily summary stats into a dedicated focus workspace.

--- a/src/core/log.js
+++ b/src/core/log.js
@@ -5,12 +5,7 @@ import { buildLogModel } from '../ui/log/model.js';
 import { getActiveView } from '../ui/viewManager.js';
 import { saveState } from './storage.js';
 import classicLogPresenter from '../ui/views/classic/logPresenter.js';
-
-const AUTO_READ_TYPES = new Set(['passive', 'upgrade']);
-
-function shouldAutoRead(type) {
-  return typeof type === 'string' && AUTO_READ_TYPES.has(type);
-}
+import { shouldAutoRead } from './loggingRules.js';
 
 export function addLog(message, type = 'info') {
   const state = getState();

--- a/src/core/loggingRules.js
+++ b/src/core/loggingRules.js
@@ -1,0 +1,22 @@
+const AUTO_READ_TYPES = new Set(['passive', 'hustle', 'upgrade']);
+
+function normalizeTypeId(type) {
+  if (typeof type !== 'string' || !type) {
+    return '';
+  }
+  const separatorIndex = type.indexOf(':');
+  if (separatorIndex === -1) {
+    return type;
+  }
+  return type.slice(0, separatorIndex);
+}
+
+export function shouldAutoRead(type) {
+  const normalized = normalizeTypeId(type);
+  return AUTO_READ_TYPES.has(normalized);
+}
+
+export default {
+  AUTO_READ_TYPES,
+  shouldAutoRead
+};

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -40,7 +40,13 @@ function normalizeLogEntry(entry) {
   normalized.id = typeof entry.id === 'string' && entry.id ? entry.id : createId();
   normalized.message = entry.message != null ? String(entry.message) : '';
   normalized.type = typeof entry.type === 'string' && entry.type ? entry.type : 'info';
-  normalized.read = entry.read === true || shouldAutoRead(normalized.type);
+  if (entry.read === true) {
+    normalized.read = true;
+  } else if (entry.read === false) {
+    normalized.read = false;
+  } else {
+    normalized.read = shouldAutoRead(normalized.type);
+  }
   return normalized;
 }
 

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -1,5 +1,6 @@
 import { DEFAULT_DAY_HOURS } from './constants.js';
 import { structuredClone, createId } from './helpers.js';
+import { shouldAutoRead } from './loggingRules.js';
 import {
   createEmptyCharacterState,
   createEmptySkillState,
@@ -39,7 +40,7 @@ function normalizeLogEntry(entry) {
   normalized.id = typeof entry.id === 'string' && entry.id ? entry.id : createId();
   normalized.message = entry.message != null ? String(entry.message) : '';
   normalized.type = typeof entry.type === 'string' && entry.type ? entry.type : 'info';
-  normalized.read = entry.read === true;
+  normalized.read = entry.read === true || shouldAutoRead(normalized.type);
   return normalized;
 }
 

--- a/tests/loggingRules.test.js
+++ b/tests/loggingRules.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const { shouldAutoRead } = await import('../src/core/loggingRules.js');
+
+test('auto-read applies to hustle payouts', () => {
+  assert.equal(shouldAutoRead('hustle'), true);
+  assert.equal(shouldAutoRead('hustle:payout'), true);
+});
+
+test('auto-read applies to passive payouts', () => {
+  assert.equal(shouldAutoRead('passive'), true);
+  assert.equal(shouldAutoRead('passive:education'), true);
+});
+
+test('auto-read ignores other notification types', () => {
+  assert.equal(shouldAutoRead('warning'), false);
+  assert.equal(shouldAutoRead('info'), false);
+});

--- a/tests/stateManagement.test.js
+++ b/tests/stateManagement.test.js
@@ -122,6 +122,22 @@ test('ensureStateShape populates default hustle, asset, and upgrade state', () =
   }
 });
 
+test('ensureStateShape preserves explicit log read flags and seeds missing ones', () => {
+  const state = buildDefaultState();
+  state.log = [
+    { id: 'manual-unread', message: 'Keep me unread', timestamp: 1, type: 'info', read: false },
+    { id: 'manual-read', message: 'Already read', timestamp: 2, type: 'warning', read: true },
+    { id: 'auto-seed', message: 'Passive payout', timestamp: 3, type: 'passive:payout' }
+  ];
+
+  ensureStateShape(state);
+
+  const [manualUnread, manualRead, autoSeeded] = state.log;
+  assert.equal(manualUnread.read, false, 'explicit unread flag should be kept');
+  assert.equal(manualRead.read, true, 'explicit read flag should be kept');
+  assert.equal(autoSeeded.read, true, 'auto-read eligible entries without a flag should be seeded');
+});
+
 test('ensureNicheStateShape repairs popularity map and fallback day', () => {
   const state = {
     day: 4,


### PR DESCRIPTION
## Summary
- add shared logging rules that flag hustle, passive, and upgrade payouts as read automatically
- normalize saved log entries with the shared rules and document the notification tweak
- cover the auto-read helper with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dff4295260832c9fe5a1b4968d341a