### PR TITLE
Update blogpress quick action time placement

### DIFF
--- a/src/ui/views/browser/components/blogpress.js
+++ b/src/ui/views/browser/components/blogpress.js
@@ -663,19 +663,16 @@ function renderActionPanel(instance) {
     const label = document.createElement('div');
     label.className = 'blogpress-action__label';
     label.textContent = action.label;
-    const meta = document.createElement('span');
-    meta.className = 'blogpress-action__meta';
-    const parts = [];
-    if (action.time > 0) parts.push(formatHours(action.time));
-    if (action.cost > 0) parts.push(formatCurrency(action.cost));
-    meta.textContent = parts.length ? parts.join(' • ') : 'Instant';
-    label.appendChild(meta);
     item.appendChild(label);
 
     const button = document.createElement('button');
     button.type = 'button';
     button.className = 'blogpress-button blogpress-button--primary';
-    button.textContent = action.available ? 'Run' : 'Locked';
+    const requirementParts = [];
+    if (action.time > 0) requirementParts.push(formatHours(action.time));
+    if (action.cost > 0) requirementParts.push(formatCurrency(action.cost));
+    const requirementLabel = requirementParts.length ? requirementParts.join('/') : 'Instant';
+    button.textContent = action.available ? `Run • ${requirementLabel}` : requirementLabel;
     button.disabled = !action.available;
     if (action.disabledReason) {
       button.title = action.disabledReason;

--- a/src/ui/views/browser/components/blogpress.js
+++ b/src/ui/views/browser/components/blogpress.js
@@ -318,7 +318,8 @@ function renderHomeView(model) {
       const button = document.createElement('button');
       button.type = 'button';
       button.className = 'blogpress-button blogpress-button--ghost';
-      button.textContent = quick.label;
+      const timeLabel = quick.time > 0 ? ` (${formatHours(quick.time)})` : '';
+      button.textContent = `${quick.label}${timeLabel}`;
       button.disabled = !quick.available;
       if (quick.disabledReason) {
         button.title = quick.disabledReason;
@@ -330,10 +331,15 @@ function renderHomeView(model) {
       });
       const effort = document.createElement('span');
       effort.className = 'blogpress-table__meta';
-      const partsMeta = [];
-      if (quick.time > 0) partsMeta.push(formatHours(quick.time));
-      if (quick.cost > 0) partsMeta.push(formatCurrency(quick.cost));
-      effort.textContent = partsMeta.length ? partsMeta.join(' • ') : 'Instant';
+      const costParts = [];
+      if (quick.cost > 0) costParts.push(formatCurrency(quick.cost));
+      if (costParts.length) {
+        effort.textContent = costParts.join(' • ');
+      } else if (quick.time > 0) {
+        effort.textContent = 'No cash needed';
+      } else {
+        effort.textContent = 'Instant';
+      }
       actionCell.append(button, effort);
     } else {
       const none = document.createElement('span');

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -3305,11 +3305,6 @@ a {
   gap: 0.35rem;
 }
 
-.blogpress-action__meta {
-  color: var(--browser-muted);
-  font-size: 0.82rem;
-}
-
 .blogpress-field {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- move the blogpress quick action time into the button label so the action reads with its duration
- adjust the quick action meta row to focus on cash costs and highlight when no money is required

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dffef9275c832c8c1fb95e429bbc16