### PR TITLE
Add browser stylesheet structure overview

### DIFF
--- a/docs/ui/browser-styles-structure.md
+++ b/docs/ui/browser-styles-structure.md
@@ -1,0 +1,26 @@
+# Browser UI stylesheet structure
+
+## Load order to enforce after splitting
+1. **Base / theme** – global tokens, layout shell, and utility rules that define `--browser-*` variables, chrome, tabs, layout wrappers, and home spacing helpers. (Current file lines 19-555.)
+2. **Shared widgets & utilities** – reusable widgets (todo, bank, apps), notifications, generic cards/pages, About You / Bank app details, and supporting animations. (Lines 556-2410.)
+3. **Workspace modules** – app-specific bundles loaded in the order they appear now so overrides cascade correctly:
+   - Digishelf (2411-2922)
+   - BlogPress (2928-3475)
+   - Learnly (3480-4022)
+   - ShopStack (4030-4575)
+   - VideoTube (4582-5051)
+   - Shopily (5056-5902)
+   - Trends (5908-6252)
+   - ServerHub (6259-7002)
+4. **Overlays & launch flows** – modal overlay shell, launch dialog skin, and keyframes (7007-7221).
+
+Keeping this load order preserves variable definitions, shared utility mixins, and the expectation that workspace modules can rely on prior base/widget styles without redefining them.
+
+## Cross-section dependencies to watch
+- **Design tokens** – All sections rely on the base `--browser-*` properties for color, spacing, radius, and shadows. Workspace themes (e.g., Shopily, ServerHub) only redefine shades via these tokens, so the base variables must load first.
+- **Home spacing variables** – The global `.browser-stage__pane--home` defines `--browser-home-spacing`, `--browser-home-widget-gap`, and `--browser-home-widget-spacer`, which are consumed by widgets (`.browser-home__widgets`, `.apps-widget`, etc.). When extracting widgets ensure the home pane rules remain upstream.
+- **Shared widget state** – `.browser-button` variants and `.browser-button.is-spinning` are referenced by multiple modules (home widgets trigger the spinner, server/workspace buttons inherit pill radii). Keep the base button styles adjacent to utilities so workspace-specific buttons (ShopStack, ServerHub) can inherit transitions and radius tokens.
+- **Dark mode hooks** – Several workspaces add `:root[data-browser-theme="night"] …` overrides (Learnly, VideoTube). These selectors assume the base night theme variables are already defined and cascade into module styles. Future modules should follow the same pattern rather than redefining root colors.
+- **Launch dialog skins** – The shared overlay component (`body.has-launch-dialog`, `.launch-dialog…`) sits in the overlay section but is re-themed per workspace via modifiers (`.launch-dialog--blogpress`, `--digishelf`, `--serverhub`). When splitting files keep the overlay core before any brand-specific modifiers so additional workspaces can append their skins.
+
+Documenting these dependencies should help future contributors decide where to place new rules and avoid regressions when the stylesheet is modularized.

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -1,3 +1,21 @@
+/*
+ * Browser stylesheet map
+ * Load order target: base → shared widgets → workspaces → overlays
+ * Sections
+ * - Global shell & theming (lines 19-555): :root theme tokens, body, chrome, layout. Custom props: --browser-*, --browser-home-*, --browser-session-button-width.
+ * - Shared widgets & utilities (lines 556-2410): Home widgets, notifications, browser pages/cards, About You, Bank app. Custom props: --todo-widget-row-height, --todo-widget-max-height, --progress.
+ * - Workspaces:
+ *   • Digishelf (lines 2411-2922) – digital marketplace; defines --digishelf-progress.
+ *   • BlogPress (lines 2928-3475) – publishing workspace; consumes shared --browser-* tokens.
+ *   • Learnly (lines 3480-4022) – education workspace; includes night theme tweaks.
+ *   • ShopStack (lines 4030-4575) – marketplace inventory; builds on .browser-button variants.
+ *   • VideoTube (lines 4582-5051) – streaming studio; uses --videotube-quality/progress.
+ *   • Shopily (lines 5056-5902) – ecommerce operations; uses --shopily-progress.
+ *   • Trends (lines 5908-6252) – analytics dashboard; relies on shared palette.
+ *   • ServerHub (lines 6259-7002) – operations suite; uses --serverhub-progress.
+ * - Overlays & launch dialog (lines 7007-7221): shared overlay shell with app-specific modifiers and animations.
+ */
+
 :root,
 :root[data-browser-theme="day"] {
   color-scheme: light;


### PR DESCRIPTION
## Summary
- add a header comment to `styles/browser.css` that maps section ranges, shared tokens, and the intended load order
- document cross-section dependencies and the proposed stylesheet load order in `docs/ui/browser-styles-structure.md`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0627d353c832c935b9fa175dca81c