### PR TITLE
fix: stabilize header action button width

### DIFF
--- a/src/ui/views/browser/headerActionPresenter.js
+++ b/src/ui/views/browser/headerActionPresenter.js
@@ -3,7 +3,8 @@ import todoWidget from './widgets/todoWidget.js';
 
 const state = {
   primaryButton: null,
-  onPrimaryAction: null
+  onPrimaryAction: null,
+  primaryButtonMinWidth: null
 };
 
 function resolveButtons() {
@@ -52,6 +53,7 @@ function renderAction(model) {
     : model?.button?.title || 'Wrap today when you are ready to reset the grind.';
 
   button.textContent = label;
+  ensurePrimaryButtonWidth(button, label);
   button.dataset.actionMode = hasTasks ? 'task' : (model?.button?.mode || 'end');
 
   if (hasTasks && nextTask?.id) {
@@ -74,6 +76,34 @@ function renderAction(model) {
   button.disabled = Boolean(model?.button?.disabled);
 
   bindPrimaryButton(button);
+}
+
+function ensurePrimaryButtonWidth(button, label) {
+  if (!button) return;
+
+  const measureWidth = () => {
+    button.style.removeProperty('--browser-session-button-width');
+    const width = Math.ceil(button.getBoundingClientRect().width);
+    if (width > 0) {
+      state.primaryButtonMinWidth = width;
+      button.style.setProperty('--browser-session-button-width', `${width}px`);
+    }
+  };
+
+  if (label === 'Next Task') {
+    measureWidth();
+    return;
+  }
+
+  if (state.primaryButtonMinWidth) {
+    button.style.setProperty('--browser-session-button-width', `${state.primaryButtonMinWidth}px`);
+    return;
+  }
+
+  const originalText = button.textContent;
+  button.textContent = 'Next Task';
+  measureWidth();
+  button.textContent = originalText;
 }
 
 function renderAutoForward() {

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -425,6 +425,11 @@ a {
   font-weight: 600;
 }
 
+#browser-session-button {
+  justify-content: center;
+  min-width: var(--browser-session-button-width, auto);
+}
+
 .browser-button--icon {
   padding: 0.45rem 0.65rem;
 }


### PR DESCRIPTION
## Summary
- ensure the browser header action button remembers the wider "Next Task" width and applies it when the shorter label is shown
- center the header action text and expose a CSS hook to keep the button width consistent

## Testing
- Not run (not available in CI environment)

------
https://chatgpt.com/codex/tasks/task_e_68e059d233d0832cbd1d5a068d81dbd9