### PR TITLE
Ensure DigiShelf launch panel stays open when switching plans

### DIFF
--- a/src/ui/views/browser/components/digishelf/index.js
+++ b/src/ui/views/browser/components/digishelf/index.js
@@ -16,6 +16,7 @@ import {
   initialState,
   ensureSelection,
   reduceSetView,
+  reduceOpenLaunch,
   reduceToggleLaunch,
   reduceSelectInstance,
   derivePath,
@@ -213,7 +214,7 @@ function selectInstance(type, id) {
 function handlePlanSelect(planId) {
   const model = presenter.getModel();
   presenter.updateState(state => {
-    const next = reduceToggleLaunch(state, model);
+    const next = reduceOpenLaunch(state, model);
     const targetView = planId === 'stockPhotos' ? VIEW_STOCK : VIEW_EBOOKS;
     return reduceSetView(next, model, targetView);
   });

--- a/src/ui/views/browser/components/digishelf/state.js
+++ b/src/ui/views/browser/components/digishelf/state.js
@@ -67,12 +67,10 @@ export function reduceToggleLaunch(state = initialState, model = {}) {
 }
 
 export function reduceOpenLaunch(state = initialState, model = {}) {
-  if (state.launchOpen) {
-    const next = { ...state };
-    ensureSelection(next, model);
-    return next;
-  }
-  const next = { ...state, launchOpen: true };
+  const next = {
+    ...state,
+    ...(state.launchOpen ? {} : { launchOpen: true })
+  };
   ensureSelection(next, model);
   return next;
 }

--- a/src/ui/views/browser/components/digishelf/state.js
+++ b/src/ui/views/browser/components/digishelf/state.js
@@ -66,6 +66,17 @@ export function reduceToggleLaunch(state = initialState, model = {}) {
   return next;
 }
 
+export function reduceOpenLaunch(state = initialState, model = {}) {
+  if (state.launchOpen) {
+    const next = { ...state };
+    ensureSelection(next, model);
+    return next;
+  }
+  const next = { ...state, launchOpen: true };
+  ensureSelection(next, model);
+  return next;
+}
+
 export function reduceSelectInstance(state = initialState, model = {}, type, id) {
   const next = { ...state };
   if (type === 'stockPhotos') {
@@ -115,6 +126,7 @@ export default {
   ensureSelection,
   reduceSetView,
   reduceToggleLaunch,
+  reduceOpenLaunch,
   reduceSelectInstance,
   derivePath,
   getSelectedCollection,


### PR DESCRIPTION
## Summary
- add a reducer to explicitly open the DigiShelf launch panel while preserving shared selection logic
- update plan selection to force the launch panel open before switching views

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0569f0198832c89509f25db4604f2