### PR TITLE
Fix bank widget highlight alignment

### DIFF
--- a/src/ui/views/browser/widgets/bankWidget.js
+++ b/src/ui/views/browser/widgets/bankWidget.js
@@ -117,10 +117,19 @@ function createChip({ label, value, tone = 'neutral', note, position }) {
 function renderHighlights(header = {}) {
   if (!elements?.highlights) return;
 
-  const chips = [];
+  const columns = {
+    left: [],
+    right: []
+  };
+
+  function pushChip(chip) {
+    if (!chip) return;
+    const position = chip.dataset.position === 'right' ? 'right' : 'left';
+    columns[position].push(chip);
+  }
   const quick = header?.quickObligation || null;
   const quickAmount = Math.max(0, Number(quick?.amount ?? 0));
-  chips.push(
+  pushChip(
     createChip({
       label: quick?.label || 'Next due',
       value: formatCurrency(quickAmount),
@@ -133,7 +142,7 @@ function renderHighlights(header = {}) {
   const top = header?.topEarner || null;
   const topAmount = Math.max(0, Number(top?.amount ?? 0));
   const topLabel = top?.label || '—';
-  chips.push(
+  pushChip(
     createChip({
       label: 'Top earner',
       value: `${topLabel} • ${formatCurrency(topAmount)}`,
@@ -167,7 +176,7 @@ function renderHighlights(header = {}) {
     const direction = entry?.direction || slot.fallbackDirection;
     const tone = amount > 0 ? (direction === 'out' ? 'out' : 'in') : 'neutral';
     const signedAmount = direction === 'out' ? -Math.abs(amount) : Math.abs(amount);
-    chips.push(
+    pushChip(
       createChip({
         label: entry?.label || slot.fallbackLabel,
         value: formatSignedCurrency(signedAmount),
@@ -179,11 +188,17 @@ function renderHighlights(header = {}) {
   });
 
   elements.highlights.innerHTML = '';
-  if (!chips.length) {
+  const totalChips = columns.left.length + columns.right.length;
+  if (!totalChips) {
     elements.highlights.hidden = true;
     return;
   }
-  chips.forEach(chip => elements.highlights.appendChild(chip));
+  ['left', 'right'].forEach(side => {
+    const column = document.createElement('div');
+    column.className = `bank-widget__column bank-widget__column--${side}`;
+    columns[side].forEach(chip => column.appendChild(chip));
+    elements.highlights.appendChild(column);
+  });
   elements.highlights.hidden = false;
 }
 

--- a/styles/browser.css
+++ b/styles/browser.css
@@ -1149,6 +1149,19 @@ a {
   gap: 0.65rem;
 }
 
+.bank-widget__column {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.bank-widget__column--left {
+  justify-items: start;
+}
+
+.bank-widget__column--right {
+  justify-items: end;
+}
+
 .bank-widget__chip {
   display: inline-flex;
   align-items: center;
@@ -1159,14 +1172,6 @@ a {
   border: 1px solid var(--browser-panel-border);
   font-size: 0.84rem;
   line-height: 1;
-}
-
-.bank-widget__chip[data-position='left'] {
-  justify-self: start;
-}
-
-.bank-widget__chip[data-position='right'] {
-  justify-self: end;
 }
 
 .bank-widget__chip-label {


### PR DESCRIPTION
## Summary
- ensure bank snapshot highlight chips render in dedicated left and right columns so they no longer float
- update styles so the new columns anchor chips to the panel edges while keeping existing chip styling

## Testing
- npm test
- Manual: Loaded index.html in a browser and verified bank snapshot highlights stay in their columns

------
https://chatgpt.com/codex/tasks/task_e_68e0638c8d70832c86cb64877104cbfd