### PR TITLE
feat: add asset workspace presenter and shared UI primitives

### DIFF
--- a/src/ui/views/browser/components/common/domHelpers.js
+++ b/src/ui/views/browser/components/common/domHelpers.js
@@ -1,0 +1,36 @@
+function isNodeLike(value) {
+  return value != null && typeof value === 'object' && typeof value.nodeType === 'number';
+}
+
+function appendContent(target, content) {
+  if (!target || content == null) {
+    return;
+  }
+  if (Array.isArray(content)) {
+    content.forEach(item => appendContent(target, item));
+    return;
+  }
+  if (isNodeLike(content)) {
+    target.appendChild(content);
+    return;
+  }
+  if (typeof content === 'string' || typeof content === 'number' || typeof content === 'boolean') {
+    target.append(String(content));
+    return;
+  }
+  if (typeof content === 'function') {
+    const result = content(target);
+    appendContent(target, result);
+    return;
+  }
+  if (content && typeof content === 'object' && 'content' in content) {
+    appendContent(target, content.content);
+  }
+}
+
+export { isNodeLike, appendContent };
+
+export default {
+  isNodeLike,
+  appendContent
+};

--- a/src/ui/views/browser/components/common/renderDetailPanel.js
+++ b/src/ui/views/browser/components/common/renderDetailPanel.js
@@ -1,0 +1,240 @@
+import { appendContent } from './domHelpers.js';
+
+const DEFAULT_THEME = {
+  container: 'asset-detail',
+  header: 'asset-detail__header',
+  title: 'asset-detail__title',
+  subtitle: 'asset-detail__subtitle',
+  status: 'asset-detail__status',
+  tabs: 'asset-detail__tabs',
+  stats: 'asset-detail__stats',
+  stat: 'asset-detail__stat',
+  statLabel: 'asset-detail__stat-label',
+  statValue: 'asset-detail__stat-value',
+  statNote: 'asset-detail__stat-note',
+  sections: 'asset-detail__sections',
+  section: 'asset-detail__section',
+  sectionTitle: 'asset-detail__section-title',
+  sectionBody: 'asset-detail__section-body',
+  actions: 'asset-detail__actions',
+  actionButton: 'asset-detail__action',
+  empty: 'asset-detail__empty'
+};
+
+function renderStats(stats = [], theme) {
+  if (!Array.isArray(stats) || stats.length === 0) {
+    return null;
+  }
+  const list = document.createElement('div');
+  list.className = theme.stats;
+  stats.forEach(entry => {
+    if (!entry) return;
+    const item = document.createElement('div');
+    item.className = entry.className || theme.stat;
+    if (entry.tone) {
+      item.dataset.tone = String(entry.tone);
+    }
+    const label = document.createElement('span');
+    label.className = theme.statLabel;
+    appendContent(label, entry.label ?? '');
+    const value = document.createElement('strong');
+    value.className = theme.statValue;
+    appendContent(value, entry.value ?? '');
+    item.append(label, value);
+    if (entry.note) {
+      const note = document.createElement('span');
+      note.className = theme.statNote;
+      appendContent(note, entry.note);
+      item.appendChild(note);
+    }
+    list.appendChild(item);
+  });
+  return list;
+}
+
+function renderSections(sections = [], theme) {
+  if (!Array.isArray(sections) || sections.length === 0) {
+    return null;
+  }
+  const wrapper = document.createElement('div');
+  wrapper.className = theme.sections;
+  sections.forEach(section => {
+    if (!section) return;
+    const article = document.createElement('section');
+    article.className = section.className || theme.section;
+    if (section.tone) {
+      article.dataset.tone = String(section.tone);
+    }
+    if (section.title) {
+      const heading = document.createElement('h3');
+      heading.className = theme.sectionTitle;
+      appendContent(heading, section.title);
+      article.appendChild(heading);
+    }
+    if (section.body) {
+      const body = document.createElement('p');
+      body.className = theme.sectionBody;
+      appendContent(body, section.body);
+      article.appendChild(body);
+    }
+    if (Array.isArray(section.items)) {
+      const list = document.createElement('ul');
+      list.className = `${theme.sectionBody} ${theme.sectionBody}--list`.trim();
+      section.items.forEach(item => {
+        const li = document.createElement('li');
+        appendContent(li, item);
+        list.appendChild(li);
+      });
+      article.appendChild(list);
+    }
+    if (section.footer) {
+      const footer = document.createElement('footer');
+      appendContent(footer, section.footer);
+      article.appendChild(footer);
+    }
+    wrapper.appendChild(article);
+  });
+  return wrapper;
+}
+
+function renderActions(actions = [], theme, context = {}) {
+  if (!Array.isArray(actions) || actions.length === 0) {
+    return null;
+  }
+  const group = document.createElement('div');
+  group.className = theme.actions;
+  actions.forEach(action => {
+    if (!action) return;
+    const button = document.createElement('button');
+    button.type = action.type || 'button';
+    button.className = action.className || theme.actionButton;
+    if (action.id) {
+      button.id = action.id;
+    }
+    if (action.disabled) {
+      button.disabled = true;
+    }
+    appendContent(button, action.label ?? '');
+    if (typeof action.onClick === 'function') {
+      button.addEventListener('click', event => {
+        event.preventDefault();
+        if (button.disabled) return;
+        action.onClick(context, event);
+      });
+    }
+    group.appendChild(button);
+  });
+  return group;
+}
+
+function renderHeader(header = {}, theme) {
+  if (!header.title && !header.subtitle && !header.status) {
+    return null;
+  }
+  const wrapper = document.createElement('header');
+  wrapper.className = theme.header;
+  if (header.title) {
+    const title = document.createElement('h2');
+    title.className = theme.title;
+    appendContent(title, header.title);
+    wrapper.appendChild(title);
+  }
+  if (header.subtitle) {
+    const subtitle = document.createElement('p');
+    subtitle.className = theme.subtitle;
+    appendContent(subtitle, header.subtitle);
+    wrapper.appendChild(subtitle);
+  }
+  if (header.status) {
+    const status = document.createElement('span');
+    status.className = header.status.className || theme.status;
+    if (header.status.tone) {
+      status.dataset.tone = String(header.status.tone);
+    }
+    appendContent(status, header.status.label ?? header.status);
+    wrapper.appendChild(status);
+  }
+  if (Array.isArray(header.tabs) && header.tabs.length) {
+    const tabs = document.createElement('div');
+    tabs.className = theme.tabs;
+    header.tabs.forEach(tab => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = tab.label ?? tab;
+      if (tab.isActive) {
+        button.classList.add('is-active');
+        button.disabled = true;
+      }
+      if (typeof tab.onClick === 'function') {
+        button.addEventListener('click', event => {
+          event.preventDefault();
+          tab.onClick(event, tab);
+        });
+      }
+      tabs.appendChild(button);
+    });
+    wrapper.appendChild(tabs);
+  }
+  return wrapper;
+}
+
+export function renderDetailPanel(options = {}) {
+  const {
+    className,
+    theme: themeOverride = {},
+    isEmpty,
+    emptyState,
+    header,
+    stats,
+    sections,
+    actions,
+    context
+  } = options;
+
+  const theme = { ...DEFAULT_THEME, ...themeOverride };
+  const container = document.createElement('aside');
+  container.className = className || theme.container;
+
+  if (isEmpty) {
+    const empty = document.createElement('div');
+    empty.className = theme.empty;
+    if (emptyState?.title) {
+      const title = document.createElement('h3');
+      appendContent(title, emptyState.title);
+      empty.appendChild(title);
+    }
+    if (emptyState?.message) {
+      const message = document.createElement('p');
+      appendContent(message, emptyState.message);
+      empty.appendChild(message);
+    }
+    container.appendChild(empty);
+    return container;
+  }
+
+  const headerNode = renderHeader(header, theme);
+  if (headerNode) {
+    container.appendChild(headerNode);
+  }
+
+  const statsNode = renderStats(stats, theme);
+  if (statsNode) {
+    container.appendChild(statsNode);
+  }
+
+  const sectionsNode = renderSections(sections, theme);
+  if (sectionsNode) {
+    container.appendChild(sectionsNode);
+  }
+
+  const actionsNode = renderActions(actions, theme, context);
+  if (actionsNode) {
+    container.appendChild(actionsNode);
+  }
+
+  return container;
+}
+
+export default {
+  renderDetailPanel
+};

--- a/src/ui/views/browser/components/common/renderInstanceTable.js
+++ b/src/ui/views/browser/components/common/renderInstanceTable.js
@@ -1,0 +1,199 @@
+import { appendContent } from './domHelpers.js';
+
+const DEFAULT_THEME = {
+  container: 'asset-table',
+  table: 'asset-table__table',
+  headCell: 'asset-table__heading',
+  row: 'asset-table__row',
+  cell: 'asset-table__cell',
+  actionsCell: 'asset-table__cell--actions',
+  actions: 'asset-table__actions',
+  actionButton: 'asset-table__action',
+  empty: 'asset-table__empty'
+};
+
+function applyDataset(element, dataset = {}) {
+  if (!element || !dataset || typeof dataset !== 'object') return;
+  Object.entries(dataset).forEach(([key, value]) => {
+    if (value != null) {
+      element.dataset[key] = String(value);
+    }
+  });
+}
+
+function createActionButton(action = {}, theme, row) {
+  const button = document.createElement('button');
+  button.type = action.type || 'button';
+  button.className = action.className || theme.actionButton;
+  button.dataset.rowAction = 'true';
+  if (action.id) {
+    button.dataset.actionId = action.id;
+  }
+  if (action.title) {
+    button.title = action.title;
+  }
+  if (action.disabled) {
+    button.disabled = true;
+  }
+  appendContent(button, action.label ?? '');
+  if (typeof action.onSelect === 'function') {
+    button.addEventListener('click', event => {
+      event.stopPropagation();
+      if (button.disabled) return;
+      action.onSelect(row.id, action, event);
+    });
+  }
+  return button;
+}
+
+function renderEmptyState(emptyState, theme) {
+  if (!emptyState) return null;
+  const wrapper = document.createElement('div');
+  wrapper.className = theme.empty;
+  if (emptyState.title) {
+    const heading = document.createElement('h3');
+    appendContent(heading, emptyState.title);
+    wrapper.appendChild(heading);
+  }
+  if (emptyState.message) {
+    const message = document.createElement('p');
+    appendContent(message, emptyState.message);
+    wrapper.appendChild(message);
+  }
+  if (Array.isArray(emptyState.actions)) {
+    const actions = document.createElement('div');
+    actions.className = theme.actions;
+    emptyState.actions.forEach(action => {
+      if (!action) return;
+      actions.appendChild(createActionButton(action, theme, {}));
+    });
+    wrapper.appendChild(actions);
+  }
+  return wrapper;
+}
+
+function resolveCellConfig(cell) {
+  if (cell && typeof cell === 'object' && !Array.isArray(cell)) {
+    return cell;
+  }
+  return { content: cell };
+}
+
+export function renderInstanceTable(options = {}) {
+  const {
+    className,
+    columns = [],
+    rows = [],
+    selectedId,
+    onSelect,
+    caption,
+    theme: themeOverride = {},
+    emptyState
+  } = options;
+
+  const theme = { ...DEFAULT_THEME, ...themeOverride };
+
+  const container = document.createElement('div');
+  container.className = className || theme.container;
+
+  if (!Array.isArray(rows) || rows.length === 0) {
+    const empty = renderEmptyState(emptyState, theme);
+    if (empty) {
+      container.appendChild(empty);
+    }
+    return container;
+  }
+
+  const table = document.createElement('table');
+  table.className = theme.table;
+
+  if (caption) {
+    const captionNode = document.createElement('caption');
+    appendContent(captionNode, caption);
+    table.appendChild(captionNode);
+  }
+
+  if (columns.length) {
+    const thead = document.createElement('thead');
+    const headRow = document.createElement('tr');
+    columns.forEach(column => {
+      if (!column) return;
+      const th = document.createElement('th');
+      th.scope = 'col';
+      th.className = column.className || theme.headCell;
+      appendContent(th, column.label ?? '');
+      if (column.dataset) {
+        applyDataset(th, column.dataset);
+      }
+      headRow.appendChild(th);
+    });
+    thead.appendChild(headRow);
+    table.appendChild(thead);
+  }
+
+  const tbody = document.createElement('tbody');
+
+  rows.forEach(row => {
+    if (!row) return;
+    const tr = document.createElement('tr');
+    tr.className = row.className ? `${theme.row} ${row.className}`.trim() : theme.row;
+    if (row.id) {
+      tr.dataset.rowId = row.id;
+    }
+    if (row.tone) {
+      tr.dataset.tone = String(row.tone);
+    }
+    const isSelected = row.isSelected ?? (selectedId != null && row.id === selectedId);
+    if (isSelected) {
+      tr.classList.add('is-selected');
+      tr.setAttribute('aria-selected', 'true');
+    }
+
+    if (typeof onSelect === 'function' && row.selectable !== false) {
+      tr.addEventListener('click', event => {
+        const actionTarget = event.target.closest('[data-row-action]');
+        if (actionTarget) return;
+        onSelect(row.id, row, event);
+      });
+    }
+
+    row.cells.forEach(cell => {
+      const cellConfig = resolveCellConfig(cell);
+      const td = document.createElement('td');
+      td.className = cellConfig.className
+        ? `${theme.cell} ${cellConfig.className}`.trim()
+        : theme.cell;
+      if (cellConfig.align) {
+        td.dataset.align = cellConfig.align;
+      }
+      if (cellConfig.dataset) {
+        applyDataset(td, cellConfig.dataset);
+      }
+      appendContent(td, cellConfig.content ?? '');
+      tr.appendChild(td);
+    });
+
+    if (Array.isArray(row.actions) && row.actions.length) {
+      const actionCell = document.createElement('td');
+      actionCell.className = `${theme.cell} ${theme.actionsCell}`.trim();
+      const actionGroup = document.createElement('div');
+      actionGroup.className = theme.actions;
+      row.actions.forEach(action => {
+        if (!action) return;
+        actionGroup.appendChild(createActionButton(action, theme, row));
+      });
+      actionCell.appendChild(actionGroup);
+      tr.appendChild(actionCell);
+    }
+
+    tbody.appendChild(tr);
+  });
+
+  table.appendChild(tbody);
+  container.appendChild(table);
+  return container;
+}
+
+export default {
+  renderInstanceTable
+};

--- a/src/ui/views/browser/components/common/renderKpiGrid.js
+++ b/src/ui/views/browser/components/common/renderKpiGrid.js
@@ -1,0 +1,83 @@
+import { appendContent } from './domHelpers.js';
+
+const DEFAULT_THEME = {
+  container: 'asset-kpis',
+  grid: 'asset-kpis__grid',
+  card: 'asset-kpi',
+  label: 'asset-kpi__label',
+  value: 'asset-kpi__value',
+  note: 'asset-kpi__note',
+  empty: 'asset-kpis__empty'
+};
+
+function formatValue(item) {
+  if (typeof item.formatValue === 'function') {
+    return item.formatValue(item.value, item);
+  }
+  if (item.valueNode) {
+    return item.valueNode;
+  }
+  if (item.value != null) {
+    return String(item.value);
+  }
+  return '';
+}
+
+export function renderKpiGrid(options = {}) {
+  const { items = [], className, theme: themeOverride = {}, emptyState } = options;
+  const theme = { ...DEFAULT_THEME, ...themeOverride };
+
+  const section = document.createElement('section');
+  section.className = className || theme.container;
+
+  if (!Array.isArray(items) || items.length === 0) {
+    if (emptyState?.message) {
+      const empty = document.createElement('p');
+      empty.className = theme.empty;
+      appendContent(empty, emptyState.message);
+      section.appendChild(empty);
+    }
+    return section;
+  }
+
+  const grid = document.createElement('div');
+  grid.className = theme.grid;
+
+  items.forEach(item => {
+    if (!item) return;
+    const card = document.createElement('article');
+    card.className = item.className || theme.card;
+    if (item.id) {
+      card.dataset.metricId = item.id;
+    }
+    if (item.tone) {
+      card.dataset.tone = String(item.tone);
+    }
+
+    const label = document.createElement('span');
+    label.className = theme.label;
+    appendContent(label, item.label ?? '');
+
+    const value = document.createElement('p');
+    value.className = theme.value;
+    appendContent(value, formatValue(item));
+
+    card.append(label, value);
+
+    if (item.note) {
+      const note = document.createElement('span');
+      note.className = theme.note;
+      appendContent(note, item.note);
+      card.appendChild(note);
+    }
+
+    grid.appendChild(card);
+  });
+
+  section.appendChild(grid);
+  return section;
+}
+
+export default {
+  renderKpiGrid
+};

--- a/src/ui/views/browser/components/common/renderWorkspaceHeader.js
+++ b/src/ui/views/browser/components/common/renderWorkspaceHeader.js
@@ -1,0 +1,156 @@
+import { createNavTabs } from './navBuilders.js';
+import { appendContent } from './domHelpers.js';
+
+const DEFAULT_THEME = {
+  header: 'asset-workspace__header',
+  intro: 'asset-workspace__intro',
+  title: 'asset-workspace__title',
+  subtitle: 'asset-workspace__subtitle',
+  meta: 'asset-workspace__meta',
+  badges: 'asset-workspace__badges',
+  badge: 'asset-workspace__badge',
+  actions: 'asset-workspace__actions',
+  actionButton: 'asset-workspace__action',
+  nav: 'asset-workspace__tabs'
+};
+
+function createActionButton(action = {}, theme) {
+  const button = document.createElement('button');
+  button.type = action.type || 'button';
+  button.className = action.className || theme.actionButton;
+  if (action.id) {
+    button.id = action.id;
+  }
+  if (action.title) {
+    button.title = action.title;
+  }
+  if (action['aria-label']) {
+    button.setAttribute('aria-label', action['aria-label']);
+  } else if (action.ariaLabel) {
+    button.setAttribute('aria-label', action.ariaLabel);
+  }
+  if (action.dataset && typeof action.dataset === 'object') {
+    Object.entries(action.dataset).forEach(([key, value]) => {
+      if (value != null) {
+        button.dataset[key] = String(value);
+      }
+    });
+  }
+  if (action.disabled) {
+    button.disabled = true;
+  }
+  appendContent(button, action.label ?? '');
+  if (typeof action.onClick === 'function') {
+    button.addEventListener('click', event => {
+      event.preventDefault();
+      if (button.disabled) return;
+      action.onClick(event);
+    });
+  }
+  return button;
+}
+
+function renderBadges(badges = [], theme) {
+  if (!Array.isArray(badges) || badges.length === 0) {
+    return null;
+  }
+  const list = document.createElement('div');
+  list.className = theme.badges;
+  badges.forEach(badgeConfig => {
+    if (!badgeConfig) return;
+    const badge = document.createElement('span');
+    badge.className = badgeConfig.className || theme.badge;
+    if (badgeConfig.id) {
+      badge.id = badgeConfig.id;
+    }
+    if (badgeConfig.tone) {
+      badge.dataset.tone = String(badgeConfig.tone);
+    }
+    appendContent(badge, badgeConfig.label ?? '');
+    list.appendChild(badge);
+  });
+  return list;
+}
+
+function resolveNavConfig(nav, theme) {
+  if (!nav) {
+    return null;
+  }
+  if (typeof HTMLElement !== 'undefined' && nav instanceof HTMLElement) {
+    return nav;
+  }
+  const config = { navClassName: theme.nav, datasetKey: 'view', withAriaPressed: true, ...nav };
+  return createNavTabs(config);
+}
+
+export function renderWorkspaceHeader(options = {}) {
+  const {
+    className,
+    title,
+    subtitle,
+    meta,
+    badges,
+    actions,
+    nav,
+    theme: themeOverride = {},
+    description
+  } = options;
+
+  const theme = { ...DEFAULT_THEME, ...themeOverride };
+  const header = document.createElement('header');
+  header.className = className || theme.header;
+
+  if (title || subtitle || meta || badges?.length) {
+    const intro = document.createElement('div');
+    intro.className = theme.intro;
+
+    if (title) {
+      const heading = document.createElement('h1');
+      heading.className = theme.title;
+      appendContent(heading, title);
+      intro.appendChild(heading);
+    }
+
+    if (subtitle) {
+      const subheading = document.createElement('p');
+      subheading.className = theme.subtitle;
+      appendContent(subheading, subtitle);
+      intro.appendChild(subheading);
+    }
+
+    const badgeList = renderBadges(badges, theme);
+    if (badgeList) {
+      intro.appendChild(badgeList);
+    }
+
+    if (meta || description) {
+      const metaNode = document.createElement('p');
+      metaNode.className = theme.meta;
+      appendContent(metaNode, meta ?? description ?? '');
+      intro.appendChild(metaNode);
+    }
+
+    header.appendChild(intro);
+  }
+
+  if (Array.isArray(actions) && actions.length) {
+    const actionsRow = document.createElement('div');
+    actionsRow.className = theme.actions;
+    actions.forEach(action => {
+      if (!action) return;
+      actionsRow.appendChild(createActionButton(action, theme));
+    });
+    header.appendChild(actionsRow);
+  }
+
+  const navNode = resolveNavConfig(nav, theme);
+  if (navNode) {
+    header.appendChild(navNode);
+  }
+
+  return header;
+}
+
+export default {
+  renderWorkspaceHeader
+};

--- a/src/ui/views/browser/utils/createAssetWorkspace.js
+++ b/src/ui/views/browser/utils/createAssetWorkspace.js
@@ -1,0 +1,270 @@
+import { createTabbedWorkspacePresenter } from './createTabbedWorkspacePresenter.js';
+import { renderWorkspaceHeader } from '../components/common/renderWorkspaceHeader.js';
+import { renderKpiGrid } from '../components/common/renderKpiGrid.js';
+import { renderInstanceTable } from '../components/common/renderInstanceTable.js';
+import { renderDetailPanel } from '../components/common/renderDetailPanel.js';
+import { appendContent } from '../components/common/domHelpers.js';
+
+function ensureArray(value) {
+  return Array.isArray(value) ? value : value == null ? [] : [value];
+}
+
+function toMap(items = []) {
+  const map = new Map();
+  items.forEach(item => {
+    if (item && item.id != null) {
+      map.set(item.id, item);
+    }
+  });
+  return map;
+}
+
+function buildNavButtons(views, state, model, context, resolveView) {
+  return views
+    .filter(view => view && view.hide !== true)
+    .map(view => {
+      const badge = typeof view.badge === 'function'
+        ? view.badge({ model, state, view, context })
+        : view.badge;
+      const label = typeof view.label === 'function'
+        ? view.label({ model, state, view, context })
+        : (view.label || view.id);
+      const targetView = view.id;
+      return {
+        label,
+        view: targetView,
+        badge,
+        isActive: resolveView(state.view) === targetView
+      };
+    });
+}
+
+function normalizeNavConfig(navConfig, options) {
+  if (!navConfig) {
+    return null;
+  }
+  if (typeof HTMLElement !== 'undefined' && navConfig instanceof HTMLElement) {
+    return navConfig;
+  }
+  const { buttons = [], onSelect, theme } = navConfig;
+  const config = {
+    navClassName: theme?.nav,
+    buttonClassName: theme?.button,
+    badgeClassName: theme?.badge,
+    datasetKey: 'view',
+    withAriaPressed: true,
+    ...navConfig,
+    buttons,
+    onSelect
+  };
+  if (typeof config.onSelect !== 'function') {
+    config.onSelect = options.setView;
+  }
+  config.buttons = buttons.map(button => ({
+    ...button,
+    onSelect: config.onSelect
+  }));
+  return config;
+}
+
+function createSharedContext(presenter, helpers) {
+  return {
+    get model() {
+      return presenter.getModel();
+    },
+    get state() {
+      return presenter.getState();
+    },
+    presenter,
+    ...helpers
+  };
+}
+
+function renderSections(sections = [], context) {
+  const fragment = document.createDocumentFragment();
+  ensureArray(sections).forEach(section => {
+    if (!section) return;
+    switch (section.type) {
+      case 'kpis':
+        fragment.appendChild(renderKpiGrid(section.options || section));
+        break;
+      case 'table':
+        fragment.appendChild(renderInstanceTable(section.options || section));
+        break;
+      case 'detail':
+        fragment.appendChild(renderDetailPanel({ ...section.options, context }));
+        break;
+      default:
+        appendContent(fragment, section.content ?? section);
+    }
+  });
+  return fragment;
+}
+
+export function createAssetWorkspacePresenter(config = {}) {
+  const {
+    className = 'asset-workspace',
+    state: initialState = {},
+    defaultView,
+    views = [],
+    header,
+    ensureSelection,
+    deriveSummary,
+    derivePath,
+    renderLocked,
+    beforeRender,
+    afterRender,
+    isLocked,
+    syncNavigation,
+    onViewChange
+  } = config;
+
+  if (!Array.isArray(views) || views.length === 0) {
+    throw new Error('createAssetWorkspacePresenter requires at least one view definition.');
+  }
+
+  const viewMap = toMap(views);
+  if (viewMap.size === 0) {
+    throw new Error('createAssetWorkspacePresenter requires view definitions with an id property.');
+  }
+
+  const fallbackView = viewMap.has(defaultView) ? defaultView : views[0].id;
+
+  function resolveView(viewId) {
+    return viewMap.has(viewId) ? viewId : fallbackView;
+  }
+
+  const presenter = createTabbedWorkspacePresenter({
+    className,
+    state: { ...initialState, view: resolveView(initialState.view) },
+    ensureSelection(state, model) {
+      if (!viewMap.has(state.view)) {
+        state.view = fallbackView;
+      }
+      if (typeof ensureSelection === 'function') {
+        ensureSelection(state, model);
+      }
+    },
+    deriveSummary,
+    derivePath,
+    renderLocked,
+    beforeRender,
+    afterRender(context) {
+      if (typeof afterRender === 'function') {
+        afterRender({ ...context, setView });
+      }
+    },
+    isLocked,
+    syncNavigation(context) {
+      if (!context?.mount) return;
+      const activeView = resolveView(context.state?.view);
+      context.mount.querySelectorAll('[data-view]').forEach(button => {
+        const isActive = resolveView(button.dataset.view) === activeView;
+        button.classList.toggle('is-active', isActive);
+        button.setAttribute('aria-pressed', String(isActive));
+      });
+      if (typeof syncNavigation === 'function') {
+        syncNavigation({ ...context, setView });
+      }
+    },
+    renderHeader(model, state, context) {
+      if (header === false) {
+        return null;
+      }
+      const sharedContext = createSharedContext(presenter, { setView, updateState, refresh });
+      const headerInput = typeof header === 'function'
+        ? header(model, state, sharedContext)
+        : header || {};
+      if (!headerInput) {
+        return null;
+      }
+      let navConfig = headerInput.nav;
+      if (navConfig !== false) {
+        const buttons = Array.isArray(navConfig?.buttons) && navConfig.buttons.length
+          ? navConfig.buttons
+          : buildNavButtons(views, state, model, sharedContext, resolveView);
+        navConfig = normalizeNavConfig({ ...navConfig, buttons }, { setView });
+      }
+      const actions = typeof headerInput.actions === 'function'
+        ? headerInput.actions(sharedContext)
+        : headerInput.actions;
+      const badges = typeof headerInput.badges === 'function'
+        ? headerInput.badges(sharedContext)
+        : headerInput.badges;
+      return renderWorkspaceHeader({
+        ...headerInput,
+        nav: navConfig,
+        actions,
+        badges
+      });
+    },
+    renderViews(model, state, context) {
+      const sharedContext = createSharedContext(presenter, { setView, updateState, refresh });
+      const activeView = viewMap.get(resolveView(state.view));
+      if (!activeView) {
+        return null;
+      }
+      const viewContext = {
+        model,
+        state,
+        presenter,
+        setView,
+        updateState,
+        refresh,
+        renderKpiGrid,
+        renderInstanceTable,
+        renderDetailPanel,
+        context: sharedContext
+      };
+      if (typeof activeView.render === 'function') {
+        return activeView.render(viewContext);
+      }
+      if (activeView.sections) {
+        return renderSections(activeView.sections, sharedContext);
+      }
+      return null;
+    }
+  });
+
+  function refresh(model = presenter.getModel()) {
+    presenter.render(model, { mount: presenter.getMount() });
+  }
+
+  function updateState(updater, { rerender = true } = {}) {
+    presenter.updateState(updater);
+    if (rerender) {
+      refresh();
+    }
+  }
+
+  function setView(viewId, { rerender = true } = {}) {
+    const previous = presenter.getState();
+    const target = resolveView(viewId);
+    presenter.updateState(state => ({ ...state, view: target }));
+    const nextState = presenter.getState();
+    if (typeof onViewChange === 'function') {
+      onViewChange(target, {
+        previousView: previous?.view,
+        state: nextState,
+        model: presenter.getModel(),
+        setView,
+        refresh,
+        updateState
+      });
+    }
+    if (rerender) {
+      refresh();
+    }
+  }
+
+  return {
+    ...presenter,
+    setView,
+    refresh,
+    updateAndRender: updateState
+  };
+}
+
+export default {
+  createAssetWorkspacePresenter
+};

--- a/tests/ui/workspaces/assetWorkspacePresenter.test.js
+++ b/tests/ui/workspaces/assetWorkspacePresenter.test.js
@@ -1,0 +1,208 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+import { createAssetWorkspacePresenter } from '../../../src/ui/views/browser/utils/createAssetWorkspace.js';
+
+function ensureArray(value) {
+  return Array.isArray(value) ? value : value == null ? [] : [value];
+}
+
+test('createAssetWorkspacePresenter composes workspace UI from declarative config', async t => {
+  const dom = new JSDOM('<div id="root"></div>');
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+
+  t.after(() => {
+    dom.window.close();
+    delete globalThis.window;
+    delete globalThis.document;
+  });
+
+  const mount = dom.window.document.getElementById('root');
+  const launchEvents = [];
+
+  const DETAIL_BY_ID = {
+    alpha: {
+      payout: '$120',
+      upkeep: '$30',
+      roi: '120%',
+      summary: 'Alpha app is cruising with daily subscribers.',
+      notes: ['Strong retention', 'Upgrades unlocked']
+    },
+    beta: {
+      payout: '$0',
+      upkeep: '$12',
+      roi: '0%',
+      summary: 'Beta app is prepping for launch.',
+      notes: ['Assign niche soon', 'Queue marketing drip']
+    }
+  };
+
+  const model = {
+    summary: {
+      meta: 'Launchpad humming',
+      hero: [
+        { id: 'active', label: 'Active apps', value: 1, note: 'Live today' },
+        { id: 'setup', label: 'In setup', value: 1 }
+      ]
+    },
+    instances: [
+      { id: 'alpha', label: 'Alpha App', status: { label: 'Active', tone: 'ready' }, payout: 120 },
+      { id: 'beta', label: 'Beta App', status: { label: 'Setup', tone: 'pending' }, payout: 0 }
+    ]
+  };
+
+  const presenter = createAssetWorkspacePresenter({
+    className: 'sample-workspace',
+    defaultView: 'overview',
+    state: { view: 'overview', selectedId: null },
+    ensureSelection(state, currentModel) {
+      if (!state.selectedId) {
+        const first = ensureArray(currentModel.instances)[0];
+        state.selectedId = first?.id ?? null;
+      }
+    },
+    header(modelSnapshot) {
+      return {
+        className: 'sample-header',
+        title: 'Sample Asset Console',
+        subtitle: modelSnapshot.summary?.meta,
+        actions: [
+          {
+            label: 'Launch asset',
+            className: 'sample-header__action',
+            dataset: { testid: 'launch-action' },
+            onClick: () => launchEvents.push('launch')
+          }
+        ],
+        nav: {
+          navClassName: 'sample-tabs',
+          buttonClassName: 'sample-tab'
+        }
+      };
+    },
+    views: [
+      {
+        id: 'overview',
+        label: 'Overview',
+        render({ model: renderModel, state, renderKpiGrid, renderInstanceTable, renderDetailPanel, updateState }) {
+          const section = document.createElement('section');
+          section.className = 'overview-view';
+
+          const selected = ensureArray(renderModel.instances).find(entry => entry.id === state.selectedId) || null;
+          const detail = selected ? DETAIL_BY_ID[selected.id] : null;
+
+          section.append(
+            renderKpiGrid({
+              className: 'sample-kpis',
+              items: ensureArray(renderModel.summary?.hero).map(item => ({
+                id: item.id,
+                label: item.label,
+                value: item.value,
+                note: item.note
+              }))
+            }),
+            renderInstanceTable({
+              className: 'sample-table',
+              columns: [
+                { id: 'name', label: 'App' },
+                { id: 'status', label: 'Status' },
+                { id: 'payout', label: 'Daily payout' }
+              ],
+              rows: ensureArray(renderModel.instances).map(instance => ({
+                id: instance.id,
+                cells: [
+                  instance.label,
+                  instance.status?.label || '',
+                  `$${instance.payout}`
+                ]
+              })),
+              selectedId: state.selectedId,
+              onSelect: rowId => updateState(current => ({ ...current, selectedId: rowId }))
+            }),
+            renderDetailPanel({
+              className: 'sample-detail',
+              isEmpty: !selected,
+              emptyState: {
+                title: 'Pick an instance',
+                message: 'Choose an instance to inspect payout trends.'
+              },
+              header: selected && {
+                title: selected.label,
+                status: { label: selected.status?.label || '', tone: selected.status?.tone }
+              },
+              stats: detail
+                ? [
+                    { label: 'Payout', value: detail.payout },
+                    { label: 'Upkeep', value: detail.upkeep },
+                    { label: 'ROI', value: detail.roi }
+                  ]
+                : [],
+              sections: detail
+                ? [
+                    { title: 'Summary', body: detail.summary },
+                    { title: 'Notes', items: detail.notes }
+                  ]
+                : []
+            })
+          );
+
+          return section;
+        }
+      },
+      {
+        id: 'upgrades',
+        label: 'Upgrades',
+        render() {
+          const section = document.createElement('section');
+          section.className = 'upgrades-view';
+          section.textContent = 'Upgrade catalog placeholder';
+          return section;
+        }
+      }
+    ]
+  });
+
+  presenter.render(model, { mount });
+
+  const header = mount.querySelector('.sample-header');
+  assert.ok(header, 'workspace header should render');
+  assert.match(header.textContent, /Sample Asset Console/);
+  assert.match(header.textContent, /Launchpad humming/);
+
+  const navButtons = [...mount.querySelectorAll('.sample-tab')];
+  assert.equal(navButtons.length, 2, 'expected nav buttons for each view');
+  assert.deepEqual(
+    navButtons.map(button => button.dataset.view),
+    ['overview', 'upgrades'],
+    'nav buttons should advertise matching dataset view values'
+  );
+
+  const kpiCards = [...mount.querySelectorAll('.sample-kpis .asset-kpi')];
+  assert.equal(kpiCards.length, 2, 'expected KPI cards for hero metrics');
+  assert.ok(kpiCards[0].textContent.includes('Active apps'));
+
+  const rows = [...mount.querySelectorAll('.sample-table tbody tr')];
+  assert.equal(rows.length, 2, 'expected table rows for each instance');
+  assert.ok(rows[0].classList.contains('is-selected'), 'first row selected by ensureSelection');
+
+  let detail = mount.querySelector('.sample-detail');
+  assert.ok(detail.textContent.includes('Alpha app is cruising'));
+
+  rows[1].dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+  const updatedRows = [...mount.querySelectorAll('.sample-table tbody tr')];
+  assert.ok(updatedRows[1].classList.contains('is-selected'), 'click should select new row');
+  assert.ok(!updatedRows[0].classList.contains('is-selected'), 'first row should lose selection');
+
+  detail = mount.querySelector('.sample-detail');
+  assert.ok(detail.textContent.includes('Beta app is prepping'), 'detail panel updates for selection');
+
+  const launchButton = header.querySelector('[data-testid="launch-action"]');
+  launchButton.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+  assert.equal(launchEvents.length, 1, 'header action invokes provided handler');
+
+  navButtons[1].dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+  assert.ok(mount.querySelector('.upgrades-view'), 'switching views renders alternate section');
+  assert.ok(!mount.querySelector('.overview-view'), 'overview content should be replaced');
+});


### PR DESCRIPTION
## Summary
- add `createAssetWorkspacePresenter` for assembling asset workspaces from declarative view configs
- extract reusable workspace UI primitives for headers, KPI grids, instance tables, and detail panels
- add unit coverage to verify the presenter builds the expected DOM for sample configurations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e05dc6e960832c98a24f674afbc20d