### PR TITLE
Add Learnly free courses and skill-gated workspace unlocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Online Hustle Simulator is a browser-based incremental game about orchestrating 
 - **Audience Niches & Trends** – Each passive asset can target a whimsical niche that re-rolls in popularity every day. Assign builds to hot audiences for up to +30% payouts (or unassign to ride out a slump), monitor the daily popularity board, and review a seven-day highlight recap right from the dashboard.
 - **Dynamic Random Events** – Assets and niches can now spark multi-day streaks. Viral tailwinds start strong and taper each sunrise, while setbacks recover step-by-step until they expire, giving payouts a little extra drama beyond daily niche rolls.
 - **Skills & Experience** – Hustles, asset launches, quality pushes, upgrades, and study milestones award skill XP across ten creative disciplines. Skill tiers (Novice → Master) grant celebratory log entries, while total skill XP feeds an overall creator level that tracks your long-term momentum.
-- **Knowledge Tracks** – Paying tuition enrolls you in longer-form courses that auto-schedule their daily study load until graduation. Completed courses unlock advanced assets, inject gig-specific payout boosts, and now apply passive-income modifiers to matching assets; if the scheduler runs out of hours, you’ll receive gentle warnings and the course simply waits for tomorrow.
+- **Knowledge Tracks** – Paying tuition enrolls you in longer-form courses that auto-schedule their daily study load until graduation. Completed courses unlock advanced assets, inject gig-specific payout boosts, and now apply passive-income modifiers to matching assets; if the scheduler runs out of hours, you’ll receive gentle warnings and the course simply waits for tomorrow. A new Free Courses tab spotlights jumpstart programs that award enough XP to hit level 1 in their focus skill so BlogPress, VideoTube, DigiShelf, Shopily, and ServerHub unlock the moment you graduate.
 - **Daily Recap Log** – Every launch, maintenance result, payout, and study milestone is written to the log so you can reconstruct exactly what happened during busy streaks.
 
 ### Interface Overview
@@ -31,6 +31,11 @@ Online Hustle Simulator is a browser-based incremental game about orchestrating 
 - **Audience Q&A Blast** – Spend 1h with at least one active blog to earn $12 from checklist upsells (+$4 after Brand Voice Lab). Limited to one spotlight stream per day, so pick your prime time.
 - **Bundle Promo Push** – Spend 2.5h once you have two active blogs plus an e-book to pocket $48 immediately (+$6 after E-Commerce Playbook).
 - **Micro Survey Dash** – Fire off 15-minute surveys for $1 a pop (up to four per day; Guerrilla Buzz Workshop adds +$1.50 each) to keep pockets of time profitable.
+- **Storycraft Jumpstart** – Free; 1h/day for 3 days lets you outline pillar posts, grants +120 Writing XP (level 1), and unlocks BlogPress without spending tuition.
+- **Creator Studio Jumpstart** – Free; 1h/day for 3 days pairs you with a coach, awards +120 Visual Production XP (level 1), and unlocks VideoTube.
+- **Digital Shelf Primer** – Free; 1h/day for 3 days polishes metadata basics, grants +120 Editing XP (level 1), and unlocks DigiShelf alongside gallery boosts.
+- **Commerce Launch Primer** – Free; 1h/day for 3 days shadows fulfillment leads, awards +120 Commerce Operations XP (level 1), and unlocks Shopily.
+- **Micro SaaS Jumpstart** – Free; 1h/day for 3 days mentors you through deploy scripts, grants +120 Software Development XP (level 1), and unlocks ServerHub.
 - **Outline Mastery Workshop** – Pay $140 upfront; 2h/day for 5 days auto-reserve to unlock e-book production chops and boost writing/narration gigs.
 - **Photo Catalog Curation** – Pay $95 upfront; 1.5h/day for 4 days auto-reserve to polish your stock gallery workflow and increase Event Photo Gig payouts by 20%.
 - **E-Commerce Playbook** – Pay $260 upfront; 2h/day for 7 days auto-reserve to prep dropshipping ventures (+$6 Bundle Promo Push, +20% Dropship Pack Party).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Learnly adds a Free Courses tab stocked with XP-rich jumpstarts that unlock BlogPress, VideoTube, DigiShelf, Shopily, and ServerHub once you hit level 1 in their focus skill.
 - Passive income and upgrade completion notifications now arrive pre-read, and the welcome-back alert no longer appears so the tray only spotlights actionable events.
 - Random event engine now tracks multi-day boosts and setbacks for assets and niches, including the vlog’s viral streak migrating onto the shared system.
 - TimoDoro Task Log now spotlights completed work only, grouping hustle hours into Hustles, Education, Upkeep, and Upgrades with hour-focused summaries.

--- a/docs/features/learnly.md
+++ b/docs/features/learnly.md
@@ -10,6 +10,7 @@ Reimagine the education experience inside the browser shell as a dedicated Learn
 
 ## Key Details
 - Catalog view organizes courses by skill constellations such as Writing & Storycraft, Promotion & Funnels, and Technical Skills. Badges surface the focus areas directly on each card.
+- Free Courses tab curates tuition-free jumpstarts that award enough XP to reach level 1 in their headline skill, unlocking BlogPress, VideoTube, DigiShelf, Shopily, and ServerHub the moment you graduate.
 - Completed courses drop out of the catalog once you graduate so the grid always spotlights fresh study leads.
 - Course detail pages reuse existing descriptions, tuition, duration, and bonus definitions, adding sections for “What you’ll learn,” “Requirements,” and “Certificate of Completion.”
 - My Courses tab lists active and completed enrollments, displaying hours reserved per day, tuition already paid, and a drop-course confirmation that keeps tuition sunk.

--- a/src/game/hustles/knowledgeHustles.js
+++ b/src/game/hustles/knowledgeHustles.js
@@ -105,7 +105,19 @@ export function buildTrackViewModel(track, state = getState()) {
 }
 
 export function createKnowledgeHustles() {
-  return Object.values(KNOWLEDGE_TRACKS).map(track => {
+  const orderedTracks = Object.values(KNOWLEDGE_TRACKS)
+    .map((track, index) => ({ track, index }))
+    .sort((a, b) => {
+      const aFree = (Number(a.track.tuition) || 0) <= 0;
+      const bFree = (Number(b.track.tuition) || 0) <= 0;
+      if (aFree === bFree) {
+        return a.index - b.index;
+      }
+      return aFree ? 1 : -1;
+    })
+    .map(entry => entry.track);
+
+  return orderedTracks.map(track => {
     const presenter = createKnowledgeTrackPresenter(track);
 
     return {

--- a/src/game/requirements/knowledgeTracks.js
+++ b/src/game/requirements/knowledgeTracks.js
@@ -1,4 +1,90 @@
 export const KNOWLEDGE_TRACKS = {
+  storycraftJumpstart: {
+    id: 'storycraftJumpstart',
+    name: 'Storycraft Jumpstart',
+    description: 'Outline pillar posts for 3 days (1h/day) and polish headlines without paying tuition.',
+    hoursPerDay: 1,
+    days: 3,
+    tuition: 0,
+    instantBoosts: [
+      {
+        assetId: 'blog',
+        assetName: 'Personal Blog Network',
+        type: 'multiplier',
+        amount: 0.05
+      }
+    ]
+  },
+  vlogStudioJumpstart: {
+    id: 'vlogStudioJumpstart',
+    name: 'Creator Studio Jumpstart',
+    description: 'Shadow a creator coach for 3 days (1h/day) to frame shots, light sets, and warm up edits. Tuition free.',
+    hoursPerDay: 1,
+    days: 3,
+    tuition: 0,
+    instantBoosts: [
+      {
+        assetId: 'vlog',
+        assetName: 'Weekly Vlog Channel',
+        type: 'multiplier',
+        amount: 0.05
+      }
+    ]
+  },
+  digitalShelfPrimer: {
+    id: 'digitalShelfPrimer',
+    name: 'Digital Shelf Primer',
+    description: 'Curate e-books and galleries for 3 days (1h/day) to master metadata, covers, and storefront polish — no tuition required.',
+    hoursPerDay: 1,
+    days: 3,
+    tuition: 0,
+    instantBoosts: [
+      {
+        assetId: 'ebook',
+        assetName: 'Digital E-Book Series',
+        type: 'multiplier',
+        amount: 0.05
+      },
+      {
+        assetId: 'stockPhotos',
+        assetName: 'Stock Photo Gallery',
+        type: 'multiplier',
+        amount: 0.05
+      }
+    ]
+  },
+  commerceLaunchPrimer: {
+    id: 'commerceLaunchPrimer',
+    name: 'Commerce Launch Primer',
+    description: 'Shadow a fulfillment lead for 3 days (1h/day) to set up shipping flows and customer support scripts for free.',
+    hoursPerDay: 1,
+    days: 3,
+    tuition: 0,
+    instantBoosts: [
+      {
+        assetId: 'dropshipping',
+        assetName: 'Dropshipping Product Lab',
+        type: 'multiplier',
+        amount: 0.05
+      }
+    ]
+  },
+  microSaasJumpstart: {
+    id: 'microSaasJumpstart',
+    name: 'Micro SaaS Jumpstart',
+    description: 'Pair with senior engineers for 3 days (1h/day) to ship deploy scripts and uptime monitors with zero tuition.',
+    hoursPerDay: 1,
+    days: 3,
+    tuition: 0,
+    instantBoosts: [
+      {
+        assetId: 'saas',
+        assetName: 'SaaS Micro-App',
+        type: 'multiplier',
+        amount: 0.05
+      }
+    ]
+  },
   outlineMastery: {
     id: 'outlineMastery',
     name: 'Outline Mastery Workshop',
@@ -276,6 +362,11 @@ export const KNOWLEDGE_TRACKS = {
 };
 
 export const KNOWLEDGE_REWARDS = {
+  storycraftJumpstart: { baseXp: 120, skills: ['writing'] },
+  vlogStudioJumpstart: { baseXp: 120, skills: ['visual'] },
+  digitalShelfPrimer: { baseXp: 120, skills: ['editing'] },
+  commerceLaunchPrimer: { baseXp: 120, skills: ['commerce'] },
+  microSaasJumpstart: { baseXp: 120, skills: ['software'] },
   outlineMastery: { baseXp: 120, skills: ['writing'] },
   photoLibrary: {
     baseXp: 120,

--- a/src/ui/cards/model/blogpress.js
+++ b/src/ui/cards/model/blogpress.js
@@ -19,6 +19,7 @@ import {
 } from '../../../game/assets/quality.js';
 import { describeAssetLaunchAvailability } from './assets.js';
 import { registerModelBuilder } from '../modelBuilderRegistry.js';
+import { buildSkillLock } from './skillLocks.js';
 
 function clampNumber(value) {
   const number = Number(value);
@@ -328,6 +329,18 @@ export default function buildBlogpressModel(assetDefinitions = [], upgradeDefini
       summary: { total: 0, active: 0, setup: 0, needsUpkeep: 0, meta: 'BlogPress locked' },
       pricing: null,
       launch: null
+    };
+  }
+
+  const lock = buildSkillLock(state, 'blogpress');
+  if (lock) {
+    return {
+      definition: null,
+      instances: [],
+      summary: { total: 0, active: 0, setup: 0, needsUpkeep: 0, meta: lock.meta },
+      pricing: null,
+      launch: null,
+      lock
     };
   }
 

--- a/src/ui/cards/model/digishelf.js
+++ b/src/ui/cards/model/digishelf.js
@@ -19,6 +19,7 @@ import {
 } from '../../../game/assets/quality.js';
 import { describeAssetLaunchAvailability } from './assets.js';
 import { registerModelBuilder } from '../modelBuilderRegistry.js';
+import { buildSkillLock } from './skillLocks.js';
 
 const QUICK_ACTION_MAP = {
   ebook: ['writeChapter'],
@@ -388,6 +389,33 @@ export default function buildDigishelfModel(assetDefinitions = [], state = getSt
   const definitionMap = new Map(ensureArray(assetDefinitions).map(definition => [definition?.id, definition]));
   const ebookDefinition = definitionMap.get('ebook') || null;
   const stockDefinition = definitionMap.get('stockPhotos') || null;
+
+  const lock = buildSkillLock(state, 'digishelf');
+  if (lock) {
+    const meta = lock.meta;
+    const buildLocked = () => ({
+      definition: null,
+      instances: [],
+      summary: { total: 0, active: 0, setup: 0, needsUpkeep: 0, meta },
+      launch: null,
+      plan: null
+    });
+    return {
+      ebook: buildLocked(),
+      stock: buildLocked(),
+      overview: {
+        ebooksActive: 0,
+        stockActive: 0,
+        totalDaily: 0,
+        ebookDaily: 0,
+        stockDaily: 0,
+        meta
+      },
+      pricing: [],
+      summary: { meta, totalActive: 0 },
+      lock
+    };
+  }
 
   const ebook = buildModelForDefinition(ebookDefinition, state, PLAN_COPY.ebook);
   const stock = buildModelForDefinition(stockDefinition, state, PLAN_COPY.stockPhotos);

--- a/src/ui/cards/model/serverhub.js
+++ b/src/ui/cards/model/serverhub.js
@@ -20,6 +20,7 @@ import {
 import { describeAssetLaunchAvailability } from './assets.js';
 import { registerModelBuilder } from '../modelBuilderRegistry.js';
 import { getUpgradeSnapshot, describeUpgradeStatus } from './upgrades.js';
+import { buildSkillLock } from './skillLocks.js';
 
 function clampNumber(value) {
   const number = Number(value);
@@ -425,6 +426,19 @@ export default function buildServerHubModel(assetDefinitions = [], upgradeDefini
       launch: null,
       upgrades: [],
       pricing: []
+    };
+  }
+
+  const lock = buildSkillLock(state, 'serverhub');
+  if (lock) {
+    return {
+      definition: null,
+      instances: [],
+      summary: { meta: lock.meta },
+      launch: null,
+      upgrades: [],
+      pricing: [],
+      lock
     };
   }
 

--- a/src/ui/cards/model/shopily.js
+++ b/src/ui/cards/model/shopily.js
@@ -21,6 +21,7 @@ import {
 import { getUpgradeSnapshot, describeUpgradeStatus } from './upgrades.js';
 import { describeAssetLaunchAvailability } from './assets.js';
 import { registerModelBuilder } from '../modelBuilderRegistry.js';
+import { buildSkillLock } from './skillLocks.js';
 
 function clampNumber(value) {
   const number = Number(value);
@@ -385,6 +386,20 @@ export default function buildShopilyModel(assetDefinitions = [], upgradeDefiniti
       pricing: null,
       upgrades: [],
       launch: null
+    };
+  }
+
+  const lock = buildSkillLock(state, 'shopily');
+  if (lock) {
+    return {
+      definition: null,
+      instances: [],
+      summary: { total: 0, active: 0, setup: 0, needsUpkeep: 0, meta: lock.meta },
+      metrics: { totalStores: 0, dailySales: 0, dailyUpkeep: 0, netDaily: 0 },
+      pricing: null,
+      upgrades: [],
+      launch: null,
+      lock
     };
   }
 

--- a/src/ui/cards/model/skillLocks.js
+++ b/src/ui/cards/model/skillLocks.js
@@ -1,0 +1,93 @@
+import { getSkillDefinition } from '../../../game/skills/data.js';
+import { KNOWLEDGE_TRACKS } from '../../../game/requirements.js';
+
+export const WORKSPACE_SKILL_LOCKS = {
+  blogpress: {
+    workspaceLabel: 'BlogPress',
+    skillId: 'writing',
+    requiredLevel: 1,
+    courseId: 'storycraftJumpstart'
+  },
+  videotube: {
+    workspaceLabel: 'VideoTube',
+    skillId: 'visual',
+    requiredLevel: 1,
+    courseId: 'vlogStudioJumpstart'
+  },
+  digishelf: {
+    workspaceLabel: 'DigiShelf',
+    skillId: 'editing',
+    requiredLevel: 1,
+    courseId: 'digitalShelfPrimer'
+  },
+  shopily: {
+    workspaceLabel: 'Shopily',
+    skillId: 'commerce',
+    requiredLevel: 1,
+    courseId: 'commerceLaunchPrimer'
+  },
+  serverhub: {
+    workspaceLabel: 'ServerHub',
+    skillId: 'software',
+    requiredLevel: 1,
+    courseId: 'microSaasJumpstart'
+  }
+};
+
+const COURSE_TO_WORKSPACE = new Map();
+Object.entries(WORKSPACE_SKILL_LOCKS).forEach(([workspaceId, config]) => {
+  if (!config?.courseId) return;
+  COURSE_TO_WORKSPACE.set(config.courseId, { workspaceId, ...config });
+});
+
+export function buildSkillLock(state = {}, workspaceId) {
+  const config = WORKSPACE_SKILL_LOCKS[workspaceId];
+  if (!config) return null;
+  const skillEntry = state?.skills?.[config.skillId] || {};
+  const currentLevel = Number(skillEntry.level) || 0;
+  const requiredLevel = Number(config.requiredLevel) || 0;
+  if (currentLevel >= requiredLevel) {
+    return null;
+  }
+
+  const skillDefinition = getSkillDefinition(config.skillId);
+  const skillName = skillDefinition?.name || config.skillName || config.skillId;
+  const courseDefinition = config.courseId ? KNOWLEDGE_TRACKS[config.courseId] : null;
+  const courseName = courseDefinition?.name || config.courseName || null;
+  const meta = config.meta || `Locked — ${skillName} Lv ${requiredLevel}`;
+
+  return {
+    type: 'skill',
+    workspaceId,
+    workspaceLabel: config.workspaceLabel || workspaceId,
+    skillId: config.skillId,
+    skillName,
+    requiredLevel,
+    currentLevel,
+    courseId: config.courseId || null,
+    courseName,
+    meta
+  };
+}
+
+export function getWorkspaceLockByCourse(courseId) {
+  if (!courseId) return null;
+  const config = COURSE_TO_WORKSPACE.get(courseId);
+  if (!config) return null;
+  const skillDefinition = getSkillDefinition(config.skillId);
+  const skillName = skillDefinition?.name || config.skillName || config.skillId;
+  const courseDefinition = KNOWLEDGE_TRACKS[config.courseId] || null;
+  return {
+    workspaceId: config.workspaceId,
+    workspaceLabel: config.workspaceLabel || config.workspaceId,
+    skillId: config.skillId,
+    skillName,
+    requiredLevel: Number(config.requiredLevel) || 0,
+    courseId: config.courseId,
+    courseName: courseDefinition?.name || config.courseName || null
+  };
+}
+
+export function getWorkspaceSkillLockConfig(workspaceId) {
+  return WORKSPACE_SKILL_LOCKS[workspaceId] || null;
+}

--- a/src/ui/cards/model/videotube.js
+++ b/src/ui/cards/model/videotube.js
@@ -20,6 +20,7 @@ import {
 import { setAssetInstanceName } from '../../../game/assets/actions.js';
 import { describeAssetLaunchAvailability } from './assets.js';
 import { registerModelBuilder } from '../modelBuilderRegistry.js';
+import { buildSkillLock } from './skillLocks.js';
 
 function clampNumber(value) {
   const number = Number(value);
@@ -387,6 +388,19 @@ export default function buildVideoTubeModel(assetDefinitions = [], state = getSt
       stats: { lifetime: 0, daily: 0, active: 0, averageQuality: 0, milestonePercent: 0 },
       analytics: { videos: [], niches: [] },
       launch: null
+    };
+  }
+
+  const lock = buildSkillLock(state, 'videotube');
+  if (lock) {
+    return {
+      definition: null,
+      instances: [],
+      summary: { total: 0, active: 0, setup: 0, meta: lock.meta },
+      stats: { lifetime: 0, daily: 0, active: 0, averageQuality: 0, milestonePercent: 0 },
+      analytics: { videos: [], niches: [] },
+      launch: null,
+      lock
     };
   }
 

--- a/src/ui/views/browser/components/blogpress.js
+++ b/src/ui/views/browser/components/blogpress.js
@@ -912,12 +912,17 @@ function renderBlueprintView(model) {
   return container;
 }
 
-function renderLockedState() {
+function renderLockedState(lock) {
   const container = document.createElement('section');
   container.className = 'blogpress-view blogpress-view--locked';
   const message = document.createElement('p');
   message.className = 'blogpress-empty__message';
-  message.textContent = 'BlogPress unlocks once the Personal Blog blueprint is discovered.';
+  if (lock?.type === 'skill') {
+    const courseNote = lock.courseName ? ` Complete ${lock.courseName} in Learnly to level up instantly.` : '';
+    message.textContent = `${lock.workspaceLabel || 'This workspace'} unlocks at ${lock.skillName} Lv ${lock.requiredLevel}.${courseNote}`;
+  } else {
+    message.textContent = 'BlogPress unlocks once the Personal Blog blueprint is discovered.';
+  }
   container.appendChild(message);
   return container;
 }
@@ -958,7 +963,7 @@ export function render(model = {}, context = {}) {
 
   if (!currentModel.definition) {
     currentMount.innerHTML = '';
-    currentMount.appendChild(renderLockedState());
+    currentMount.appendChild(renderLockedState(currentModel.lock));
     const summary = currentModel.summary || {};
     const urlPath = workspacePathController.getPath();
     return { ...summary, urlPath };

--- a/src/ui/views/browser/components/digishelf.js
+++ b/src/ui/views/browser/components/digishelf.js
@@ -884,6 +884,21 @@ function renderMain(model) {
   return wrapper;
 }
 
+function renderLockedState(lock) {
+  const wrapper = document.createElement('section');
+  wrapper.className = 'digishelf digishelf--locked';
+  const message = document.createElement('p');
+  message.className = 'digishelf-empty';
+  if (lock?.type === 'skill') {
+    const courseNote = lock.courseName ? ` Complete ${lock.courseName} in Learnly to level up instantly.` : '';
+    message.textContent = `${lock.workspaceLabel || 'DigiShelf'} unlocks at ${lock.skillName} Lv ${lock.requiredLevel}.${courseNote}`;
+  } else {
+    message.textContent = 'DigiShelf unlocks once the digital asset blueprints are discovered.';
+  }
+  wrapper.appendChild(message);
+  return wrapper;
+}
+
 function render(model, { mount, page } = {}) {
   if (mount) {
     currentMount = mount;
@@ -896,6 +911,13 @@ function render(model, { mount, page } = {}) {
   }
 
   currentModel = model || currentModel;
+  if (currentModel.lock) {
+    currentMount.innerHTML = '';
+    currentMount.appendChild(renderLockedState(currentModel.lock));
+    const meta = currentModel?.summary?.meta || currentModel?.overview?.meta || '';
+    return { meta };
+  }
+
   ensureState(currentModel);
 
   currentMount.innerHTML = '';

--- a/src/ui/views/browser/components/serverhub.js
+++ b/src/ui/views/browser/components/serverhub.js
@@ -889,8 +889,29 @@ function renderBody(model) {
   }
 }
 
+function renderLockedState(lock) {
+  const wrapper = document.createElement('section');
+  wrapper.className = 'serverhub serverhub--locked';
+  const message = document.createElement('p');
+  message.className = 'serverhub-empty';
+  if (lock?.type === 'skill') {
+    const courseNote = lock.courseName ? ` Complete ${lock.courseName} in Learnly to level up instantly.` : '';
+    message.textContent = `${lock.workspaceLabel || 'This console'} unlocks at ${lock.skillName} Lv ${lock.requiredLevel}.${courseNote}`;
+  } else {
+    message.textContent = 'ServerHub unlocks once the SaaS Micro-App blueprint is discovered.';
+  }
+  wrapper.appendChild(message);
+  return wrapper;
+}
+
 function renderApp() {
   if (!currentMount) return;
+  if (!currentModel.definition) {
+    currentMount.innerHTML = '';
+    currentMount.appendChild(renderLockedState(currentModel.lock));
+    return;
+  }
+
   ensureSelectedApp();
   currentMount.innerHTML = '';
   const root = document.createElement('div');

--- a/src/ui/views/browser/components/shopily.js
+++ b/src/ui/views/browser/components/shopily.js
@@ -1235,8 +1235,29 @@ function renderPricingView(model) {
   return container;
 }
 
+function renderLockedState(lock) {
+  const section = document.createElement('section');
+  section.className = 'shopily shopily--locked';
+  const message = document.createElement('p');
+  message.className = 'shopily-empty';
+  if (lock?.type === 'skill') {
+    const courseNote = lock.courseName ? ` Complete ${lock.courseName} in Learnly to level up instantly.` : '';
+    message.textContent = `${lock.workspaceLabel || 'Shopily'} unlocks at ${lock.skillName} Lv ${lock.requiredLevel}.${courseNote}`;
+  } else {
+    message.textContent = 'Shopily unlocks once the Dropshipping blueprint is discovered.';
+  }
+  section.appendChild(message);
+  return section;
+}
+
 function renderApp() {
   if (!currentMount) {
+    workspacePathController.sync();
+    return;
+  }
+  if (!currentModel.definition) {
+    currentMount.innerHTML = '';
+    currentMount.appendChild(renderLockedState(currentModel.lock));
     workspacePathController.sync();
     return;
   }

--- a/src/ui/views/browser/components/videotube.js
+++ b/src/ui/views/browser/components/videotube.js
@@ -712,12 +712,17 @@ function renderAnalyticsView(model) {
   return container;
 }
 
-function renderLockedState() {
+function renderLockedState(lock) {
   const container = document.createElement('section');
   container.className = 'videotube-view videotube-view--locked';
   const message = document.createElement('p');
   message.className = 'videotube-empty';
-  message.textContent = 'VideoTube unlocks once the Vlog blueprint is discovered.';
+  if (lock?.type === 'skill') {
+    const courseNote = lock.courseName ? ` Complete ${lock.courseName} in Learnly to level up instantly.` : '';
+    message.textContent = `${lock.workspaceLabel || 'This workspace'} unlocks at ${lock.skillName} Lv ${lock.requiredLevel}.${courseNote}`;
+  } else {
+    message.textContent = 'VideoTube unlocks once the Vlog blueprint is discovered.';
+  }
   container.appendChild(message);
   return container;
 }
@@ -761,7 +766,7 @@ export function render(model = {}, context = {}) {
 
   if (!currentModel.definition) {
     currentMount.innerHTML = '';
-    currentMount.appendChild(renderLockedState());
+    currentMount.appendChild(renderLockedState(currentModel.lock));
     return currentModel.summary || {};
   }
 

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -3517,6 +3517,10 @@ a {
   gap: 1.6rem;
 }
 
+.learnly-view--free {
+  gap: 1.2rem;
+}
+
 .learnly-filter {
   display: flex;
   flex-wrap: wrap;
@@ -3557,6 +3561,24 @@ a {
   gap: 1.4rem;
 }
 
+.learnly-free-intro {
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  padding: 1.2rem 1.4rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.learnly-free-intro h2 {
+  margin: 0;
+}
+
+.learnly-free-intro p {
+  margin: 0;
+  color: var(--browser-muted);
+}
+
 .learnly-card {
   background: var(--browser-panel);
   border: 1px solid var(--browser-panel-border);
@@ -3569,6 +3591,11 @@ a {
   transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
 }
 
+.learnly-card--free {
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.12), rgba(59, 130, 246, 0.04));
+  border-color: rgba(16, 185, 129, 0.45);
+}
+
 .learnly-card:hover,
 .learnly-card:focus-within {
   transform: translateY(-4px);
@@ -3576,10 +3603,20 @@ a {
   box-shadow: var(--browser-shadow-card);
 }
 
+.learnly-card--free:hover,
+.learnly-card--free:focus-within {
+  border-color: rgba(16, 185, 129, 0.6);
+}
+
 .learnly-card__badges {
   display: flex;
   flex-wrap: wrap;
   gap: 0.4rem;
+}
+
+.learnly-card--free .learnly-badge {
+  background: rgba(16, 185, 129, 0.18);
+  color: #047857;
 }
 
 .learnly-badge {
@@ -3600,6 +3637,25 @@ a {
   margin: 0;
   color: var(--browser-muted);
   line-height: 1.5;
+}
+
+.learnly-card__unlock {
+  margin: 0;
+  font-weight: 600;
+  color: #047857;
+}
+
+:root[data-browser-theme="night"] .learnly-card--free {
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.2), rgba(59, 130, 246, 0.1));
+  border-color: rgba(16, 185, 129, 0.55);
+}
+
+:root[data-browser-theme="night"] .learnly-card--free .learnly-badge {
+  color: #bbf7d0;
+}
+
+:root[data-browser-theme="night"] .learnly-card__unlock {
+  color: #bbf7d0;
 }
 
 .learnly-card__stats {
@@ -3646,11 +3702,21 @@ a {
   box-shadow: 0 12px 26px rgba(37, 99, 235, 0.28);
 }
 
+.learnly-card--free .learnly-button--primary {
+  background: #10b981;
+  box-shadow: 0 12px 28px rgba(16, 185, 129, 0.32);
+}
+
 .learnly-button--primary:hover:not(:disabled),
 .learnly-button--primary:focus-visible:not(:disabled) {
   transform: translateY(-1px);
   box-shadow: 0 16px 30px rgba(37, 99, 235, 0.32);
   outline: none;
+}
+
+.learnly-card--free .learnly-button--primary:hover:not(:disabled),
+.learnly-card--free .learnly-button--primary:focus-visible:not(:disabled) {
+  box-shadow: 0 16px 32px rgba(16, 185, 129, 0.36);
 }
 
 .learnly-button--ghost {


### PR DESCRIPTION
## Summary
- add tuition-free jumpstart tracks that grant level-1 XP for BlogPress, VideoTube, DigiShelf, Shopily, and ServerHub unlocks
- wire shared skill-lock metadata into browser workspace cards so each app surfaces the Learnly course requirement and gating copy
- refresh Learnly with a Free Courses tab, skill-aware detail navigation, routing, and styling to highlight the new unlock path
- document the new free courses and unlock flow in the Learnly design note, changelog, and README

## Testing
- `npm test`

## Manual Testing
- Not performed (browser UI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dff81e3820832c853ea6913fc55f82