### PR TITLE
Fix mobile widget layout on landing page

### DIFF
--- a/styles/browser.css
+++ b/styles/browser.css
@@ -488,27 +488,15 @@ a {
 
 .browser-home__widgets {
   width: 100%;
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
   gap: var(--browser-home-widget-gap, var(--browser-home-spacing, 1.5rem));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
   align-items: stretch;
-  justify-content: space-between;
   margin: 0;
 }
 
 .browser-home__widgets > .browser-widget {
-  flex: 1 1 0;
-  min-width: 280px;
-}
-
-@media (max-width: 900px) {
-  .browser-home__widgets {
-    flex-direction: column;
-  }
-
-  .browser-home__widgets > .browser-widget {
-    min-width: 0;
-  }
+  min-width: 0;
 }
 
 .browser-home__header {


### PR DESCRIPTION
## Summary
- switch the landing widgets container to a responsive CSS grid so cards wrap cleanly
- remove hard-coded flex sizing so widgets stack on narrow screens without overlap

## Testing
- npm test
- Manual: Loaded index.html via local http.server and inspected in a mobile-width viewport

------
https://chatgpt.com/codex/tasks/task_e_68e0284ccb40832cba23ed343d70aaed