### PR TITLE
Register finance card model builder

### DIFF
--- a/src/ui/cards.js
+++ b/src/ui/cards.js
@@ -44,7 +44,7 @@ function synthesizeModels(baseModels = {}, registries = {}, force = false) {
     models.upgrades = buildUpgradeModels(registries.upgrades);
     generated = true;
   }
-  if (force || typeof models.finance !== 'object' || models.finance === null) {
+  if (typeof models.finance !== 'object' || models.finance === null) {
     models.finance = buildFinanceModel(registries);
     generated = true;
   }

--- a/src/ui/cards/model/index.js
+++ b/src/ui/cards/model/index.js
@@ -53,6 +53,11 @@ function registerDefaultCardBuilders() {
     registries => buildUpgradeModels(registries.upgrades),
     { isDefault: true }
   );
+  registerModelBuilder(
+    'finance',
+    registries => buildFinanceModel(registries),
+    { isDefault: true }
+  );
 }
 
 ensureDefaultBuilders(registerDefaultCardBuilders);

--- a/src/ui/views/browser/apps/finance.js
+++ b/src/ui/views/browser/apps/finance.js
@@ -1,5 +1,4 @@
 import { formatHours, formatMoney } from '../../../../core/helpers.js';
-import { buildFinanceModel } from '../../../cards/model/index.js';
 import { getPageByType } from './pageLookup.js';
 
 function formatCurrency(amount) {
@@ -682,17 +681,6 @@ function renderFinanceEducation(entries = []) {
   return section;
 }
 
-function ensureFinanceModel(registries = {}, models = {}) {
-  if (models && typeof models.finance === 'object' && models.finance !== null) {
-    return models.finance;
-  }
-  const financeModel = buildFinanceModel(registries);
-  if (models) {
-    models.finance = financeModel;
-  }
-  return financeModel;
-}
-
 export default function renderFinance(context = {}, registries = {}, models = {}) {
   const page = getPageByType('finance');
   if (!page) return null;
@@ -703,7 +691,13 @@ export default function renderFinance(context = {}, registries = {}, models = {}
   });
   if (!refs) return null;
 
-  const financeModel = ensureFinanceModel(registries, models);
+  let financeModel = null;
+  if (models && typeof models.finance === 'object' && models.finance !== null) {
+    financeModel = models.finance;
+  } else {
+    console.warn('Finance view expected models.finance but it was missing. Rendering fallback view.');
+  }
+
   const model = financeModel || {};
 
   const container = document.createElement('div');


### PR DESCRIPTION
## Summary
- register the finance card model as a default builder so it is included in buildModelMap output
- rely on registry-provided finance models during card synthesis while keeping a fallback for missing data
- simplify the finance browser app to consume the shared finance model and log when it is unavailable

## Testing
- node --test tests/ui/cardsModel.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e01aeb31bc832ca29885f7bb9f103b