### PR TITLE
Expose view helper exports for Shopily and BlogPress

### DIFF
--- a/src/ui/views/browser/components/blogpress.js
+++ b/src/ui/views/browser/components/blogpress.js
@@ -7,6 +7,10 @@ import { showLaunchConfirmation } from '../utils/launchDialog.js';
 import { createTabbedWorkspacePresenter } from '../utils/createTabbedWorkspacePresenter.js';
 import { createNavTabs } from './common/navBuilders.js';
 import { renderWorkspaceLock } from './common/renderWorkspaceLock.js';
+import renderHomeView from './blogpress/views/homeView.js';
+import renderDetailView from './blogpress/views/detailView.js';
+import renderPricingView from './blogpress/views/pricingView.js';
+import renderBlueprintsView from './blogpress/views/blueprintsView.js';
 
 const VIEW_HOME = 'home';
 const VIEW_DETAIL = 'detail';
@@ -18,8 +22,7 @@ const INITIAL_STATE = {
   selectedBlogId: null
 };
 
-const formatCurrency = amount =>
-  baseFormatCurrency(amount, { precision: 'integer', clampZero: true });
+const formatCurrency = amount => baseFormatCurrency(amount, { precision: 'integer', clampZero: true });
 
 const { describeSetupSummary, describeUpkeepSummary } = createCurrencyLifecycleSummary({
   formatCurrency: value => `$${formatMoney(value)}`,
@@ -72,20 +75,6 @@ function ensureSelectedBlog(state = {}, model = {}) {
   draftState.selectedBlogId = resolved?.id ?? null;
 }
 
-function setView(view, options = {}) {
-  presenter.updateState(currentState => {
-    const next = { ...currentState };
-    const nextView = view || VIEW_HOME;
-    if (nextView === VIEW_DETAIL && options.blogId) {
-      next.selectedBlogId = options.blogId;
-    }
-    next.view = nextView;
-    ensureSelectedBlog(next, presenter.getModel());
-    return next;
-  });
-  presenter.render(presenter.getModel());
-}
-
 function handleQuickAction(instanceId, actionId) {
   if (!instanceId || !actionId) return;
   performQualityAction('blog', instanceId, actionId);
@@ -94,6 +83,16 @@ function handleQuickAction(instanceId, actionId) {
 function handleNicheSelect(instanceId, value) {
   if (!instanceId) return;
   selectBlogpressNiche('blog', instanceId, value);
+}
+
+async function handleBlueprintLaunch(model, launch = {}) {
+  if (!launch.onClick) return;
+  const confirmed = await confirmBlogLaunch(model.definition);
+  if (!confirmed) {
+    return;
+  }
+  launch.onClick();
+  setView(VIEW_HOME);
 }
 
 function renderHeader(model, state = INITIAL_STATE) {
@@ -116,13 +115,13 @@ function renderHeader(model, state = INITIAL_STATE) {
     badgeClassName: 'blogpress-tab__badge',
     datasetKey: 'view',
     withAriaPressed: true,
-    onSelect: setView,
+    onSelect: view => setView(view),
     buttons: [
       {
         label: 'My Blogs',
         view: VIEW_HOME,
         badge: activeCount || null,
-        isActive: state.view === VIEW_HOME
+        isActive: state.view === VIEW_HOME || state.view === VIEW_DETAIL
       },
       {
         label: 'Pricing',
@@ -159,736 +158,68 @@ function renderHeader(model, state = INITIAL_STATE) {
   return header;
 }
 
-function renderSummaryBar(model) {
-  const summary = document.createElement('div');
-  summary.className = 'blogpress-summary';
-  const total = model.summary?.total || 0;
-  const active = model.summary?.active || 0;
-  const needsUpkeep = model.summary?.needsUpkeep || 0;
-  const summaryItems = [
-    `${active} active`,
-    `${total} total`,
-    needsUpkeep > 0 ? `${needsUpkeep} need upkeep` : 'Upkeep funded'
-  ];
-  summary.textContent = summaryItems.join(' • ');
-  return summary;
-}
+function renderViews(model, state = INITIAL_STATE) {
+  const formatters = {
+    formatCurrency,
+    formatHours,
+    formatMoney,
+    formatNetCurrency
+  };
 
-function createTableCell(content, className) {
-  const cell = document.createElement('td');
-  if (className) {
-    cell.className = className;
-  }
-  if (content instanceof Node) {
-    cell.appendChild(content);
-  } else {
-    cell.textContent = content;
-  }
-  return cell;
-}
-
-function renderHomeView(model, state = INITIAL_STATE) {
-  const container = document.createElement('section');
-  container.className = 'blogpress-view blogpress-view--home';
-
-  container.appendChild(renderSummaryBar(model));
-
-  const instances = Array.isArray(model.instances) ? model.instances : [];
-  if (!instances.length) {
-    const empty = document.createElement('div');
-    empty.className = 'blogpress-empty';
-    const message = document.createElement('p');
-    message.textContent = 'No blogs live yet. Launch a blueprint to start earning cozy ad pennies.';
-    const cta = document.createElement('button');
-    cta.type = 'button';
-    cta.className = 'blogpress-button blogpress-button--primary';
-    cta.textContent = 'Launch first blog';
-    cta.addEventListener('click', () => setView(VIEW_BLUEPRINTS));
-    empty.append(message, cta);
-    container.appendChild(empty);
-    return container;
-  }
-
-  const table = document.createElement('table');
-  table.className = 'blogpress-table';
-  const thead = document.createElement('thead');
-  const headRow = document.createElement('tr');
-  ['Blog', 'Niche', 'Status', 'Latest payout', 'Upkeep', 'Quality', 'Quick action'].forEach(label => {
-    const th = document.createElement('th');
-    th.textContent = label;
-    headRow.appendChild(th);
-  });
-  thead.appendChild(headRow);
-  table.appendChild(thead);
-
-  const tbody = document.createElement('tbody');
-  instances.forEach(instance => {
-    const row = document.createElement('tr');
-    row.dataset.blogId = instance.id;
-    if (instance.id === state.selectedBlogId) {
-      row.classList.add('is-selected');
-    }
-
-    const nameButton = document.createElement('button');
-    nameButton.type = 'button';
-    nameButton.className = 'blogpress-table__link';
-    nameButton.textContent = instance.label;
-    nameButton.addEventListener('click', () => setView(VIEW_DETAIL, { blogId: instance.id }));
-    row.appendChild(createTableCell(nameButton, 'blogpress-table__cell blogpress-table__cell--label'));
-
-    const niche = instance.niche;
-    const nicheCell = document.createElement('div');
-    nicheCell.className = 'blogpress-niche';
-    const nicheName = document.createElement('span');
-    nicheName.className = 'blogpress-niche__name';
-    nicheName.textContent = niche?.name || 'Unassigned';
-    nicheCell.appendChild(nicheName);
-    if (niche?.label) {
-      const tone = (niche.label || 'steady').toLowerCase().replace(/[^a-z0-9]+/g, '-');
-      const badge = document.createElement('span');
-      badge.className = `blogpress-badge blogpress-badge--tone-${tone}`;
-      badge.textContent = niche.label;
-      nicheCell.appendChild(badge);
-    }
-    row.appendChild(createTableCell(nicheCell));
-
-    const status = document.createElement('span');
-    status.className = `blogpress-status blogpress-status--${instance.status?.id || 'setup'}`;
-    status.textContent = instance.status?.label || 'Setup';
-    row.appendChild(createTableCell(status));
-
-    const payoutCell = document.createElement('div');
-    payoutCell.className = 'blogpress-payout';
-    const latest = document.createElement('strong');
-    latest.textContent = instance.latestPayout > 0 ? formatCurrency(instance.latestPayout) : '—';
-    const average = document.createElement('span');
-    average.textContent = instance.averagePayout > 0
-      ? `Avg ${formatCurrency(instance.averagePayout)}`
-      : instance.status?.id === 'active'
-        ? 'No earnings yet'
-        : 'Launch pending';
-    payoutCell.append(latest, average);
-    row.appendChild(createTableCell(payoutCell));
-
-    const upkeep = document.createElement('span');
-    const parts = [];
-    const maintenanceHours = instance.maintenance?.parts?.find(part => part.includes('h'));
-    if (maintenanceHours) parts.push(maintenanceHours);
-    const maintenanceCost = instance.maintenance?.parts?.find(part => part.includes('$'));
-    if (maintenanceCost) parts.push(maintenanceCost);
-    upkeep.textContent = parts.length ? parts.join(' • ') : 'None';
-    row.appendChild(createTableCell(upkeep));
-
-    const qualityCell = document.createElement('div');
-    qualityCell.className = 'blogpress-quality';
-    const levelBadge = document.createElement('span');
-    levelBadge.className = 'blogpress-quality__level';
-    levelBadge.textContent = `Q${instance.qualityLevel}`;
-    const levelLabel = document.createElement('span');
-    levelLabel.className = 'blogpress-quality__label';
-    levelLabel.textContent = instance.qualityInfo?.name || 'Skeleton Drafts';
-    qualityCell.append(levelBadge, levelLabel);
-    row.appendChild(createTableCell(qualityCell));
-
-    const actionCell = document.createElement('div');
-    actionCell.className = 'blogpress-table__actions';
-    if (instance.quickAction) {
-      const quick = instance.quickAction;
-      const button = document.createElement('button');
-      button.type = 'button';
-      button.className = 'blogpress-button blogpress-button--ghost';
-      button.textContent = quick.label;
-      button.disabled = !quick.available;
-      if (quick.disabledReason) {
-        button.title = quick.disabledReason;
-      }
-      button.addEventListener('click', event => {
-        event.stopPropagation();
-        if (button.disabled) return;
-        handleQuickAction(instance.id, quick.id);
-      });
-      const effort = document.createElement('span');
-      effort.className = 'blogpress-table__meta';
-      const partsMeta = [];
-      if (quick.time > 0) partsMeta.push(formatHours(quick.time));
-      if (quick.cost > 0) partsMeta.push(formatCurrency(quick.cost));
-      effort.textContent = partsMeta.length ? partsMeta.join(' • ') : 'Instant';
-      actionCell.append(button, effort);
-    } else {
-      const none = document.createElement('span');
-      none.className = 'blogpress-table__meta';
-      none.textContent = 'No actions unlocked yet';
-      actionCell.appendChild(none);
-    }
-    row.appendChild(createTableCell(actionCell, 'blogpress-table__cell blogpress-table__cell--actions'));
-
-    tbody.appendChild(row);
-  });
-
-  table.appendChild(tbody);
-  container.appendChild(table);
-  return container;
-}
-
-function createBackButton(label = 'Back to blogs') {
-  const button = document.createElement('button');
-  button.type = 'button';
-  button.className = 'blogpress-button blogpress-button--link';
-  button.textContent = label;
-  button.addEventListener('click', () => setView(VIEW_HOME));
-  return button;
-}
-
-function renderOverviewPanel(instance) {
-  const panel = document.createElement('article');
-  panel.className = 'blogpress-panel blogpress-panel--overview';
-
-  const title = document.createElement('h2');
-  title.textContent = instance.label;
-  panel.appendChild(title);
-
-  const badge = document.createElement('span');
-  badge.className = `blogpress-badge blogpress-badge--${instance.status?.id || 'setup'}`;
-  badge.textContent = instance.status?.label || 'Setup';
-  panel.appendChild(badge);
-
-  const list = document.createElement('dl');
-  list.className = 'blogpress-stats';
-
-  const stats = [
-    { label: 'Lifetime income', value: formatCurrency(instance.lifetimeIncome) },
-    { label: 'Estimated spend', value: formatCurrency(instance.estimatedSpend) },
-    {
-      label: 'Yesterday payout',
-      value: instance.latestPayout > 0 ? formatCurrency(instance.latestPayout) : '—'
-    },
-    {
-      label: 'Average / day',
-      value: instance.averagePayout > 0 ? formatCurrency(instance.averagePayout) : 'No earnings yet'
-    },
-    {
-      label: 'Pending payout',
-      value: instance.pendingIncome > 0 ? formatCurrency(instance.pendingIncome) : 'None in queue'
-    }
-  ];
-
-  stats.forEach(entry => {
-    const dt = document.createElement('dt');
-    dt.textContent = entry.label;
-    const dd = document.createElement('dd');
-    dd.textContent = entry.value;
-    list.append(dt, dd);
-  });
-
-  panel.appendChild(list);
-  return panel;
-}
-
-function renderNichePanel(instance) {
-  const panel = document.createElement('article');
-  panel.className = 'blogpress-panel blogpress-panel--niche';
-
-  const title = document.createElement('h3');
-  title.textContent = 'Audience niche';
-  panel.appendChild(title);
-
-  const current = document.createElement('p');
-  current.className = 'blogpress-panel__lead';
-  current.textContent = instance.niche?.name || 'Unassigned — pick a specialty once and lock it in.';
-  panel.appendChild(current);
-
-  if (instance.niche?.summary) {
-    const summary = document.createElement('p');
-    summary.className = 'blogpress-panel__note';
-    summary.textContent = instance.niche.summary;
-    panel.appendChild(summary);
-  }
-
-  if (!instance.nicheLocked) {
-    const field = document.createElement('label');
-    field.className = 'blogpress-field';
-    field.textContent = 'Choose niche';
-
-    const select = document.createElement('select');
-    select.className = 'blogpress-select';
-    const placeholder = document.createElement('option');
-    placeholder.value = '';
-    placeholder.textContent = 'Select a niche';
-    select.appendChild(placeholder);
-    instance.nicheOptions.forEach(option => {
-      const opt = document.createElement('option');
-      opt.value = option.id;
-      opt.textContent = option.label
-        ? `${option.name} (${option.label})`
-        : option.name;
-      select.appendChild(opt);
-    });
-    select.addEventListener('change', () => {
-      handleNicheSelect(instance.id, select.value);
-      setView(VIEW_DETAIL, { blogId: instance.id });
-    });
-    field.appendChild(select);
-    const hint = document.createElement('p');
-    hint.className = 'blogpress-panel__hint';
-    hint.textContent = 'Niches lock after selection, so pick the trend that feels dreamy.';
-    panel.append(field, hint);
-  } else {
-    const locked = document.createElement('p');
-    locked.className = 'blogpress-panel__hint';
-    locked.textContent = 'Niche locked — ride the trend or pair with boosts to pivot later.';
-    panel.appendChild(locked);
-  }
-
-  return panel;
-}
-
-function renderQualityPanel(instance) {
-  const panel = document.createElement('article');
-  panel.className = 'blogpress-panel blogpress-panel--quality';
-
-  const header = document.createElement('div');
-  header.className = 'blogpress-panel__header';
-  const title = document.createElement('h3');
-  title.textContent = `Quality ${instance.qualityLevel} — ${instance.qualityInfo?.name || 'Skeleton Drafts'}`;
-  header.appendChild(title);
-  panel.appendChild(header);
-
-  if (instance.qualityInfo?.description) {
-    const description = document.createElement('p');
-    description.className = 'blogpress-panel__note';
-    description.textContent = instance.qualityInfo.description;
-    panel.appendChild(description);
-  }
-
-  const progress = document.createElement('div');
-  progress.className = 'blogpress-progress';
-  const fill = document.createElement('div');
-  fill.className = 'blogpress-progress__fill';
-  fill.style.width = `${Math.round((instance.milestone.percent || 0) * 100)}%`;
-  progress.appendChild(fill);
-  panel.appendChild(progress);
-
-  if (instance.milestone.nextLevel) {
-    const milestone = document.createElement('p');
-    milestone.className = 'blogpress-panel__note';
-    milestone.textContent = `Next milestone: Quality ${instance.milestone.nextLevel.level} — ${instance.milestone.nextLevel.name}. ${instance.milestone.nextLevel.description || ''}`;
-    panel.appendChild(milestone);
-  } else {
-    const milestone = document.createElement('p');
-    milestone.className = 'blogpress-panel__note';
-    milestone.textContent = 'Top tier unlocked — this blog is shining bright!';
-    panel.appendChild(milestone);
-  }
-
-  const summary = document.createElement('p');
-  summary.className = 'blogpress-panel__hint';
-  summary.textContent = instance.milestone.summary;
-  panel.appendChild(summary);
-
-  const range = document.createElement('p');
-  range.className = 'blogpress-panel__range';
-  range.textContent = `Daily range at this tier: ${formatRange(instance.qualityRange)}`;
-  panel.appendChild(range);
-
-  return panel;
-}
-
-function renderIncomePanel(instance) {
-  const panel = document.createElement('article');
-  panel.className = 'blogpress-panel blogpress-panel--income';
-
-  const title = document.createElement('h3');
-  title.textContent = 'Income recap';
-  panel.appendChild(title);
-
-  const stats = document.createElement('dl');
-  stats.className = 'blogpress-stats';
-
-  const entries = [
-    {
-      label: 'Daily average',
-      value:
-        instance.averagePayout > 0
-          ? formatCurrency(instance.averagePayout)
-          : instance.status?.id === 'active'
-            ? 'No earnings yet'
-            : 'Launch pending'
-    },
-    {
-      label: 'Latest payout',
-      value: instance.latestPayout > 0 ? formatCurrency(instance.latestPayout) : '—'
-    },
-    {
-      label: 'Lifetime income',
-      value: formatCurrency(instance.lifetimeIncome)
-    },
-    {
-      label: 'Lifetime spend',
-      value: formatCurrency(instance.estimatedSpend)
-    },
-    {
-      label: 'Lifetime net',
-      value: formatNetCurrency(instance.lifetimeNet || 0, { precision: 'integer', zeroDisplay: '$0' })
-    },
-    {
-      label: 'Pending payout',
-      value: instance.pendingIncome > 0 ? formatCurrency(instance.pendingIncome) : 'No payout queued'
-    }
-  ];
-
-  if (instance.daysActive > 0) {
-    const daysLabel = instance.daysActive === 1 ? '1 day' : `${instance.daysActive} days`;
-    entries.push({ label: 'Days live', value: daysLabel });
-  }
-
-  entries.forEach(entry => {
-    const dt = document.createElement('dt');
-    dt.textContent = entry.label;
-    const dd = document.createElement('dd');
-    dd.textContent = entry.value;
-    stats.append(dt, dd);
-  });
-
-  panel.appendChild(stats);
-
-  const upkeepMessage = document.createElement('p');
-  const upkeepParts = instance.maintenance?.parts || [];
-  const upkeepSummary = upkeepParts.length ? upkeepParts.join(' • ') : 'No upkeep';
-  if (instance.status?.id === 'active') {
-    if (instance.maintenanceFunded) {
-      upkeepMessage.className = 'blogpress-panel__hint';
-      upkeepMessage.textContent = `Upkeep covered today (${upkeepSummary}). Expect the payout at day end.`;
-    } else {
-      upkeepMessage.className = 'blogpress-panel__warning';
-      upkeepMessage.textContent = `Upkeep still due (${upkeepSummary}). Fund hours or cash to restart payouts.`;
-    }
-  } else {
-    upkeepMessage.className = 'blogpress-panel__hint';
-    upkeepMessage.textContent = 'Income tracking begins once launch prep wraps.';
-  }
-  panel.appendChild(upkeepMessage);
-
-  return panel;
-}
-
-function renderPayoutPanel(instance) {
-  const panel = document.createElement('article');
-  panel.className = 'blogpress-panel blogpress-panel--payout';
-  const title = document.createElement('h3');
-  title.textContent = 'Payout recap';
-  panel.appendChild(title);
-
-  const total = document.createElement('p');
-  total.className = 'blogpress-panel__lead';
-  total.textContent = instance.latestPayout > 0
-    ? `Latest payout: ${formatCurrency(instance.latestPayout)}`
-    : 'No payout logged yesterday.';
-  panel.appendChild(total);
-
-  if (instance.payoutBreakdown.entries.length) {
-    const list = document.createElement('ul');
-    list.className = 'blogpress-list';
-    instance.payoutBreakdown.entries.forEach(entry => {
-      const item = document.createElement('li');
-      item.className = 'blogpress-list__item';
-      const label = document.createElement('span');
-      label.className = 'blogpress-list__label';
-      label.textContent = entry.label;
-      const value = document.createElement('span');
-      value.className = 'blogpress-list__value';
-      const amount = Number(entry.amount) || 0;
-      value.textContent = amount >= 0 ? `+${formatCurrency(amount)}` : `−${formatCurrency(Math.abs(amount))}`;
-      item.append(label, value);
-      list.appendChild(item);
-    });
-    panel.appendChild(list);
-  } else {
-    const empty = document.createElement('p');
-    empty.className = 'blogpress-panel__hint';
-    empty.textContent = 'Run quick actions and fund upkeep to unlock modifier breakdowns.';
-    panel.appendChild(empty);
-  }
-
-  return panel;
-}
-
-function renderActionPanel(instance) {
-  const panel = document.createElement('article');
-  panel.className = 'blogpress-panel blogpress-panel--actions';
-  const title = document.createElement('h3');
-  title.textContent = 'Upgrade actions';
-  panel.appendChild(title);
-
-  if (!instance.actions.length) {
-    const note = document.createElement('p');
-    note.className = 'blogpress-panel__hint';
-    note.textContent = 'No quality actions unlocked yet. Progress through story beats to reveal them.';
-    panel.appendChild(note);
-    return panel;
-  }
-
-  const list = document.createElement('ul');
-  list.className = 'blogpress-action-list';
-
-  instance.actions.forEach(action => {
-    const item = document.createElement('li');
-    item.className = 'blogpress-action';
-    const label = document.createElement('div');
-    label.className = 'blogpress-action__label';
-    label.textContent = action.label;
-    const meta = document.createElement('span');
-    meta.className = 'blogpress-action__meta';
-    const parts = [];
-    if (action.time > 0) parts.push(formatHours(action.time));
-    if (action.cost > 0) parts.push(formatCurrency(action.cost));
-    meta.textContent = parts.length ? parts.join(' • ') : 'Instant';
-    label.appendChild(meta);
-    item.appendChild(label);
-
-    const button = document.createElement('button');
-    button.type = 'button';
-    button.className = 'blogpress-button blogpress-button--primary';
-    button.textContent = action.available ? 'Run' : 'Locked';
-    button.disabled = !action.available;
-    if (action.disabledReason) {
-      button.title = action.disabledReason;
-    }
-    button.addEventListener('click', () => {
-      if (button.disabled) return;
-      handleQuickAction(instance.id, action.id);
-    });
-    item.appendChild(button);
-
-    list.appendChild(item);
-  });
-
-  panel.appendChild(list);
-  return panel;
-}
-
-function renderUpkeepPanel(instance) {
-  const panel = document.createElement('article');
-  panel.className = 'blogpress-panel blogpress-panel--upkeep';
-  const title = document.createElement('h3');
-  title.textContent = 'Daily upkeep';
-  panel.appendChild(title);
-
-  const upkeepParts = instance.maintenance?.parts || [];
-  const note = document.createElement('p');
-  note.className = 'blogpress-panel__lead';
-  note.textContent = upkeepParts.length ? upkeepParts.join(' • ') : 'No upkeep required';
-  panel.appendChild(note);
-
-  if (instance.status?.id === 'active' && !instance.maintenanceFunded) {
-    const warning = document.createElement('p');
-    warning.className = 'blogpress-panel__warning';
-    warning.textContent = 'Upkeep missed today — fund it to unlock tomorrow’s payout.';
-    panel.appendChild(warning);
-  } else {
-    const hint = document.createElement('p');
-    hint.className = 'blogpress-panel__hint';
-    hint.textContent = 'Keep hours and cash funded to secure the next payday.';
-    panel.appendChild(hint);
-  }
-
-  return panel;
-}
-
-function renderDetailView(model, state = INITIAL_STATE) {
-  const instance = model.instances.find(entry => entry.id === state.selectedBlogId);
-  if (!instance) {
-    return renderHomeView(model, state);
-  }
-
-  const container = document.createElement('section');
-  container.className = 'blogpress-view blogpress-view--detail';
-
-  const back = createBackButton();
-  container.appendChild(back);
-  container.appendChild(renderOverviewPanel(instance));
-
-  const grid = document.createElement('div');
-  grid.className = 'blogpress-detail-grid';
-  grid.append(
-    renderNichePanel(instance),
-    renderQualityPanel(instance),
-    renderIncomePanel(instance),
-    renderPayoutPanel(instance),
-    renderActionPanel(instance),
-    renderUpkeepPanel(instance)
-  );
-  container.appendChild(grid);
-
-  return container;
-}
-
-function renderPricingView(model) {
-  const pricing = model.pricing || {};
-  const container = document.createElement('section');
-  container.className = 'blogpress-view blogpress-view--pricing';
-
-  const intro = document.createElement('div');
-  intro.className = 'blogpress-pricing__intro';
-  const title = document.createElement('h2');
-  title.textContent = 'BlogPress pricing & growth map';
-  const lead = document.createElement('p');
-  const setup = pricing.setup || {};
-  const maintenance = pricing.maintenance || {};
-  lead.textContent = `Blueprint: ${setup.days || 0} day${setup.days === 1 ? '' : 's'} × ${formatHours(setup.hoursPerDay || 0)} ($${formatMoney(setup.cost || 0)}) • Daily upkeep ${formatHours(maintenance.hours || 0)} • $${formatMoney(maintenance.cost || 0)}`;
-  intro.append(title, lead);
-  container.appendChild(intro);
-
-  const grid = document.createElement('div');
-  grid.className = 'blogpress-pricing__grid';
-  pricing.levels?.forEach(level => {
-    const card = document.createElement('article');
-    card.className = 'blogpress-plan';
-    const heading = document.createElement('h3');
-    heading.textContent = `Quality ${level.level} — ${level.name}`;
-    const range = document.createElement('p');
-    range.className = 'blogpress-plan__range';
-    range.textContent = `Income: ${formatRange(level.income)}`;
-    const description = document.createElement('p');
-    description.textContent = level.description || '';
-    card.append(heading, range, description);
-    grid.appendChild(card);
-  });
-  container.appendChild(grid);
-
-  const nicheBlock = document.createElement('section');
-  nicheBlock.className = 'blogpress-pricing__section';
-  const nicheTitle = document.createElement('h3');
-  nicheTitle.textContent = 'Niche heat map';
-  const nicheNote = document.createElement('p');
-  const topNiches = pricing.topNiches || [];
-  nicheNote.textContent = topNiches.length
-    ? `Top picks today: ${topNiches.map(entry => `${entry.name} (${entry.label || 'steady'})`).join(', ')}.`
-    : 'Niche intel unlocks once blueprints are live.';
-  nicheBlock.append(nicheTitle, nicheNote);
-  const nicheHint = document.createElement('p');
-  nicheHint.className = 'blogpress-panel__hint';
-  nicheHint.textContent = 'Pick once per blog — a locked niche hugs its trend multiplier for life.';
-  nicheBlock.appendChild(nicheHint);
-  container.appendChild(nicheBlock);
-
-  const actionBlock = document.createElement('section');
-  actionBlock.className = 'blogpress-pricing__section';
-  const actionTitle = document.createElement('h3');
-  actionTitle.textContent = 'Quality action lineup';
-  actionBlock.appendChild(actionTitle);
-  const actionList = document.createElement('ul');
-  actionList.className = 'blogpress-list';
-  pricing.actions?.forEach(action => {
-    const item = document.createElement('li');
-    item.className = 'blogpress-list__item';
-    const label = document.createElement('span');
-    label.className = 'blogpress-list__label';
-    label.textContent = action.label;
-    const value = document.createElement('span');
-    value.className = 'blogpress-list__value';
-    const parts = [];
-    if (action.time > 0) parts.push(formatHours(action.time));
-    if (action.cost > 0) parts.push(formatCurrency(action.cost));
-    value.textContent = parts.length ? parts.join(' • ') : 'Instant';
-    item.append(label, value);
-    actionList.appendChild(item);
-  });
-  actionBlock.appendChild(actionList);
-  container.appendChild(actionBlock);
-
-  const upgradeBlock = document.createElement('section');
-  upgradeBlock.className = 'blogpress-pricing__section';
-  const upgradeTitle = document.createElement('h3');
-  upgradeTitle.textContent = 'Upgrade boosts';
-  upgradeBlock.appendChild(upgradeTitle);
-  const upgradeList = document.createElement('ul');
-  upgradeList.className = 'blogpress-list';
-  if (pricing.upgrades?.length) {
-    pricing.upgrades.forEach(upgrade => {
-      const item = document.createElement('li');
-      item.className = 'blogpress-list__item';
-      const label = document.createElement('span');
-      label.className = 'blogpress-list__label';
-      label.textContent = upgrade.name;
-      const value = document.createElement('span');
-      value.className = 'blogpress-list__value';
-      value.textContent = `${formatCurrency(upgrade.cost)} • ${upgrade.description}`;
-      item.append(label, value);
-      upgradeList.appendChild(item);
-    });
-  } else {
-    const item = document.createElement('li');
-    item.className = 'blogpress-list__item';
-    item.textContent = 'Upgrades unlock once your first blog goes live.';
-    upgradeList.appendChild(item);
-  }
-  upgradeBlock.appendChild(upgradeList);
-  container.appendChild(upgradeBlock);
-
-  return container;
-}
-
-function renderBlueprintView(model) {
-  const container = document.createElement('section');
-  container.className = 'blogpress-view blogpress-view--blueprint';
-
-  const card = document.createElement('article');
-  card.className = 'blogpress-blueprint';
-  const title = document.createElement('h2');
-  title.textContent = 'Spin up a new blog';
-  const summary = document.createElement('p');
-  const setup = model.pricing?.setup || {};
-  summary.textContent = `${setup.days || 0} day blueprint • ${formatHours(setup.hoursPerDay || 0)} focus per day • $${formatMoney(setup.cost || 0)} upfront.`;
-  card.append(title, summary);
-
-  const launch = model.launch || {};
-  if (launch.availability?.reasons?.length) {
-    const list = document.createElement('ul');
-    list.className = 'blogpress-requirements';
-    launch.availability.reasons.forEach(reason => {
-      const item = document.createElement('li');
-      item.textContent = reason;
-      list.appendChild(item);
-    });
-    card.appendChild(list);
-  }
-
-  const button = document.createElement('button');
-  button.type = 'button';
-  button.className = 'blogpress-button blogpress-button--primary';
-  button.textContent = launch.label || 'Launch blog';
-  button.disabled = launch.disabled || launch.availability?.disabled;
-  button.addEventListener('click', async () => {
-    if (button.disabled) return;
-    const confirmed = await confirmBlogLaunch(model.definition);
-    if (!confirmed) {
-      return;
-    }
-    launch.onClick?.();
-    setView(VIEW_HOME);
-  });
-  card.appendChild(button);
-
-  const hint = document.createElement('p');
-  hint.className = 'blogpress-panel__hint';
-  hint.textContent = 'Reminder: niches lock after launch, so browse the heat map before committing!';
-  card.appendChild(hint);
-
-  container.appendChild(card);
-  return container;
-}
-
-function renderCurrentView(model, state = INITIAL_STATE) {
   switch (state.view) {
     case VIEW_PRICING:
-      return renderPricingView(model);
+      return renderPricingView({
+        pricing: model.pricing,
+        formatters,
+        formatRange
+      });
     case VIEW_BLUEPRINTS:
-      return renderBlueprintView(model);
-    case VIEW_DETAIL:
-      return renderDetailView(model, state);
+      return renderBlueprintsView({
+        launch: model.launch,
+        pricing: model.pricing,
+        formatters,
+        onLaunch: launchData => handleBlueprintLaunch(model, launchData)
+      });
+    case VIEW_DETAIL: {
+      const instance = Array.isArray(model.instances)
+        ? model.instances.find(entry => entry.id === state.selectedBlogId)
+        : null;
+      if (!instance) {
+        return renderHomeView({
+          model,
+          state,
+          formatters,
+          handlers: {
+            onViewDetail: blogId => setView(VIEW_DETAIL, { blogId }),
+            onShowBlueprints: () => setView(VIEW_BLUEPRINTS),
+            onRunQuickAction: handleQuickAction
+          }
+        });
+      }
+      return renderDetailView({
+        instance,
+        formatters,
+        formatRange,
+        handlers: {
+          onBack: () => setView(VIEW_HOME),
+          onSelectNiche: handleNicheSelect,
+          onViewDetail: blogId => setView(VIEW_DETAIL, { blogId }),
+          onRunAction: (blogId, actionId) => handleQuickAction(blogId, actionId)
+        }
+      });
+    }
     case VIEW_HOME:
     default:
-      return renderHomeView(model, state);
+      return renderHomeView({
+        model,
+        state,
+        formatters,
+        handlers: {
+          onViewDetail: blogId => setView(VIEW_DETAIL, { blogId }),
+          onShowBlueprints: () => setView(VIEW_BLUEPRINTS),
+          onRunQuickAction: handleQuickAction
+        }
+      });
   }
 }
 
@@ -946,12 +277,25 @@ const presenter = createTabbedWorkspacePresenter({
   ensureSelection: ensureSelectedBlog,
   renderLocked: renderLockedWorkspace,
   renderHeader,
-  renderViews: renderCurrentView,
+  renderViews,
   deriveSummary: deriveWorkspaceSummary,
   derivePath: deriveWorkspacePath,
   syncNavigation,
   isLocked: model => !model?.definition
 });
+
+function setView(view, options = {}) {
+  presenter.updateState(currentState => {
+    const next = { ...currentState };
+    const nextView = view || VIEW_HOME;
+    if (nextView === VIEW_DETAIL && options.blogId) {
+      next.selectedBlogId = options.blogId;
+    }
+    next.view = nextView;
+    return next;
+  });
+  presenter.render(presenter.getModel());
+}
 
 export function render(model = {}, context = {}) {
   return presenter.render(model, context);

--- a/src/ui/views/browser/components/blogpress/views/blueprintsView.js
+++ b/src/ui/views/browser/components/blogpress/views/blueprintsView.js
@@ -1,0 +1,53 @@
+export default function renderBlueprintsView(options = {}) {
+  const {
+    launch = {},
+    pricing = {},
+    formatters = {},
+    onLaunch = () => {}
+  } = options;
+
+  const formatHours = formatters.formatHours || (value => String(value ?? ''));
+  const formatMoney = formatters.formatMoney || (value => String(value ?? ''));
+
+  const container = document.createElement('section');
+  container.className = 'blogpress-view blogpress-view--blueprint';
+
+  const card = document.createElement('article');
+  card.className = 'blogpress-blueprint';
+  const title = document.createElement('h2');
+  title.textContent = 'Spin up a new blog';
+  const summary = document.createElement('p');
+  const setup = pricing.setup || {};
+  summary.textContent = `${setup.days || 0} day blueprint • ${formatHours(setup.hoursPerDay || 0)} focus per day • $${formatMoney(setup.cost || 0)} upfront.`;
+  card.append(title, summary);
+
+  if (launch.availability?.reasons?.length) {
+    const list = document.createElement('ul');
+    list.className = 'blogpress-requirements';
+    launch.availability.reasons.forEach(reason => {
+      const item = document.createElement('li');
+      item.textContent = reason;
+      list.appendChild(item);
+    });
+    card.appendChild(list);
+  }
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'blogpress-button blogpress-button--primary';
+  button.textContent = launch.label || 'Launch blog';
+  button.disabled = Boolean(launch.disabled || launch.availability?.disabled);
+  button.addEventListener('click', () => {
+    if (button.disabled) return;
+    onLaunch(launch);
+  });
+  card.appendChild(button);
+
+  const hint = document.createElement('p');
+  hint.className = 'blogpress-panel__hint';
+  hint.textContent = 'Reminder: niches lock after launch, so browse the heat map before committing!';
+  card.appendChild(hint);
+
+  container.appendChild(card);
+  return container;
+}

--- a/src/ui/views/browser/components/blogpress/views/detailView.js
+++ b/src/ui/views/browser/components/blogpress/views/detailView.js
@@ -1,0 +1,402 @@
+export function createBackButton(onBack = () => {}, label = 'Back to blogs') {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'blogpress-button blogpress-button--link';
+  button.textContent = label;
+  button.addEventListener('click', onBack);
+  return button;
+}
+
+export function renderOverviewPanel(instance, formatCurrency) {
+  const panel = document.createElement('article');
+  panel.className = 'blogpress-panel blogpress-panel--overview';
+
+  const title = document.createElement('h2');
+  title.textContent = instance.label;
+  panel.appendChild(title);
+
+  const badge = document.createElement('span');
+  badge.className = `blogpress-badge blogpress-badge--${instance.status?.id || 'setup'}`;
+  badge.textContent = instance.status?.label || 'Setup';
+  panel.appendChild(badge);
+
+  const list = document.createElement('dl');
+  list.className = 'blogpress-stats';
+
+  const stats = [
+    { label: 'Lifetime income', value: formatCurrency(instance.lifetimeIncome) },
+    { label: 'Estimated spend', value: formatCurrency(instance.estimatedSpend) },
+    {
+      label: 'Yesterday payout',
+      value: instance.latestPayout > 0 ? formatCurrency(instance.latestPayout) : '—'
+    },
+    {
+      label: 'Average / day',
+      value: instance.averagePayout > 0 ? formatCurrency(instance.averagePayout) : 'No earnings yet'
+    },
+    {
+      label: 'Pending payout',
+      value: instance.pendingIncome > 0 ? formatCurrency(instance.pendingIncome) : 'None in queue'
+    }
+  ];
+
+  stats.forEach(entry => {
+    const dt = document.createElement('dt');
+    dt.textContent = entry.label;
+    const dd = document.createElement('dd');
+    dd.textContent = entry.value;
+    list.append(dt, dd);
+  });
+
+  panel.appendChild(list);
+  return panel;
+}
+
+export function renderNichePanel(instance, handlers = {}) {
+  const panel = document.createElement('article');
+  panel.className = 'blogpress-panel blogpress-panel--niche';
+
+  const title = document.createElement('h3');
+  title.textContent = 'Audience niche';
+  panel.appendChild(title);
+
+  const current = document.createElement('p');
+  current.className = 'blogpress-panel__lead';
+  current.textContent = instance.niche?.name || 'Unassigned — pick a specialty once and lock it in.';
+  panel.appendChild(current);
+
+  if (instance.niche?.summary) {
+    const summary = document.createElement('p');
+    summary.className = 'blogpress-panel__note';
+    summary.textContent = instance.niche.summary;
+    panel.appendChild(summary);
+  }
+
+  if (!instance.nicheLocked) {
+    const field = document.createElement('label');
+    field.className = 'blogpress-field';
+    field.textContent = 'Choose niche';
+
+    const select = document.createElement('select');
+    select.className = 'blogpress-select';
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = 'Select a niche';
+    select.appendChild(placeholder);
+    instance.nicheOptions.forEach(option => {
+      const opt = document.createElement('option');
+      opt.value = option.id;
+      opt.textContent = option.label ? `${option.name} (${option.label})` : option.name;
+      select.appendChild(opt);
+    });
+    select.addEventListener('change', () => {
+      if (!select.value) return;
+      if (handlers.onSelectNiche) handlers.onSelectNiche(instance.id, select.value);
+      if (handlers.onViewDetail) handlers.onViewDetail(instance.id);
+    });
+    field.appendChild(select);
+    const hint = document.createElement('p');
+    hint.className = 'blogpress-panel__hint';
+    hint.textContent = 'Niches lock after selection, so pick the trend that feels dreamy.';
+    panel.append(field, hint);
+  } else {
+    const locked = document.createElement('p');
+    locked.className = 'blogpress-panel__hint';
+    locked.textContent = 'Niche locked — ride the trend or pair with boosts to pivot later.';
+    panel.appendChild(locked);
+  }
+
+  return panel;
+}
+
+export function renderQualityPanel(instance, formatRange) {
+  const panel = document.createElement('article');
+  panel.className = 'blogpress-panel blogpress-panel--quality';
+
+  const header = document.createElement('div');
+  header.className = 'blogpress-panel__header';
+  const title = document.createElement('h3');
+  title.textContent = `Quality ${instance.qualityLevel} — ${instance.qualityInfo?.name || 'Skeleton Drafts'}`;
+  header.appendChild(title);
+  panel.appendChild(header);
+
+  if (instance.qualityInfo?.description) {
+    const description = document.createElement('p');
+    description.className = 'blogpress-panel__note';
+    description.textContent = instance.qualityInfo.description;
+    panel.appendChild(description);
+  }
+
+  const progress = document.createElement('div');
+  progress.className = 'blogpress-progress';
+  const fill = document.createElement('div');
+  fill.className = 'blogpress-progress__fill';
+  fill.style.width = `${Math.round((instance.milestone.percent || 0) * 100)}%`;
+  progress.appendChild(fill);
+  panel.appendChild(progress);
+
+  if (instance.milestone.nextLevel) {
+    const milestone = document.createElement('p');
+    milestone.className = 'blogpress-panel__note';
+    milestone.textContent = `Next milestone: Quality ${instance.milestone.nextLevel.level} — ${instance.milestone.nextLevel.name}. ${instance.milestone.nextLevel.description || ''}`;
+    panel.appendChild(milestone);
+  } else {
+    const milestone = document.createElement('p');
+    milestone.className = 'blogpress-panel__note';
+    milestone.textContent = 'Top tier unlocked — this blog is shining bright!';
+    panel.appendChild(milestone);
+  }
+
+  const summary = document.createElement('p');
+  summary.className = 'blogpress-panel__hint';
+  summary.textContent = instance.milestone.summary;
+  panel.appendChild(summary);
+
+  const range = document.createElement('p');
+  range.className = 'blogpress-panel__range';
+  range.textContent = `Daily range at this tier: ${formatRange(instance.qualityRange)}`;
+  panel.appendChild(range);
+
+  return panel;
+}
+
+export function renderIncomePanel(instance, formatCurrency, formatNetCurrency) {
+  const panel = document.createElement('article');
+  panel.className = 'blogpress-panel blogpress-panel--income';
+
+  const title = document.createElement('h3');
+  title.textContent = 'Income recap';
+  panel.appendChild(title);
+
+  const stats = document.createElement('dl');
+  stats.className = 'blogpress-stats';
+
+  const entries = [
+    {
+      label: 'Daily average',
+      value:
+        instance.averagePayout > 0
+          ? formatCurrency(instance.averagePayout)
+          : instance.status?.id === 'active'
+            ? 'No earnings yet'
+            : 'Launch pending'
+    },
+    {
+      label: 'Latest payout',
+      value: instance.latestPayout > 0 ? formatCurrency(instance.latestPayout) : '—'
+    },
+    {
+      label: 'Lifetime income',
+      value: formatCurrency(instance.lifetimeIncome)
+    },
+    {
+      label: 'Lifetime spend',
+      value: formatCurrency(instance.estimatedSpend)
+    },
+    {
+      label: 'Lifetime net',
+      value: formatNetCurrency(instance.lifetimeNet || 0, { precision: 'integer', zeroDisplay: '$0' })
+    },
+    {
+      label: 'Pending payout',
+      value: instance.pendingIncome > 0 ? formatCurrency(instance.pendingIncome) : 'No payout queued'
+    }
+  ];
+
+  if (instance.daysActive > 0) {
+    const daysLabel = instance.daysActive === 1 ? '1 day' : `${instance.daysActive} days`;
+    entries.push({ label: 'Days live', value: daysLabel });
+  }
+
+  entries.forEach(entry => {
+    const dt = document.createElement('dt');
+    dt.textContent = entry.label;
+    const dd = document.createElement('dd');
+    dd.textContent = entry.value;
+    stats.append(dt, dd);
+  });
+
+  panel.appendChild(stats);
+
+  const upkeepMessage = document.createElement('p');
+  const upkeepParts = instance.maintenance?.parts || [];
+  const upkeepSummary = upkeepParts.length ? upkeepParts.join(' • ') : 'No upkeep';
+  if (instance.status?.id === 'active') {
+    if (instance.maintenanceFunded) {
+      upkeepMessage.className = 'blogpress-panel__hint';
+      upkeepMessage.textContent = `Upkeep covered today (${upkeepSummary}). Expect the payout at day end.`;
+    } else {
+      upkeepMessage.className = 'blogpress-panel__warning';
+      upkeepMessage.textContent = `Upkeep still due (${upkeepSummary}). Fund hours or cash to restart payouts.`;
+    }
+  } else {
+    upkeepMessage.className = 'blogpress-panel__hint';
+    upkeepMessage.textContent = 'Income tracking begins once launch prep wraps.';
+  }
+  panel.appendChild(upkeepMessage);
+
+  return panel;
+}
+
+export function renderPayoutPanel(instance, formatCurrency) {
+  const panel = document.createElement('article');
+  panel.className = 'blogpress-panel blogpress-panel--payout';
+  const title = document.createElement('h3');
+  title.textContent = 'Payout recap';
+  panel.appendChild(title);
+
+  const total = document.createElement('p');
+  total.className = 'blogpress-panel__lead';
+  total.textContent = instance.latestPayout > 0
+    ? `Latest payout: ${formatCurrency(instance.latestPayout)}`
+    : 'No payout logged yesterday.';
+  panel.appendChild(total);
+
+  if (instance.payoutBreakdown.entries.length) {
+    const list = document.createElement('ul');
+    list.className = 'blogpress-list';
+    instance.payoutBreakdown.entries.forEach(entry => {
+      const item = document.createElement('li');
+      item.className = 'blogpress-list__item';
+      const label = document.createElement('span');
+      label.className = 'blogpress-list__label';
+      label.textContent = entry.label;
+      const value = document.createElement('span');
+      value.className = 'blogpress-list__value';
+      const amount = Number(entry.amount) || 0;
+      value.textContent = amount >= 0 ? `+${formatCurrency(amount)}` : `−${formatCurrency(Math.abs(amount))}`;
+      item.append(label, value);
+      list.appendChild(item);
+    });
+    panel.appendChild(list);
+  } else {
+    const empty = document.createElement('p');
+    empty.className = 'blogpress-panel__hint';
+    empty.textContent = 'Run quick actions and fund upkeep to unlock modifier breakdowns.';
+    panel.appendChild(empty);
+  }
+
+  return panel;
+}
+
+export function renderActionPanel(instance, handlers = {}, formatHours, formatCurrency) {
+  const panel = document.createElement('article');
+  panel.className = 'blogpress-panel blogpress-panel--actions';
+  const title = document.createElement('h3');
+  title.textContent = 'Upgrade actions';
+  panel.appendChild(title);
+
+  if (!instance.actions.length) {
+    const note = document.createElement('p');
+    note.className = 'blogpress-panel__hint';
+    note.textContent = 'No quality actions unlocked yet. Progress through story beats to reveal them.';
+    panel.appendChild(note);
+    return panel;
+  }
+
+  const list = document.createElement('ul');
+  list.className = 'blogpress-action-list';
+
+  instance.actions.forEach(action => {
+    const item = document.createElement('li');
+    item.className = 'blogpress-action';
+    const label = document.createElement('div');
+    label.className = 'blogpress-action__label';
+    label.textContent = action.label;
+    const meta = document.createElement('span');
+    meta.className = 'blogpress-action__meta';
+    const parts = [];
+    if (action.time > 0) parts.push(formatHours(action.time));
+    if (action.cost > 0) parts.push(formatCurrency(action.cost));
+    meta.textContent = parts.length ? parts.join(' • ') : 'Instant';
+    label.appendChild(meta);
+    item.appendChild(label);
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'blogpress-button blogpress-button--primary';
+    button.textContent = action.available ? 'Run' : 'Locked';
+    button.disabled = !action.available;
+    if (action.disabledReason) {
+      button.title = action.disabledReason;
+    }
+    button.addEventListener('click', () => {
+      if (button.disabled) return;
+      if (handlers.onRunAction) handlers.onRunAction(instance.id, action.id);
+    });
+    item.appendChild(button);
+
+    list.appendChild(item);
+  });
+
+  panel.appendChild(list);
+  return panel;
+}
+
+export function renderUpkeepPanel(instance) {
+  const panel = document.createElement('article');
+  panel.className = 'blogpress-panel blogpress-panel--upkeep';
+  const title = document.createElement('h3');
+  title.textContent = 'Daily upkeep';
+  panel.appendChild(title);
+
+  const upkeepParts = instance.maintenance?.parts || [];
+  const note = document.createElement('p');
+  note.className = 'blogpress-panel__lead';
+  note.textContent = upkeepParts.length ? upkeepParts.join(' • ') : 'No upkeep required';
+  panel.appendChild(note);
+
+  if (instance.status?.id === 'active' && !instance.maintenanceFunded) {
+    const warning = document.createElement('p');
+    warning.className = 'blogpress-panel__warning';
+    warning.textContent = 'Upkeep missed today — fund it to unlock tomorrow’s payout.';
+    panel.appendChild(warning);
+  } else {
+    const hint = document.createElement('p');
+    hint.className = 'blogpress-panel__hint';
+    hint.textContent = 'Keep hours and cash funded to secure the next payday.';
+    panel.appendChild(hint);
+  }
+
+  return panel;
+}
+
+export default function renderDetailView(options = {}) {
+  const {
+    instance = null,
+    formatters = {},
+    handlers = {},
+    formatRange = () => 'No payout yet'
+  } = options;
+
+  if (!instance) {
+    return null;
+  }
+
+  const formatCurrency = formatters.formatCurrency || (value => String(value ?? ''));
+  const formatNetCurrency = formatters.formatNetCurrency || ((value) => String(value ?? ''));
+  const formatHours = formatters.formatHours || (value => String(value ?? ''));
+
+  const container = document.createElement('section');
+  container.className = 'blogpress-view blogpress-view--detail';
+
+  container.appendChild(createBackButton(handlers.onBack));
+  container.appendChild(renderOverviewPanel(instance, formatCurrency));
+
+  const grid = document.createElement('div');
+  grid.className = 'blogpress-detail-grid';
+  grid.append(
+    renderNichePanel(instance, {
+      onSelectNiche: handlers.onSelectNiche,
+      onViewDetail: handlers.onViewDetail
+    }),
+    renderQualityPanel(instance, formatRange),
+    renderIncomePanel(instance, formatCurrency, formatNetCurrency),
+    renderPayoutPanel(instance, formatCurrency),
+    renderActionPanel(instance, handlers, formatHours, formatCurrency),
+    renderUpkeepPanel(instance)
+  );
+  container.appendChild(grid);
+
+  return container;
+}

--- a/src/ui/views/browser/components/blogpress/views/homeView.js
+++ b/src/ui/views/browser/components/blogpress/views/homeView.js
@@ -1,0 +1,180 @@
+export function renderSummaryBar(model = {}) {
+  const summary = document.createElement('div');
+  summary.className = 'blogpress-summary';
+  const total = model.summary?.total || 0;
+  const active = model.summary?.active || 0;
+  const needsUpkeep = model.summary?.needsUpkeep || 0;
+  const summaryItems = [
+    `${active} active`,
+    `${total} total`,
+    needsUpkeep > 0 ? `${needsUpkeep} need upkeep` : 'Upkeep funded'
+  ];
+  summary.textContent = summaryItems.join(' • ');
+  return summary;
+}
+
+export function createTableCell(content, className) {
+  const cell = document.createElement('td');
+  if (className) {
+    cell.className = className;
+  }
+  if (content instanceof Node) {
+    cell.appendChild(content);
+  } else {
+    cell.textContent = content;
+  }
+  return cell;
+}
+
+export default function renderHomeView(options = {}) {
+  const {
+    model = {},
+    state = {},
+    formatters = {},
+    handlers = {}
+  } = options;
+
+  const formatCurrency = formatters.formatCurrency || (value => String(value ?? ''));
+  const formatHours = formatters.formatHours || (value => String(value ?? ''));
+
+  const container = document.createElement('section');
+  container.className = 'blogpress-view blogpress-view--home';
+
+  container.appendChild(renderSummaryBar(model));
+
+  const instances = Array.isArray(model.instances) ? model.instances : [];
+  if (!instances.length) {
+    const empty = document.createElement('div');
+    empty.className = 'blogpress-empty';
+    const message = document.createElement('p');
+    message.textContent = 'No blogs live yet. Launch a blueprint to start earning cozy ad pennies.';
+    const cta = document.createElement('button');
+    cta.type = 'button';
+    cta.className = 'blogpress-button blogpress-button--primary';
+    cta.textContent = 'Launch first blog';
+    cta.addEventListener('click', handlers.onShowBlueprints || (() => {}));
+    empty.append(message, cta);
+    container.appendChild(empty);
+    return container;
+  }
+
+  const table = document.createElement('table');
+  table.className = 'blogpress-table';
+  const thead = document.createElement('thead');
+  const headRow = document.createElement('tr');
+  ['Blog', 'Niche', 'Status', 'Latest payout', 'Upkeep', 'Quality', 'Quick action'].forEach(label => {
+    const th = document.createElement('th');
+    th.textContent = label;
+    headRow.appendChild(th);
+  });
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+  instances.forEach(instance => {
+    const row = document.createElement('tr');
+    row.dataset.blogId = instance.id;
+    if (instance.id === state.selectedBlogId) {
+      row.classList.add('is-selected');
+    }
+
+    const nameButton = document.createElement('button');
+    nameButton.type = 'button';
+    nameButton.className = 'blogpress-table__link';
+    nameButton.textContent = instance.label;
+    nameButton.addEventListener('click', () => (handlers.onViewDetail || (() => {}))(instance.id));
+    row.appendChild(createTableCell(nameButton, 'blogpress-table__cell blogpress-table__cell--label'));
+
+    const niche = instance.niche;
+    const nicheCell = document.createElement('div');
+    nicheCell.className = 'blogpress-niche';
+    const nicheName = document.createElement('span');
+    nicheName.className = 'blogpress-niche__name';
+    nicheName.textContent = niche?.name || 'Unassigned';
+    nicheCell.appendChild(nicheName);
+    if (niche?.label) {
+      const tone = (niche.label || 'steady').toLowerCase().replace(/[^a-z0-9]+/g, '-');
+      const badge = document.createElement('span');
+      badge.className = `blogpress-badge blogpress-badge--tone-${tone}`;
+      badge.textContent = niche.label;
+      nicheCell.appendChild(badge);
+    }
+    row.appendChild(createTableCell(nicheCell));
+
+    const status = document.createElement('span');
+    status.className = `blogpress-status blogpress-status--${instance.status?.id || 'setup'}`;
+    status.textContent = instance.status?.label || 'Setup';
+    row.appendChild(createTableCell(status));
+
+    const payoutCell = document.createElement('div');
+    payoutCell.className = 'blogpress-payout';
+    const latest = document.createElement('strong');
+    latest.textContent = instance.latestPayout > 0 ? formatCurrency(instance.latestPayout) : '—';
+    const average = document.createElement('span');
+    average.textContent = instance.averagePayout > 0
+      ? `Avg ${formatCurrency(instance.averagePayout)}`
+      : instance.status?.id === 'active'
+        ? 'No earnings yet'
+        : 'Launch pending';
+    payoutCell.append(latest, average);
+    row.appendChild(createTableCell(payoutCell));
+
+    const upkeep = document.createElement('span');
+    const parts = [];
+    const maintenanceHours = instance.maintenance?.parts?.find(part => part.includes('h'));
+    if (maintenanceHours) parts.push(maintenanceHours);
+    const maintenanceCost = instance.maintenance?.parts?.find(part => part.includes('$'));
+    if (maintenanceCost) parts.push(maintenanceCost);
+    upkeep.textContent = parts.length ? parts.join(' • ') : 'None';
+    row.appendChild(createTableCell(upkeep));
+
+    const qualityCell = document.createElement('div');
+    qualityCell.className = 'blogpress-quality';
+    const levelBadge = document.createElement('span');
+    levelBadge.className = 'blogpress-quality__level';
+    levelBadge.textContent = `Q${instance.qualityLevel}`;
+    const levelLabel = document.createElement('span');
+    levelLabel.className = 'blogpress-quality__label';
+    levelLabel.textContent = instance.qualityInfo?.name || 'Skeleton Drafts';
+    qualityCell.append(levelBadge, levelLabel);
+    row.appendChild(createTableCell(qualityCell));
+
+    const actionCell = document.createElement('div');
+    actionCell.className = 'blogpress-table__actions';
+    if (instance.quickAction) {
+      const quick = instance.quickAction;
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'blogpress-button blogpress-button--ghost';
+      button.textContent = quick.label;
+      button.disabled = !quick.available;
+      if (quick.disabledReason) {
+        button.title = quick.disabledReason;
+      }
+      button.addEventListener('click', event => {
+        event.stopPropagation();
+        if (button.disabled) return;
+        (handlers.onRunQuickAction || (() => {}))(instance.id, quick.id);
+      });
+      const effort = document.createElement('span');
+      effort.className = 'blogpress-table__meta';
+      const partsMeta = [];
+      if (quick.time > 0) partsMeta.push(formatHours(quick.time));
+      if (quick.cost > 0) partsMeta.push(formatCurrency(quick.cost));
+      effort.textContent = partsMeta.length ? partsMeta.join(' • ') : 'Instant';
+      actionCell.append(button, effort);
+    } else {
+      const none = document.createElement('span');
+      none.className = 'blogpress-table__meta';
+      none.textContent = 'No actions unlocked yet';
+      actionCell.appendChild(none);
+    }
+    row.appendChild(createTableCell(actionCell, 'blogpress-table__cell blogpress-table__cell--actions'));
+
+    tbody.appendChild(row);
+  });
+
+  table.appendChild(tbody);
+  container.appendChild(table);
+  return container;
+}

--- a/src/ui/views/browser/components/blogpress/views/pricingView.js
+++ b/src/ui/views/browser/components/blogpress/views/pricingView.js
@@ -1,0 +1,117 @@
+import { ensureArray } from '../../../../../../core/helpers.js';
+
+export default function renderPricingView(options = {}) {
+  const {
+    pricing = {},
+    formatters = {},
+    formatRange = () => 'No payout yet'
+  } = options;
+
+  const formatCurrency = formatters.formatCurrency || (value => String(value ?? ''));
+  const formatHours = formatters.formatHours || (value => String(value ?? ''));
+  const formatMoney = formatters.formatMoney || (value => String(value ?? ''));
+
+  const container = document.createElement('section');
+  container.className = 'blogpress-view blogpress-view--pricing';
+
+  const intro = document.createElement('div');
+  intro.className = 'blogpress-pricing__intro';
+  const title = document.createElement('h2');
+  title.textContent = 'BlogPress pricing & growth map';
+  const lead = document.createElement('p');
+  const setup = pricing.setup || {};
+  const maintenance = pricing.maintenance || {};
+  lead.textContent = `Blueprint: ${setup.days || 0} day${setup.days === 1 ? '' : 's'} × ${formatHours(setup.hoursPerDay || 0)} ($${formatMoney(setup.cost || 0)}) • Daily upkeep ${formatHours(maintenance.hours || 0)} • $${formatMoney(maintenance.cost || 0)}`;
+  intro.append(title, lead);
+  container.appendChild(intro);
+
+  const grid = document.createElement('div');
+  grid.className = 'blogpress-pricing__grid';
+  ensureArray(pricing.levels).forEach(level => {
+    const card = document.createElement('article');
+    card.className = 'blogpress-plan';
+    const heading = document.createElement('h3');
+    heading.textContent = `Quality ${level.level} — ${level.name}`;
+    const range = document.createElement('p');
+    range.className = 'blogpress-plan__range';
+    range.textContent = `Income: ${formatRange(level.income)}`;
+    const description = document.createElement('p');
+    description.textContent = level.description || '';
+    card.append(heading, range, description);
+    grid.appendChild(card);
+  });
+  container.appendChild(grid);
+
+  const nicheBlock = document.createElement('section');
+  nicheBlock.className = 'blogpress-pricing__section';
+  const nicheTitle = document.createElement('h3');
+  nicheTitle.textContent = 'Niche heat map';
+  const nicheNote = document.createElement('p');
+  const topNiches = ensureArray(pricing.topNiches);
+  nicheNote.textContent = topNiches.length
+    ? `Top picks today: ${topNiches.map(entry => `${entry.name} (${entry.label || 'steady'})`).join(', ')}.`
+    : 'Niche intel unlocks once blueprints are live.';
+  nicheBlock.append(nicheTitle, nicheNote);
+  const nicheHint = document.createElement('p');
+  nicheHint.className = 'blogpress-panel__hint';
+  nicheHint.textContent = 'Pick once per blog — a locked niche hugs its trend multiplier for life.';
+  nicheBlock.appendChild(nicheHint);
+  container.appendChild(nicheBlock);
+
+  const actionBlock = document.createElement('section');
+  actionBlock.className = 'blogpress-pricing__section';
+  const actionTitle = document.createElement('h3');
+  actionTitle.textContent = 'Quality action lineup';
+  actionBlock.appendChild(actionTitle);
+  const actionList = document.createElement('ul');
+  actionList.className = 'blogpress-list';
+  ensureArray(pricing.actions).forEach(action => {
+    const item = document.createElement('li');
+    item.className = 'blogpress-list__item';
+    const label = document.createElement('span');
+    label.className = 'blogpress-list__label';
+    label.textContent = action.label;
+    const value = document.createElement('span');
+    value.className = 'blogpress-list__value';
+    const parts = [];
+    if (action.time > 0) parts.push(formatHours(action.time));
+    if (action.cost > 0) parts.push(formatCurrency(action.cost));
+    value.textContent = parts.length ? parts.join(' • ') : 'Instant';
+    item.append(label, value);
+    actionList.appendChild(item);
+  });
+  actionBlock.appendChild(actionList);
+  container.appendChild(actionBlock);
+
+  const upgradeBlock = document.createElement('section');
+  upgradeBlock.className = 'blogpress-pricing__section';
+  const upgradeTitle = document.createElement('h3');
+  upgradeTitle.textContent = 'Upgrade boosts';
+  upgradeBlock.appendChild(upgradeTitle);
+  const upgradeList = document.createElement('ul');
+  upgradeList.className = 'blogpress-list';
+  const upgrades = ensureArray(pricing.upgrades);
+  if (upgrades.length) {
+    upgrades.forEach(upgrade => {
+      const item = document.createElement('li');
+      item.className = 'blogpress-list__item';
+      const label = document.createElement('span');
+      label.className = 'blogpress-list__label';
+      label.textContent = upgrade.name;
+      const value = document.createElement('span');
+      value.className = 'blogpress-list__value';
+      value.textContent = `${formatCurrency(upgrade.cost)} • ${upgrade.description}`;
+      item.append(label, value);
+      upgradeList.appendChild(item);
+    });
+  } else {
+    const item = document.createElement('li');
+    item.className = 'blogpress-list__item';
+    item.textContent = 'Upgrades unlock once your first blog goes live.';
+    upgradeList.appendChild(item);
+  }
+  upgradeBlock.appendChild(upgradeList);
+  container.appendChild(upgradeBlock);
+
+  return container;
+}

--- a/src/ui/views/browser/components/digishelf/detailPane.js
+++ b/src/ui/views/browser/components/digishelf/detailPane.js
@@ -1,0 +1,257 @@
+import createStatusBadge from './statusBadge.js';
+
+function createSection(titleText) {
+  const section = document.createElement('section');
+  section.className = 'digishelf-panel';
+  const header = document.createElement('header');
+  header.className = 'digishelf-panel__header';
+  const title = document.createElement('h3');
+  title.textContent = titleText;
+  header.appendChild(title);
+  section.appendChild(header);
+  return section;
+}
+
+function renderNichePanel(instance, assetId, dependencies = {}) {
+  const { onSelectNiche = () => {} } = dependencies;
+  const panel = createSection('Audience Niche');
+  const content = document.createElement('div');
+  content.className = 'digishelf-panel__body';
+
+  if (instance.niche) {
+    const badge = document.createElement('div');
+    badge.className = 'digishelf-niche';
+    const name = document.createElement('strong');
+    name.textContent = instance.niche.name;
+    const note = document.createElement('span');
+    note.textContent = instance.niche.summary || 'Steady interest today';
+    badge.append(name, note);
+    content.appendChild(badge);
+  }
+
+  if (!instance.nicheLocked && Array.isArray(instance.nicheOptions) && instance.nicheOptions.length) {
+    const field = document.createElement('label');
+    field.className = 'digishelf-field';
+    field.textContent = 'Assign a niche';
+    const select = document.createElement('select');
+    select.className = 'digishelf-select';
+    select.innerHTML = '<option value="">Choose a niche</option>';
+    instance.nicheOptions.forEach(option => {
+      const opt = document.createElement('option');
+      opt.value = option.id;
+      opt.textContent = `${option.name} (${option.label || 'steady'})`;
+      select.appendChild(opt);
+    });
+    select.addEventListener('change', event => {
+      const { value } = event.target;
+      if (value) {
+        onSelectNiche(assetId, instance.id, value);
+      }
+    });
+    content.appendChild(field);
+    content.appendChild(select);
+  } else if (!instance.niche) {
+    const hint = document.createElement('p');
+    hint.className = 'digishelf-panel__hint';
+    hint.textContent = 'Niches unlock after launch wraps. Check back tomorrow!';
+    content.appendChild(hint);
+  } else {
+    const locked = document.createElement('p');
+    locked.className = 'digishelf-panel__hint';
+    locked.textContent = 'Niche locked in — ride the trend and stack modifiers.';
+    content.appendChild(locked);
+  }
+
+  panel.appendChild(content);
+  return panel;
+}
+
+function renderQualityPanel(instance) {
+  const panel = createSection('Quality Ladder');
+  const content = document.createElement('div');
+  content.className = 'digishelf-panel__body';
+
+  const header = document.createElement('div');
+  header.className = 'digishelf-quality';
+  const level = document.createElement('strong');
+  level.textContent = `Quality ${instance.milestone?.level ?? 0}`;
+  const note = document.createElement('span');
+  note.textContent = instance.qualityInfo?.name || 'Milestone in progress';
+  header.append(level, note);
+
+  const progress = document.createElement('div');
+  progress.className = 'digishelf-progress';
+  const fill = document.createElement('div');
+  fill.className = 'digishelf-progress__fill';
+  fill.style.setProperty('--digishelf-progress', `${Math.round((instance.milestone?.percent ?? 0) * 100)}%`);
+  progress.appendChild(fill);
+
+  const summary = document.createElement('p');
+  summary.className = 'digishelf-panel__hint';
+  summary.textContent = instance.milestone?.summary || 'Complete milestone actions to unlock bigger payouts.';
+
+  content.append(header, progress, summary);
+
+  panel.appendChild(content);
+  return panel;
+}
+
+function renderPayoutPanel(instance, formatCurrency) {
+  const panel = createSection('Payout Recap');
+  const content = document.createElement('div');
+  content.className = 'digishelf-panel__body';
+
+  if (instance.payoutBreakdown?.entries?.length) {
+    const list = document.createElement('ul');
+    list.className = 'digishelf-list';
+    instance.payoutBreakdown.entries.forEach(entry => {
+      const item = document.createElement('li');
+      item.className = 'digishelf-list__item';
+      const label = document.createElement('span');
+      label.className = 'digishelf-list__label';
+      label.textContent = entry.label;
+      const value = document.createElement('span');
+      value.className = 'digishelf-list__value';
+      value.textContent = entry.percent !== null && entry.percent !== undefined
+        ? `${Math.round(entry.percent * 100)}%`
+        : formatCurrency(entry.amount);
+      item.append(label, value);
+      list.appendChild(item);
+    });
+    const total = document.createElement('div');
+    total.className = 'digishelf-panel__total';
+    total.textContent = `Today: ${formatCurrency(instance.payoutBreakdown.total)}`;
+    content.append(list, total);
+  } else {
+    const empty = document.createElement('p');
+    empty.className = 'digishelf-panel__hint';
+    empty.textContent = 'Complete launch and upkeep to start logging daily royalties.';
+    content.appendChild(empty);
+  }
+
+  panel.appendChild(content);
+  return panel;
+}
+
+function renderRoiPanel(instance, formatCurrency) {
+  const panel = createSection('Lifetime ROI');
+  const content = document.createElement('div');
+  content.className = 'digishelf-panel__body digishelf-panel__body--grid';
+
+  const spend = document.createElement('div');
+  spend.className = 'digishelf-stat';
+  spend.innerHTML = `<span class="digishelf-stat__label">Invested</span><strong class="digishelf-stat__value">${formatCurrency(instance.estimatedSpend)}</strong>`;
+
+  const earned = document.createElement('div');
+  earned.className = 'digishelf-stat';
+  earned.innerHTML = `<span class="digishelf-stat__label">Earned</span><strong class="digishelf-stat__value">${formatCurrency(instance.lifetimeIncome)}</strong>`;
+
+  const roi = document.createElement('div');
+  roi.className = 'digishelf-stat';
+  const roiValue = Number.isFinite(instance.roi) ? `${Math.round(instance.roi * 100)}%` : '—';
+  roi.innerHTML = `<span class="digishelf-stat__label">Return</span><strong class="digishelf-stat__value">${roiValue}</strong>`;
+
+  content.append(spend, earned, roi);
+  panel.appendChild(content);
+  return panel;
+}
+
+function renderActionPanel(instance, assetId, dependencies = {}) {
+  const {
+    formatHours = value => String(value ?? ''),
+    formatMoney = value => String(value ?? ''),
+    onRunAction = () => {}
+  } = dependencies;
+
+  const panel = createSection('Action Queue');
+  const content = document.createElement('div');
+  content.className = 'digishelf-panel__body';
+
+  if (!instance.actions || !instance.actions.length) {
+    const empty = document.createElement('p');
+    empty.className = 'digishelf-panel__hint';
+    empty.textContent = 'No quality actions unlocked yet.';
+    content.appendChild(empty);
+  } else {
+    const list = document.createElement('ul');
+    list.className = 'digishelf-action-list';
+    instance.actions.forEach(action => {
+      const item = document.createElement('li');
+      item.className = 'digishelf-action';
+      const label = document.createElement('div');
+      label.className = 'digishelf-action__label';
+      label.textContent = action.label;
+      const meta = document.createElement('div');
+      meta.className = 'digishelf-action__meta';
+      const parts = [];
+      if (action.time > 0) parts.push(formatHours(action.time));
+      if (action.cost > 0) parts.push(`$${formatMoney(action.cost)}`);
+      meta.textContent = parts.join(' • ') || 'No cost';
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'digishelf-button digishelf-button--ghost';
+      button.textContent = action.available ? 'Run Action' : 'Locked';
+      button.disabled = !action.available;
+      if (action.disabledReason) {
+        button.title = action.disabledReason;
+      }
+      button.addEventListener('click', () => {
+        if (button.disabled) return;
+        onRunAction(assetId, instance.id, action.id);
+      });
+      item.append(label, meta, button);
+      list.appendChild(item);
+    });
+    content.appendChild(list);
+  }
+
+  panel.appendChild(content);
+  return panel;
+}
+
+export default function renderDetailPane(options = {}) {
+  const {
+    instance = null,
+    assetId = 'ebook',
+    formatters = {},
+    onSelectNiche = () => {},
+    onRunAction = () => {}
+  } = options;
+
+  const detail = document.createElement('aside');
+  detail.className = 'digishelf-detail';
+
+  if (!instance) {
+    const empty = document.createElement('p');
+    empty.className = 'digishelf-panel__hint';
+    empty.textContent = 'Select a resource to review milestones, modifiers, and ROI.';
+    detail.appendChild(empty);
+    return detail;
+  }
+
+  const header = document.createElement('header');
+  header.className = 'digishelf-detail__header';
+  const name = document.createElement('h2');
+  name.textContent = instance.label;
+  const status = createStatusBadge(instance);
+  const payout = document.createElement('p');
+  payout.className = 'digishelf-detail__payout';
+  const formatCurrency = formatters.formatCurrency || (value => String(value ?? ''));
+  payout.textContent = `Today ${formatCurrency(instance.latestPayout)} • Range ${formatCurrency(instance.qualityRange?.min ?? 0)} – ${formatCurrency(instance.qualityRange?.max ?? 0)}`;
+  header.append(name, status, payout);
+
+  detail.append(
+    header,
+    renderNichePanel(instance, assetId, { onSelectNiche }),
+    renderQualityPanel(instance),
+    renderPayoutPanel(instance, formatCurrency),
+    renderRoiPanel(instance, formatCurrency),
+    renderActionPanel(instance, assetId, {
+      formatHours: formatters.formatHours,
+      formatMoney: formatters.formatMoney,
+      onRunAction
+    })
+  );
+
+  return detail;
+}

--- a/src/ui/views/browser/components/digishelf/hero.js
+++ b/src/ui/views/browser/components/digishelf/hero.js
@@ -1,0 +1,158 @@
+function createHeroStat(label, value, tone = 'default') {
+  const stat = document.createElement('div');
+  stat.className = `digishelf-hero__stat digishelf-hero__stat--${tone}`;
+
+  const statValue = document.createElement('span');
+  statValue.className = 'digishelf-hero__value';
+  statValue.textContent = value;
+  const statLabel = document.createElement('span');
+  statLabel.className = 'digishelf-hero__label';
+  statLabel.textContent = label;
+
+  stat.append(statValue, statLabel);
+  return stat;
+}
+
+function renderLaunchCard(assetId, model, dependencies = {}) {
+  const {
+    formatHours = value => String(value ?? ''),
+    formatMoney = value => String(value ?? ''),
+    onConfirmLaunch = async () => true
+  } = dependencies;
+
+  if (!model?.definition || !model.launch) {
+    const locked = document.createElement('article');
+    locked.className = 'digishelf-launch digishelf-launch--locked';
+    const heading = document.createElement('h3');
+    heading.textContent = 'Locked';
+    const note = document.createElement('p');
+    note.textContent = 'Complete requirements in the classic dashboard to unlock this resource.';
+    locked.append(heading, note);
+    return locked;
+  }
+
+  const card = document.createElement('article');
+  card.className = 'digishelf-launch';
+
+  const title = document.createElement('h3');
+  title.textContent = model.definition.name;
+
+  const summary = document.createElement('p');
+  summary.textContent = model.definition.description || 'Launch a fresh income stream in minutes.';
+
+  const meta = document.createElement('p');
+  meta.className = 'digishelf-launch__meta';
+  const setup = model.definition.setup || {};
+  const upkeep = model.definition.maintenance || {};
+  const setupParts = [];
+  if (setup.days > 0) {
+    setupParts.push(`${setup.days} day${setup.days === 1 ? '' : 's'}`);
+  }
+  if (setup.hoursPerDay > 0) {
+    setupParts.push(`${formatHours(setup.hoursPerDay)}/day`);
+  }
+  if (setup.cost > 0) {
+    setupParts.push(`$${formatMoney(setup.cost)} upfront`);
+  }
+  const upkeepParts = [];
+  if (upkeep.hours > 0) {
+    upkeepParts.push(`${formatHours(upkeep.hours)}/day`);
+  }
+  if (upkeep.cost > 0) {
+    upkeepParts.push(`$${formatMoney(upkeep.cost)}/day`);
+  }
+  meta.textContent = `${setupParts.join(' • ') || 'Instant launch'} • ${upkeepParts.join(' + ') || 'No upkeep'}`;
+
+  const actions = document.createElement('div');
+  actions.className = 'digishelf-launch__actions';
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'digishelf-button digishelf-button--primary';
+  button.textContent = model.launch.label || 'Launch';
+  button.disabled = Boolean(model.launch.disabled || model.launch.availability?.disabled);
+  button.addEventListener('click', async () => {
+    if (button.disabled) return;
+    const confirmed = await onConfirmLaunch(model.definition);
+    if (!confirmed) {
+      return;
+    }
+    model.launch.onClick?.();
+  });
+
+  actions.appendChild(button);
+
+  if (Array.isArray(model.launch.availability?.reasons) && model.launch.availability.reasons.length) {
+    const reasons = document.createElement('ul');
+    reasons.className = 'digishelf-launch__reasons';
+    model.launch.availability.reasons.forEach(reason => {
+      const item = document.createElement('li');
+      item.textContent = reason;
+      reasons.appendChild(item);
+    });
+    card.append(title, summary, meta, actions, reasons);
+  } else {
+    card.append(title, summary, meta, actions);
+  }
+
+  card.dataset.assetId = assetId;
+  return card;
+}
+
+export default function renderHero(options = {}) {
+  const {
+    model = {},
+    state = {},
+    formatCurrency = value => String(value ?? ''),
+    formatHours = value => String(value ?? ''),
+    formatMoney = value => String(value ?? ''),
+    onToggleLaunch = () => {},
+    onConfirmLaunch = async () => true
+  } = options;
+
+  const hero = document.createElement('section');
+  hero.className = 'digishelf-hero';
+
+  const copy = document.createElement('div');
+  copy.className = 'digishelf-hero__copy';
+
+  const heading = document.createElement('h1');
+  heading.textContent = 'DigiShelf';
+
+  const subheading = document.createElement('p');
+  subheading.textContent = 'Your digital creations, one shelf away from the world.';
+
+  copy.append(heading, subheading);
+
+  const stats = document.createElement('div');
+  stats.className = 'digishelf-hero__stats';
+  stats.append(
+    createHeroStat('Active E-Book Series', `${model.overview?.ebooksActive ?? 0}`),
+    createHeroStat('Active Photo Galleries', `${model.overview?.stockActive ?? 0}`),
+    createHeroStat('Daily Royalties', formatCurrency(model.overview?.totalDaily ?? 0), 'accent')
+  );
+
+  const actions = document.createElement('div');
+  actions.className = 'digishelf-hero__actions';
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'digishelf-button digishelf-button--primary';
+  button.textContent = 'Publish a new resource';
+  button.addEventListener('click', onToggleLaunch);
+
+  actions.appendChild(button);
+
+  hero.append(copy, stats, actions);
+
+  if (state.launchOpen) {
+    const launchPanel = document.createElement('div');
+    launchPanel.className = 'digishelf-launcher';
+    launchPanel.append(
+      renderLaunchCard('ebook', model.ebook, { formatHours, formatMoney, onConfirmLaunch }),
+      renderLaunchCard('stockPhotos', model.stock, { formatHours, formatMoney, onConfirmLaunch })
+    );
+    hero.appendChild(launchPanel);
+  }
+
+  return hero;
+}

--- a/src/ui/views/browser/components/digishelf/index.js
+++ b/src/ui/views/browser/components/digishelf/index.js
@@ -8,7 +8,6 @@ import { formatCurrency as baseFormatCurrency } from '../../utils/formatting.js'
 import { createCurrencyLifecycleSummary } from '../../utils/lifecycleSummaries.js';
 import { showLaunchConfirmation } from '../../utils/launchDialog.js';
 import { createTabbedWorkspacePresenter } from '../../utils/createTabbedWorkspacePresenter.js';
-import { createNavTabs } from '../common/navBuilders.js';
 import { renderWorkspaceLock } from '../common/renderWorkspaceLock.js';
 import {
   VIEW_EBOOKS,
@@ -23,24 +22,18 @@ import {
   getSelectedCollection,
   getSelectedInstance
 } from './state.js';
-
-const QUICK_ACTION_LABELS = {
-  ebook: {
-    writeChapter: 'Write Volume'
-  },
-  stockPhotos: {
-    planShoot: 'Launch Gallery',
-    batchEdit: 'Upload Batch'
-  }
-};
+import renderHero from './hero.js';
+import renderTabNavigation from './tabNavigation.js';
+import renderInventoryTable from './inventoryTable.js';
+import renderDetailPane from './detailPane.js';
+import renderPricingCards from './pricingCards.js';
 
 function clampNumber(value) {
   const number = Number(value);
   return Number.isFinite(number) ? number : 0;
 }
 
-const formatCurrency = amount =>
-  baseFormatCurrency(amount, { precision: 'integer', clampZero: true });
+const formatCurrency = amount => baseFormatCurrency(amount, { precision: 'integer', clampZero: true });
 
 const { describeSetupSummary: describeLaunchSetup, describeUpkeepSummary: describeLaunchUpkeep } =
   createCurrencyLifecycleSummary({
@@ -76,748 +69,77 @@ function handleNicheSelect(assetId, instanceId, value) {
   selectDigishelfNiche(assetId, instanceId, value);
 }
 
-function createHeroStat(label, value, tone = 'default') {
-  const stat = document.createElement('div');
-  stat.className = `digishelf-hero__stat digishelf-hero__stat--${tone}`;
-
-  const statValue = document.createElement('span');
-  statValue.className = 'digishelf-hero__value';
-  statValue.textContent = value;
-  const statLabel = document.createElement('span');
-  statLabel.className = 'digishelf-hero__label';
-  statLabel.textContent = label;
-
-  stat.append(statValue, statLabel);
-  return stat;
-}
-
-function renderLaunchCard(assetId, model) {
-  if (!model?.definition || !model.launch) {
-    const locked = document.createElement('article');
-    locked.className = 'digishelf-launch digishelf-launch--locked';
-    const heading = document.createElement('h3');
-    heading.textContent = 'Locked';
-    const note = document.createElement('p');
-    note.textContent = 'Complete requirements in the classic dashboard to unlock this resource.';
-    locked.append(heading, note);
-    return locked;
-  }
-
-  const card = document.createElement('article');
-  card.className = 'digishelf-launch';
-
-  const title = document.createElement('h3');
-  title.textContent = model.definition.name;
-
-  const summary = document.createElement('p');
-  summary.textContent = model.definition.description || 'Launch a fresh income stream in minutes.';
-
-  const meta = document.createElement('p');
-  meta.className = 'digishelf-launch__meta';
-  const setup = model.definition.setup || {};
-  const upkeep = model.definition.maintenance || {};
-  const setupParts = [];
-  if (setup.days > 0) {
-    setupParts.push(`${setup.days} day${setup.days === 1 ? '' : 's'}`);
-  }
-  if (setup.hoursPerDay > 0) {
-    setupParts.push(`${formatHours(setup.hoursPerDay)}/day`);
-  }
-  if (setup.cost > 0) {
-    setupParts.push(`$${formatMoney(setup.cost)} upfront`);
-  }
-  const upkeepParts = [];
-  if (upkeep.hours > 0) {
-    upkeepParts.push(`${formatHours(upkeep.hours)}/day`);
-  }
-  if (upkeep.cost > 0) {
-    upkeepParts.push(`$${formatMoney(upkeep.cost)}/day`);
-  }
-  meta.textContent = `${setupParts.join(' • ') || 'Instant launch'} • ${upkeepParts.join(' + ') || 'No upkeep'}`;
-
-  const actions = document.createElement('div');
-  actions.className = 'digishelf-launch__actions';
-
-  const button = document.createElement('button');
-  button.type = 'button';
-  button.className = 'digishelf-button digishelf-button--primary';
-  button.textContent = model.launch.label || 'Launch';
-  button.disabled = Boolean(model.launch.disabled || model.launch.availability?.disabled);
-  button.addEventListener('click', async () => {
-    if (button.disabled) return;
-    const confirmed = await confirmResourceLaunch(model.definition);
-    if (!confirmed) {
-      return;
-    }
-    model.launch.onClick?.();
-  });
-
-  actions.appendChild(button);
-
-  if (Array.isArray(model.launch.availability?.reasons) && model.launch.availability.reasons.length) {
-    const reasons = document.createElement('ul');
-    reasons.className = 'digishelf-launch__reasons';
-    model.launch.availability.reasons.forEach(reason => {
-      const item = document.createElement('li');
-      item.textContent = reason;
-      reasons.appendChild(item);
-    });
-    card.append(title, summary, meta, actions, reasons);
-  } else {
-    card.append(title, summary, meta, actions);
-  }
-
-  card.dataset.assetId = assetId;
-  return card;
-}
-
-function renderHero(model, state = initialState) {
-  const hero = document.createElement('section');
-  hero.className = 'digishelf-hero';
-
-  const copy = document.createElement('div');
-  copy.className = 'digishelf-hero__copy';
-
-  const heading = document.createElement('h1');
-  heading.textContent = 'DigiShelf';
-
-  const subheading = document.createElement('p');
-  subheading.textContent = 'Your digital creations, one shelf away from the world.';
-
-  copy.append(heading, subheading);
-
-  const stats = document.createElement('div');
-  stats.className = 'digishelf-hero__stats';
-  stats.append(
-    createHeroStat('Active E-Book Series', `${model.overview?.ebooksActive ?? 0}`),
-    createHeroStat('Active Photo Galleries', `${model.overview?.stockActive ?? 0}`),
-    createHeroStat('Daily Royalties', formatCurrency(model.overview?.totalDaily ?? 0), 'accent')
-  );
-
-  const actions = document.createElement('div');
-  actions.className = 'digishelf-hero__actions';
-  const button = document.createElement('button');
-  button.type = 'button';
-  button.className = 'digishelf-button digishelf-button--primary';
-  button.textContent = 'Publish a new resource';
-  button.addEventListener('click', toggleLaunchPanel);
-
-  actions.appendChild(button);
-
-  hero.append(copy, stats, actions);
-
-  if (state.launchOpen) {
-    const launchPanel = document.createElement('div');
-    launchPanel.className = 'digishelf-launcher';
-    launchPanel.append(
-      renderLaunchCard('ebook', model.ebook),
-      renderLaunchCard('stockPhotos', model.stock)
-    );
-    hero.appendChild(launchPanel);
-  }
-
-  return hero;
-}
-
-function renderTabs(state = initialState) {
-  return createNavTabs({
-    navClassName: 'digishelf-tabs',
-    buttonClassName: 'digishelf-tab',
-    datasetKey: 'view',
-    withAriaPressed: true,
-    onSelect: setView,
-    buttons: [
-      {
-        label: 'E-Books',
-        view: VIEW_EBOOKS,
-        isActive: state.view === VIEW_EBOOKS
-      },
-      {
-        label: 'Stock Photos',
-        view: VIEW_STOCK,
-        isActive: state.view === VIEW_STOCK
-      },
-      {
-        label: 'Pricing & Plans',
-        view: VIEW_PRICING,
-        isActive: state.view === VIEW_PRICING
-      }
-    ]
-  });
-}
-
-function renderStatusBadge(instance) {
-  const badge = document.createElement('span');
-  badge.className = `digishelf-badge digishelf-badge--${instance.status?.id || 'setup'}`;
-  badge.textContent = instance.status?.label || 'Setup';
-  return badge;
-}
-
-function renderUpkeepCell(instance) {
-  const wrapper = document.createElement('div');
-  wrapper.className = 'digishelf-upkeep';
-  const maintenance = instance.maintenance;
-  if (maintenance?.parts?.length) {
-    const value = document.createElement('strong');
-    value.textContent = maintenance.parts.join(' + ');
-    wrapper.appendChild(value);
-  } else {
-    const none = document.createElement('span');
-    none.textContent = 'None';
-    wrapper.appendChild(none);
-  }
-
-  const status = document.createElement('span');
-  status.className = instance.maintenanceFunded
-    ? 'digishelf-upkeep__status is-funded'
-    : 'digishelf-upkeep__status is-missed';
-  status.textContent = instance.maintenanceFunded ? 'Funded' : 'Skipped today';
-  wrapper.appendChild(status);
-  return wrapper;
-}
-
-function renderActionButton(label, { disabled = false, title = '', onClick }) {
-  const button = document.createElement('button');
-  button.type = 'button';
-  button.className = 'digishelf-button digishelf-button--ghost';
-  button.textContent = label;
-  button.disabled = Boolean(disabled);
-  if (title) {
-    button.title = title;
-  }
-  button.addEventListener('click', event => {
-    event.stopPropagation();
-    if (button.disabled) return;
-    onClick?.();
-  });
-  return button;
-}
-
-function findActionById(instance, actionId) {
-  if (!actionId) return null;
-  return instance.actions?.find(action => action.id === actionId) || null;
-}
-
-function renderEbookRow(instance, state = initialState) {
-  const row = document.createElement('tr');
-  row.dataset.instanceId = instance.id;
-  if (state.selectedType === 'ebook' && state.selectedId === instance.id) {
-    row.classList.add('is-selected');
-  }
-
-  row.addEventListener('click', () => selectInstance('ebook', instance.id));
-
-  const titleCell = document.createElement('td');
-  titleCell.className = 'digishelf-cell digishelf-cell--label';
-  const title = document.createElement('div');
-  title.className = 'digishelf-label';
-  const name = document.createElement('strong');
-  name.textContent = instance.label;
-  const status = renderStatusBadge(instance);
-  title.append(name, status);
-  titleCell.appendChild(title);
-
-  const earningsCell = document.createElement('td');
-  earningsCell.className = 'digishelf-cell digishelf-cell--earnings';
-  const payout = document.createElement('strong');
-  payout.textContent = formatCurrency(instance.latestPayout || instance.averagePayout);
-  const range = document.createElement('span');
-  range.textContent = `${formatCurrency(instance.qualityRange?.min ?? 0)} – ${formatCurrency(instance.qualityRange?.max ?? 0)}`;
-  earningsCell.append(payout, range);
-
-  const milestoneCell = document.createElement('td');
-  milestoneCell.className = 'digishelf-cell';
-  const milestone = document.createElement('div');
-  milestone.className = 'digishelf-milestone';
-  const level = document.createElement('strong');
-  level.textContent = `Quality ${instance.milestone?.level ?? 0}`;
-  const summary = document.createElement('span');
-  summary.textContent = instance.milestone?.summary || 'Progress brewing.';
-  milestone.append(level, summary);
-  milestoneCell.appendChild(milestone);
-
-  const upkeepCell = document.createElement('td');
-  upkeepCell.className = 'digishelf-cell';
-  upkeepCell.appendChild(renderUpkeepCell(instance));
-
-  const actionsCell = document.createElement('td');
-  actionsCell.className = 'digishelf-cell digishelf-cell--actions';
-  const actionWrapper = document.createElement('div');
-  actionWrapper.className = 'digishelf-actions';
-
-  const quickActions = getDigishelfQuickActionIds('ebook');
-  quickActions.forEach(actionId => {
-    const action = findActionById(instance, actionId);
-    if (!action) return;
-    const label = QUICK_ACTION_LABELS.ebook?.[actionId] || action.label;
-    const button = renderActionButton(label, {
-      disabled: !action.available,
-      title: action.disabledReason,
-      onClick: () => handleQualityAction('ebook', instance.id, actionId)
-    });
-    actionWrapper.appendChild(button);
-  });
-
-  const detailButton = renderActionButton('View Details', {
-    onClick: () => selectInstance('ebook', instance.id)
-  });
-  actionWrapper.appendChild(detailButton);
-
-  actionsCell.appendChild(actionWrapper);
-
-  row.append(titleCell, earningsCell, milestoneCell, upkeepCell, actionsCell);
-  return row;
-}
-
-function renderStockRow(instance, state = initialState) {
-  const row = document.createElement('tr');
-  row.dataset.instanceId = instance.id;
-  if (state.selectedType === 'stockPhotos' && state.selectedId === instance.id) {
-    row.classList.add('is-selected');
-  }
-
-  row.addEventListener('click', () => selectInstance('stockPhotos', instance.id));
-
-  const titleCell = document.createElement('td');
-  titleCell.className = 'digishelf-cell digishelf-cell--label';
-  const label = document.createElement('div');
-  label.className = 'digishelf-label';
-  const name = document.createElement('strong');
-  name.textContent = instance.label;
-  const status = renderStatusBadge(instance);
-  label.append(name, status);
-  titleCell.appendChild(label);
-
-  const photosCell = document.createElement('td');
-  photosCell.className = 'digishelf-cell';
-  const totalShoots = clampNumber(instance.progress?.shoots);
-  const totalEdits = clampNumber(instance.progress?.editing);
-  const uploads = document.createElement('strong');
-  uploads.textContent = `${totalShoots} shoots / ${totalEdits} edits`;
-  const hint = document.createElement('span');
-  hint.textContent = 'Shoots • Edits logged';
-  photosCell.append(uploads, hint);
-
-  const earningsCell = document.createElement('td');
-  earningsCell.className = 'digishelf-cell digishelf-cell--earnings';
-  const payout = document.createElement('strong');
-  payout.textContent = formatCurrency(instance.latestPayout || instance.averagePayout);
-  const range = document.createElement('span');
-  range.textContent = `${formatCurrency(instance.qualityRange?.min ?? 0)} – ${formatCurrency(instance.qualityRange?.max ?? 0)}`;
-  earningsCell.append(payout, range);
-
-  const upkeepCell = document.createElement('td');
-  upkeepCell.className = 'digishelf-cell';
-  upkeepCell.appendChild(renderUpkeepCell(instance));
-
-  const actionsCell = document.createElement('td');
-  actionsCell.className = 'digishelf-cell digishelf-cell--actions';
-  const actionWrapper = document.createElement('div');
-  actionWrapper.className = 'digishelf-actions';
-
-  const quickActions = getDigishelfQuickActionIds('stockPhotos');
-  quickActions.forEach(actionId => {
-    const action = findActionById(instance, actionId);
-    if (!action) return;
-    const label = QUICK_ACTION_LABELS.stockPhotos?.[actionId] || action.label;
-    const button = renderActionButton(label, {
-      disabled: !action.available,
-      title: action.disabledReason,
-      onClick: () => handleQualityAction('stockPhotos', instance.id, actionId)
-    });
-    actionWrapper.appendChild(button);
-  });
-
-  const detailLink = document.createElement('button');
-  detailLink.type = 'button';
-  detailLink.className = 'digishelf-button digishelf-button--link';
-  detailLink.textContent = 'View Details';
-  detailLink.addEventListener('click', event => {
-    event.stopPropagation();
-    selectInstance('stockPhotos', instance.id);
-  });
-  actionWrapper.appendChild(detailLink);
-
-  actionsCell.appendChild(actionWrapper);
-
-  row.append(titleCell, photosCell, earningsCell, upkeepCell, actionsCell);
-  return row;
-}
-
-function renderTable(instances, type, state = initialState) {
-  const table = document.createElement('table');
-  table.className = 'digishelf-table';
-  const thead = document.createElement('thead');
-  const headRow = document.createElement('tr');
-
-  const headers = type === 'ebook'
-    ? ['Title', 'Daily Earnings', 'Quality Milestone', 'Upkeep', 'Actions']
-    : ['Gallery', 'Photos Uploaded', 'Daily Earnings', 'Upkeep', 'Actions'];
-
-  headers.forEach(label => {
-    const th = document.createElement('th');
-    th.textContent = label;
-    headRow.appendChild(th);
-  });
-  thead.appendChild(headRow);
-  table.appendChild(thead);
-
-  const tbody = document.createElement('tbody');
-
-  if (!instances.length) {
-    const emptyRow = document.createElement('tr');
-    const emptyCell = document.createElement('td');
-    emptyCell.colSpan = headers.length;
-    emptyCell.className = 'digishelf-empty';
-    emptyCell.textContent = type === 'ebook'
-      ? 'No e-book series live yet. Spin one up to start collecting royalties.'
-      : 'No stock galleries live yet. Launch a collection to start syndicating shots.';
-    emptyRow.appendChild(emptyCell);
-    tbody.appendChild(emptyRow);
-  } else {
-    instances.forEach(instance => {
-      const row = type === 'ebook'
-        ? renderEbookRow(instance, state)
-        : renderStockRow(instance, state);
-      tbody.appendChild(row);
-    });
-  }
-
-  table.appendChild(tbody);
-  return table;
-}
-
-function createSection(titleText) {
-  const section = document.createElement('section');
-  section.className = 'digishelf-panel';
-  const header = document.createElement('header');
-  header.className = 'digishelf-panel__header';
-  const title = document.createElement('h3');
-  title.textContent = titleText;
-  header.appendChild(title);
-  section.appendChild(header);
-  return section;
-}
-
-function renderNichePanel(instance, assetId) {
-  const panel = createSection('Audience Niche');
-  const content = document.createElement('div');
-  content.className = 'digishelf-panel__body';
-
-  if (instance.niche) {
-    const badge = document.createElement('div');
-    badge.className = 'digishelf-niche';
-    const name = document.createElement('strong');
-    name.textContent = instance.niche.name;
-    const note = document.createElement('span');
-    note.textContent = instance.niche.summary || 'Steady interest today';
-    badge.append(name, note);
-    content.appendChild(badge);
-  }
-
-  if (!instance.nicheLocked && Array.isArray(instance.nicheOptions) && instance.nicheOptions.length) {
-    const field = document.createElement('label');
-    field.className = 'digishelf-field';
-    field.textContent = 'Assign a niche';
-    const select = document.createElement('select');
-    select.className = 'digishelf-select';
-    select.innerHTML = '<option value="">Choose a niche</option>';
-    instance.nicheOptions.forEach(option => {
-      const opt = document.createElement('option');
-      opt.value = option.id;
-      opt.textContent = `${option.name} (${option.label || 'steady'})`;
-      select.appendChild(opt);
-    });
-    select.addEventListener('change', event => {
-      const { value } = event.target;
-      if (value) {
-        handleNicheSelect(assetId, instance.id, value);
-      }
-    });
-    content.appendChild(field);
-    content.appendChild(select);
-  } else if (!instance.niche) {
-    const hint = document.createElement('p');
-    hint.className = 'digishelf-panel__hint';
-    hint.textContent = 'Niches unlock after launch wraps. Check back tomorrow!';
-    content.appendChild(hint);
-  } else {
-    const locked = document.createElement('p');
-    locked.className = 'digishelf-panel__hint';
-    locked.textContent = 'Niche locked in — ride the trend and stack modifiers.';
-    content.appendChild(locked);
-  }
-
-  panel.appendChild(content);
-  return panel;
-}
-
-function renderQualityPanel(instance) {
-  const panel = createSection('Quality Ladder');
-  const content = document.createElement('div');
-  content.className = 'digishelf-panel__body';
-
-  const header = document.createElement('div');
-  header.className = 'digishelf-quality';
-  const level = document.createElement('strong');
-  level.textContent = `Quality ${instance.milestone?.level ?? 0}`;
-  const note = document.createElement('span');
-  note.textContent = instance.qualityInfo?.name || 'Milestone in progress';
-  header.append(level, note);
-
-  const progress = document.createElement('div');
-  progress.className = 'digishelf-progress';
-  const fill = document.createElement('div');
-  fill.className = 'digishelf-progress__fill';
-  fill.style.setProperty('--digishelf-progress', `${Math.round((instance.milestone?.percent ?? 0) * 100)}%`);
-  progress.appendChild(fill);
-
-  const summary = document.createElement('p');
-  summary.className = 'digishelf-panel__hint';
-  summary.textContent = instance.milestone?.summary || 'Complete milestone actions to unlock bigger payouts.';
-
-  content.append(header, progress, summary);
-
-  panel.appendChild(content);
-  return panel;
-}
-
-function renderPayoutPanel(instance) {
-  const panel = createSection('Payout Recap');
-  const content = document.createElement('div');
-  content.className = 'digishelf-panel__body';
-
-  if (instance.payoutBreakdown?.entries?.length) {
-    const list = document.createElement('ul');
-    list.className = 'digishelf-list';
-    instance.payoutBreakdown.entries.forEach(entry => {
-      const item = document.createElement('li');
-      item.className = 'digishelf-list__item';
-      const label = document.createElement('span');
-      label.className = 'digishelf-list__label';
-      label.textContent = entry.label;
-      const value = document.createElement('span');
-      value.className = 'digishelf-list__value';
-      value.textContent = entry.percent !== null
-        ? `${Math.round(entry.percent * 100)}%`
-        : formatCurrency(entry.amount);
-      item.append(label, value);
-      list.appendChild(item);
-    });
-    const total = document.createElement('div');
-    total.className = 'digishelf-panel__total';
-    total.textContent = `Today: ${formatCurrency(instance.payoutBreakdown.total)}`;
-    content.append(list, total);
-  } else {
-    const empty = document.createElement('p');
-    empty.className = 'digishelf-panel__hint';
-    empty.textContent = 'Complete launch and upkeep to start logging daily royalties.';
-    content.appendChild(empty);
-  }
-
-  panel.appendChild(content);
-  return panel;
-}
-
-function renderRoiPanel(instance) {
-  const panel = createSection('Lifetime ROI');
-  const content = document.createElement('div');
-  content.className = 'digishelf-panel__body digishelf-panel__body--grid';
-
-  const spend = document.createElement('div');
-  spend.className = 'digishelf-stat';
-  spend.innerHTML = `<span class="digishelf-stat__label">Invested</span><strong class="digishelf-stat__value">${formatCurrency(instance.estimatedSpend)}</strong>`;
-
-  const earned = document.createElement('div');
-  earned.className = 'digishelf-stat';
-  earned.innerHTML = `<span class="digishelf-stat__label">Earned</span><strong class="digishelf-stat__value">${formatCurrency(instance.lifetimeIncome)}</strong>`;
-
-  const roi = document.createElement('div');
-  roi.className = 'digishelf-stat';
-  const roiValue = Number.isFinite(instance.roi) ? `${Math.round(instance.roi * 100)}%` : '—';
-  roi.innerHTML = `<span class="digishelf-stat__label">Return</span><strong class="digishelf-stat__value">${roiValue}</strong>`;
-
-  content.append(spend, earned, roi);
-  panel.appendChild(content);
-  return panel;
-}
-
-function renderActionPanel(instance, assetId) {
-  const panel = createSection('Action Queue');
-  const content = document.createElement('div');
-  content.className = 'digishelf-panel__body';
-
-  if (!instance.actions || !instance.actions.length) {
-    const empty = document.createElement('p');
-    empty.className = 'digishelf-panel__hint';
-    empty.textContent = 'No quality actions unlocked yet.';
-    content.appendChild(empty);
-  } else {
-    const list = document.createElement('ul');
-    list.className = 'digishelf-action-list';
-    instance.actions.forEach(action => {
-      const item = document.createElement('li');
-      item.className = 'digishelf-action';
-      const label = document.createElement('div');
-      label.className = 'digishelf-action__label';
-      label.textContent = action.label;
-      const meta = document.createElement('div');
-      meta.className = 'digishelf-action__meta';
-      const parts = [];
-      if (action.time > 0) parts.push(formatHours(action.time));
-      if (action.cost > 0) parts.push(`$${formatMoney(action.cost)}`);
-      meta.textContent = parts.join(' • ') || 'No cost';
-      const button = renderActionButton('Run Action', {
-        disabled: !action.available,
-        title: action.disabledReason,
-        onClick: () => handleQualityAction(assetId, instance.id, action.id)
-      });
-      item.append(label, meta, button);
-      list.appendChild(item);
-    });
-    content.appendChild(list);
-  }
-
-  panel.appendChild(content);
-  return panel;
-}
-
-function renderDetail(instance, assetId) {
-  const aside = document.createElement('aside');
-  aside.className = 'digishelf-detail';
-
-  if (!instance) {
-    const empty = document.createElement('p');
-    empty.className = 'digishelf-panel__hint';
-    empty.textContent = 'Select a resource to review milestones, modifiers, and ROI.';
-    aside.appendChild(empty);
-    return aside;
-  }
-
-  const header = document.createElement('header');
-  header.className = 'digishelf-detail__header';
-  const name = document.createElement('h2');
-  name.textContent = instance.label;
-  const status = renderStatusBadge(instance);
-  const payout = document.createElement('p');
-  payout.className = 'digishelf-detail__payout';
-  payout.textContent = `Today ${formatCurrency(instance.latestPayout)} • Range ${formatCurrency(instance.qualityRange?.min ?? 0)} – ${formatCurrency(instance.qualityRange?.max ?? 0)}`;
-  header.append(name, status, payout);
-
-  aside.append(
-    header,
-    renderNichePanel(instance, assetId),
-    renderQualityPanel(instance),
-    renderPayoutPanel(instance),
-    renderRoiPanel(instance),
-    renderActionPanel(instance, assetId)
-  );
-
-  return aside;
-}
-
-function renderPricing(pricing = []) {
-  const section = document.createElement('section');
-  section.className = 'digishelf-pricing';
-
-  const intro = document.createElement('div');
-  intro.className = 'digishelf-pricing__intro';
-  const heading = document.createElement('h2');
-  heading.textContent = 'Pricing & Scaling Plans';
-  const note = document.createElement('p');
-  note.textContent = 'Compare launch effort, upkeep, and daily earning potential for each digital asset lane.';
-  intro.append(heading, note);
-
-  const grid = document.createElement('div');
-  grid.className = 'digishelf-pricing__grid';
-
-  pricing.forEach(plan => {
-    const card = document.createElement('article');
-    card.className = 'digishelf-plan';
-    const title = document.createElement('h3');
-    title.textContent = plan.title;
-    const subtitle = document.createElement('p');
-    subtitle.className = 'digishelf-plan__subtitle';
-    subtitle.textContent = plan.subtitle;
-    const summary = document.createElement('p');
-    summary.textContent = plan.summary;
-
-    const stats = document.createElement('ul');
-    stats.className = 'digishelf-plan__stats';
-
-    const setupItem = document.createElement('li');
-    setupItem.innerHTML = `<span>Setup</span><strong>${plan.setup.days || plan.setup.hoursPerDay ? `${plan.setup.days}d • ${formatHours(plan.setup.hoursPerDay)}` : 'Instant'} • $${formatMoney(plan.setup.cost)}</strong>`;
-
-    const upkeepItem = document.createElement('li');
-    upkeepItem.innerHTML = `<span>Upkeep</span><strong>${plan.upkeep.hours ? `${formatHours(plan.upkeep.hours)}/day` : 'No hours'} • $${formatMoney(plan.upkeep.cost)}/day</strong>`;
-
-    const payoutItem = document.createElement('li');
-    payoutItem.innerHTML = `<span>Avg Daily Payout</span><strong>${formatCurrency(plan.averageDaily)}</strong>`;
-
-    stats.append(setupItem, upkeepItem, payoutItem);
-
-    const requirements = document.createElement('p');
-    requirements.className = 'digishelf-plan__requirements';
-    const education = plan.education?.length
-      ? `Requires courses: ${plan.education.join(', ')}`
-      : 'No courses required';
-    const equipment = plan.equipment?.length
-      ? `Gear: ${plan.equipment.join(', ')}`
-      : 'Starter gear only';
-    requirements.textContent = `${education} • ${equipment}`;
-
-    const cta = document.createElement('button');
-    cta.type = 'button';
-    cta.className = 'digishelf-button digishelf-button--primary';
-    cta.textContent = plan.cta || 'Launch';
-    cta.addEventListener('click', () => {
-      const model = presenter.getModel();
-      presenter.updateState(state => {
-        const next = reduceToggleLaunch(state, model);
-        const targetView = plan.id === 'stockPhotos' ? VIEW_STOCK : VIEW_EBOOKS;
-        return reduceSetView(next, model, targetView);
-      });
-      presenter.render(model);
-    });
-
-    card.append(title, subtitle, summary, stats, requirements, cta);
-    grid.appendChild(card);
-  });
-
-  section.append(intro, grid);
-  return section;
-}
-
-function renderMain(model, state = initialState) {
-  if (state.view === VIEW_PRICING) {
-    return renderPricing(model.pricing);
-  }
-
-  const wrapper = document.createElement('div');
-  wrapper.className = 'digishelf-grid';
-
-  const type = state.view === VIEW_STOCK ? 'stockPhotos' : 'ebook';
-  const collection = getSelectedCollection(state, model);
-  const table = renderTable(collection.instances || [], type, state);
-  wrapper.appendChild(table);
-
-  const selected = getSelectedInstance(state, model);
-  wrapper.appendChild(renderDetail(selected, type));
-
-  return wrapper;
-}
-
-function renderHeader(model, state, context) {
+function renderHeader(model, state) {
   const fragment = document.createDocumentFragment();
   fragment.append(
-    renderHero(model, state),
-    renderTabs(state)
+    renderHero({
+      model,
+      state,
+      formatCurrency,
+      formatHours,
+      formatMoney,
+      onToggleLaunch: toggleLaunchPanel,
+      onConfirmLaunch: confirmResourceLaunch
+    }),
+    renderTabNavigation(state, view => setView(view))
   );
   return fragment;
 }
 
+function renderPricingView(model) {
+  return renderPricingCards({
+    pricing: model.pricing,
+    formatters: { formatCurrency, formatHours, formatMoney },
+    onSelectPlan: handlePlanSelect
+  });
+}
+
+function renderCollectionsView(model, state = initialState) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'digishelf-grid';
+
+  const type = state.view === VIEW_STOCK ? 'stockPhotos' : 'ebook';
+  const collection = getSelectedCollection(state, model) || {};
+  const formatters = { formatCurrency, formatHours, formatMoney };
+
+  const quickActions = {
+    ebook: getDigishelfQuickActionIds('ebook'),
+    stockPhotos: getDigishelfQuickActionIds('stockPhotos')
+  };
+
+  wrapper.appendChild(
+    renderInventoryTable({
+      instances: collection.instances || [],
+      type,
+      state,
+      formatters,
+      quickActions,
+      handlers: {
+        onSelectInstance: selectInstance,
+        onRunQuickAction: handleQualityAction
+      }
+    })
+  );
+
+  const selected = getSelectedInstance(state, model);
+  wrapper.appendChild(
+    renderDetailPane({
+      instance: selected,
+      assetId: type,
+      formatters,
+      onSelectNiche: handleNicheSelect,
+      onRunAction: handleQualityAction
+    })
+  );
+
+  return wrapper;
+}
+
 function renderViews(model, state = initialState) {
-  return renderMain(model, state);
+  if (state.view === VIEW_PRICING) {
+    return renderPricingView(model);
+  }
+  return renderCollectionsView(model, state);
 }
 
 function syncNavigation({ mount, state }) {
@@ -888,6 +210,16 @@ function selectInstance(type, id) {
   presenter.render(model);
 }
 
+function handlePlanSelect(planId) {
+  const model = presenter.getModel();
+  presenter.updateState(state => {
+    const next = reduceToggleLaunch(state, model);
+    const targetView = planId === 'stockPhotos' ? VIEW_STOCK : VIEW_EBOOKS;
+    return reduceSetView(next, model, targetView);
+  });
+  presenter.render(model);
+}
+
 function render(model = {}, context = {}) {
   return presenter.render(model, context);
 }
@@ -895,4 +227,3 @@ function render(model = {}, context = {}) {
 export default { render };
 
 export { render };
-

--- a/src/ui/views/browser/components/digishelf/inventoryTable.js
+++ b/src/ui/views/browser/components/digishelf/inventoryTable.js
@@ -1,0 +1,283 @@
+import createStatusBadge from './statusBadge.js';
+
+const QUICK_ACTION_LABELS = {
+  ebook: {
+    writeChapter: 'Write Volume'
+  },
+  stockPhotos: {
+    planShoot: 'Launch Gallery',
+    batchEdit: 'Upload Batch'
+  }
+};
+
+function clampNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function renderUpkeepCell(instance) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'digishelf-upkeep';
+  const maintenance = instance.maintenance;
+  if (maintenance?.parts?.length) {
+    const value = document.createElement('strong');
+    value.textContent = maintenance.parts.join(' + ');
+    wrapper.appendChild(value);
+  } else {
+    const none = document.createElement('span');
+    none.textContent = 'None';
+    wrapper.appendChild(none);
+  }
+
+  const status = document.createElement('span');
+  status.className = instance.maintenanceFunded
+    ? 'digishelf-upkeep__status is-funded'
+    : 'digishelf-upkeep__status is-missed';
+  status.textContent = instance.maintenanceFunded ? 'Funded' : 'Skipped today';
+  wrapper.appendChild(status);
+  return wrapper;
+}
+
+function renderActionButton(label, { disabled = false, title = '', onClick }) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'digishelf-button digishelf-button--ghost';
+  button.textContent = label;
+  button.disabled = Boolean(disabled);
+  if (title) {
+    button.title = title;
+  }
+  button.addEventListener('click', event => {
+    event.stopPropagation();
+    if (button.disabled) return;
+    onClick?.();
+  });
+  return button;
+}
+
+function findActionById(instance, actionId) {
+  if (!actionId) return null;
+  return instance.actions?.find(action => action.id === actionId) || null;
+}
+
+function renderEbookRow(instance, state, dependencies = {}) {
+  const {
+    formatCurrency = value => String(value ?? ''),
+    onSelectInstance = () => {},
+    onRunQuickAction = () => {},
+    quickActions = []
+  } = dependencies;
+
+  const row = document.createElement('tr');
+  row.dataset.instanceId = instance.id;
+  if (state.selectedType === 'ebook' && state.selectedId === instance.id) {
+    row.classList.add('is-selected');
+  }
+
+  row.addEventListener('click', () => onSelectInstance('ebook', instance.id));
+
+  const titleCell = document.createElement('td');
+  titleCell.className = 'digishelf-cell digishelf-cell--label';
+  const title = document.createElement('div');
+  title.className = 'digishelf-label';
+  const name = document.createElement('strong');
+  name.textContent = instance.label;
+  const status = createStatusBadge(instance);
+  title.append(name, status);
+  titleCell.appendChild(title);
+
+  const earningsCell = document.createElement('td');
+  earningsCell.className = 'digishelf-cell digishelf-cell--earnings';
+  const payout = document.createElement('strong');
+  payout.textContent = formatCurrency(instance.latestPayout || instance.averagePayout);
+  const range = document.createElement('span');
+  range.textContent = `${formatCurrency(instance.qualityRange?.min ?? 0)} – ${formatCurrency(instance.qualityRange?.max ?? 0)}`;
+  earningsCell.append(payout, range);
+
+  const milestoneCell = document.createElement('td');
+  milestoneCell.className = 'digishelf-cell';
+  const milestone = document.createElement('div');
+  milestone.className = 'digishelf-milestone';
+  const level = document.createElement('strong');
+  level.textContent = `Quality ${instance.milestone?.level ?? 0}`;
+  const summary = document.createElement('span');
+  summary.textContent = instance.milestone?.summary || 'Progress brewing.';
+  milestone.append(level, summary);
+  milestoneCell.appendChild(milestone);
+
+  const upkeepCell = document.createElement('td');
+  upkeepCell.className = 'digishelf-cell';
+  upkeepCell.appendChild(renderUpkeepCell(instance));
+
+  const actionsCell = document.createElement('td');
+  actionsCell.className = 'digishelf-cell digishelf-cell--actions';
+  const actionWrapper = document.createElement('div');
+  actionWrapper.className = 'digishelf-actions';
+
+  quickActions.forEach(actionId => {
+    const action = findActionById(instance, actionId);
+    if (!action) return;
+    const label = QUICK_ACTION_LABELS.ebook?.[actionId] || action.label;
+    const button = renderActionButton(label, {
+      disabled: !action.available,
+      title: action.disabledReason,
+      onClick: () => onRunQuickAction('ebook', instance.id, actionId)
+    });
+    actionWrapper.appendChild(button);
+  });
+
+  const detailButton = renderActionButton('View Details', {
+    onClick: () => onSelectInstance('ebook', instance.id)
+  });
+  actionWrapper.appendChild(detailButton);
+
+  actionsCell.appendChild(actionWrapper);
+
+  row.append(titleCell, earningsCell, milestoneCell, upkeepCell, actionsCell);
+  return row;
+}
+
+function renderStockRow(instance, state, dependencies = {}) {
+  const {
+    formatCurrency = value => String(value ?? ''),
+    formatHours = value => String(value ?? ''),
+    onSelectInstance = () => {},
+    onRunQuickAction = () => {},
+    quickActions = []
+  } = dependencies;
+
+  const row = document.createElement('tr');
+  row.dataset.instanceId = instance.id;
+  if (state.selectedType === 'stockPhotos' && state.selectedId === instance.id) {
+    row.classList.add('is-selected');
+  }
+
+  row.addEventListener('click', () => onSelectInstance('stockPhotos', instance.id));
+
+  const titleCell = document.createElement('td');
+  titleCell.className = 'digishelf-cell digishelf-cell--label';
+  const label = document.createElement('div');
+  label.className = 'digishelf-label';
+  const name = document.createElement('strong');
+  name.textContent = instance.label;
+  const status = createStatusBadge(instance);
+  label.append(name, status);
+  titleCell.appendChild(label);
+
+  const photosCell = document.createElement('td');
+  photosCell.className = 'digishelf-cell';
+  const totalShoots = clampNumber(instance.progress?.shoots);
+  const totalEdits = clampNumber(instance.progress?.editing);
+  const uploads = document.createElement('strong');
+  uploads.textContent = `${totalShoots} shoots / ${totalEdits} edits`;
+  const hint = document.createElement('span');
+  hint.textContent = 'Shoots • Edits logged';
+  photosCell.append(uploads, hint);
+
+  const earningsCell = document.createElement('td');
+  earningsCell.className = 'digishelf-cell digishelf-cell--earnings';
+  const payout = document.createElement('strong');
+  payout.textContent = formatCurrency(instance.latestPayout || instance.averagePayout);
+  const range = document.createElement('span');
+  range.textContent = `${formatCurrency(instance.qualityRange?.min ?? 0)} – ${formatCurrency(instance.qualityRange?.max ?? 0)}`;
+  earningsCell.append(payout, range);
+
+  const upkeepCell = document.createElement('td');
+  upkeepCell.className = 'digishelf-cell';
+  upkeepCell.appendChild(renderUpkeepCell(instance));
+
+  const actionsCell = document.createElement('td');
+  actionsCell.className = 'digishelf-cell digishelf-cell--actions';
+  const actionWrapper = document.createElement('div');
+  actionWrapper.className = 'digishelf-actions';
+
+  quickActions.forEach(actionId => {
+    const action = findActionById(instance, actionId);
+    if (!action) return;
+    const label = QUICK_ACTION_LABELS.stockPhotos?.[actionId] || action.label;
+    const button = renderActionButton(label, {
+      disabled: !action.available,
+      title: action.disabledReason,
+      onClick: () => onRunQuickAction('stockPhotos', instance.id, actionId)
+    });
+    actionWrapper.appendChild(button);
+  });
+
+  const detailButton = document.createElement('button');
+  detailButton.type = 'button';
+  detailButton.className = 'digishelf-button digishelf-button--link';
+  detailButton.textContent = 'View Details';
+  detailButton.addEventListener('click', event => {
+    event.stopPropagation();
+    onSelectInstance('stockPhotos', instance.id);
+  });
+  actionWrapper.appendChild(detailButton);
+
+  actionsCell.appendChild(actionWrapper);
+
+  row.append(titleCell, photosCell, earningsCell, upkeepCell, actionsCell);
+  return row;
+}
+
+export default function renderInventoryTable(options = {}) {
+  const {
+    instances = [],
+    type = 'ebook',
+    state = {},
+    formatters = {},
+    quickActions = {},
+    handlers = {}
+  } = options;
+
+  const table = document.createElement('table');
+  table.className = 'digishelf-table';
+  const thead = document.createElement('thead');
+  const headRow = document.createElement('tr');
+
+  const headers = type === 'ebook'
+    ? ['Title', 'Daily Earnings', 'Quality Milestone', 'Upkeep', 'Actions']
+    : ['Gallery', 'Photos Uploaded', 'Daily Earnings', 'Upkeep', 'Actions'];
+
+  headers.forEach(label => {
+    const th = document.createElement('th');
+    th.textContent = label;
+    headRow.appendChild(th);
+  });
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+
+  if (!instances.length) {
+    const emptyRow = document.createElement('tr');
+    const emptyCell = document.createElement('td');
+    emptyCell.colSpan = headers.length;
+    emptyCell.className = 'digishelf-empty';
+    emptyCell.textContent = type === 'ebook'
+      ? 'No e-book series live yet. Spin one up to start collecting royalties.'
+      : 'No stock galleries live yet. Launch a collection to start syndicating shots.';
+    emptyRow.appendChild(emptyCell);
+    tbody.appendChild(emptyRow);
+  } else {
+    instances.forEach(instance => {
+      const row = type === 'ebook'
+        ? renderEbookRow(instance, state, {
+            formatCurrency: formatters.formatCurrency,
+            onSelectInstance: handlers.onSelectInstance,
+            onRunQuickAction: handlers.onRunQuickAction,
+            quickActions: quickActions.ebook || []
+          })
+        : renderStockRow(instance, state, {
+            formatCurrency: formatters.formatCurrency,
+            formatHours: formatters.formatHours,
+            onSelectInstance: handlers.onSelectInstance,
+            onRunQuickAction: handlers.onRunQuickAction,
+            quickActions: quickActions.stockPhotos || []
+          });
+      tbody.appendChild(row);
+    });
+  }
+
+  table.appendChild(tbody);
+  return table;
+}

--- a/src/ui/views/browser/components/digishelf/pricingCards.js
+++ b/src/ui/views/browser/components/digishelf/pricingCards.js
@@ -1,0 +1,79 @@
+import { ensureArray } from '../../../../../core/helpers.js';
+
+export default function renderPricingCards(options = {}) {
+  const {
+    pricing = [],
+    formatters = {},
+    onSelectPlan = () => {}
+  } = options;
+
+  const formatCurrency = formatters.formatCurrency || (value => String(value ?? ''));
+  const formatHours = formatters.formatHours || (value => String(value ?? ''));
+  const formatMoney = formatters.formatMoney || (value => String(value ?? ''));
+
+  const section = document.createElement('section');
+  section.className = 'digishelf-pricing';
+
+  const intro = document.createElement('div');
+  intro.className = 'digishelf-pricing__intro';
+  const heading = document.createElement('h2');
+  heading.textContent = 'Pricing & Scaling Plans';
+  const note = document.createElement('p');
+  note.textContent = 'Compare launch effort, upkeep, and daily earning potential for each digital asset lane.';
+  intro.append(heading, note);
+
+  const grid = document.createElement('div');
+  grid.className = 'digishelf-pricing__grid';
+
+  ensureArray(pricing).forEach(plan => {
+    const card = document.createElement('article');
+    card.className = 'digishelf-plan';
+    const title = document.createElement('h3');
+    title.textContent = plan.title;
+    const subtitle = document.createElement('p');
+    subtitle.className = 'digishelf-plan__subtitle';
+    subtitle.textContent = plan.subtitle;
+    const summary = document.createElement('p');
+    summary.textContent = plan.summary;
+
+    const stats = document.createElement('ul');
+    stats.className = 'digishelf-plan__stats';
+
+    const setupItem = document.createElement('li');
+    const setupHours = plan.setup.hoursPerDay ? `${formatHours(plan.setup.hoursPerDay)}` : 'Instant';
+    const setupDays = plan.setup.days ? `${plan.setup.days}d` : '';
+    const setupLabel = [setupDays, setupHours].filter(Boolean).join(' • ') || 'Instant';
+    setupItem.innerHTML = `<span>Setup</span><strong>${setupLabel} • $${formatMoney(plan.setup.cost)}</strong>`;
+
+    const upkeepItem = document.createElement('li');
+    const upkeepHours = plan.upkeep.hours ? `${formatHours(plan.upkeep.hours)}/day` : 'No hours';
+    upkeepItem.innerHTML = `<span>Upkeep</span><strong>${upkeepHours} • $${formatMoney(plan.upkeep.cost)}/day</strong>`;
+
+    const payoutItem = document.createElement('li');
+    payoutItem.innerHTML = `<span>Avg Daily Payout</span><strong>${formatCurrency(plan.averageDaily)}</strong>`;
+
+    stats.append(setupItem, upkeepItem, payoutItem);
+
+    const requirements = document.createElement('p');
+    requirements.className = 'digishelf-plan__requirements';
+    const education = ensureArray(plan.education).length
+      ? `Requires courses: ${plan.education.join(', ')}`
+      : 'No courses required';
+    const equipment = ensureArray(plan.equipment).length
+      ? `Gear: ${plan.equipment.join(', ')}`
+      : 'Starter gear only';
+    requirements.textContent = `${education} • ${equipment}`;
+
+    const cta = document.createElement('button');
+    cta.type = 'button';
+    cta.className = 'digishelf-button digishelf-button--primary';
+    cta.textContent = plan.cta || 'Launch';
+    cta.addEventListener('click', () => onSelectPlan(plan.id));
+
+    card.append(title, subtitle, summary, stats, requirements, cta);
+    grid.appendChild(card);
+  });
+
+  section.append(intro, grid);
+  return section;
+}

--- a/src/ui/views/browser/components/digishelf/statusBadge.js
+++ b/src/ui/views/browser/components/digishelf/statusBadge.js
@@ -1,0 +1,6 @@
+export default function createStatusBadge(instance = {}) {
+  const badge = document.createElement('span');
+  badge.className = `digishelf-badge digishelf-badge--${instance.status?.id || 'setup'}`;
+  badge.textContent = instance.status?.label || 'Setup';
+  return badge;
+}

--- a/src/ui/views/browser/components/digishelf/tabNavigation.js
+++ b/src/ui/views/browser/components/digishelf/tabNavigation.js
@@ -1,0 +1,29 @@
+import { createNavTabs } from '../common/navBuilders.js';
+import { VIEW_EBOOKS, VIEW_STOCK, VIEW_PRICING } from './state.js';
+
+export default function renderTabNavigation(state, onSelect = () => {}) {
+  return createNavTabs({
+    navClassName: 'digishelf-tabs',
+    buttonClassName: 'digishelf-tab',
+    datasetKey: 'view',
+    withAriaPressed: true,
+    onSelect,
+    buttons: [
+      {
+        label: 'E-Books',
+        view: VIEW_EBOOKS,
+        isActive: state?.view === VIEW_EBOOKS
+      },
+      {
+        label: 'Stock Photos',
+        view: VIEW_STOCK,
+        isActive: state?.view === VIEW_STOCK
+      },
+      {
+        label: 'Pricing & Plans',
+        view: VIEW_PRICING,
+        isActive: state?.view === VIEW_PRICING
+      }
+    ]
+  });
+}

--- a/src/ui/views/browser/components/shopily/index.js
+++ b/src/ui/views/browser/components/shopily/index.js
@@ -28,6 +28,9 @@ import {
   getSelectedStore,
   getSelectedUpgrade
 } from './state.js';
+import renderDashboardView from './views/dashboardView.js';
+import renderUpgradesView from './views/upgradesView.js';
+import renderPricingView from './views/pricingView.js';
 
 const UPGRADE_STATUS_TONES = {
   owned: 'owned',
@@ -36,12 +39,9 @@ const UPGRADE_STATUS_TONES = {
   locked: 'locked'
 };
 
-const formatCurrency = amount =>
-  baseFormatCurrency(amount, { precision: 'integer', clampZero: true });
-const formatSignedCurrency = amount =>
-  baseFormatSignedCurrency(amount, { precision: 'cent' });
-const formatPercent = value =>
-  baseFormatPercent(value, { nullFallback: '—', signDisplay: 'always' });
+const formatCurrency = amount => baseFormatCurrency(amount, { precision: 'integer', clampZero: true });
+const formatSignedCurrency = amount => baseFormatSignedCurrency(amount, { precision: 'cent' });
+const formatPercent = value => baseFormatPercent(value, { nullFallback: '—', signDisplay: 'always' });
 
 const {
   describeSetupSummary: describePlanSetupSummary,
@@ -63,11 +63,6 @@ function handleQuickAction(instanceId, actionId) {
 function handleNicheSelect(instanceId, value) {
   if (!instanceId) return;
   selectShopilyNiche('dropshipping', instanceId, value);
-}
-
-function handleUpgradeSelect(upgradeId) {
-  if (!upgradeId) return;
-  setView(VIEW_UPGRADES, { upgradeId });
 }
 
 function formatKeyLabel(key) {
@@ -182,6 +177,40 @@ function collectDetailStrings(definition) {
     .filter(Boolean);
 }
 
+function describeEffectSummary(effects = {}, affects = {}) {
+  const effectParts = [];
+  Object.entries(effects).forEach(([effect, value]) => {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric) || numeric === 1) return;
+    const percent = Math.round((numeric - 1) * 100);
+    let label;
+    switch (effect) {
+      case 'payout_mult':
+        label = `${percent >= 0 ? '+' : ''}${percent}% payout`;
+        break;
+      case 'quality_progress_mult':
+        label = `${percent >= 0 ? '+' : ''}${percent}% quality speed`;
+        break;
+      case 'setup_time_mult':
+        label = `${percent >= 0 ? '+' : ''}${percent}% setup speed`;
+        break;
+      case 'maint_time_mult':
+        label = `${percent >= 0 ? '+' : ''}${percent}% upkeep speed`;
+        break;
+      default:
+        label = `${effect}: ${numeric}`;
+    }
+    effectParts.push(label);
+  });
+  if (!effectParts.length) return '';
+  const scope = [];
+  const assetIds = ensureArray(affects.assets?.ids);
+  if (assetIds.length) scope.push(`stores (${assetIds.join(', ')})`);
+  const assetTags = ensureArray(affects.assets?.tags);
+  if (assetTags.length) scope.push(`tags ${assetTags.join(', ')}`);
+  return scope.length ? `${effectParts.join(' • ')} → ${scope.join(' & ')}` : effectParts.join(' • ');
+}
+
 function collectUpgradeHighlights(upgrade) {
   const highlights = [];
   const effectSummary = describeEffectSummary(upgrade?.effects || {}, upgrade?.affects || {});
@@ -222,7 +251,9 @@ function createLaunchButton(launch) {
   return button;
 }
 
-function renderTopBar(model, state, context = {}) {
+function renderTopBar(model, state, context = {}, dependencies = {}) {
+  const { onViewChange = () => {}, createLaunch = createLaunchButton } = dependencies;
+
   const bar = document.createElement('header');
   bar.className = 'shopily-topbar';
 
@@ -243,7 +274,7 @@ function renderTopBar(model, state, context = {}) {
     badgeClassName: 'shopily-nav__badge',
     datasetKey: 'view',
     withAriaPressed: true,
-    onSelect: setView,
+    onSelect: (view, options) => onViewChange(view, options),
     buttons: [
       {
         label: 'My Stores',
@@ -267,7 +298,7 @@ function renderTopBar(model, state, context = {}) {
 
   const actions = document.createElement('div');
   actions.className = 'shopily-topbar__actions';
-  actions.appendChild(createLaunchButton(model.launch));
+  actions.appendChild(createLaunch(model.launch));
 
   const topRow = document.createElement('div');
   topRow.className = 'shopily-topbar__row';
@@ -277,907 +308,58 @@ function renderTopBar(model, state, context = {}) {
   return bar;
 }
 
-function describeMetricTone(value) {
-  const numeric = Number(value) || 0;
-  if (numeric > 0) return 'positive';
-  if (numeric < 0) return 'negative';
-  return 'neutral';
-}
-
-function renderMetrics(metrics = {}) {
-  const grid = document.createElement('dl');
-  grid.className = 'shopily-metrics';
-  const entries = [
-    {
-      label: 'Total Stores',
-      value: metrics.totalStores || 0,
-      note: 'Active & in setup',
-      tone: 'neutral'
-    },
-    {
-      label: 'Daily Sales',
-      value: formatCurrency(metrics.dailySales || 0),
-      note: 'Yesterday’s payouts',
-      tone: describeMetricTone(metrics.dailySales)
-    },
-    {
-      label: 'Daily Upkeep',
-      value: formatCurrency(metrics.dailyUpkeep || 0),
-      note: 'Cash needed each day',
-      tone: describeMetricTone(-(metrics.dailyUpkeep || 0))
-    },
-    {
-      label: 'Net / Day',
-      value: formatSignedCurrency(metrics.netDaily || 0),
-      note: 'Sales minus upkeep',
-      tone: describeMetricTone(metrics.netDaily)
-    }
-  ];
-
-  entries.forEach(entry => {
-    const item = document.createElement('div');
-    item.className = 'shopily-metric';
-    item.dataset.tone = entry.tone;
-
-    const label = document.createElement('dt');
-    label.className = 'shopily-metric__label';
-    label.textContent = entry.label;
-
-    const value = document.createElement('dd');
-    value.className = 'shopily-metric__value';
-    value.textContent = entry.value;
-
-    const note = document.createElement('span');
-    note.className = 'shopily-metric__note';
-    note.textContent = entry.note;
-
-    item.append(label, value, note);
-    grid.appendChild(item);
-  });
-
-  return grid;
-}
-
-function renderHero(model) {
-  const hero = document.createElement('section');
-  hero.className = 'shopily-hero';
-
-  const body = document.createElement('div');
-  body.className = 'shopily-hero__body';
-
-  const headline = document.createElement('h2');
-  headline.textContent = 'Your store, your brand, powered by Shopily.';
-  const summary = document.createElement('p');
-  summary.textContent = model.summary?.meta || 'Launch your first storefront to kick off the commerce flywheel.';
-
-  const ctaRow = document.createElement('div');
-  ctaRow.className = 'shopily-hero__cta';
-  ctaRow.appendChild(createLaunchButton(model.launch));
-
-  body.append(headline, summary, ctaRow);
-  hero.append(body, renderMetrics(model.metrics));
-  return hero;
-}
-
-function formatNicheDelta(delta) {
-  if (delta === null || delta === undefined) return '';
-  const numeric = Number(delta);
-  if (!Number.isFinite(numeric) || numeric === 0) return '';
-  const icon = numeric > 0 ? '⬆️' : '⬇️';
-  return `${icon} ${Math.abs(Math.round(numeric * 100))}%`;
-}
-
-function renderStoreTable(instances = [], state = initialState) {
-  const table = document.createElement('table');
-  table.className = 'shopily-table';
-
-  const thead = document.createElement('thead');
-  const headRow = document.createElement('tr');
-  ['Store', 'Niche', 'Daily Earnings', 'Upkeep', 'ROI', 'Actions'].forEach(label => {
-    const th = document.createElement('th');
-    th.textContent = label;
-    headRow.appendChild(th);
-  });
-  thead.appendChild(headRow);
-  table.appendChild(thead);
-
-  const tbody = document.createElement('tbody');
-
-  if (!instances.length) {
-    const emptyRow = document.createElement('tr');
-    const cell = document.createElement('td');
-    cell.colSpan = 6;
-    cell.className = 'shopily-table__empty';
-    cell.textContent = 'No stores yet. Launch your first shop to start capturing daily sales.';
-    emptyRow.appendChild(cell);
-    tbody.appendChild(emptyRow);
-  } else {
-    instances.forEach(instance => {
-      const row = document.createElement('tr');
-      row.dataset.storeId = instance.id;
-      if (instance.id === state.selectedStoreId) {
-        row.classList.add('is-selected');
-      }
-      row.addEventListener('click', () => setView(VIEW_DASHBOARD, { storeId: instance.id }));
-
-      const nameCell = document.createElement('td');
-      nameCell.className = 'shopily-table__cell--label';
-      nameCell.textContent = instance.label;
-
-      const nicheCell = document.createElement('td');
-      if (instance.niche) {
-        const nicheWrap = document.createElement('div');
-        nicheWrap.className = 'shopily-niche';
-        const nicheName = document.createElement('strong');
-        nicheName.className = 'shopily-niche__name';
-        nicheName.textContent = instance.niche.name;
-        const nicheTrend = document.createElement('span');
-        nicheTrend.className = 'shopily-niche__trend';
-        const delta = formatNicheDelta(instance.niche.delta);
-        nicheTrend.textContent = delta || `${formatPercent(instance.niche.multiplier - 1)} boost`;
-        nicheWrap.append(nicheName, nicheTrend);
-        nicheCell.appendChild(nicheWrap);
-      } else {
-        nicheCell.textContent = 'Unassigned';
-      }
-
-      const earningsCell = document.createElement('td');
-      earningsCell.textContent = formatCurrency(instance.latestPayout || 0);
-
-      const upkeepCell = document.createElement('td');
-      upkeepCell.textContent = formatCurrency(instance.maintenanceCost || 0);
-
-      const roiCell = document.createElement('td');
-      roiCell.textContent = formatPercent(instance.roi);
-
-      const actionCell = document.createElement('td');
-      actionCell.className = 'shopily-table__cell--actions';
-      const upgradeButton = document.createElement('button');
-      upgradeButton.type = 'button';
-      upgradeButton.className = 'shopily-button shopily-button--ghost';
-      upgradeButton.textContent = 'Upgrade Store';
-      upgradeButton.addEventListener('click', event => {
-        event.stopPropagation();
-        setView(VIEW_UPGRADES, { storeId: instance.id });
-      });
-      const detailButton = document.createElement('button');
-      detailButton.type = 'button';
-      detailButton.className = 'shopily-button shopily-button--link';
-      detailButton.textContent = 'View Details';
-      detailButton.addEventListener('click', event => {
-        event.stopPropagation();
-        setView(VIEW_DASHBOARD, { storeId: instance.id });
-      });
-      actionCell.append(upgradeButton, detailButton);
-
-      row.append(nameCell, nicheCell, earningsCell, upkeepCell, roiCell, actionCell);
-      tbody.appendChild(row);
-    });
-  }
-
-  table.appendChild(tbody);
-  return table;
-}
-
-function renderQualityPanel(instance) {
-  const panel = document.createElement('section');
-  panel.className = 'shopily-panel';
-
-  const heading = document.createElement('h3');
-  heading.textContent = `Quality ${instance.qualityLevel}`;
-  panel.appendChild(heading);
-
-  if (instance.qualityInfo?.description) {
-    const note = document.createElement('p');
-    note.className = 'shopily-panel__note';
-    note.textContent = instance.qualityInfo.description;
-    panel.appendChild(note);
-  }
-
-  const progress = document.createElement('div');
-  progress.className = 'shopily-progress';
-  const fill = document.createElement('div');
-  fill.className = 'shopily-progress__fill';
-  fill.style.setProperty('--shopily-progress', String((instance.milestone?.percent || 0) * 100));
-  progress.appendChild(fill);
-
-  const summary = document.createElement('p');
-  summary.className = 'shopily-panel__note';
-  summary.textContent = instance.milestone?.summary || 'Push quality actions to unlock the next tier.';
-
-  panel.append(progress, summary);
-  return panel;
-}
-
-function renderNichePanel(instance) {
-  const panel = document.createElement('section');
-  panel.className = 'shopily-panel';
-
-  const heading = document.createElement('h3');
-  heading.textContent = 'Audience niche';
-  panel.appendChild(heading);
-
-  if (instance.niche) {
-    const nicheLine = document.createElement('p');
-    nicheLine.className = 'shopily-panel__lead';
-    nicheLine.textContent = instance.niche.name;
-    panel.appendChild(nicheLine);
-
-    const vibe = document.createElement('p');
-    vibe.className = 'shopily-panel__note';
-    const delta = formatNicheDelta(instance.niche.delta);
-    const boost = formatPercent(instance.niche.multiplier - 1);
-    vibe.textContent = `${instance.niche.summary || 'Trend snapshot unavailable.'} ${delta ? `(${delta})` : boost !== '—' ? `(${boost})` : ''}`.trim();
-    panel.appendChild(vibe);
-  } else {
-    const empty = document.createElement('p');
-    empty.className = 'shopily-panel__note';
-    empty.textContent = 'No niche assigned yet. Pick a trending lane for bonus payouts.';
-    panel.appendChild(empty);
-  }
-
-  if (!instance.nicheLocked && ensureArray(instance.nicheOptions).length) {
-    const field = document.createElement('label');
-    field.className = 'shopily-field';
-    field.textContent = 'Assign niche';
-
-    const select = document.createElement('select');
-    select.className = 'shopily-select';
-    const placeholder = document.createElement('option');
-    placeholder.value = '';
-    placeholder.textContent = 'Choose a niche';
-    select.appendChild(placeholder);
-
-    instance.nicheOptions.forEach(option => {
-      const optionEl = document.createElement('option');
-      optionEl.value = option.id;
-      optionEl.textContent = `${option.name} — ${formatPercent(option.multiplier - 1)} boost`;
-      select.appendChild(optionEl);
-    });
-
-    select.value = instance.niche?.id || '';
-    select.addEventListener('change', event => {
-      handleNicheSelect(instance.id, event.target.value || null);
-    });
-
-    field.appendChild(select);
-    panel.appendChild(field);
-  } else if (instance.nicheLocked && instance.niche) {
-    const locked = document.createElement('p');
-    locked.className = 'shopily-panel__hint';
-    locked.textContent = 'Niche locked in — upgrades can refresh trend strength.';
-    panel.appendChild(locked);
-  }
-
-  return panel;
-}
-
-function renderStatsPanel(instance) {
-  const panel = document.createElement('section');
-  panel.className = 'shopily-panel';
-
-  const heading = document.createElement('h3');
-  heading.textContent = 'Store health';
-  panel.appendChild(heading);
-
-  const list = document.createElement('dl');
-  list.className = 'shopily-stats';
-  const entries = [
-    { label: 'Latest payout', value: formatCurrency(instance.latestPayout || 0) },
-    { label: 'Average / day', value: formatCurrency(instance.averagePayout || 0) },
-    { label: 'Lifetime sales', value: formatCurrency(instance.lifetimeIncome || 0) },
-    { label: 'Lifetime spend', value: formatCurrency(instance.lifetimeSpend || 0) },
-    { label: 'Profit to date', value: formatSignedCurrency(instance.profit || 0) },
-    { label: 'Lifetime ROI', value: formatPercent(instance.roi) },
-    { label: 'Resale value', value: formatCurrency(instance.resaleValue || 0) }
-  ];
-
-  entries.forEach(entry => {
-    const row = document.createElement('div');
-    row.className = 'shopily-stats__row';
-    const term = document.createElement('dt');
-    term.textContent = entry.label;
-    const value = document.createElement('dd');
-    value.textContent = entry.value;
-    row.append(term, value);
-    list.appendChild(row);
-  });
-
-  panel.appendChild(list);
-
-  if (!instance.maintenanceFunded) {
-    const warning = document.createElement('p');
-    warning.className = 'shopily-panel__warning';
-    warning.textContent = 'Maintenance unfunded — cover daily upkeep to avoid shutdowns.';
-    panel.appendChild(warning);
-  }
-
-  if (instance.maintenance?.parts?.length) {
-    const upkeep = document.createElement('p');
-    upkeep.className = 'shopily-panel__note';
-    upkeep.textContent = `Daily upkeep: ${instance.maintenance.parts.join(' • ')}`;
-    panel.appendChild(upkeep);
-  }
-
-  return panel;
-}
-
-function renderPayoutBreakdown(instance) {
-  const panel = document.createElement('section');
-  panel.className = 'shopily-panel';
-
-  const heading = document.createElement('h3');
-  heading.textContent = 'Payout recap';
-  panel.appendChild(heading);
-
-  if (!instance.payoutBreakdown.entries.length) {
-    const note = document.createElement('p');
-    note.className = 'shopily-panel__note';
-    note.textContent = 'No payout modifiers yet. Unlock upgrades and courses to stack multipliers.';
-    panel.appendChild(note);
-  } else {
-    const list = document.createElement('ul');
-    list.className = 'shopily-list';
-    instance.payoutBreakdown.entries.forEach(entry => {
-      const item = document.createElement('li');
-      item.className = 'shopily-list__item';
-      const label = document.createElement('span');
-      label.className = 'shopily-list__label';
-      label.textContent = entry.label;
-      const value = document.createElement('span');
-      value.className = 'shopily-list__value';
-      const amount = formatCurrency(entry.amount || 0);
-      const percent = entry.percent !== null && entry.percent !== undefined
-        ? ` (${formatPercent(entry.percent)})`
-        : '';
-      value.textContent = `${amount}${percent}`;
-      item.append(label, value);
-      list.appendChild(item);
-    });
-    panel.appendChild(list);
-  }
-
-  const total = document.createElement('p');
-  total.className = 'shopily-panel__note';
-  total.textContent = `Yesterday’s total: ${formatCurrency(instance.payoutBreakdown.total || 0)}`;
-  panel.appendChild(total);
-
-  return panel;
-}
-
-function renderActionList(instance) {
-  const panel = document.createElement('section');
-  panel.className = 'shopily-panel';
-
-  const heading = document.createElement('h3');
-  heading.textContent = 'Quality actions';
-  panel.appendChild(heading);
-
-  if (!instance.actions.length) {
-    const empty = document.createElement('p');
-    empty.className = 'shopily-panel__note';
-    empty.textContent = 'No actions unlocked yet. Install upgrades to expand your playbook.';
-    panel.appendChild(empty);
-    return panel;
-  }
-
-  const list = document.createElement('ul');
-  list.className = 'shopily-action-list';
-
-  instance.actions.forEach(action => {
-    const item = document.createElement('li');
-    item.className = 'shopily-action';
-
-    const label = document.createElement('div');
-    label.className = 'shopily-action__label';
-    label.textContent = action.label;
-
-    const meta = document.createElement('div');
-    meta.className = 'shopily-action__meta';
-    const time = action.time > 0 ? formatHours(action.time) : 'Instant';
-    const cost = action.cost > 0 ? formatCurrency(action.cost) : 'No spend';
-    meta.textContent = `${time} • ${cost}`;
-
-    const button = document.createElement('button');
-    button.type = 'button';
-    button.className = 'shopily-button shopily-button--secondary';
-    button.textContent = action.available ? 'Run now' : 'Locked';
-    button.disabled = !action.available;
-    if (action.disabledReason) {
-      button.title = action.disabledReason;
-    }
-    button.addEventListener('click', () => {
-      if (button.disabled) return;
-      handleQuickAction(instance.id, action.id);
-    });
-
-    item.append(label, meta, button);
-    list.appendChild(item);
-  });
-
-  panel.appendChild(list);
-  return panel;
-}
-
-function renderStoreDetail(instance) {
-  const detail = document.createElement('aside');
-  detail.className = 'shopily-detail';
-
-  if (!instance) {
-    const empty = document.createElement('div');
-    empty.className = 'shopily-detail__empty';
-    empty.textContent = 'Select a store to inspect payouts, niches, and upgrades.';
-    detail.appendChild(empty);
-    return detail;
-  }
-
-  const header = document.createElement('header');
-  header.className = 'shopily-detail__header';
-  const title = document.createElement('h2');
-  title.textContent = instance.label;
-  const status = document.createElement('span');
-  status.className = 'shopily-status';
-  status.dataset.state = instance.status?.id || 'setup';
-  status.textContent = instance.status?.label || 'Setup';
-  header.append(title, status);
-  detail.appendChild(header);
-
-  if (instance.pendingIncome > 0) {
-    const pending = document.createElement('p');
-    pending.className = 'shopily-panel__hint';
-    pending.textContent = `Pending payouts: ${formatCurrency(instance.pendingIncome)} once upkeep clears.`;
-    detail.appendChild(pending);
-  }
-
-  detail.append(
-    renderStatsPanel(instance),
-    renderQualityPanel(instance),
-    renderNichePanel(instance),
-    renderPayoutBreakdown(instance),
-    renderActionList(instance)
-  );
-
-  return detail;
-}
-
-function renderDashboardView(model, state = initialState) {
-  const container = document.createElement('section');
-  container.className = 'shopily-view shopily-view--dashboard';
-
-  container.appendChild(renderHero(model));
-
-  const grid = document.createElement('div');
-  grid.className = 'shopily-grid';
-  const selectedStore = getSelectedStore(state, model);
-  grid.append(
-    renderStoreTable(model.instances, state),
-    renderStoreDetail(selectedStore)
-  );
-  container.appendChild(grid);
-
-  return container;
-}
-
-function describeEffectSummary(effects = {}, affects = {}) {
-  const effectParts = [];
-  Object.entries(effects).forEach(([effect, value]) => {
-    const numeric = Number(value);
-    if (!Number.isFinite(numeric) || numeric === 1) return;
-    const percent = Math.round((numeric - 1) * 100);
-    let label;
-    switch (effect) {
-      case 'payout_mult':
-        label = `${percent >= 0 ? '+' : ''}${percent}% payout`;
-        break;
-      case 'quality_progress_mult':
-        label = `${percent >= 0 ? '+' : ''}${percent}% quality speed`;
-        break;
-      case 'setup_time_mult':
-        label = `${percent >= 0 ? '+' : ''}${percent}% setup speed`;
-        break;
-      case 'maint_time_mult':
-        label = `${percent >= 0 ? '+' : ''}${percent}% upkeep speed`;
-        break;
-      default:
-        label = `${effect}: ${numeric}`;
-    }
-    effectParts.push(label);
-  });
-  if (!effectParts.length) return '';
-  const scope = [];
-  const assetIds = ensureArray(affects.assets?.ids);
-  if (assetIds.length) scope.push(`stores (${assetIds.join(', ')})`);
-  const assetTags = ensureArray(affects.assets?.tags);
-  if (assetTags.length) scope.push(`tags ${assetTags.join(', ')}`);
-  return scope.length ? `${effectParts.join(' • ')} → ${scope.join(' & ')}` : effectParts.join(' • ');
-}
-
-function renderUpgradeCard(upgrade, state = initialState) {
-  const card = document.createElement('article');
-  card.className = 'shopily-upgrade';
-  const tone = describeUpgradeSnapshotTone(upgrade.snapshot);
-  card.dataset.status = tone;
-  if (upgrade.id === state.selectedUpgradeId) {
-    card.classList.add('is-active');
-  }
-  card.tabIndex = 0;
-
-  card.addEventListener('click', () => handleUpgradeSelect(upgrade.id));
-  card.addEventListener('keydown', event => {
-    if (event.defaultPrevented) return;
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      handleUpgradeSelect(upgrade.id);
-    }
-  });
-
-  const header = document.createElement('header');
-  header.className = 'shopily-upgrade__header';
-
-  const title = document.createElement('h3');
-  title.textContent = upgrade.name;
-  header.appendChild(title);
-
-  if (upgrade.tag?.label) {
-    const badge = document.createElement('span');
-    badge.className = 'shopily-upgrade__badge';
-    badge.textContent = upgrade.tag.label;
-    header.appendChild(badge);
-  }
-
-  const summary = document.createElement('p');
-  summary.className = 'shopily-upgrade__summary';
-  summary.textContent = upgrade.description || 'Commerce boost';
-
-  const highlights = document.createElement('ul');
-  highlights.className = 'shopily-upgrade__highlights';
-  const highlightEntries = collectUpgradeHighlights(upgrade);
-  if (!highlightEntries.length) {
-    const fallback = document.createElement('li');
-    fallback.textContent = 'Stacks with dropshipping payouts and progress.';
-    highlights.appendChild(fallback);
-  } else {
-    highlightEntries.forEach(entry => {
-      const item = document.createElement('li');
-      item.textContent = entry;
-      highlights.appendChild(item);
-    });
-  }
-
-  const footer = document.createElement('div');
-  footer.className = 'shopily-upgrade__footer';
-
-  const meta = document.createElement('div');
-  meta.className = 'shopily-upgrade__meta';
-
-  const price = document.createElement('span');
-  price.className = 'shopily-upgrade__price';
-  price.textContent = formatCurrency(upgrade.cost || 0);
-
-  const status = document.createElement('span');
-  status.className = 'shopily-upgrade__status';
-  status.textContent = upgrade.status || 'Progress for this soon';
-
-  meta.append(price, status);
-
-  const actions = document.createElement('div');
-  actions.className = 'shopily-upgrade__actions';
-
-  const viewButton = document.createElement('button');
-  viewButton.type = 'button';
-  viewButton.className = 'shopily-button shopily-button--ghost';
-  viewButton.textContent = 'View product';
-  viewButton.addEventListener('click', event => {
-    event.stopPropagation();
-    handleUpgradeSelect(upgrade.id);
-  });
-
-  actions.appendChild(viewButton);
-  footer.append(meta, actions);
-
-  card.append(header, summary, highlights, footer);
-  return card;
-}
-
-function renderUpgradeDetail(upgrade) {
-  const detail = document.createElement('aside');
-  detail.className = 'shopily-upgrade-detail';
-
-  if (!upgrade) {
-    const empty = document.createElement('div');
-    empty.className = 'shopily-upgrade-detail__empty';
-    empty.textContent = 'Select an upgrade to review requirements, highlights, and checkout.';
-    detail.appendChild(empty);
-    return detail;
-  }
-
-  const tone = describeUpgradeSnapshotTone(upgrade.snapshot);
-
-  const header = document.createElement('header');
-  header.className = 'shopily-upgrade-detail__header';
-
-  const titleBlock = document.createElement('div');
-  titleBlock.className = 'shopily-upgrade-detail__title';
-
-  if (upgrade.tag?.label) {
-    const badge = document.createElement('span');
-    badge.className = 'shopily-upgrade-detail__tag';
-    badge.textContent = upgrade.tag.label;
-    titleBlock.appendChild(badge);
-  }
-
-  const heading = document.createElement('h2');
-  heading.textContent = upgrade.name;
-  titleBlock.appendChild(heading);
-
-  const blurb = document.createElement('p');
-  blurb.className = 'shopily-upgrade-detail__blurb';
-  blurb.textContent = upgrade.description || 'Commerce boost';
-  titleBlock.appendChild(blurb);
-
-  const priceBlock = document.createElement('div');
-  priceBlock.className = 'shopily-upgrade-detail__price';
-  const priceLabel = document.createElement('span');
-  priceLabel.textContent = 'Price';
-  const priceValue = document.createElement('strong');
-  priceValue.textContent = formatCurrency(upgrade.cost || 0);
-  priceBlock.append(priceLabel, priceValue);
-
-  header.append(titleBlock, priceBlock);
-
-  const statusRow = document.createElement('div');
-  statusRow.className = 'shopily-upgrade-detail__status-row';
-
-  const statusBadge = document.createElement('span');
-  statusBadge.className = `shopily-upgrade-detail__badge shopily-upgrade-detail__badge--${tone}`;
-  if (upgrade.snapshot?.purchased) {
-    statusBadge.textContent = 'Owned';
-  } else if (upgrade.snapshot?.ready) {
-    statusBadge.textContent = 'Ready to buy';
-  } else if (upgrade.snapshot?.affordable === false) {
-    statusBadge.textContent = 'Save up';
-  } else {
-    statusBadge.textContent = 'Locked';
-  }
-
-  const statusNote = document.createElement('p');
-  statusNote.className = 'shopily-upgrade-detail__note';
-  statusNote.textContent = describeUpgradeAffordability(upgrade);
-
-  statusRow.append(statusBadge, statusNote);
-
-  const actions = document.createElement('div');
-  actions.className = 'shopily-upgrade-detail__actions';
-  const button = document.createElement('button');
-  button.type = 'button';
-  button.className = 'shopily-button shopily-button--primary';
-  if (upgrade.snapshot?.purchased) {
-    button.textContent = 'Owned and active';
-    button.disabled = true;
-  } else if (upgrade.snapshot?.ready) {
-    button.textContent = 'Buy now';
-  } else if (upgrade.snapshot?.affordable === false) {
-    button.textContent = 'Save up to buy';
-    button.disabled = true;
-  } else {
-    button.textContent = 'Locked';
-    button.disabled = true;
-  }
-  button.addEventListener('click', () => {
-    if (button.disabled) return;
-    upgrade.action?.onClick?.();
-  });
-  actions.appendChild(button);
-
-  const highlightsSection = document.createElement('section');
-  highlightsSection.className = 'shopily-upgrade-detail__section';
-  const highlightsHeading = document.createElement('h3');
-  highlightsHeading.textContent = 'Highlights';
-  const highlightList = document.createElement('ul');
-  highlightList.className = 'shopily-upgrade-detail__list';
-  const detailHighlights = collectUpgradeHighlights(upgrade);
-  if (!detailHighlights.length) {
-    const item = document.createElement('li');
-    item.textContent = 'Instantly boosts dropshipping payouts and action progress.';
-    highlightList.appendChild(item);
-  } else {
-    detailHighlights.forEach(entry => {
-      const item = document.createElement('li');
-      item.textContent = entry;
-      highlightList.appendChild(item);
-    });
-  }
-  highlightsSection.append(highlightsHeading, highlightList);
-
-  const requirementsSection = document.createElement('section');
-  requirementsSection.className = 'shopily-upgrade-detail__section';
-  const requirementsHeading = document.createElement('h3');
-  requirementsHeading.textContent = 'Prerequisites';
-  const requirementList = document.createElement('ul');
-  requirementList.className = 'shopily-upgrade-detail__requirements';
-  const requirementEntries = getRequirementEntries(upgrade);
-  if (!requirementEntries.length) {
-    const item = document.createElement('li');
-    item.className = 'shopily-upgrade-detail__requirement is-met';
-    item.textContent = 'No prerequisites — ready when you are!';
-    requirementList.appendChild(item);
-  } else {
-    requirementEntries.forEach(entry => {
-      const item = document.createElement('li');
-      item.className = 'shopily-upgrade-detail__requirement';
-      if (entry.met) {
-        item.classList.add('is-met');
-      }
-      const icon = document.createElement('span');
-      icon.className = 'shopily-upgrade-detail__requirement-icon';
-      icon.textContent = entry.met ? '✓' : '•';
-      const text = document.createElement('span');
-      text.className = 'shopily-upgrade-detail__requirement-text';
-      text.innerHTML = entry.html;
-      item.append(icon, text);
-      requirementList.appendChild(item);
-    });
-  }
-  requirementsSection.append(requirementsHeading, requirementList);
-
-  const detailsSection = document.createElement('section');
-  detailsSection.className = 'shopily-upgrade-detail__section';
-  const detailsHeading = document.createElement('h3');
-  detailsHeading.textContent = 'Detailed specs';
-  const detailList = document.createElement('ul');
-  detailList.className = 'shopily-upgrade-detail__list';
-  const details = collectDetailStrings(upgrade.definition);
-  if (!details.length) {
-    const item = document.createElement('li');
-    item.textContent = 'No additional notes — install and enjoy the boost!';
-    detailList.appendChild(item);
-  } else {
-    details.forEach(entry => {
-      const item = document.createElement('li');
-      if (typeof Node !== 'undefined' && entry instanceof Node) {
-        item.appendChild(entry);
-      } else {
-        item.innerHTML = entry;
-      }
-      detailList.appendChild(item);
-    });
-  }
-  detailsSection.append(detailsHeading, detailList);
-
-  detail.append(header, statusRow, actions, highlightsSection, requirementsSection, detailsSection);
-  return detail;
-}
-
-function renderUpgradesView(model, state = initialState) {
-  const container = document.createElement('section');
-  container.className = 'shopily-view shopily-view--upgrades';
-
-  const upgrades = ensureArray(model.upgrades);
-
-  const intro = document.createElement('div');
-  intro.className = 'shopily-upgrades__intro';
-  intro.innerHTML = '<h2>Commerce upgrade ladder</h2><p>These infrastructure plays reuse the existing upgrade logic so every purchase hits immediately.</p>';
-
-  const layout = document.createElement('div');
-  layout.className = 'shopily-upgrades__layout';
-
-  const catalog = document.createElement('div');
-  catalog.className = 'shopily-upgrades__catalog';
-  catalog.appendChild(intro);
-
-  const list = document.createElement('div');
-  list.className = 'shopily-upgrades';
-  if (!upgrades.length) {
-    const empty = document.createElement('p');
-    empty.className = 'shopily-empty';
-    empty.textContent = 'No commerce upgrades unlocked yet. Build more stores and finish the E-Commerce Playbook to reveal new boosts.';
-    list.appendChild(empty);
-  } else {
-    upgrades.forEach(upgrade => {
-      list.appendChild(renderUpgradeCard(upgrade, state));
-    });
-  }
-
-  catalog.appendChild(list);
-
-  const selectedUpgrade = getSelectedUpgrade(state, model);
-  layout.append(catalog, renderUpgradeDetail(selectedUpgrade));
-  container.appendChild(layout);
-
-  return container;
-}
-
-function renderPlanCard(plan) {
-  const card = document.createElement('article');
-  card.className = 'shopily-plan';
-
-  const header = document.createElement('header');
-  header.className = 'shopily-plan__header';
-  const title = document.createElement('h3');
-  title.textContent = plan.name;
-  header.appendChild(title);
-
-  const summary = document.createElement('p');
-  summary.className = 'shopily-plan__summary';
-  summary.textContent = plan.summary;
-
-  const list = document.createElement('ul');
-  list.className = 'shopily-plan__list';
-  const items = [
-    { label: 'Setup cost', value: formatCurrency(plan.setupCost || 0) },
-    {
-      label: 'Setup timeline',
-      value: describePlanSetupSummary({
-        days: plan.setupDays,
-        hoursPerDay: plan.setupHours
-      })
-    },
-    {
-      label: 'Daily upkeep',
-      value: describePlanUpkeepSummary({
-        hours: plan.upkeepHours,
-        cost: plan.upkeepCost
-      })
-    },
-    { label: 'Expected sales', value: plan.expectedSales || '$0/day' }
-  ];
-
-  items.forEach(entry => {
-    const item = document.createElement('li');
-    item.className = 'shopily-plan__item';
-    const label = document.createElement('span');
-    label.className = 'shopily-plan__label';
-    label.textContent = entry.label;
-    const value = document.createElement('span');
-    value.className = 'shopily-plan__value';
-    value.textContent = entry.value;
-    item.append(label, value);
-    list.appendChild(item);
-  });
-
-  card.append(header, summary, list);
-  return card;
-}
-
-function renderPricingView(model) {
-  const container = document.createElement('section');
-  container.className = 'shopily-view shopily-view--pricing';
-
-  const intro = document.createElement('div');
-  intro.className = 'shopily-pricing__intro';
-  intro.innerHTML = '<h2>Plans & expectations</h2><p>Each tier references the existing dropshipping backend — setup costs, upkeep, and payout ladders stay perfectly in sync.</p>';
-  container.appendChild(intro);
-
-  const grid = document.createElement('div');
-  grid.className = 'shopily-pricing';
-
-  const plans = ensureArray(model.pricing?.plans);
-  if (!plans.length) {
-    const empty = document.createElement('p');
-    empty.className = 'shopily-empty';
-    empty.textContent = 'Pricing data unlocks once dropshipping is available.';
-    grid.appendChild(empty);
-  } else {
-    plans.forEach(plan => grid.appendChild(renderPlanCard(plan)));
-  }
-
-  container.appendChild(grid);
-  return container;
-}
-
-function renderHeader(model, state, context) {
-  return renderTopBar(model, state, context);
-}
-
 function renderViews(model, state = initialState) {
+  const formatters = {
+    formatCurrency,
+    formatSignedCurrency,
+    formatPercent,
+    formatHours
+  };
+
+  const selectors = {
+    getSelectedStore,
+    getSelectedUpgrade
+  };
+
+  const handlers = {
+    onSelectStore: storeId => setView(VIEW_DASHBOARD, { storeId }),
+    onShowUpgradesForStore: storeId => setView(VIEW_UPGRADES, { storeId }),
+    onRunAction: handleQuickAction,
+    onSelectNiche: handleNicheSelect,
+    onSelectUpgrade: upgradeId => setView(VIEW_UPGRADES, { upgradeId })
+  };
+
   switch (state.view) {
     case VIEW_UPGRADES:
-      return renderUpgradesView(model, state);
+      return renderUpgradesView({
+        model,
+        state,
+        formatters,
+        handlers: { onSelectUpgrade: handlers.onSelectUpgrade },
+        selectors,
+        describeSnapshotTone: describeUpgradeSnapshotTone,
+        describeAffordability: describeUpgradeAffordability,
+        collectHighlights: collectUpgradeHighlights,
+        collectRequirementEntries: getRequirementEntries,
+        collectDetailStrings
+      });
     case VIEW_PRICING:
-      return renderPricingView(model);
+      return renderPricingView({
+        model,
+        formatters,
+        describeSetup: describePlanSetupSummary,
+        describeUpkeep: describePlanUpkeepSummary
+      });
     case VIEW_DASHBOARD:
     default:
-      return renderDashboardView(model, state);
+      return renderDashboardView({
+        model,
+        state,
+        formatters,
+        handlers,
+        selectors,
+        createLaunchButton
+      });
   }
 }
 
@@ -1210,9 +392,7 @@ function renderLockedWorkspace(model = {}, mount) {
 }
 
 function deriveWorkspaceSummary(model = {}) {
-  const summary = typeof model?.summary === 'object' && model.summary
-    ? { ...model.summary }
-    : {};
+  const summary = typeof model?.summary === 'object' && model.summary ? { ...model.summary } : {};
   if (!summary.meta) {
     summary.meta = 'Launch your first store';
   }
@@ -1225,7 +405,11 @@ const presenter = createTabbedWorkspacePresenter({
   ensureSelection,
   derivePath,
   deriveSummary: deriveWorkspaceSummary,
-  renderHeader,
+  renderHeader: (model, state, context) =>
+    renderTopBar(model, state, context, {
+      onViewChange: view => setView(view),
+      createLaunch: createLaunchButton
+    }),
   renderViews,
   renderLocked: renderLockedWorkspace,
   syncNavigation,

--- a/src/ui/views/browser/components/shopily/metrics.js
+++ b/src/ui/views/browser/components/shopily/metrics.js
@@ -1,0 +1,68 @@
+import { ensureArray } from '../../../../../core/helpers.js';
+
+function describeMetricTone(value) {
+  const numeric = Number(value) || 0;
+  if (numeric > 0) return 'positive';
+  if (numeric < 0) return 'negative';
+  return 'neutral';
+}
+
+export default function renderMetrics(metrics = {}, formatters = {}) {
+  const {
+    formatCurrency = value => String(value ?? ''),
+    formatSignedCurrency = value => String(value ?? '')
+  } = formatters;
+
+  const entries = ensureArray([
+    {
+      label: 'Total Stores',
+      value: metrics.totalStores || 0,
+      note: 'Active & in setup',
+      tone: 'neutral'
+    },
+    {
+      label: 'Daily Sales',
+      value: formatCurrency(metrics.dailySales || 0),
+      note: 'Yesterday’s payouts',
+      tone: describeMetricTone(metrics.dailySales)
+    },
+    {
+      label: 'Daily Upkeep',
+      value: formatCurrency(metrics.dailyUpkeep || 0),
+      note: 'Cash needed each day',
+      tone: describeMetricTone(-(metrics.dailyUpkeep || 0))
+    },
+    {
+      label: 'Net / Day',
+      value: formatSignedCurrency(metrics.netDaily || 0),
+      note: 'Sales minus upkeep',
+      tone: describeMetricTone(metrics.netDaily)
+    }
+  ]);
+
+  const grid = document.createElement('dl');
+  grid.className = 'shopily-metrics';
+
+  entries.forEach(entry => {
+    const item = document.createElement('div');
+    item.className = 'shopily-metric';
+    item.dataset.tone = entry.tone;
+
+    const label = document.createElement('dt');
+    label.className = 'shopily-metric__label';
+    label.textContent = entry.label;
+
+    const value = document.createElement('dd');
+    value.className = 'shopily-metric__value';
+    value.textContent = entry.value;
+
+    const note = document.createElement('span');
+    note.className = 'shopily-metric__note';
+    note.textContent = entry.note;
+
+    item.append(label, value, note);
+    grid.appendChild(item);
+  });
+
+  return grid;
+}

--- a/src/ui/views/browser/components/shopily/storeDetail.js
+++ b/src/ui/views/browser/components/shopily/storeDetail.js
@@ -1,0 +1,314 @@
+import { ensureArray } from '../../../../../core/helpers.js';
+
+function formatNicheDelta(delta, formatPercent) {
+  if (delta === null || delta === undefined) return '';
+  const numeric = Number(delta);
+  if (!Number.isFinite(numeric) || numeric === 0) return '';
+  const icon = numeric > 0 ? '⬆️' : '⬇️';
+  return `${icon} ${Math.abs(Math.round(numeric * 100))}%`;
+}
+
+function renderQualityPanel(instance, formatters = {}) {
+  const panel = document.createElement('section');
+  panel.className = 'shopily-panel';
+
+  const heading = document.createElement('h3');
+  heading.textContent = `Quality ${instance.qualityLevel}`;
+  panel.appendChild(heading);
+
+  if (instance.qualityInfo?.description) {
+    const note = document.createElement('p');
+    note.className = 'shopily-panel__note';
+    note.textContent = instance.qualityInfo.description;
+    panel.appendChild(note);
+  }
+
+  const progress = document.createElement('div');
+  progress.className = 'shopily-progress';
+  const fill = document.createElement('div');
+  fill.className = 'shopily-progress__fill';
+  fill.style.setProperty('--shopily-progress', String((instance.milestone?.percent || 0) * 100));
+  progress.appendChild(fill);
+
+  const summary = document.createElement('p');
+  summary.className = 'shopily-panel__note';
+  summary.textContent = instance.milestone?.summary || 'Push quality actions to unlock the next tier.';
+
+  panel.append(progress, summary);
+  return panel;
+}
+
+function renderNichePanel(instance, dependencies = {}) {
+  const { formatPercent = value => String(value ?? ''), onSelectNiche = () => {} } = dependencies;
+
+  const panel = document.createElement('section');
+  panel.className = 'shopily-panel';
+
+  const heading = document.createElement('h3');
+  heading.textContent = 'Audience niche';
+  panel.appendChild(heading);
+
+  if (instance.niche) {
+    const nicheLine = document.createElement('p');
+    nicheLine.className = 'shopily-panel__lead';
+    nicheLine.textContent = instance.niche.name;
+    panel.appendChild(nicheLine);
+
+    const vibe = document.createElement('p');
+    vibe.className = 'shopily-panel__note';
+    const delta = formatNicheDelta(instance.niche.delta, formatPercent);
+    const boost = formatPercent(instance.niche.multiplier - 1);
+    vibe.textContent = `${instance.niche.summary || 'Trend snapshot unavailable.'} ${
+      delta ? `(${delta})` : boost !== '—' ? `(${boost})` : ''
+    }`.trim();
+    panel.appendChild(vibe);
+  } else {
+    const empty = document.createElement('p');
+    empty.className = 'shopily-panel__note';
+    empty.textContent = 'No niche assigned yet. Pick a trending lane for bonus payouts.';
+    panel.appendChild(empty);
+  }
+
+  if (!instance.nicheLocked && ensureArray(instance.nicheOptions).length) {
+    const field = document.createElement('label');
+    field.className = 'shopily-field';
+    field.textContent = 'Assign niche';
+
+    const select = document.createElement('select');
+    select.className = 'shopily-select';
+
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = 'Choose a niche';
+    select.appendChild(placeholder);
+
+    instance.nicheOptions.forEach(option => {
+      const optionEl = document.createElement('option');
+      optionEl.value = option.id;
+      optionEl.textContent = `${option.name} — ${formatPercent(option.multiplier - 1)} boost`;
+      select.appendChild(optionEl);
+    });
+
+    select.value = instance.niche?.id || '';
+    select.addEventListener('change', event => {
+      onSelectNiche(instance.id, event.target.value || null);
+    });
+
+    field.appendChild(select);
+    panel.appendChild(field);
+  } else if (instance.nicheLocked && instance.niche) {
+    const locked = document.createElement('p');
+    locked.className = 'shopily-panel__hint';
+    locked.textContent = 'Niche locked in — upgrades can refresh trend strength.';
+    panel.appendChild(locked);
+  }
+
+  return panel;
+}
+
+function renderStatsPanel(instance, formatters = {}) {
+  const { formatCurrency = value => String(value ?? ''), formatSignedCurrency = value => String(value ?? ''), formatPercent = value => String(value ?? '') } = formatters;
+
+  const panel = document.createElement('section');
+  panel.className = 'shopily-panel';
+
+  const heading = document.createElement('h3');
+  heading.textContent = 'Store health';
+  panel.appendChild(heading);
+
+  const list = document.createElement('dl');
+  list.className = 'shopily-stats';
+  const entries = [
+    { label: 'Latest payout', value: formatCurrency(instance.latestPayout || 0) },
+    { label: 'Average / day', value: formatCurrency(instance.averagePayout || 0) },
+    { label: 'Lifetime sales', value: formatCurrency(instance.lifetimeIncome || 0) },
+    { label: 'Lifetime spend', value: formatCurrency(instance.lifetimeSpend || 0) },
+    { label: 'Profit to date', value: formatSignedCurrency(instance.profit || 0) },
+    { label: 'Lifetime ROI', value: formatPercent(instance.roi) },
+    { label: 'Resale value', value: formatCurrency(instance.resaleValue || 0) }
+  ];
+
+  entries.forEach(entry => {
+    const row = document.createElement('div');
+    row.className = 'shopily-stats__row';
+    const term = document.createElement('dt');
+    term.textContent = entry.label;
+    const value = document.createElement('dd');
+    value.textContent = entry.value;
+    row.append(term, value);
+    list.appendChild(row);
+  });
+
+  panel.appendChild(list);
+
+  if (!instance.maintenanceFunded) {
+    const warning = document.createElement('p');
+    warning.className = 'shopily-panel__warning';
+    warning.textContent = 'Maintenance unfunded — cover daily upkeep to avoid shutdowns.';
+    panel.appendChild(warning);
+  }
+
+  if (ensureArray(instance.maintenance?.parts).length) {
+    const upkeep = document.createElement('p');
+    upkeep.className = 'shopily-panel__note';
+    upkeep.textContent = `Daily upkeep: ${instance.maintenance.parts.join(' • ')}`;
+    panel.appendChild(upkeep);
+  }
+
+  return panel;
+}
+
+function renderPayoutBreakdown(instance, formatters = {}) {
+  const { formatCurrency = value => String(value ?? ''), formatPercent = value => String(value ?? '') } = formatters;
+
+  const panel = document.createElement('section');
+  panel.className = 'shopily-panel';
+
+  const heading = document.createElement('h3');
+  heading.textContent = 'Payout recap';
+  panel.appendChild(heading);
+
+  const entries = ensureArray(instance.payoutBreakdown?.entries);
+  if (!entries.length) {
+    const note = document.createElement('p');
+    note.className = 'shopily-panel__note';
+    note.textContent = 'No payout modifiers yet. Unlock upgrades and courses to stack multipliers.';
+    panel.appendChild(note);
+  } else {
+    const list = document.createElement('ul');
+    list.className = 'shopily-list';
+    entries.forEach(entry => {
+      const item = document.createElement('li');
+      item.className = 'shopily-list__item';
+      const label = document.createElement('span');
+      label.className = 'shopily-list__label';
+      label.textContent = entry.label;
+      const value = document.createElement('span');
+      value.className = 'shopily-list__value';
+      const amount = formatCurrency(entry.amount || 0);
+      const percent = entry.percent !== null && entry.percent !== undefined ? ` (${formatPercent(entry.percent)})` : '';
+      value.textContent = `${amount}${percent}`;
+      item.append(label, value);
+      list.appendChild(item);
+    });
+    panel.appendChild(list);
+  }
+
+  const total = document.createElement('p');
+  total.className = 'shopily-panel__note';
+  total.textContent = `Yesterday’s total: ${formatCurrency(instance.payoutBreakdown?.total || 0)}`;
+  panel.appendChild(total);
+
+  return panel;
+}
+
+function renderActionList(instance, dependencies = {}) {
+  const { formatHours = value => String(value ?? ''), formatCurrency = value => String(value ?? ''), onRunAction = () => {} } = dependencies;
+
+  const panel = document.createElement('section');
+  panel.className = 'shopily-panel';
+
+  const heading = document.createElement('h3');
+  heading.textContent = 'Quality actions';
+  panel.appendChild(heading);
+
+  const actions = ensureArray(instance.actions);
+  if (!actions.length) {
+    const empty = document.createElement('p');
+    empty.className = 'shopily-panel__note';
+    empty.textContent = 'No actions unlocked yet. Install upgrades to expand your playbook.';
+    panel.appendChild(empty);
+    return panel;
+  }
+
+  const list = document.createElement('ul');
+  list.className = 'shopily-action-list';
+
+  actions.forEach(action => {
+    const item = document.createElement('li');
+    item.className = 'shopily-action';
+
+    const label = document.createElement('div');
+    label.className = 'shopily-action__label';
+    label.textContent = action.label;
+
+    const meta = document.createElement('div');
+    meta.className = 'shopily-action__meta';
+    const time = action.time > 0 ? formatHours(action.time) : 'Instant';
+    const cost = action.cost > 0 ? formatCurrency(action.cost) : 'No spend';
+    meta.textContent = `${time} • ${cost}`;
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'shopily-button shopily-button--secondary';
+    button.textContent = action.available ? 'Run now' : 'Locked';
+    button.disabled = !action.available;
+    if (action.disabledReason) {
+      button.title = action.disabledReason;
+    }
+    button.addEventListener('click', () => {
+      if (button.disabled) return;
+      onRunAction(instance.id, action.id);
+    });
+
+    item.append(label, meta, button);
+    list.appendChild(item);
+  });
+
+  panel.appendChild(list);
+  return panel;
+}
+
+export default function createStoreDetail(instance, dependencies = {}) {
+  const {
+    formatCurrency = value => String(value ?? ''),
+    formatSignedCurrency = value => String(value ?? ''),
+    formatPercent = value => String(value ?? ''),
+    formatHours = value => String(value ?? ''),
+    onRunAction = () => {},
+    onSelectNiche = () => {}
+  } = dependencies;
+
+  const detail = document.createElement('aside');
+  detail.className = 'shopily-detail';
+
+  if (!instance) {
+    const empty = document.createElement('div');
+    empty.className = 'shopily-detail__empty';
+    empty.textContent = 'Select a store to inspect payouts, niches, and upgrades.';
+    detail.appendChild(empty);
+    return detail;
+  }
+
+  const header = document.createElement('header');
+  header.className = 'shopily-detail__header';
+  const title = document.createElement('h2');
+  title.textContent = instance.label;
+  const status = document.createElement('span');
+  status.className = 'shopily-status';
+  status.dataset.state = instance.status?.id || 'setup';
+  status.textContent = instance.status?.label || 'Setup';
+  header.append(title, status);
+  detail.appendChild(header);
+
+  if (instance.pendingIncome > 0) {
+    const pending = document.createElement('p');
+    pending.className = 'shopily-panel__hint';
+    pending.textContent = `Pending payouts: ${formatCurrency(instance.pendingIncome)} once upkeep clears.`;
+    detail.appendChild(pending);
+  }
+
+  const formatters = { formatCurrency, formatSignedCurrency, formatPercent };
+  const actionDependencies = { formatHours, formatCurrency, onRunAction };
+  const nicheDependencies = { formatPercent, onSelectNiche };
+
+  detail.append(
+    renderStatsPanel(instance, formatters),
+    renderQualityPanel(instance, formatters),
+    renderNichePanel(instance, nicheDependencies),
+    renderPayoutBreakdown(instance, formatters),
+    renderActionList(instance, actionDependencies)
+  );
+
+  return detail;
+}

--- a/src/ui/views/browser/components/shopily/upgradeCard.js
+++ b/src/ui/views/browser/components/shopily/upgradeCard.js
@@ -1,0 +1,102 @@
+export default function createUpgradeCard(upgrade, state = {}, dependencies = {}) {
+  const {
+    formatCurrency = value => String(value ?? ''),
+    describeSnapshotTone = () => 'locked',
+    collectHighlights = () => [],
+    onSelect = () => {}
+  } = dependencies;
+
+  const card = document.createElement('article');
+  card.className = 'shopily-upgrade';
+  const tone = describeSnapshotTone(upgrade.snapshot);
+  card.dataset.status = tone;
+  if (upgrade.id === state.selectedUpgradeId) {
+    card.classList.add('is-active');
+  }
+  card.tabIndex = 0;
+
+  const handleSelect = event => {
+    if (event) {
+      const key = event.key;
+      if (key && key !== 'Enter' && key !== ' ') return;
+      event.preventDefault();
+      event.stopPropagation();
+    }
+    onSelect(upgrade.id);
+  };
+
+  card.addEventListener('click', () => handleSelect());
+  card.addEventListener('keydown', event => {
+    if (event.defaultPrevented) return;
+    if (event.key === 'Enter' || event.key === ' ') {
+      handleSelect(event);
+    }
+  });
+
+  const header = document.createElement('header');
+  header.className = 'shopily-upgrade__header';
+
+  const title = document.createElement('h3');
+  title.textContent = upgrade.name;
+  header.appendChild(title);
+
+  if (upgrade.tag?.label) {
+    const badge = document.createElement('span');
+    badge.className = 'shopily-upgrade__badge';
+    badge.textContent = upgrade.tag.label;
+    header.appendChild(badge);
+  }
+
+  const summary = document.createElement('p');
+  summary.className = 'shopily-upgrade__summary';
+  summary.textContent = upgrade.description || 'Commerce boost';
+
+  const highlights = document.createElement('ul');
+  highlights.className = 'shopily-upgrade__highlights';
+  const highlightEntries = collectHighlights(upgrade);
+  if (!highlightEntries.length) {
+    const fallback = document.createElement('li');
+    fallback.textContent = 'Stacks with dropshipping payouts and progress.';
+    highlights.appendChild(fallback);
+  } else {
+    highlightEntries.forEach(entry => {
+      const item = document.createElement('li');
+      item.textContent = entry;
+      highlights.appendChild(item);
+    });
+  }
+
+  const footer = document.createElement('div');
+  footer.className = 'shopily-upgrade__footer';
+
+  const meta = document.createElement('div');
+  meta.className = 'shopily-upgrade__meta';
+
+  const price = document.createElement('span');
+  price.className = 'shopily-upgrade__price';
+  price.textContent = formatCurrency(upgrade.cost || 0);
+
+  const status = document.createElement('span');
+  status.className = 'shopily-upgrade__status';
+  status.textContent = upgrade.status || 'Progress for this soon';
+
+  meta.append(price, status);
+
+  const actions = document.createElement('div');
+  actions.className = 'shopily-upgrade__actions';
+
+  const viewButton = document.createElement('button');
+  viewButton.type = 'button';
+  viewButton.className = 'shopily-button shopily-button--ghost';
+  viewButton.textContent = 'View product';
+  viewButton.addEventListener('click', event => {
+    event.stopPropagation();
+    onSelect(upgrade.id);
+  });
+
+  actions.appendChild(viewButton);
+  footer.append(meta, actions);
+
+  card.append(header, summary, highlights, footer);
+  return card;
+}

--- a/src/ui/views/browser/components/shopily/views/dashboardView.js
+++ b/src/ui/views/browser/components/shopily/views/dashboardView.js
@@ -1,0 +1,172 @@
+import { ensureArray } from '../../../../../../core/helpers.js';
+import renderMetrics from '../metrics.js';
+import createStoreDetail from '../storeDetail.js';
+
+function formatNicheDelta(delta, formatPercent) {
+  if (delta === null || delta === undefined) return '';
+  const numeric = Number(delta);
+  if (!Number.isFinite(numeric) || numeric === 0) return '';
+  const icon = numeric > 0 ? '⬆️' : '⬇️';
+  return `${icon} ${Math.abs(Math.round(numeric * 100))}%`;
+}
+
+export function renderHero(model, dependencies = {}) {
+  const { formatters = {}, createLaunchButton = () => document.createElement('button') } = dependencies;
+
+  const hero = document.createElement('section');
+  hero.className = 'shopily-hero';
+
+  const body = document.createElement('div');
+  body.className = 'shopily-hero__body';
+
+  const headline = document.createElement('h2');
+  headline.textContent = 'Your store, your brand, powered by Shopily.';
+  const summary = document.createElement('p');
+  summary.textContent = model.summary?.meta || 'Launch your first storefront to kick off the commerce flywheel.';
+
+  const ctaRow = document.createElement('div');
+  ctaRow.className = 'shopily-hero__cta';
+  ctaRow.appendChild(createLaunchButton(model.launch));
+
+  body.append(headline, summary, ctaRow);
+  hero.append(body, renderMetrics(model.metrics, formatters));
+  return hero;
+}
+
+export function renderStoreTable(instances = [], state = {}, dependencies = {}) {
+  const {
+    formatCurrency = value => String(value ?? ''),
+    formatPercent = value => String(value ?? ''),
+    onSelectStore = () => {},
+    onShowUpgradesForStore = () => {}
+  } = dependencies;
+
+  const table = document.createElement('table');
+  table.className = 'shopily-table';
+
+  const thead = document.createElement('thead');
+  const headRow = document.createElement('tr');
+  ['Store', 'Niche', 'Daily Earnings', 'Upkeep', 'ROI', 'Actions'].forEach(label => {
+    const th = document.createElement('th');
+    th.textContent = label;
+    headRow.appendChild(th);
+  });
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+
+  if (!instances.length) {
+    const emptyRow = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 6;
+    cell.className = 'shopily-table__empty';
+    cell.textContent = 'No stores yet. Launch your first shop to start capturing daily sales.';
+    emptyRow.appendChild(cell);
+    tbody.appendChild(emptyRow);
+  } else {
+    instances.forEach(instance => {
+      const row = document.createElement('tr');
+      row.dataset.storeId = instance.id;
+      if (instance.id === state.selectedStoreId) {
+        row.classList.add('is-selected');
+      }
+      row.addEventListener('click', () => onSelectStore(instance.id));
+
+      const nameCell = document.createElement('td');
+      nameCell.className = 'shopily-table__cell--label';
+      nameCell.textContent = instance.label;
+
+      const nicheCell = document.createElement('td');
+      if (instance.niche) {
+        const nicheWrap = document.createElement('div');
+        nicheWrap.className = 'shopily-niche';
+        const nicheName = document.createElement('strong');
+        nicheName.className = 'shopily-niche__name';
+        nicheName.textContent = instance.niche.name;
+        const nicheTrend = document.createElement('span');
+        nicheTrend.className = 'shopily-niche__trend';
+        const delta = formatNicheDelta(instance.niche.delta, formatPercent);
+        nicheTrend.textContent = delta || `${formatPercent(instance.niche.multiplier - 1)} boost`;
+        nicheWrap.append(nicheName, nicheTrend);
+        nicheCell.appendChild(nicheWrap);
+      } else {
+        nicheCell.textContent = 'Unassigned';
+      }
+
+      const earningsCell = document.createElement('td');
+      earningsCell.textContent = formatCurrency(instance.latestPayout || 0);
+
+      const upkeepCell = document.createElement('td');
+      upkeepCell.textContent = formatCurrency(instance.maintenanceCost || 0);
+
+      const roiCell = document.createElement('td');
+      roiCell.textContent = formatPercent(instance.roi);
+
+      const actionCell = document.createElement('td');
+      actionCell.className = 'shopily-table__cell--actions';
+      const upgradeButton = document.createElement('button');
+      upgradeButton.type = 'button';
+      upgradeButton.className = 'shopily-button shopily-button--ghost';
+      upgradeButton.textContent = 'Upgrade Store';
+      upgradeButton.addEventListener('click', event => {
+        event.stopPropagation();
+        onShowUpgradesForStore(instance.id);
+      });
+      const detailButton = document.createElement('button');
+      detailButton.type = 'button';
+      detailButton.className = 'shopily-button shopily-button--link';
+      detailButton.textContent = 'View Details';
+      detailButton.addEventListener('click', event => {
+        event.stopPropagation();
+        onSelectStore(instance.id);
+      });
+      actionCell.append(upgradeButton, detailButton);
+
+      row.append(nameCell, nicheCell, earningsCell, upkeepCell, roiCell, actionCell);
+      tbody.appendChild(row);
+    });
+  }
+
+  table.appendChild(tbody);
+  return table;
+}
+
+export default function renderDashboardView(options = {}) {
+  const {
+    model = {},
+    state = {},
+    formatters = {},
+    handlers = {},
+    selectors = {},
+    createLaunchButton = () => document.createElement('button')
+  } = options;
+
+  const container = document.createElement('section');
+  container.className = 'shopily-view shopily-view--dashboard';
+
+  container.appendChild(renderHero(model, { formatters, createLaunchButton }));
+
+  const grid = document.createElement('div');
+  grid.className = 'shopily-grid';
+  const selectedStore = selectors.getSelectedStore ? selectors.getSelectedStore(state, model) : null;
+  grid.append(
+    renderStoreTable(ensureArray(model.instances), state, {
+      formatCurrency: formatters.formatCurrency,
+      formatPercent: formatters.formatPercent,
+      onSelectStore: handlers.onSelectStore,
+      onShowUpgradesForStore: handlers.onShowUpgradesForStore
+    }),
+    createStoreDetail(selectedStore, {
+      formatCurrency: formatters.formatCurrency,
+      formatSignedCurrency: formatters.formatSignedCurrency,
+      formatPercent: formatters.formatPercent,
+      formatHours: formatters.formatHours,
+      onRunAction: handlers.onRunAction,
+      onSelectNiche: handlers.onSelectNiche
+    })
+  );
+  container.appendChild(grid);
+
+  return container;
+}

--- a/src/ui/views/browser/components/shopily/views/pricingView.js
+++ b/src/ui/views/browser/components/shopily/views/pricingView.js
@@ -1,0 +1,101 @@
+import { ensureArray } from '../../../../../../core/helpers.js';
+
+export function renderPlanCard(plan = {}, dependencies = {}) {
+  const {
+    formatCurrency = value => String(value ?? ''),
+    describeSetup = () => 'Instant setup',
+    describeUpkeep = () => 'No upkeep'
+  } = dependencies;
+
+  const card = document.createElement('article');
+  card.className = 'shopily-plan';
+
+  const header = document.createElement('header');
+  header.className = 'shopily-plan__header';
+  const title = document.createElement('h3');
+  title.textContent = plan.name;
+  header.appendChild(title);
+
+  const summary = document.createElement('p');
+  summary.className = 'shopily-plan__summary';
+  summary.textContent = plan.summary;
+
+  const list = document.createElement('ul');
+  list.className = 'shopily-plan__list';
+  const items = [
+    { label: 'Setup cost', value: formatCurrency(plan.setupCost || 0) },
+    {
+      label: 'Setup timeline',
+      value: describeSetup({
+        days: plan.setupDays,
+        hoursPerDay: plan.setupHours
+      })
+    },
+    {
+      label: 'Daily upkeep',
+      value: describeUpkeep({
+        hours: plan.upkeepHours,
+        cost: plan.upkeepCost
+      })
+    },
+    { label: 'Expected sales', value: plan.expectedSales || '$0/day' }
+  ];
+
+  items.forEach(entry => {
+    const item = document.createElement('li');
+    item.className = 'shopily-plan__item';
+    const label = document.createElement('span');
+    label.className = 'shopily-plan__label';
+    label.textContent = entry.label;
+    const value = document.createElement('span');
+    value.className = 'shopily-plan__value';
+    value.textContent = entry.value;
+    item.append(label, value);
+    list.appendChild(item);
+  });
+
+  card.append(header, summary, list);
+  return card;
+}
+
+export default function renderPricingView(options = {}) {
+  const {
+    model = {},
+    formatters = {},
+    describeSetup = () => 'Instant setup',
+    describeUpkeep = () => 'No upkeep'
+  } = options;
+
+  const formatCurrency = formatters.formatCurrency || (value => String(value ?? ''));
+
+  const container = document.createElement('section');
+  container.className = 'shopily-view shopily-view--pricing';
+
+  const intro = document.createElement('div');
+  intro.className = 'shopily-pricing__intro';
+  intro.innerHTML = '<h2>Plans & expectations</h2><p>Each tier references the existing dropshipping backend — setup costs, upkeep, and payout ladders stay perfectly in sync.</p>';
+  container.appendChild(intro);
+
+  const grid = document.createElement('div');
+  grid.className = 'shopily-pricing';
+
+  const plans = ensureArray(model.pricing?.plans);
+  if (!plans.length) {
+    const empty = document.createElement('p');
+    empty.className = 'shopily-empty';
+    empty.textContent = 'Pricing data unlocks once dropshipping is available.';
+    grid.appendChild(empty);
+  } else {
+    plans.forEach(plan => {
+      const card = renderPlanCard(plan, {
+        formatCurrency,
+        describeSetup,
+        describeUpkeep
+      });
+      grid.appendChild(card);
+    });
+  }
+
+  container.appendChild(grid);
+  return container;
+}

--- a/src/ui/views/browser/components/shopily/views/upgradesView.js
+++ b/src/ui/views/browser/components/shopily/views/upgradesView.js
@@ -1,0 +1,248 @@
+import { ensureArray } from '../../../../../../core/helpers.js';
+import createUpgradeCard from '../upgradeCard.js';
+
+export function renderUpgradeDetail(upgrade, dependencies = {}) {
+  const {
+    formatCurrency = value => String(value ?? ''),
+    describeSnapshotTone = () => 'locked',
+    describeAffordability = () => 'Progress the requirements to unlock this purchase.',
+    collectHighlights = () => [],
+    collectRequirementEntries = () => [],
+    collectDetailStrings = () => []
+  } = dependencies;
+
+  const detail = document.createElement('aside');
+  detail.className = 'shopily-upgrade-detail';
+
+  if (!upgrade) {
+    const empty = document.createElement('div');
+    empty.className = 'shopily-upgrade-detail__empty';
+    empty.textContent = 'Select an upgrade to review requirements, highlights, and checkout.';
+    detail.appendChild(empty);
+    return detail;
+  }
+
+  const tone = describeSnapshotTone(upgrade.snapshot);
+
+  const header = document.createElement('header');
+  header.className = 'shopily-upgrade-detail__header';
+
+  const titleBlock = document.createElement('div');
+  titleBlock.className = 'shopily-upgrade-detail__title';
+
+  if (upgrade.tag?.label) {
+    const badge = document.createElement('span');
+    badge.className = 'shopily-upgrade-detail__tag';
+    badge.textContent = upgrade.tag.label;
+    titleBlock.appendChild(badge);
+  }
+
+  const heading = document.createElement('h2');
+  heading.textContent = upgrade.name;
+  titleBlock.appendChild(heading);
+
+  const blurb = document.createElement('p');
+  blurb.className = 'shopily-upgrade-detail__blurb';
+  blurb.textContent = upgrade.description || 'Commerce boost';
+  titleBlock.appendChild(blurb);
+
+  const priceBlock = document.createElement('div');
+  priceBlock.className = 'shopily-upgrade-detail__price';
+  const priceLabel = document.createElement('span');
+  priceLabel.textContent = 'Price';
+  const priceValue = document.createElement('strong');
+  priceValue.textContent = formatCurrency(upgrade.cost || 0);
+  priceBlock.append(priceLabel, priceValue);
+
+  header.append(titleBlock, priceBlock);
+
+  const statusRow = document.createElement('div');
+  statusRow.className = 'shopily-upgrade-detail__status-row';
+
+  const statusBadge = document.createElement('span');
+  statusBadge.className = `shopily-upgrade-detail__badge shopily-upgrade-detail__badge--${tone}`;
+  if (upgrade.snapshot?.purchased) {
+    statusBadge.textContent = 'Owned';
+  } else if (upgrade.snapshot?.ready) {
+    statusBadge.textContent = 'Ready to buy';
+  } else if (upgrade.snapshot?.affordable === false) {
+    statusBadge.textContent = 'Save up';
+  } else {
+    statusBadge.textContent = 'Locked';
+  }
+
+  const statusNote = document.createElement('p');
+  statusNote.className = 'shopily-upgrade-detail__note';
+  statusNote.textContent = describeAffordability(upgrade);
+
+  statusRow.append(statusBadge, statusNote);
+
+  const actions = document.createElement('div');
+  actions.className = 'shopily-upgrade-detail__actions';
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'shopily-button shopily-button--primary';
+  if (upgrade.snapshot?.purchased) {
+    button.textContent = 'Owned and active';
+    button.disabled = true;
+  } else if (upgrade.snapshot?.ready) {
+    button.textContent = 'Buy now';
+  } else if (upgrade.snapshot?.affordable === false) {
+    button.textContent = 'Save up to buy';
+    button.disabled = true;
+  } else {
+    button.textContent = 'Locked';
+    button.disabled = true;
+  }
+  button.addEventListener('click', () => {
+    if (button.disabled) return;
+    upgrade.action?.onClick?.();
+  });
+  actions.appendChild(button);
+
+  const highlightsSection = document.createElement('section');
+  highlightsSection.className = 'shopily-upgrade-detail__section';
+  const highlightsHeading = document.createElement('h3');
+  highlightsHeading.textContent = 'Highlights';
+  const highlightList = document.createElement('ul');
+  highlightList.className = 'shopily-upgrade-detail__list';
+  const detailHighlights = collectHighlights(upgrade);
+  if (!detailHighlights.length) {
+    const item = document.createElement('li');
+    item.textContent = 'Instantly boosts dropshipping payouts and action progress.';
+    highlightList.appendChild(item);
+  } else {
+    detailHighlights.forEach(entry => {
+      const item = document.createElement('li');
+      item.textContent = entry;
+      highlightList.appendChild(item);
+    });
+  }
+  highlightsSection.append(highlightsHeading, highlightList);
+
+  const requirementsSection = document.createElement('section');
+  requirementsSection.className = 'shopily-upgrade-detail__section';
+  const requirementsHeading = document.createElement('h3');
+  requirementsHeading.textContent = 'Prerequisites';
+  const requirementList = document.createElement('ul');
+  requirementList.className = 'shopily-upgrade-detail__requirements';
+  const requirementEntries = collectRequirementEntries(upgrade);
+  if (!requirementEntries.length) {
+    const item = document.createElement('li');
+    item.className = 'shopily-upgrade-detail__requirement is-met';
+    item.textContent = 'No prerequisites — ready when you are!';
+    requirementList.appendChild(item);
+  } else {
+    requirementEntries.forEach(entry => {
+      const item = document.createElement('li');
+      item.className = 'shopily-upgrade-detail__requirement';
+      if (entry.met) {
+        item.classList.add('is-met');
+      }
+      const icon = document.createElement('span');
+      icon.className = 'shopily-upgrade-detail__requirement-icon';
+      icon.textContent = entry.met ? '✓' : '•';
+      const text = document.createElement('span');
+      text.className = 'shopily-upgrade-detail__requirement-text';
+      text.innerHTML = entry.html;
+      item.append(icon, text);
+      requirementList.appendChild(item);
+    });
+  }
+  requirementsSection.append(requirementsHeading, requirementList);
+
+  const detailsSection = document.createElement('section');
+  detailsSection.className = 'shopily-upgrade-detail__section';
+  const detailsHeading = document.createElement('h3');
+  detailsHeading.textContent = 'Detailed specs';
+  const detailList = document.createElement('ul');
+  detailList.className = 'shopily-upgrade-detail__list';
+  const details = collectDetailStrings(upgrade.definition);
+  if (!details.length) {
+    const item = document.createElement('li');
+    item.textContent = 'No additional notes — install and enjoy the boost!';
+    detailList.appendChild(item);
+  } else {
+    details.forEach(entry => {
+      const item = document.createElement('li');
+      if (typeof Node !== 'undefined' && entry instanceof Node) {
+        item.appendChild(entry);
+      } else {
+        item.innerHTML = entry;
+      }
+      detailList.appendChild(item);
+    });
+  }
+  detailsSection.append(detailsHeading, detailList);
+
+  detail.append(header, statusRow, actions, highlightsSection, requirementsSection, detailsSection);
+  return detail;
+}
+
+export default function renderUpgradesView(options = {}) {
+  const {
+    model = {},
+    state = {},
+    formatters = {},
+    handlers = {},
+    selectors = {},
+    describeSnapshotTone = () => 'locked',
+    describeAffordability = () => 'Progress the requirements to unlock this purchase.',
+    collectHighlights = () => [],
+    collectRequirementEntries = () => [],
+    collectDetailStrings = () => []
+  } = options;
+
+  const container = document.createElement('section');
+  container.className = 'shopily-view shopily-view--upgrades';
+
+  const intro = document.createElement('div');
+  intro.className = 'shopily-upgrades__intro';
+  intro.innerHTML = '<h2>Commerce upgrade ladder</h2><p>These infrastructure plays reuse the existing upgrade logic so every purchase hits immediately.</p>';
+
+  const layout = document.createElement('div');
+  layout.className = 'shopily-upgrades__layout';
+
+  const catalog = document.createElement('div');
+  catalog.className = 'shopily-upgrades__catalog';
+  catalog.appendChild(intro);
+
+  const list = document.createElement('div');
+  list.className = 'shopily-upgrades';
+  const upgrades = ensureArray(model.upgrades);
+  if (!upgrades.length) {
+    const empty = document.createElement('p');
+    empty.className = 'shopily-empty';
+    empty.textContent = 'No commerce upgrades unlocked yet. Build more stores and finish the E-Commerce Playbook to reveal new boosts.';
+    list.appendChild(empty);
+  } else {
+    upgrades.forEach(upgrade => {
+      list.appendChild(
+        createUpgradeCard(upgrade, state, {
+          formatCurrency: formatters.formatCurrency,
+          describeSnapshotTone,
+          collectHighlights,
+          onSelect: handlers.onSelectUpgrade
+        })
+      );
+    });
+  }
+
+  catalog.appendChild(list);
+
+  const selectedUpgrade = selectors.getSelectedUpgrade ? selectors.getSelectedUpgrade(state, model) : null;
+  layout.append(
+    catalog,
+    renderUpgradeDetail(selectedUpgrade, {
+      formatCurrency: formatters.formatCurrency,
+      describeSnapshotTone,
+      describeAffordability,
+      collectHighlights,
+      collectRequirementEntries,
+      collectDetailStrings
+    })
+  );
+  container.appendChild(layout);
+
+  return container;
+}


### PR DESCRIPTION
## Summary
- export Shopily dashboard, upgrade, and pricing helper builders so they can be imported directly in view unit tests
- expose BlogPress home and detail view panel/table factories to support focused testing of stateless renderers

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68e04d9969c4832ca2882b042362c350