### PR TITLE
Fix test DOM loader to use index shell

### DIFF
--- a/tests/helpers/setupDom.js
+++ b/tests/helpers/setupDom.js
@@ -8,7 +8,7 @@ import browserView from '../../src/ui/views/browser/index.js';
 let dom;
 
 function loadBrowserShellHtml() {
-  const htmlUrl = new URL('../../browser.html', import.meta.url);
+  const htmlUrl = new URL('../../index.html', import.meta.url);
   const filePath = fileURLToPath(htmlUrl);
   return readFileSync(filePath, 'utf-8');
 }


### PR DESCRIPTION
## Summary
- update the test DOM helper to load the new `index.html` shell instead of the removed `browser.html`

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e017372fdc832cabe184c00cda26d6