### PR TITLE
Add shared daily lifecycle summary formatter

### DIFF
--- a/src/ui/views/browser/components/blogpress.js
+++ b/src/ui/views/browser/components/blogpress.js
@@ -2,7 +2,7 @@ import { formatHours, formatMoney } from '../../../../core/helpers.js';
 import { selectBlogpressNiche } from '../../../cards/model/index.js';
 import { performQualityAction } from '../../../../game/assets/index.js';
 import { formatCurrency as baseFormatCurrency, formatNetCurrency } from '../utils/formatting.js';
-import { createLifecycleSummary } from '../utils/lifecycleSummaries.js';
+import { createDailyLifecycleSummary } from '../utils/lifecycleSummaries.js';
 import { showLaunchConfirmation } from '../utils/launchDialog.js';
 import { createWorkspacePathController } from '../utils/workspacePaths.js';
 
@@ -42,13 +42,8 @@ const workspacePathController = createWorkspacePathController({
 const formatCurrency = amount =>
   baseFormatCurrency(amount, { precision: 'integer', clampZero: true });
 
-const { describeSetupSummary, describeUpkeepSummary } = createLifecycleSummary({
-  parseValue: value => {
-    const numeric = Number(value);
-    return Number.isFinite(numeric) ? numeric : 0;
-  },
-  formatSetupHours: hours => `${formatHours(hours)} per day`,
-  formatUpkeepHours: hours => `${formatHours(hours)} per day`,
+const { describeSetupSummary, describeUpkeepSummary } = createDailyLifecycleSummary({
+  formatHoursValue: formatHours,
   formatSetupCost: cost => `$${formatMoney(cost)} upfront`,
   formatUpkeepCost: cost => `$${formatMoney(cost)} per day`,
   setupFallback: 'Instant launch',

--- a/src/ui/views/browser/components/serverhub.js
+++ b/src/ui/views/browser/components/serverhub.js
@@ -6,7 +6,7 @@ import {
   formatNetCurrency as baseFormatNetCurrency,
   formatPercent as baseFormatPercent
 } from '../utils/formatting.js';
-import { createLifecycleSummary } from '../utils/lifecycleSummaries.js';
+import { createDailyLifecycleSummary } from '../utils/lifecycleSummaries.js';
 import { showLaunchConfirmation } from '../utils/launchDialog.js';
 
 const VIEW_APPS = 'apps';
@@ -40,19 +40,16 @@ const ACTION_CONSOLE_ORDER = [
   { id: 'deployEdgeNodes', label: 'Deploy Edge Nodes' }
 ];
 
-const { describeSetupSummary: formatSetupSummary, describeUpkeepSummary: formatUpkeepSummary } =
-  createLifecycleSummary({
-    parseValue: value => {
-      const numeric = Number(value);
-      return Number.isFinite(numeric) ? numeric : 0;
-    },
-    formatSetupHours: hours => `${formatHours(hours)} per day`,
-    formatUpkeepHours: hours => `${formatHours(hours)} per day`,
-    formatSetupCost: cost => `${formatCurrency(cost)} upfront`,
-    formatUpkeepCost: cost => `${formatCurrency(cost)} per day`,
-    setupFallback: 'Instant setup',
-    upkeepFallback: 'No upkeep required'
-  });
+const {
+  describeSetupSummary: formatSetupSummary,
+  describeUpkeepSummary: formatUpkeepSummary
+} = createDailyLifecycleSummary({
+  formatHoursValue: formatHours,
+  formatSetupCost: cost => `${formatCurrency(cost)} upfront`,
+  formatUpkeepCost: cost => `${formatCurrency(cost)} per day`,
+  setupFallback: 'Instant setup',
+  upkeepFallback: 'No upkeep required'
+});
 
 function confirmLaunchWithDetails(definition = {}) {
   const resourceName = definition.singular || definition.name || 'app';


### PR DESCRIPTION
## Summary
- add a themed createDailyLifecycleSummary helper that standardizes parsing, hour phrasing, and fallbacks
- refactor blogpress, digishelf, serverhub, and shopily components to consume the shared lifecycle formatter
- replace bespoke setup/upkeep copy in shopily plans and digishelf launch cards with the centralized helper

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e01fd84edc832cbddd7049623e1d8b