### PR TITLE
Fix auto-read handling for passive and upgrade notifications

### DIFF
--- a/src/core/log.js
+++ b/src/core/log.js
@@ -1,16 +1,11 @@
 import { MAX_LOG_ENTRIES } from './constants.js';
 import { createId } from './helpers.js';
 import { getState } from './state.js';
+import { shouldAutoRead } from './logRules.js';
 import { buildLogModel } from '../ui/log/model.js';
 import { getActiveView } from '../ui/viewManager.js';
 import { saveState } from './storage.js';
 import classicLogPresenter from '../ui/views/classic/logPresenter.js';
-
-const AUTO_READ_TYPES = new Set(['passive', 'upgrade']);
-
-function shouldAutoRead(type) {
-  return typeof type === 'string' && AUTO_READ_TYPES.has(type);
-}
 
 export function addLog(message, type = 'info') {
   const state = getState();

--- a/src/core/logRules.js
+++ b/src/core/logRules.js
@@ -1,0 +1,9 @@
+const AUTO_READ_TYPES = new Set(['passive', 'upgrade']);
+
+export function shouldAutoRead(type) {
+  if (typeof type !== 'string') return false;
+  return AUTO_READ_TYPES.has(type);
+}
+
+export { AUTO_READ_TYPES };
+

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -1,6 +1,5 @@
 import { DEFAULT_DAY_HOURS } from './constants.js';
 import { structuredClone, createId } from './helpers.js';
-import { shouldAutoRead } from './logRules.js';
 import {
   createEmptyCharacterState,
   createEmptySkillState,
@@ -41,7 +40,7 @@ function normalizeLogEntry(entry) {
   normalized.message = entry.message != null ? String(entry.message) : '';
   const type = typeof entry.type === 'string' && entry.type ? entry.type : 'info';
   normalized.type = type;
-  normalized.read = entry.read === true || shouldAutoRead(type);
+  normalized.read = entry.read === true;
   return normalized;
 }
 

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -1,5 +1,6 @@
 import { DEFAULT_DAY_HOURS } from './constants.js';
 import { structuredClone, createId } from './helpers.js';
+import { shouldAutoRead } from './logRules.js';
 import {
   createEmptyCharacterState,
   createEmptySkillState,
@@ -38,8 +39,9 @@ function normalizeLogEntry(entry) {
   normalized.timestamp = Number.isFinite(timestamp) ? timestamp : Date.now();
   normalized.id = typeof entry.id === 'string' && entry.id ? entry.id : createId();
   normalized.message = entry.message != null ? String(entry.message) : '';
-  normalized.type = typeof entry.type === 'string' && entry.type ? entry.type : 'info';
-  normalized.read = entry.read === true;
+  const type = typeof entry.type === 'string' && entry.type ? entry.type : 'info';
+  normalized.type = type;
+  normalized.read = entry.read === true || shouldAutoRead(type);
   return normalized;
 }
 

--- a/src/game/offline.js
+++ b/src/game/offline.js
@@ -18,5 +18,4 @@ export function handleOfflineProgress(lastSaved) {
     }
   }
 
-  addLog('While you were away, the clock paused. Advance in-game days to keep assets earning.', 'info');
 }

--- a/tests/hustles.test.js
+++ b/tests/hustles.test.js
@@ -232,14 +232,13 @@ test('fulfillment ops masterclass boosts dropshipping asset payouts and logs the
   }
 });
 
-test('offline progress adds a friendly reminder when nothing resolves', () => {
+test('offline progress stays quiet when nothing resolves', () => {
   const state = getState();
   const beforeLogLength = state.log.length;
 
   handleOfflineProgress(Date.now() - 60000);
 
-  assert.equal(state.log.length, beforeLogLength + 1);
-  assert.match(state.log.at(-1).message, /While you were away, the clock paused/);
+  assert.equal(state.log.length, beforeLogLength);
 });
 
 test('audience call can only run once per day', () => {


### PR DESCRIPTION
## Summary
- move notification auto-read rules into a shared module and reuse them when writing to or hydrating the log
- ensure stored passive income and upgrade notifications are marked read when state loads
- drop the unnecessary "While you were away" notification when returning to the game

## Testing
- node --test tests/persistence.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dff8fd2094832cac5d109fdbd1a757