### PR TITLE
Remove unused model builder registry functions

### DIFF
--- a/src/ui/cards/modelBuilderRegistry.js
+++ b/src/ui/cards/modelBuilderRegistry.js
@@ -20,10 +20,6 @@ function registerModelBuilder(key, builder, { isDefault = false } = {}) {
   return () => builders.delete(normalizedKey);
 }
 
-function unregisterModelBuilder(key) {
-  builders.delete(key);
-}
-
 function getModelBuilderEntries() {
   return Array.from(builders.entries());
 }
@@ -34,15 +30,6 @@ function buildModelMap(registries, context = {}) {
     models[key] = builder(registries, context);
   });
   return models;
-}
-
-function resetModelBuilders() {
-  builders.clear();
-  defaultsRegistered = false;
-}
-
-function hasRegisteredBuilders() {
-  return builders.size > 0;
 }
 
 function ensureDefaultBuilders(registerDefaults) {
@@ -57,10 +44,7 @@ function ensureDefaultBuilders(registerDefaults) {
 
 export {
   registerModelBuilder,
-  unregisterModelBuilder,
   getModelBuilderEntries,
   buildModelMap,
-  resetModelBuilders,
-  hasRegisteredBuilders,
   ensureDefaultBuilders
 };


### PR DESCRIPTION
## Summary
- drop unused helper exports from the card model builder registry
- keep remaining registry utilities untouched so existing callers continue to work

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e05a00722c832ca2300da714619a5b