### PR TITLE
Add fallback HTML loader for browser shell tests

### DIFF
--- a/tests/helpers/setupDom.js
+++ b/tests/helpers/setupDom.js
@@ -8,9 +8,18 @@ import browserView from '../../src/ui/views/browser/index.js';
 let dom;
 
 function loadBrowserShellHtml() {
-  const htmlUrl = new URL('../../browser.html', import.meta.url);
-  const filePath = fileURLToPath(htmlUrl);
-  return readFileSync(filePath, 'utf-8');
+  const browserShellUrl = new URL('../../browser.html', import.meta.url);
+
+  try {
+    const filePath = fileURLToPath(browserShellUrl);
+    return readFileSync(filePath, 'utf-8');
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+
+    const fallbackUrl = new URL('../../index.html', import.meta.url);
+    const fallbackPath = fileURLToPath(fallbackUrl);
+    return readFileSync(fallbackPath, 'utf-8');
+  }
 }
 
 export function ensureTestDom() {


### PR DESCRIPTION
## Summary
- fallback to index.html when browser.html is not available in the test DOM loader
- keep integration tests working after the browser shell file rename

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e015d44c3c832cb2642102e1e2bedd