### PR TITLE
Refine lifecycle summary presets

### DIFF
--- a/src/ui/views/browser/components/blogpress.js
+++ b/src/ui/views/browser/components/blogpress.js
@@ -2,7 +2,7 @@ import { formatHours, formatMoney } from '../../../../core/helpers.js';
 import { selectBlogpressNiche } from '../../../cards/model/index.js';
 import { performQualityAction } from '../../../../game/assets/index.js';
 import { formatCurrency as baseFormatCurrency, formatNetCurrency } from '../utils/formatting.js';
-import { createLifecycleSummary } from '../utils/lifecycleSummaries.js';
+import { createCurrencyLifecycleSummary } from '../utils/lifecycleSummaries.js';
 import { showLaunchConfirmation } from '../utils/launchDialog.js';
 import { createTabbedWorkspacePresenter } from '../utils/createTabbedWorkspacePresenter.js';
 
@@ -19,17 +19,9 @@ const INITIAL_STATE = {
 const formatCurrency = amount =>
   baseFormatCurrency(amount, { precision: 'integer', clampZero: true });
 
-const { describeSetupSummary, describeUpkeepSummary } = createLifecycleSummary({
-  parseValue: value => {
-    const numeric = Number(value);
-    return Number.isFinite(numeric) ? numeric : 0;
-  },
-  formatSetupHours: hours => `${formatHours(hours)} per day`,
-  formatUpkeepHours: hours => `${formatHours(hours)} per day`,
-  formatSetupCost: cost => `$${formatMoney(cost)} upfront`,
-  formatUpkeepCost: cost => `$${formatMoney(cost)} per day`,
-  setupFallback: 'Instant launch',
-  upkeepFallback: 'No upkeep required'
+const { describeSetupSummary, describeUpkeepSummary } = createCurrencyLifecycleSummary({
+  formatCurrency: value => `$${formatMoney(value)}`,
+  formatDailyHours: hours => `${formatHours(hours)} per day`
 });
 
 function confirmBlogLaunch(definition = {}) {

--- a/src/ui/views/browser/components/digishelf/index.js
+++ b/src/ui/views/browser/components/digishelf/index.js
@@ -5,7 +5,7 @@ import {
 } from '../../../../cards/model/digishelf.js';
 import { performQualityAction } from '../../../../../game/assets/index.js';
 import { formatCurrency as baseFormatCurrency } from '../../utils/formatting.js';
-import { createLifecycleSummary } from '../../utils/lifecycleSummaries.js';
+import { createCurrencyLifecycleSummary } from '../../utils/lifecycleSummaries.js';
 import { showLaunchConfirmation } from '../../utils/launchDialog.js';
 import { createTabbedWorkspacePresenter } from '../../utils/createTabbedWorkspacePresenter.js';
 import {
@@ -41,14 +41,10 @@ const formatCurrency = amount =>
   baseFormatCurrency(amount, { precision: 'integer', clampZero: true });
 
 const { describeSetupSummary: describeLaunchSetup, describeUpkeepSummary: describeLaunchUpkeep } =
-  createLifecycleSummary({
+  createCurrencyLifecycleSummary({
     parseValue: clampNumber,
-    formatSetupHours: hours => `${formatHours(hours)} per day`,
-    formatUpkeepHours: hours => `${formatHours(hours)} per day`,
-    formatSetupCost: cost => `$${formatMoney(cost)} upfront`,
-    formatUpkeepCost: cost => `$${formatMoney(cost)} per day`,
-    setupFallback: 'Instant launch',
-    upkeepFallback: 'No upkeep required'
+    formatCurrency: value => `$${formatMoney(value)}`,
+    formatDailyHours: hours => `${formatHours(hours)} per day`
   });
 
 function confirmResourceLaunch(definition = {}) {

--- a/src/ui/views/browser/components/serverhub.js
+++ b/src/ui/views/browser/components/serverhub.js
@@ -6,7 +6,7 @@ import {
   formatNetCurrency as baseFormatNetCurrency,
   formatPercent as baseFormatPercent
 } from '../utils/formatting.js';
-import { createLifecycleSummary } from '../utils/lifecycleSummaries.js';
+import { createCurrencyLifecycleSummary } from '../utils/lifecycleSummaries.js';
 import { showLaunchConfirmation } from '../utils/launchDialog.js';
 import { createWorkspacePresenter } from '../utils/workspacePresenter.js';
 
@@ -41,17 +41,12 @@ const presenter = createWorkspacePresenter({
 });
 
 const { describeSetupSummary: formatSetupSummary, describeUpkeepSummary: formatUpkeepSummary } =
-  createLifecycleSummary({
-    parseValue: value => {
-      const numeric = Number(value);
-      return Number.isFinite(numeric) ? numeric : 0;
-    },
-    formatSetupHours: hours => `${formatHours(hours)} per day`,
-    formatUpkeepHours: hours => `${formatHours(hours)} per day`,
-    formatSetupCost: cost => `${formatCurrency(cost)} upfront`,
-    formatUpkeepCost: cost => `${formatCurrency(cost)} per day`,
-    setupFallback: 'Instant setup',
-    upkeepFallback: 'No upkeep required'
+  createCurrencyLifecycleSummary({
+    formatCurrency,
+    formatDailyHours: hours => `${formatHours(hours)} per day`,
+    copy: {
+      setupFallback: 'Instant setup'
+    }
   });
 
 function confirmLaunchWithDetails(definition = {}) {


### PR DESCRIPTION
## Summary
- add a currency lifecycle summary preset that shares numeric formatting and exposes copy overrides
- switch BlogPress, DigiShelf, and ServerHub to the preset for consistent launch messaging
- adopt the preset in Shopily pricing plans to reuse lifecycle wording without duplicating helpers

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68e04768b4e0832c8d3721c48aac8f4b