### PR TITLE
Add homepage widget icons linked to workspaces

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -112,7 +112,16 @@
                 >
                   <header class="browser-widget__header apps-widget__header">
                     <div class="apps-widget__intro">
-                      <h2 id="browser-widget-apps-heading">Apps</h2>
+                      <h2 id="browser-widget-apps-heading" class="browser-widget__title">
+                        <a
+                          class="browser-widget__title-link"
+                          href="https://hustle.city/apps/"
+                          data-site-target="home"
+                        >
+                          <span class="browser-widget__title-icon" aria-hidden="true">🗂️</span>
+                          <span class="browser-widget__title-text">Apps</span>
+                        </a>
+                      </h2>
                       <p id="browser-widget-apps-note">Launch a workspace in a tap — hover to preview where it leads.</p>
                     </div>
                     <div class="apps-widget__controls">
@@ -135,7 +144,16 @@
                 <section class="browser-widget todo-widget" data-widget="todo" aria-labelledby="browser-widget-todo-heading">
                   <header class="browser-widget__header todo-widget__header">
                     <div class="todo-widget__intro">
-                      <h2 id="browser-widget-todo-heading">ToDo</h2>
+                      <h2 id="browser-widget-todo-heading" class="browser-widget__title">
+                        <a
+                          class="browser-widget__title-link"
+                          href="https://timodoro.hub/"
+                          data-site-target="timodoro"
+                        >
+                          <span class="browser-widget__title-icon" aria-hidden="true">⏱️</span>
+                          <span class="browser-widget__title-text">ToDo</span>
+                        </a>
+                      </h2>
                       <p id="browser-widget-todo-note">Line up quick wins and smart upgrades to make today sparkle.</p>
                     </div>
                     <dl class="todo-widget__hours" aria-live="polite">
@@ -178,7 +196,16 @@
                 >
                   <header class="browser-widget__header">
                     <div>
-                      <h2 id="browser-widget-bank-heading">Bank Snapshot</h2>
+                      <h2 id="browser-widget-bank-heading" class="browser-widget__title">
+                        <a
+                          class="browser-widget__title-link"
+                          href="https://bankapp.hub/"
+                          data-site-target="bankapp"
+                        >
+                          <span class="browser-widget__title-icon" aria-hidden="true">🏦</span>
+                          <span class="browser-widget__title-text">Bank Snapshot</span>
+                        </a>
+                      </h2>
                       <p id="browser-widget-bank-note">Fresh totals piped in from BankApp.</p>
                     </div>
                   </header>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 - TimoDoro Task Log now spotlights completed work only, grouping hustle hours into Hustles, Education, Upkeep, and Upgrades with hour-focused summaries.
 - TimoDoro productivity hub joins the browser app roster, remixing the ToDo queue, upkeep logs, and daily summary stats into a dedicated focus workspace.
 - Browser homepage apps widget now includes an Arrange mode so players can drag tiles to swap spots, highlight favorites, and keep the order between sessions.
+- Browser homepage widget headers now sport emoji icons that jump straight into the full TimoDoro and BankApp workspaces for faster follow-up from the snapshot view.
 - Asset Arcade workspace retired from the browser prototype and hidden from the homepage launcher while we explore refreshed asset flows.
 - Shopily’s upgrades tab now mirrors a mobile top-up catalog with ShopStack-grade detail panels while the Fulfillment Automation Suite, Global Supply Mesh, and White-Label Alliance migrate out of ShopStack into the dedicated commerce app.
 - Browser chrome now features a notification bell that mirrors the event log with unread badges, read tracking, and a mark-all control.

--- a/docs/features/browser-home-redesign.md
+++ b/docs/features/browser-home-redesign.md
@@ -10,6 +10,7 @@
 - The launch stage now renders a single-column layout with `.browser-home__widgets` using CSS Grid to provide three equal columns on wide viewports, two columns on medium, and one column on narrow screens.
 - Widget cards reuse the existing presenter modules and simply stretch to fill each grid cell. Cards share a consistent padding, border radius, and drop shadow defined in `styles/browser.css` so they feel like a matched set.
 - The apps widget reuses the existing `appsWidget` module. It now renders each workspace as a tile button with an icon, label, and optional status badge derived from the service summary metadata.
+- Widget headers add upbeat emoji icons that link straight into their full browser workspaces so players can hop from the homepage snapshot into BankApp or TimoDoro with one click.
 - A compact "Arrange" toggle in the apps widget header activates drag-and-drop sorting. Tiles swap positions on drop and the custom order is stored in local storage so it persists between sessions.
 - Navigation highlighting looks for `[data-role="browser-app-launcher"]` containers in addition to the legacy sidebar list so active pages still pulse even without the sidebar.
 - The ToDo widget now aggregates quick actions, asset upgrade recommendations, and enrollable study tracks into a single scrollable list. Tasks validate hour and cash requirements before rendering so the queue always reflects moves you can take right now.

--- a/src/ui/views/browser/layoutPresenter.js
+++ b/src/ui/views/browser/layoutPresenter.js
@@ -119,10 +119,19 @@ function markActiveSite(pageId) {
   if (!containers.length) return;
 
   containers.forEach(container => {
-    container.querySelectorAll('button[data-site-target]').forEach(button => {
-      const isActive = button.dataset.siteTarget === pageId;
-      button.classList.toggle('is-active', isActive);
-      button.setAttribute('aria-pressed', String(isActive));
+    container.querySelectorAll('[data-site-target]').forEach(control => {
+      if (!(control instanceof HTMLElement)) {
+        return;
+      }
+      const isActive = control.dataset.siteTarget === pageId;
+      control.classList.toggle('is-active', isActive);
+      if (control instanceof HTMLButtonElement) {
+        control.setAttribute('aria-pressed', String(isActive));
+      } else if (isActive) {
+        control.setAttribute('aria-current', 'page');
+      } else {
+        control.removeAttribute('aria-current');
+      }
     });
   });
 }
@@ -142,10 +151,12 @@ function refreshActivePage() {
 }
 
 function handleSiteClick(event) {
-  const button = event.target.closest('button[data-site-target]');
-  if (!button) return;
+  const control = event.target.closest('[data-site-target]');
+  if (!control || !(control instanceof HTMLElement)) {
+    return;
+  }
   event.preventDefault();
-  const target = button.dataset.siteTarget || HOMEPAGE_ID;
+  const target = control.dataset.siteTarget || HOMEPAGE_ID;
   if (target === HOMEPAGE_ID) {
     setActivePage(HOMEPAGE_ID, { focus: true, recordHistory: true, ensureTab: false });
   } else {

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -559,6 +559,46 @@ a {
   font-weight: 700;
 }
 
+.browser-widget__title-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.15rem 0.55rem 0.15rem 0.4rem;
+  margin-inline-start: -0.4rem;
+  color: inherit;
+  text-decoration: none;
+  border-radius: var(--browser-radius-pill);
+  transition: color 140ms ease, background-color 140ms ease, box-shadow 140ms ease;
+}
+
+.browser-widget__title-link:hover,
+.browser-widget__title-link:focus-visible {
+  color: var(--browser-accent);
+  background-color: var(--browser-accent-soft);
+  text-decoration: none;
+}
+
+.browser-widget__title-link:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--browser-accent-soft);
+}
+
+.browser-widget__title-link.is-active {
+  color: var(--browser-accent);
+}
+
+.browser-widget__title-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1em;
+  line-height: 1;
+}
+
+.browser-widget__title-text {
+  font-weight: inherit;
+}
+
 .browser-widget__header p {
   margin: 0.2rem 0 0;
   color: var(--browser-muted);


### PR DESCRIPTION
## Summary
- add linked icons to the homepage widget headers so Apps, ToDo, and Bank Snapshot jump into their full workspaces
- style the new header links for hover, focus, and active states while keeping icons aligned with the layout
- let the browser homepage navigation recognize anchor targets so the new links stay in sync with active tabs and document the change

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68dfff66a144832c8f3e4dc28e883620