### PR TITLE
Modularize styles build pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ Each asset supports multiple instances, tracks setup progress, and rolls a daily
 2. Open `browser.html` in any modern browser. The project is a static ES-module bundle; no build tools required.
 3. Optional: serve with a simple HTTP server (e.g., `npx serve .`) to avoid `localStorage` restrictions during local testing.
 
+## Styling Workflow
+- `styles/browser.css` is generated; edit the source modules in `styles/base/`, `styles/components/`, `styles/widgets/`, `styles/workspaces/`, and `styles/overlays/` instead of modifying the bundle directly.
+- Run `npm run build:css` to regenerate the bundle after changing any module. The command runs automatically during `npm install` via the `prepare` hook but can be invoked manually while iterating on styles.
+
 ## Testing
 1. Install dev dependencies with `npm install`.
 2. Run the Node-based suite with `npm test` to exercise the day scheduler, maintenance flow, and knowledge tracks.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
+    "build:css": "node scripts/build-css.js",
+    "prepare": "npm run build:css",
     "test": "node --test"
   },
   "devDependencies": {

--- a/scripts/build-css.js
+++ b/scripts/build-css.js
@@ -1,0 +1,71 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..');
+const stylesDir = path.join(projectRoot, 'styles');
+const outputFile = path.join(stylesDir, 'browser.css');
+
+const sectionOrder = ['base', 'components', 'widgets', 'workspaces', 'overlays'];
+
+async function readSectionFiles(section) {
+  const sectionDir = path.join(stylesDir, section);
+
+  let entries;
+  try {
+    entries = await fs.readdir(sectionDir, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  }
+
+  const files = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.css'))
+    .map((entry) => entry.name)
+    .sort();
+
+  const contents = [];
+  for (const file of files) {
+    const filePath = path.join(sectionDir, file);
+    const content = await fs.readFile(filePath, 'utf8');
+    if (content.trim().length === 0) {
+      continue;
+    }
+    contents.push({ filePath, content: content.replace(/\r\n/g, '\n') });
+  }
+
+  return contents;
+}
+
+async function build() {
+  const parts = [];
+  const sources = [];
+
+  for (const section of sectionOrder) {
+    const files = await readSectionFiles(section);
+    for (const file of files) {
+      const normalized = file.content.endsWith('\n') ? file.content : `${file.content}\n`;
+      parts.push(normalized);
+      sources.push(path.relative(projectRoot, file.filePath));
+    }
+  }
+
+  const output = parts.join('');
+  await fs.writeFile(outputFile, output, 'utf8');
+
+  if (sources.length === 0) {
+    console.log('No CSS modules found. Wrote empty styles/browser.css.');
+  } else {
+    console.log(`Built ${path.relative(projectRoot, outputFile)} from ${sources.length} modules.`);
+  }
+}
+
+build().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+

--- a/styles/base/theme.css
+++ b/styles/base/theme.css
@@ -1,0 +1,86 @@
+/*
+ * Browser stylesheet map
+ * Load order target: base → shared widgets → workspaces → overlays
+ * Sections
+ * - Global shell & theming (lines 19-555): :root theme tokens, body, chrome, layout. Custom props: --browser-*, --browser-home-*, --browser-session-button-width.
+ * - Shared widgets & utilities (lines 556-2410): Home widgets, notifications, browser pages/cards, About You, Bank app. Custom props: --todo-widget-row-height, --todo-widget-max-height, --progress.
+ * - Workspaces:
+ *   • Digishelf (lines 2411-2922) – digital marketplace; defines --digishelf-progress.
+ *   • BlogPress (lines 2928-3475) – publishing workspace; consumes shared --browser-* tokens.
+ *   • Learnly (lines 3480-4022) – education workspace; includes night theme tweaks.
+ *   • ShopStack (lines 4030-4575) – marketplace inventory; builds on .browser-button variants.
+ *   • VideoTube (lines 4582-5051) – streaming studio; uses --videotube-quality/progress.
+ *   • Shopily (lines 5056-5902) – ecommerce operations; uses --shopily-progress.
+ *   • Trends (lines 5908-6252) – analytics dashboard; relies on shared palette.
+ *   • ServerHub (lines 6259-7002) – operations suite; uses --serverhub-progress.
+ * - Overlays & launch dialog (lines 7007-7221): shared overlay shell with app-specific modifiers and animations.
+ */
+
+:root,
+:root[data-browser-theme="day"] {
+  color-scheme: light;
+  font-family: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --browser-surface: #f4f6fb;
+  --browser-panel: #ffffff;
+  --browser-panel-elevated: #ffffff;
+  --browser-panel-border: rgba(15, 23, 42, 0.08);
+  --browser-muted: #64748b;
+  --browser-subtle: #94a3b8;
+  --browser-text: #1f2937;
+  --browser-accent: #2563eb;
+  --browser-accent-soft: rgba(37, 99, 235, 0.12);
+  --browser-positive: #059669;
+  --browser-danger: #ef4444;
+  --browser-radius: 16px;
+  --browser-radius-md: 14px;
+  --browser-radius-lg: 20px;
+  --browser-radius-pill: 999px;
+  --browser-shadow-card: 0 18px 38px rgba(15, 23, 42, 0.08);
+  --browser-shadow-soft: 0 20px 44px rgba(15, 23, 42, 0.06);
+  --browser-shadow-focus: 0 12px 30px rgba(37, 99, 235, 0.16);
+}
+
+:root[data-browser-theme="night"] {
+  color-scheme: dark;
+  --browser-surface: #0f1117;
+  --browser-panel: #151a27;
+  --browser-panel-elevated: #1b2233;
+  --browser-panel-border: rgba(255, 255, 255, 0.08);
+  --browser-muted: #9aa5c2;
+  --browser-subtle: #7c89a8;
+  --browser-text: #f4f7ff;
+  --browser-accent: #8baaff;
+  --browser-accent-soft: rgba(139, 170, 255, 0.18);
+  --browser-positive: #3dd68c;
+  --browser-danger: #f87171;
+  --browser-radius-md: 14px;
+  --browser-radius-pill: 999px;
+  --browser-shadow-card: 0 24px 48px rgba(2, 6, 23, 0.6);
+  --browser-shadow-soft: 0 26px 52px rgba(2, 6, 23, 0.52);
+  --browser-shadow-focus: 0 16px 38px rgba(139, 170, 255, 0.28);
+}
+
+.browser-visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--browser-surface);
+  color: var(--browser-text);
+  font-family: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  transition: background 200ms ease, color 200ms ease;
+}
+
+a {
+  color: var(--browser-accent);
+}

--- a/styles/components/layout.css
+++ b/styles/components/layout.css
@@ -1,0 +1,435 @@
+
+.browser-shell {
+  min-height: 100vh;
+  background: var(--browser-surface);
+  color: inherit;
+  display: flex;
+  flex-direction: column;
+  transition: background 200ms ease, color 200ms ease;
+}
+
+.browser-chrome {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.9rem 1.6rem;
+  background: var(--browser-panel);
+  border-bottom: 1px solid var(--browser-panel-border);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.browser-tabs {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 1.6rem 0.75rem;
+  background: var(--browser-panel);
+  border-bottom: 1px solid var(--browser-panel-border);
+  position: sticky;
+  top: 4.4rem;
+  z-index: 9;
+}
+
+.browser-tabs__list {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.browser-tab {
+  display: inline-flex;
+  align-items: stretch;
+  background: var(--browser-panel-elevated);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-pill);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  transition: background 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.browser-tab.is-active {
+  border-color: var(--browser-accent);
+  background: var(--browser-accent-soft);
+  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.16);
+}
+
+.browser-tab__button {
+  border: none;
+  background: transparent;
+  padding: 0.45rem 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+.browser-tab__button:hover,
+.browser-tab__button:focus-visible {
+  color: var(--browser-accent);
+  outline: none;
+  box-shadow: 0 0 0 2px var(--browser-accent-soft);
+  border-radius: var(--browser-radius-pill);
+}
+
+.browser-tab__icon {
+  font-size: 1rem;
+}
+
+.browser-tab__label {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.browser-tab__close {
+  border: none;
+  border-left: 1px solid var(--browser-panel-border);
+  background: transparent;
+  padding: 0.45rem 0.6rem;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  border-top-right-radius: var(--browser-radius-pill);
+  border-bottom-right-radius: var(--browser-radius-pill);
+}
+
+.browser-tab__close:hover,
+.browser-tab__close:focus-visible {
+  color: var(--browser-danger);
+  outline: none;
+  box-shadow: 0 0 0 2px var(--browser-accent-soft);
+}
+
+.browser-stage {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.browser-stage__pane {
+  flex: 1 1 auto;
+  width: 100%;
+}
+
+.browser-stage__pane[hidden] {
+  display: none !important;
+}
+
+.browser-stage__pane--workspace {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  width: 100%;
+  margin: 0 auto;
+  padding: 0.25rem 1.75rem 4rem;
+  box-sizing: border-box;
+}
+
+.browser-chrome__cluster {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.browser-notifications {
+  position: relative;
+  display: flex;
+}
+
+.browser-notifications__trigger {
+  position: relative;
+}
+
+.browser-notifications__icon {
+  font-size: 1.1rem;
+}
+
+.browser-notifications__badge {
+  position: absolute;
+  top: 0.15rem;
+  right: 0.15rem;
+  min-width: 1.15rem;
+  height: 1.15rem;
+  padding: 0 0.35rem;
+  border-radius: var(--browser-radius-pill);
+  background: var(--browser-danger);
+  color: #fff;
+  font-size: 0.68rem;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 0 0 2px var(--browser-panel);
+}
+
+.browser-notifications__panel {
+  position: absolute;
+  top: calc(100% + 0.75rem);
+  right: 0;
+  width: min(380px, 90vw);
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-md);
+  box-shadow: var(--browser-shadow-soft);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  z-index: 40;
+}
+
+.browser-notifications__panel[hidden] {
+  display: none !important;
+}
+
+.browser-notifications__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.browser-notifications__title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.browser-notifications__empty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--browser-muted);
+}
+
+.browser-notifications__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  max-height: calc(18rem * 1.3);
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+.browser-notifications__item {
+  width: 100%;
+  border: 1px solid transparent;
+  background: transparent;
+  color: inherit;
+  padding: 0.7rem 0.85rem;
+  border-radius: var(--browser-radius-md);
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 0.6rem;
+  row-gap: 0.35rem;
+  align-items: start;
+  text-align: left;
+  cursor: pointer;
+  transition: background 150ms ease, border-color 150ms ease, transform 150ms ease;
+}
+
+.browser-notifications__item:hover,
+.browser-notifications__item:focus-visible {
+  background: var(--browser-accent-soft);
+  border-color: var(--browser-accent);
+  outline: none;
+}
+
+.browser-notifications__item:active {
+  transform: translateY(1px);
+}
+
+.browser-notifications__item.is-unread {
+  border-color: var(--browser-accent);
+  background: rgba(37, 99, 235, 0.12);
+}
+
+:root[data-browser-theme="night"] .browser-notifications__item.is-unread {
+  background: rgba(139, 170, 255, 0.18);
+}
+
+.browser-notifications__message {
+  grid-column: 2;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+.browser-notifications__meta {
+  grid-column: 2;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--browser-muted);
+}
+
+.browser-notifications__indicator {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: var(--browser-accent);
+  align-self: start;
+  margin-top: 0.2rem;
+  transition: transform 150ms ease, opacity 150ms ease;
+}
+
+.browser-notifications__indicator.is-hidden {
+  opacity: 0;
+  transform: scale(0);
+}
+
+.browser-notifications__meta-label {
+  text-transform: uppercase;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  font-size: 0.7rem;
+}
+
+.browser-address {
+  display: grid;
+  grid-template-columns: min-content 1fr;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  background: var(--browser-panel-elevated);
+  border: 1px solid var(--browser-panel-border);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.browser-address__label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--browser-subtle);
+}
+
+.browser-address__input {
+  width: 100%;
+  background: transparent;
+  border: none;
+  outline: none;
+  font: inherit;
+  font-size: 0.95rem;
+  color: inherit;
+}
+
+.browser-button {
+  font: inherit;
+  border: 1px solid var(--browser-panel-border);
+  background: var(--browser-panel-elevated);
+  color: inherit;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  transition: background 150ms ease, border-color 150ms ease, transform 150ms ease;
+}
+
+.browser-button:hover {
+  border-color: var(--browser-accent);
+  background: var(--browser-accent-soft);
+}
+
+.browser-button:active {
+  transform: translateY(1px);
+}
+
+.browser-button--primary {
+  background: var(--browser-accent);
+  color: #fff;
+  border-color: transparent;
+  font-weight: 600;
+}
+
+#browser-session-button {
+  justify-content: center;
+  min-width: var(--browser-session-button-width, auto);
+}
+
+.browser-button--icon {
+  padding: 0.45rem 0.65rem;
+}
+
+.browser-button--text {
+  padding: 0.2rem 0.4rem;
+  background: transparent;
+  border: none;
+  color: var(--browser-accent);
+  font-weight: 600;
+}
+
+.browser-button--text:hover,
+.browser-button--text:focus-visible {
+  background: var(--browser-accent-soft);
+  border: none;
+  outline: none;
+  color: var(--browser-accent);
+}
+
+.browser-button--text:active {
+  transform: none;
+}
+
+.browser-theme-toggle__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.browser-layout {
+  flex: 1 1 auto;
+  padding: 3rem 1.75rem 4rem;
+  width: 100%;
+  max-width: 1180px;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+.browser-stage__pane--home .browser-layout {
+  --browser-home-spacing: clamp(0.75rem, 1vw + 0.4rem, 1.25rem);
+  --browser-home-widget-gap: clamp(0.9rem, 1vw + 0.55rem, 1.4rem);
+  --browser-home-widget-spacer: clamp(0.4rem, 0.6vw, 0.55rem);
+  max-width: none;
+  margin: 0;
+  padding: var(--browser-home-spacing);
+}
+
+.browser-main {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 2.6rem;
+}
+
+.browser-home {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--browser-home-spacing, 1.5rem);
+}
+
+.browser-home__widgets {
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--browser-home-widget-gap, var(--browser-home-spacing, 1.5rem));
+  align-items: stretch;
+  justify-content: space-between;
+  margin: 0;
+}
+

--- a/styles/overlays/overlays.css
+++ b/styles/overlays/overlays.css
@@ -1,0 +1,215 @@
+body.has-launch-dialog {
+  overflow: hidden;
+}
+
+.launch-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 5000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  background: rgba(15, 23, 42, 0.68);
+  backdrop-filter: blur(6px);
+  animation: launchDialogFade 150ms ease-out;
+}
+
+.launch-dialog {
+  position: relative;
+  width: min(480px, 100%);
+  border-radius: 22px;
+  padding: 2.5rem 2.25rem 2rem;
+  color: #f8fafc;
+  background: linear-gradient(145deg, #0b1120 0%, #111c3a 60%, #172554 100%);
+  box-shadow: 0 24px 80px rgba(8, 11, 23, 0.6);
+  overflow: hidden;
+  animation: launchDialogSlide 180ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.launch-dialog__glow {
+  position: absolute;
+  inset: -20% -30% auto;
+  height: 70%;
+  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.16), transparent 65%);
+  pointer-events: none;
+}
+
+.launch-dialog__header {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.launch-dialog__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 999px;
+  font-size: 1.5rem;
+  background: rgba(15, 118, 110, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
+}
+
+.launch-dialog__title {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.launch-dialog__tagline {
+  margin: 0;
+  font-size: 1rem;
+  color: rgba(226, 232, 240, 0.86);
+}
+
+.launch-dialog__summary {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 1rem;
+  margin: 2rem 0 2.25rem;
+}
+
+.launch-dialog__row {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem 1.5rem;
+  align-items: start;
+}
+
+.launch-dialog__label {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.launch-dialog__value {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.launch-dialog__actions {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.launch-dialog__button {
+  border: none;
+  border-radius: 999px;
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0.75rem 1.6rem;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.launch-dialog__button:focus-visible {
+  outline: 3px solid rgba(244, 244, 245, 0.75);
+  outline-offset: 3px;
+}
+
+.launch-dialog__button--primary {
+  background: linear-gradient(135deg, #22d3ee 0%, #1d4ed8 100%);
+  color: #0b1120;
+  box-shadow: 0 14px 30px rgba(45, 212, 191, 0.35);
+}
+
+.launch-dialog__button--primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 40px rgba(56, 189, 248, 0.4);
+}
+
+.launch-dialog__button--secondary {
+  background: rgba(15, 23, 42, 0.45);
+  color: rgba(226, 232, 240, 0.9);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.4);
+}
+
+.launch-dialog__button--secondary:hover {
+  transform: translateY(-1px);
+  box-shadow: inset 0 0 0 1px rgba(226, 232, 240, 0.65);
+}
+
+.launch-dialog-overlay--blogpress {
+  background: rgba(30, 19, 48, 0.72);
+}
+
+.launch-dialog--blogpress {
+  background: linear-gradient(145deg, #2a103d 0%, #441b5f 55%, #31124c 100%);
+}
+
+.launch-dialog--blogpress .launch-dialog__glow {
+  background: radial-gradient(circle at top, rgba(251, 191, 36, 0.3), transparent 70%);
+}
+
+.launch-dialog--blogpress .launch-dialog__icon {
+  background: rgba(251, 191, 36, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(253, 224, 71, 0.45);
+}
+
+.launch-dialog-overlay--digishelf {
+  background: rgba(11, 42, 62, 0.7);
+}
+
+.launch-dialog--digishelf {
+  background: linear-gradient(150deg, #0b2537 0%, #104365 55%, #0a2a42 100%);
+}
+
+.launch-dialog--digishelf .launch-dialog__glow {
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.35), transparent 70%);
+}
+
+.launch-dialog--digishelf .launch-dialog__icon {
+  background: rgba(56, 189, 248, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(125, 211, 252, 0.4);
+}
+
+.launch-dialog-overlay--serverhub {
+  background: rgba(6, 25, 41, 0.75);
+}
+
+.launch-dialog--serverhub {
+  background: linear-gradient(155deg, #071725 0%, #0c2c45 55%, #123c5c 100%);
+}
+
+.launch-dialog--serverhub .launch-dialog__glow {
+  background: radial-gradient(circle at top, rgba(99, 102, 241, 0.35), transparent 72%);
+}
+
+.launch-dialog--serverhub .launch-dialog__icon {
+  background: rgba(99, 102, 241, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(165, 180, 252, 0.45);
+}
+
+@keyframes launchDialogFade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes launchDialogSlide {
+  from {
+    opacity: 0;
+    transform: translateY(24px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}

--- a/styles/widgets/widgets.css
+++ b/styles/widgets/widgets.css
@@ -1,0 +1,1889 @@
+.browser-home__widgets > .browser-widget {
+  flex: 1 1 0;
+  min-width: 280px;
+}
+
+@media (max-width: 900px) {
+  .browser-home__widgets {
+    flex-direction: column;
+  }
+
+  .browser-home__widgets > .browser-widget {
+    min-width: 0;
+  }
+}
+
+.browser-home__header {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  text-align: left;
+}
+
+.browser-home__header h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 2.6vw, 2.6rem);
+}
+
+.browser-home__header p {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 1.05rem;
+}
+
+.browser-widget {
+  width: 100%;
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  box-shadow: var(--browser-shadow-soft);
+  padding: 1.1rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  height: 100%;
+  min-height: 0;
+}
+
+.browser-widget__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  text-align: left;
+}
+
+.browser-widget__header h2 {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+}
+
+.browser-widget__title-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.15rem 0.55rem 0.15rem 0.4rem;
+  margin-inline-start: -0.4rem;
+  color: inherit;
+  text-decoration: none;
+  border-radius: var(--browser-radius-pill);
+  transition: color 140ms ease, background-color 140ms ease, box-shadow 140ms ease;
+}
+
+.browser-widget__title-link:hover,
+.browser-widget__title-link:focus-visible {
+  color: var(--browser-accent);
+  background-color: var(--browser-accent-soft);
+  text-decoration: none;
+}
+
+.browser-widget__title-link:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--browser-accent-soft);
+}
+
+.browser-widget__title-link.is-active {
+  color: var(--browser-accent);
+}
+
+.browser-widget__title-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1em;
+  line-height: 1;
+}
+
+.browser-widget__title-text {
+  font-weight: inherit;
+}
+
+.browser-widget__header p {
+  margin: 0.2rem 0 0;
+  color: var(--browser-muted);
+  font-size: 0.85rem;
+}
+
+.todo-widget,
+.bank-widget {
+  padding: 0.95rem 1.15rem 1.2rem;
+}
+
+.todo-widget .browser-widget__header,
+.bank-widget .browser-widget__header {
+  gap: 0.65rem;
+}
+
+.apps-widget {
+  padding: 0.85rem 0.95rem 1rem;
+  gap: 0.65rem;
+  position: relative;
+}
+
+.apps-widget__header {
+  position: relative;
+  display: block;
+  padding-inline-end: 6rem;
+}
+
+.apps-widget__intro {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.apps-widget__controls {
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+.apps-widget__sort-toggle {
+  border: 1px solid var(--browser-panel-border);
+  background: var(--browser-panel-elevated);
+  color: var(--browser-subtle);
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.28rem 0.65rem;
+  border-radius: var(--browser-radius-pill);
+  cursor: pointer;
+  transition: color 140ms ease, background-color 140ms ease, border-color 140ms ease, box-shadow 140ms ease;
+}
+
+.apps-widget__sort-toggle:hover,
+.apps-widget__sort-toggle:focus-visible {
+  color: var(--browser-accent);
+  border-color: var(--browser-accent);
+  background: var(--browser-accent-soft);
+  outline: none;
+}
+
+.apps-widget__sort-toggle[aria-pressed="true"] {
+  color: var(--browser-accent);
+  border-color: var(--browser-accent);
+  background: rgba(37, 99, 235, 0.12);
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.18);
+}
+
+.apps-widget__sort-toggle:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.apps-widget.is-sorting .apps-widget__tile {
+  cursor: grab;
+  user-select: none;
+}
+
+.apps-widget.is-sorting .apps-widget__tile:active {
+  cursor: grabbing;
+}
+
+.apps-widget__tile.is-dragging {
+  opacity: 0.85;
+  box-shadow: 0 12px 34px rgba(37, 99, 235, 0.28);
+}
+
+.apps-widget__tile.is-drop-target {
+  border-color: var(--browser-accent);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.22);
+}
+
+.todo-widget {
+  gap: 1.3rem;
+  flex: 1 1 auto;
+  min-height: 0;
+  --todo-widget-row-height: 4.1rem;
+}
+
+.todo-widget__header {
+  width: 100%;
+}
+
+.todo-widget__focus {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.82rem;
+  color: var(--browser-muted);
+}
+
+.todo-widget__focus-label {
+  font-weight: 600;
+  color: var(--browser-subtle);
+  margin-right: 0.2rem;
+}
+
+.todo-widget__focus-button {
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  padding: 0.18rem 0.55rem;
+  border-radius: var(--browser-radius-pill);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 140ms ease, background-color 140ms ease;
+}
+
+.todo-widget__focus-button:hover,
+.todo-widget__focus-button:focus-visible {
+  color: var(--browser-accent);
+  background-color: var(--browser-accent-soft);
+  outline: none;
+}
+
+.todo-widget__focus-button.is-active {
+  color: var(--browser-accent);
+  background-color: var(--browser-accent-soft);
+  font-weight: 600;
+}
+
+.todo-widget__focus-separator {
+  color: var(--browser-subtle);
+  font-weight: 600;
+  margin: 0 0.08rem;
+  user-select: none;
+}
+
+.todo-widget__intro h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.todo-widget__intro p {
+  margin: 0.3rem 0 0;
+  color: var(--browser-muted);
+  font-size: 0.88rem;
+}
+
+.todo-widget__hours {
+  margin: 0;
+  display: grid;
+  gap: 0.45rem;
+  min-width: 160px;
+}
+
+.todo-widget__hours-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.85rem;
+  font-size: 0.88rem;
+}
+
+.todo-widget__hours-row dt {
+  margin: 0;
+  color: var(--browser-subtle);
+  font-weight: 600;
+}
+
+.todo-widget__hours-row dd {
+  margin: 0;
+  font-weight: 700;
+}
+
+.todo-widget__list,
+.todo-widget__done-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.todo-widget__list-wrapper {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+  scrollbar-gutter: stable;
+  max-height: var(--todo-widget-max-height, none);
+}
+
+.todo-widget__item {
+  margin: 0;
+}
+
+.todo-widget__task {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 13px;
+  border: 1px solid var(--browser-panel-border);
+  background: var(--browser-panel);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  transition: background 140ms ease, border-color 140ms ease, transform 140ms ease;
+}
+
+.todo-widget__task:hover,
+.todo-widget__task:focus-visible {
+  border-color: var(--browser-accent);
+  background: var(--browser-accent-soft);
+}
+
+.todo-widget__task:focus-visible {
+  outline: 2px solid var(--browser-accent);
+  outline-offset: 2px;
+}
+
+.todo-widget__task[aria-disabled='true'] {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.todo-widget__checkbox {
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  border: 2px solid var(--browser-muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: transparent;
+  transition: background 140ms ease, border-color 140ms ease, color 140ms ease;
+}
+
+.todo-widget__task:hover .todo-widget__checkbox {
+  border-color: var(--browser-accent);
+}
+
+.todo-widget__content {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.18rem;
+}
+
+.todo-widget__title {
+  font-weight: 600;
+}
+
+.todo-widget__meta {
+  color: var(--browser-muted);
+  font-size: 0.85rem;
+}
+
+.todo-widget__task.is-complete {
+  background: transparent;
+  border-color: rgba(148, 163, 184, 0.3);
+}
+
+.todo-widget__task.is-complete .todo-widget__checkbox {
+  background: var(--browser-accent);
+  border-color: var(--browser-accent);
+  color: #fff;
+}
+
+.todo-widget__task.is-complete .todo-widget__title {
+  color: var(--browser-muted);
+  text-decoration: line-through;
+}
+
+.todo-widget__done {
+  border-top: 1px solid var(--browser-panel-border);
+  padding-top: 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.todo-widget__done h3 {
+  margin: 0;
+  font-size: 0.88rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--browser-subtle);
+}
+
+.todo-widget__done-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.85rem;
+  padding: 0.55rem 0.7rem;
+  border-radius: 11px;
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--browser-muted);
+  font-size: 0.88rem;
+}
+
+.todo-widget__done-title {
+  text-decoration: line-through;
+}
+
+.todo-widget__done-meta {
+  font-size: 0.82rem;
+}
+
+.todo-widget__empty {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.65rem 0.9rem;
+  border-radius: 11px;
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--browser-subtle);
+  font-size: 0.88rem;
+}
+
+.todo-widget__empty-text {
+  flex: 1;
+}
+
+.todo-widget__empty-action {
+  font: inherit;
+  font-weight: 600;
+  color: #fff;
+  background: var(--browser-accent);
+  border: none;
+  border-radius: 10px;
+  padding: 0.45rem 0.8rem;
+  cursor: pointer;
+  transition: background 160ms ease, transform 160ms ease;
+}
+
+.todo-widget__empty-action:hover {
+  background: #1e4fd6;
+}
+
+.todo-widget__empty-action:active {
+  transform: translateY(1px);
+}
+
+.todo-widget__empty-action:focus-visible {
+  outline: 2px solid var(--browser-accent);
+  outline-offset: 3px;
+}
+
+.todo-widget__end {
+  margin-top: auto;
+  align-self: flex-end;
+  font: inherit;
+  font-weight: 600;
+  color: #fff;
+  background: var(--browser-accent);
+  border: none;
+  border-radius: 12px;
+  padding: 0.75rem 1.4rem;
+  cursor: pointer;
+  transition: background 160ms ease, transform 160ms ease;
+}
+
+.todo-widget__end:hover {
+  background: #1e4fd6;
+}
+
+.todo-widget__end:active {
+  transform: translateY(1px);
+}
+
+.todo-widget__end:focus-visible {
+  outline: 2px solid var(--browser-accent);
+  outline-offset: 3px;
+}
+
+.apps-widget__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+@media (max-width: 1024px) {
+  .apps-widget__list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 680px) {
+  .apps-widget__list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.apps-widget__item {
+  margin: 0;
+  display: flex;
+}
+
+.apps-widget__tile {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.9rem 0.75rem 0.9rem;
+  border-radius: 16px;
+  border: 1px solid transparent;
+  background: var(--browser-panel-elevated);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+  color: inherit;
+  font: inherit;
+  text-align: center;
+  cursor: pointer;
+  position: relative;
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+}
+
+:root[data-browser-theme="night"] .apps-widget__tile {
+  box-shadow: 0 18px 42px rgba(2, 6, 23, 0.48);
+}
+
+.apps-widget__tile:hover,
+.apps-widget__tile:focus-visible {
+  border-color: var(--browser-accent);
+  box-shadow: 0 16px 36px rgba(37, 99, 235, 0.2);
+  transform: translateY(-3px);
+  outline: none;
+}
+
+.apps-widget__tile.is-active {
+  border-color: var(--browser-accent);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+}
+
+.apps-widget__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 22px;
+  background: rgba(37, 99, 235, 0.08);
+  font-size: 1.65rem;
+}
+
+.apps-widget__label {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.18rem;
+  align-items: center;
+}
+
+.apps-widget__name {
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+.apps-widget__empty {
+  margin: 0;
+  padding: 1.6rem 1.1rem;
+  border-radius: 16px;
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  background: rgba(148, 163, 184, 0.08);
+  color: var(--browser-muted);
+  font-size: 0.88rem;
+  text-align: center;
+  grid-column: 1 / -1;
+}
+
+.bank-widget__stats {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.bank-widget__stat {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.85rem 0.9rem;
+  border-radius: var(--browser-radius-md);
+  background: var(--browser-panel-elevated);
+  border: 1px solid var(--browser-panel-border);
+}
+
+.bank-widget__label {
+  font-size: 0.8rem;
+  color: var(--browser-subtle);
+  font-weight: 600;
+}
+
+.bank-widget__value {
+  font-size: 1.08rem;
+  font-weight: 700;
+}
+
+.bank-widget__value.is-positive {
+  color: var(--browser-positive);
+}
+
+.bank-widget__value.is-negative {
+  color: var(--browser-danger);
+}
+
+.bank-widget__footnote {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.82rem;
+}
+
+.bank-widget__highlights {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
+}
+
+.bank-widget__column {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.bank-widget__column--left {
+  justify-items: start;
+}
+
+.bank-widget__column--right {
+  justify-items: end;
+}
+
+.bank-widget__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.52rem 0.82rem;
+  border-radius: var(--browser-radius-pill);
+  background: var(--browser-panel-elevated);
+  border: 1px solid var(--browser-panel-border);
+  font-size: 0.84rem;
+  line-height: 1;
+}
+
+.bank-widget__chip-label {
+  font-weight: 600;
+  color: var(--browser-subtle);
+}
+
+.bank-widget__chip-value {
+  font-weight: 700;
+}
+
+.bank-widget__chip[data-tone='out'] .bank-widget__chip-value {
+  color: var(--browser-danger);
+}
+
+.bank-widget__chip[data-tone='in'] .bank-widget__chip-value {
+  color: var(--browser-positive);
+}
+
+.browser-notification {
+  padding: 0.75rem 0.9rem;
+  border-radius: 14px;
+  border: 1px solid var(--browser-panel-border);
+  background: var(--browser-panel);
+}
+
+.browser-notification__title {
+  margin: 0;
+  font-weight: 600;
+}
+
+.browser-notification__message {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.9rem;
+}
+
+.browser-notification__action {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--browser-accent);
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+
+.browser-notification__action:hover:not(:disabled) {
+  text-decoration: underline;
+}
+
+.browser-notification__action:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.browser-page {
+  display: none;
+  flex-direction: column;
+  gap: 1.2rem;
+  padding: 1.25rem 1.6rem 1.8rem;
+  border-radius: var(--browser-radius-lg);
+  border: 1px solid var(--browser-panel-border);
+  background: var(--browser-panel-elevated);
+  box-shadow: var(--browser-shadow-soft);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.browser-page.is-active {
+  display: flex;
+}
+
+.browser-page.is-refreshing {
+  animation: browser-page-refresh 320ms ease;
+}
+
+.browser-card-grid {
+  display: grid;
+  gap: 1.35rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.browser-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.35rem;
+  border-radius: var(--browser-radius-lg);
+  border: 1px solid var(--browser-panel-border);
+  background: var(--browser-panel);
+  box-shadow: var(--browser-shadow-card);
+}
+
+.browser-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: baseline;
+}
+
+.browser-card__title {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.browser-card__summary {
+  margin: 0;
+  color: var(--browser-muted);
+}
+
+.browser-card__stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.browser-card__stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  background: var(--browser-panel-elevated);
+}
+
+.browser-card__stat-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--browser-subtle);
+}
+
+.browser-card__stat-value {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.browser-card__meta,
+.browser-card__note {
+  margin: 0;
+  color: var(--browser-subtle);
+  font-size: 0.95rem;
+}
+
+.browser-card__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.browser-card__button {
+  font: inherit;
+  padding: 0.55rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--browser-panel-border);
+  background: var(--browser-panel-elevated);
+  cursor: pointer;
+  transition: background 140ms ease, border-color 140ms ease;
+}
+
+.browser-card__button:hover {
+  border-color: var(--browser-accent);
+  background: var(--browser-accent-soft);
+}
+
+.browser-card__button--primary {
+  background: var(--browser-accent);
+  border-color: transparent;
+  color: #fff;
+}
+
+.bankapp {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.bankapp__header {
+  display: grid;
+  gap: 1.5rem;
+  padding: 1.8rem;
+  border-radius: var(--browser-radius-lg);
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  box-shadow: var(--browser-shadow-card);
+}
+
+.timodoro {
+  display: flex;
+  flex-direction: column;
+  gap: 1.8rem;
+}
+
+.timodoro__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.timodoro__title {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.timodoro__subtitle {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.95rem;
+}
+
+.timodoro__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1.15fr);
+}
+
+.timodoro__column {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.timodoro-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.timodoro-section__title {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.timodoro-section__groups {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.timodoro-subsection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.timodoro-subsection__title {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--browser-muted-strong, var(--browser-muted));
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+}
+
+.timodoro-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.timodoro-list__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid var(--browser-panel-border);
+  background: var(--browser-panel-elevated);
+}
+
+.timodoro-list__name {
+  font-weight: 600;
+}
+
+.timodoro-list__meta {
+  color: var(--browser-muted);
+  font-size: 0.9rem;
+}
+
+.timodoro-list__empty {
+  margin: 0;
+  padding: 0.85rem 0.9rem;
+  border-radius: 12px;
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  background: rgba(148, 163, 184, 0.08);
+  color: var(--browser-muted);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.timodoro-list--breakdown {
+  gap: 0.65rem;
+}
+
+.timodoro-breakdown__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 0.6rem 0.1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.timodoro-breakdown__item:last-child {
+  border-bottom: none;
+}
+
+.timodoro-breakdown__label {
+  color: var(--browser-muted);
+  font-size: 0.92rem;
+}
+
+.timodoro-breakdown__value {
+  font-weight: 600;
+}
+
+.timodoro-breakdown__empty {
+  margin: 0;
+  padding: 0.85rem 0.9rem;
+  border-radius: 12px;
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  background: rgba(148, 163, 184, 0.08);
+  color: var(--browser-muted);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.timodoro-stats__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.75rem 0.1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.timodoro-stats__item:last-child {
+  border-bottom: none;
+}
+
+.timodoro-stats__label {
+  font-size: 0.9rem;
+  color: var(--browser-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.timodoro-stats__value {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.timodoro-stats__note {
+  font-size: 0.88rem;
+  color: var(--browser-subtle);
+}
+
+@media (max-width: 960px) {
+  .timodoro__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.bankapp-summary {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.bankapp-summary__card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 1rem 1.2rem;
+  border-radius: 14px;
+  background: var(--browser-panel-elevated);
+  border: 1px solid var(--browser-panel-border);
+}
+
+.bankapp-summary__footnote {
+  margin: 0;
+  margin-top: 0.25rem;
+  font-size: 0.85rem;
+  color: var(--browser-muted);
+}
+
+.bankapp-summary__label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--browser-subtle);
+}
+
+.bankapp-summary__value {
+  font-size: 1.55rem;
+  font-weight: 700;
+}
+
+.bankapp-summary__value.is-positive {
+  color: var(--browser-positive);
+}
+
+.bankapp-summary__value.is-negative {
+  color: var(--browser-danger);
+}
+
+.bankapp-pulse {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.bankapp-pulse__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  border: 1px solid var(--browser-panel-border);
+  background: var(--browser-panel-elevated);
+}
+
+.bankapp-pulse__item--in {
+  border-color: rgba(5, 150, 105, 0.35);
+  background: rgba(5, 150, 105, 0.12);
+}
+
+.bankapp-pulse__item--out {
+  border-color: rgba(239, 68, 68, 0.35);
+  background: rgba(239, 68, 68, 0.12);
+}
+
+.aboutyou {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.aboutyou-hero {
+  display: grid;
+  gap: 1.8rem;
+  padding: 2.2rem;
+  border-radius: var(--browser-radius-lg);
+  border: 1px solid var(--browser-panel-border);
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), transparent) var(--browser-panel-elevated);
+  box-shadow: var(--browser-shadow-soft);
+}
+
+.aboutyou-hero__identity {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.aboutyou-avatar {
+  width: 72px;
+  height: 72px;
+  border-radius: 24px;
+  background: var(--browser-panel);
+  display: grid;
+  place-items: center;
+  font-size: 2rem;
+  box-shadow: var(--browser-shadow-card);
+}
+
+.aboutyou-hero__headline {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.aboutyou-hero__name {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.aboutyou-hero__title {
+  margin: 0;
+  font-weight: 600;
+  color: var(--browser-accent);
+}
+
+.aboutyou-hero__tagline,
+.aboutyou-hero__meta {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.95rem;
+}
+
+.aboutyou-hero__snapshot {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  margin: 0;
+}
+
+.aboutyou-hero__stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.aboutyou-hero__label {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--browser-subtle);
+}
+
+.aboutyou-hero__value {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.aboutyou-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.8rem;
+  border-radius: var(--browser-radius-lg);
+  border: 1px solid var(--browser-panel-border);
+  background: var(--browser-panel);
+  box-shadow: var(--browser-shadow-card);
+}
+
+.aboutyou-section__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.aboutyou-section__header h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.aboutyou-section__note {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.95rem;
+}
+
+.aboutyou-section__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.aboutyou-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.aboutyou-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  padding: 1.3rem;
+  border-radius: var(--browser-radius-md);
+  border: 1px solid rgba(37, 99, 235, 0.08);
+  background: var(--browser-panel-elevated);
+  box-shadow: var(--browser-shadow-card);
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.aboutyou-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 38px rgba(15, 23, 42, 0.12);
+}
+
+.aboutyou-card.is-locked {
+  opacity: 0.6;
+  border-style: dashed;
+}
+
+.aboutyou-card.is-maxed {
+  border-color: rgba(5, 150, 105, 0.4);
+}
+
+.aboutyou-card--education[data-state='active'] {
+  border-color: rgba(37, 99, 235, 0.35);
+}
+
+.aboutyou-card--education[data-state='completed'] {
+  border-color: rgba(5, 150, 105, 0.4);
+}
+
+.aboutyou-card__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.aboutyou-card__title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.aboutyou-card__badge {
+  padding: 0.15rem 0.55rem;
+  border-radius: var(--browser-radius-pill);
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--browser-accent);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.aboutyou-card__subtitle {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.95rem;
+}
+
+.aboutyou-card__meta {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.9rem;
+}
+
+.aboutyou-card__note {
+  margin: 0;
+  color: var(--browser-subtle);
+  font-size: 0.85rem;
+}
+
+.aboutyou-card__note--cost {
+  font-weight: 600;
+}
+
+.aboutyou-progress {
+  position: relative;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.3);
+  overflow: hidden;
+}
+
+.aboutyou-progress__fill {
+  position: absolute;
+  inset: 0;
+  width: var(--progress, 0%);
+  background: linear-gradient(90deg, var(--browser-accent), rgba(37, 99, 235, 0.65));
+}
+
+.aboutyou-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: var(--browser-radius-pill);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.aboutyou-badge--info {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--browser-accent);
+}
+
+.aboutyou-badge--success {
+  background: rgba(5, 150, 105, 0.14);
+  color: var(--browser-positive);
+}
+
+.aboutyou-badge--muted {
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--browser-muted);
+}
+
+.aboutyou-empty {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.95rem;
+}
+
+.aboutyou-asset__stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.aboutyou-asset__stat {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.6rem;
+  border-radius: var(--browser-radius-pill);
+  background: rgba(37, 99, 235, 0.1);
+  font-size: 0.85rem;
+}
+
+.aboutyou-stats {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin: 0;
+}
+
+.aboutyou-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 1rem 1.2rem;
+  border-radius: 14px;
+  border: 1px solid rgba(37, 99, 235, 0.12);
+  background: var(--browser-panel-elevated);
+}
+
+.aboutyou-stat__label {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--browser-subtle);
+}
+
+.aboutyou-stat__value {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.aboutyou-stat__meta {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 0.85rem;
+  color: var(--browser-muted);
+}
+
+.bankapp-pulse__icon {
+  font-size: 1rem;
+}
+
+.bankapp-pill {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: var(--browser-panel-elevated);
+  border: 1px solid var(--browser-panel-border);
+}
+
+.bankapp-pill__label {
+  font-weight: 600;
+}
+
+.bankapp-pill__value {
+  font-weight: 700;
+  color: var(--browser-accent);
+}
+
+.bankapp-pill__note {
+  color: var(--browser-muted);
+}
+
+.bankapp-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.8rem 1.1rem;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.16), rgba(37, 99, 235, 0.04));
+  border: 1px solid rgba(37, 99, 235, 0.3);
+}
+
+.bankapp-badge__icon {
+  font-size: 1.4rem;
+}
+
+.bankapp-badge__title {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--browser-subtle);
+}
+
+.bankapp-badge__value {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.bankapp-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.6rem;
+  border-radius: var(--browser-radius-lg);
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  box-shadow: var(--browser-shadow-soft);
+}
+
+.bankapp-section__header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.bankapp-section__header p {
+  margin: 0.4rem 0 0;
+  color: var(--browser-muted);
+}
+
+.bankapp-section__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.bankapp-ledger {
+  display: grid;
+  gap: 1.35rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.bankapp-ledger__column {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.bankapp-ledger__column h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.bankapp-history {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.bankapp-history__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 1rem 1.2rem;
+  border-radius: var(--browser-radius-lg);
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+}
+
+.bankapp-history__item[data-tone='positive'] .bankapp-history__net {
+  color: var(--browser-positive);
+}
+
+.bankapp-history__item[data-tone='negative'] .bankapp-history__net {
+  color: var(--browser-danger);
+}
+
+.bankapp-history__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.bankapp-history__label {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.bankapp-history__time {
+  font-size: 0.85rem;
+  color: var(--browser-muted);
+}
+
+.bankapp-history__totals {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.bankapp-history__net {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.bankapp-history__split {
+  font-size: 0.9rem;
+  color: var(--browser-subtle);
+}
+
+.bankapp-history__highlights {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--browser-muted);
+}
+
+.bankapp-activity {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.bankapp-activity__item {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: baseline;
+  padding: 0.85rem 1rem;
+  border-radius: var(--browser-radius-lg);
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+}
+
+.bankapp-activity__item[data-tone='positive'] .bankapp-activity__message {
+  color: var(--browser-positive);
+}
+
+.bankapp-activity__item[data-tone='negative'] .bankapp-activity__message {
+  color: var(--browser-danger);
+}
+
+.bankapp-activity__message {
+  font-size: 0.95rem;
+}
+
+.bankapp-activity__time {
+  font-size: 0.85rem;
+  color: var(--browser-muted);
+}
+
+.bankapp-ledger-group {
+  border: 1px solid var(--browser-panel-border);
+  border-radius: 14px;
+  padding: 1rem;
+  background: var(--browser-panel-elevated);
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.bankapp-ledger-group__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+}
+
+.bankapp-ledger-group__icon {
+  font-size: 1.4rem;
+}
+
+.bankapp-ledger-group__title {
+  flex: 1;
+  font-weight: 600;
+}
+
+.bankapp-ledger-group__total {
+  font-weight: 700;
+}
+
+.bankapp-ledger-group__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.bankapp-ledger-group__item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.9rem;
+}
+
+.bankapp-ledger-group__note {
+  grid-column: 1 / -1;
+  color: var(--browser-muted);
+  font-size: 0.8rem;
+}
+
+.bankapp-empty {
+  margin: 0;
+  font-style: italic;
+  color: var(--browser-subtle);
+}
+
+.bankapp-obligations,
+.bankapp-pending,
+.bankapp-education {
+  display: grid;
+  gap: 1.1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.bankapp-card {
+  border: 1px solid var(--browser-panel-border);
+  border-radius: 16px;
+  padding: 1.15rem;
+  background: var(--browser-panel-elevated);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.bankapp-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.bankapp-card__header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.bankapp-card__amount {
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--browser-accent);
+}
+
+.bankapp-card__note {
+  margin: 0;
+  color: var(--browser-muted);
+  line-height: 1.45;
+}
+
+.bankapp-card__note--muted {
+  color: var(--browser-subtle);
+}
+
+.bankapp-card__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.bankapp-card__list-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.9rem;
+}
+
+.bankapp-card__status {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--browser-subtle);
+}
+
+.bankapp-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+}
+
+.bankapp-table th,
+.bankapp-table td {
+  padding: 0.65rem 0.8rem;
+  border-bottom: 1px solid var(--browser-panel-border);
+  text-align: left;
+}
+
+.bankapp-table th {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--browser-subtle);
+}
+
+.bankapp-opportunities {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.bankapp-opportunities__block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.bankapp-opportunities__block h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.bankapp-opportunities__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.bankapp-opportunities__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.8rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--browser-panel-border);
+  background: var(--browser-panel-elevated);
+}
+
+.bankapp-opportunities__name {
+  font-weight: 600;
+}
+
+.bankapp-opportunities__value {
+  font-weight: 600;
+  color: var(--browser-accent);
+}
+
+.bankapp-opportunities__note {
+  color: var(--browser-muted);
+  font-size: 0.85rem;
+}
+
+.browser-empty {
+  margin: 0;
+  padding: 1.2rem;
+  border-radius: var(--browser-radius);
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--browser-muted);
+  text-align: center;
+}
+
+.browser-button.is-spinning {
+  position: relative;
+}
+
+.browser-button.is-spinning::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 2px solid transparent;
+  border-top-color: var(--browser-accent);
+  animation: browser-spin 520ms linear infinite;
+}
+
+@keyframes browser-spin {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+@keyframes browser-page-refresh {
+  0% {
+    opacity: 0.35;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@media (max-width: 960px) {
+  .browser-layout {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    padding: 2.2rem 1.4rem 2.5rem;
+  }
+
+  .browser-sidebar {
+    position: static;
+    width: 100%;
+  }
+
+  .browser-chrome {
+    grid-template-columns: minmax(0, 1fr);
+    row-gap: 0.75rem;
+  }
+
+  .browser-chrome__cluster--session {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .browser-main {
+    max-width: 100%;
+    margin: 0;
+  }
+
+  .browser-home {
+    width: 100%;
+  }
+
+  .todo-widget {
+    padding: 1.3rem;
+  }
+
+  .todo-widget__hours {
+    grid-template-columns: 1fr;
+    min-width: 0;
+  }
+
+  .todo-widget__end {
+    width: 100%;

--- a/styles/workspaces/workspaces.css
+++ b/styles/workspaces/workspaces.css
@@ -1,0 +1,4601 @@
+    align-self: stretch;
+    text-align: center;
+  }
+}
+
+.digishelf {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.digishelf-hero {
+  background: var(--browser-panel-elevated);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  padding: 1.8rem 2rem;
+  display: grid;
+  gap: 1.5rem;
+  box-shadow: var(--browser-shadow-soft);
+}
+
+.digishelf-hero__copy h1 {
+  margin: 0;
+  font-size: 1.65rem;
+}
+
+.digishelf-hero__copy p {
+  margin: 0.25rem 0 0;
+  color: var(--browser-muted);
+  font-size: 1.05rem;
+}
+
+.digishelf-hero__stats {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.digishelf-hero__stat {
+  border: 1px solid rgba(37, 99, 235, 0.08);
+  border-radius: var(--browser-radius-md);
+  padding: 1rem 1.2rem;
+  background: rgba(255, 255, 255, 0.72);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.digishelf-hero__stat--accent {
+  background: var(--browser-accent-soft);
+  border-color: rgba(37, 99, 235, 0.2);
+}
+
+.digishelf-hero__value {
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.digishelf-hero__label {
+  color: var(--browser-muted);
+  font-size: 0.95rem;
+}
+
+.digishelf-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.digishelf-launcher {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.digishelf-launch {
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-md);
+  padding: 1.25rem;
+  background: var(--browser-panel);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.digishelf-launch--locked {
+  opacity: 0.65;
+}
+
+.digishelf-launch__meta {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.95rem;
+}
+
+.digishelf-launch__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.digishelf-launch__reasons {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--browser-muted);
+  font-size: 0.9rem;
+}
+
+.digishelf-tabs {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.digishelf-tab {
+  border: 1px solid var(--browser-panel-border);
+  background: var(--browser-panel);
+  border-radius: var(--browser-radius-pill);
+  padding: 0.55rem 1.2rem;
+  font-weight: 600;
+  color: var(--browser-muted);
+  cursor: pointer;
+  transition: background 160ms ease, border-color 160ms ease, color 160ms ease;
+}
+
+.digishelf-tab.is-active {
+  background: var(--browser-accent-soft);
+  border-color: var(--browser-accent);
+  color: var(--browser-text);
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.18);
+}
+
+.digishelf-grid {
+  display: grid;
+  gap: 1.4rem;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.8fr);
+}
+
+@media (max-width: 1024px) {
+  .digishelf-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.digishelf-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--browser-panel);
+  border-radius: var(--browser-radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--browser-panel-border);
+}
+
+.digishelf-table thead {
+  background: rgba(37, 99, 235, 0.04);
+}
+
+.digishelf-table th,
+.digishelf-table td {
+  padding: 0.9rem 1.1rem;
+  text-align: left;
+  font-size: 0.95rem;
+}
+
+.digishelf-table tbody tr {
+  border-top: 1px solid var(--browser-panel-border);
+  transition: background 140ms ease;
+  cursor: pointer;
+}
+
+.digishelf-table tbody tr:hover {
+  background: rgba(37, 99, 235, 0.05);
+}
+
+.digishelf-table tbody tr.is-selected {
+  background: rgba(37, 99, 235, 0.12);
+}
+
+.digishelf-cell strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.digishelf-cell span {
+  color: var(--browser-muted);
+  font-size: 0.85rem;
+}
+
+.digishelf-cell--label strong {
+  font-size: 1.05rem;
+}
+
+.digishelf-label {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.digishelf-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.6rem;
+  border-radius: var(--browser-radius-pill);
+  font-size: 0.8rem;
+  font-weight: 600;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--browser-accent);
+}
+
+.digishelf-badge--setup {
+  background: rgba(251, 191, 36, 0.18);
+  color: #b45309;
+}
+
+.digishelf-badge--active {
+  background: rgba(5, 150, 105, 0.18);
+  color: var(--browser-positive);
+}
+
+.digishelf-upkeep {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.digishelf-upkeep__status {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.digishelf-upkeep__status.is-funded {
+  color: var(--browser-positive);
+}
+
+.digishelf-upkeep__status.is-missed {
+  color: var(--browser-danger);
+}
+
+.digishelf-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.digishelf-button {
+  border: 1px solid var(--browser-panel-border);
+  background: var(--browser-panel);
+  color: var(--browser-text);
+  border-radius: var(--browser-radius-pill);
+  padding: 0.5rem 1.15rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 140ms ease, box-shadow 140ms ease, background 140ms ease;
+}
+
+.digishelf-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.digishelf-button--primary {
+  background: var(--browser-accent);
+  color: #ffffff;
+  border-color: transparent;
+  box-shadow: var(--browser-shadow-card);
+}
+
+.digishelf-button--primary:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: var(--browser-shadow-focus);
+}
+
+.digishelf-button--ghost {
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--browser-accent);
+  border-color: transparent;
+}
+
+.digishelf-button--link {
+  background: transparent;
+  border: none;
+  color: var(--browser-accent);
+  padding: 0;
+}
+
+.digishelf-empty {
+  text-align: center;
+  padding: 2.5rem 1rem;
+  color: var(--browser-muted);
+}
+
+.digishelf-detail {
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.digishelf-detail__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.digishelf-detail__header h2 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.digishelf-detail__payout {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.95rem;
+}
+
+.digishelf-panel {
+  border-top: 1px solid rgba(15, 23, 42, 0.06);
+  padding-top: 1rem;
+}
+
+.digishelf-panel__header h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.05rem;
+}
+
+.digishelf-panel__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.digishelf-panel__body--grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.digishelf-panel__hint {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.9rem;
+}
+
+.digishelf-panel__total {
+  font-weight: 600;
+  color: var(--browser-text);
+}
+
+.digishelf-quality {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.digishelf-progress {
+  position: relative;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  overflow: hidden;
+}
+
+.digishelf-progress__fill {
+  --digishelf-progress: 0%;
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, var(--browser-accent) 0%, #60a5fa 100%);
+  transform: translateX(calc(-100% + var(--digishelf-progress)));
+}
+
+.digishelf-niche {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  background: rgba(37, 99, 235, 0.08);
+  padding: 0.75rem 1rem;
+  border-radius: var(--browser-radius-md);
+}
+
+.digishelf-field {
+  font-weight: 600;
+}
+
+.digishelf-select {
+  margin-top: 0.35rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--browser-radius-md);
+  border: 1px solid var(--browser-panel-border);
+  background: var(--browser-panel);
+}
+
+.digishelf-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.digishelf-list__item {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.digishelf-list__label {
+  color: var(--browser-muted);
+}
+
+.digishelf-list__value {
+  font-weight: 600;
+}
+
+.digishelf-stat {
+  background: rgba(37, 99, 235, 0.08);
+  border-radius: var(--browser-radius-md);
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.digishelf-stat__label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--browser-muted);
+}
+
+.digishelf-stat__value {
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.digishelf-action-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.digishelf-action {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.digishelf-action__label {
+  font-weight: 600;
+}
+
+.digishelf-action__meta {
+  color: var(--browser-muted);
+  font-size: 0.9rem;
+}
+
+.digishelf-pricing__intro {
+  text-align: center;
+  max-width: 640px;
+  margin: 0 auto 1.5rem;
+}
+
+.digishelf-pricing__intro h2 {
+  margin-bottom: 0.5rem;
+}
+
+.digishelf-pricing__grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.digishelf-plan {
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  background: var(--browser-panel);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  box-shadow: var(--browser-shadow-soft);
+}
+
+.digishelf-plan__subtitle {
+  margin: 0;
+  color: var(--browser-muted);
+  font-weight: 600;
+}
+
+.digishelf-plan__stats {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.digishelf-plan__stats li {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.digishelf-plan__stats span {
+  color: var(--browser-muted);
+}
+
+.digishelf-plan__requirements {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.9rem;
+}
+
+.blogpress {
+  display: flex;
+  flex-direction: column;
+  gap: 1.8rem;
+}
+
+.blogpress__header {
+  display: grid;
+  gap: 1.2rem;
+  padding: 1.6rem;
+  border-radius: var(--browser-radius-lg);
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  box-shadow: var(--browser-shadow-card);
+}
+
+.blogpress__title h1 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.blogpress__title p {
+  margin: 0.3rem 0 0;
+  color: var(--browser-muted);
+}
+
+.blogpress-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.blogpress-tab {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.95rem;
+  border-radius: var(--browser-radius-pill);
+  border: 1px solid var(--browser-panel-border);
+  background: var(--browser-panel-elevated);
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  transition: border-color 140ms ease, box-shadow 140ms ease, background 140ms ease;
+}
+
+.blogpress-tab.is-active {
+  border-color: var(--browser-accent);
+  background: var(--browser-accent-soft);
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.18);
+}
+
+.blogpress-tab__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 999px;
+  background: var(--browser-accent);
+  color: #fff;
+  font-size: 0.75rem;
+  padding: 0 0.4rem;
+}
+
+.blogpress__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.blogpress-button {
+  font: inherit;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  padding: 0.55rem 1.05rem;
+  cursor: pointer;
+  transition: transform 140ms ease, box-shadow 140ms ease, background 140ms ease;
+}
+
+.blogpress-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.blogpress-button--primary {
+  background: var(--browser-accent);
+  color: #fff;
+  box-shadow: var(--browser-shadow-focus);
+}
+
+.blogpress-button--primary:not(:disabled):hover {
+  transform: translateY(-1px);
+}
+
+.blogpress-button--ghost {
+  background: var(--browser-panel-elevated);
+  border-color: var(--browser-panel-border);
+  color: inherit;
+}
+
+.blogpress-button--ghost:not(:disabled):hover {
+  border-color: var(--browser-accent);
+}
+
+.blogpress-button--link {
+  border: none;
+  background: none;
+  color: var(--browser-accent);
+  padding: 0;
+}
+
+.blogpress__hint {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--browser-muted);
+}
+
+.blogpress-summary {
+  margin: 0 0 1.2rem;
+  padding: 0.65rem 0.9rem;
+  border-radius: 12px;
+  background: var(--browser-panel-elevated);
+  border: 1px solid var(--browser-panel-border);
+  color: var(--browser-muted);
+  font-size: 0.9rem;
+}
+
+.blogpress-view {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.blogpress-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  overflow: hidden;
+}
+
+.blogpress-table th,
+.blogpress-table td {
+  padding: 0.7rem 1rem;
+  border-bottom: 1px solid var(--browser-panel-border);
+  text-align: left;
+}
+
+.blogpress-table th {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.78rem;
+  color: var(--browser-subtle);
+}
+
+.blogpress-table tr.is-selected {
+  background: var(--browser-accent-soft);
+}
+
+.blogpress-table__cell--label {
+  width: 18%;
+}
+
+.blogpress-table__cell--actions {
+  width: 18%;
+}
+
+.blogpress-table__link {
+  border: none;
+  background: none;
+  color: var(--browser-accent);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+  padding: 0;
+}
+
+.blogpress-table__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.blogpress-table__meta {
+  font-size: 0.8rem;
+  color: var(--browser-muted);
+}
+
+.blogpress-payout {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.blogpress-payout strong {
+  font-size: 1rem;
+}
+
+.blogpress-payout span {
+  font-size: 0.85rem;
+  color: var(--browser-muted);
+}
+
+.blogpress-niche {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.blogpress-niche__name {
+  font-weight: 600;
+}
+
+.blogpress-status {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.blogpress-status--active {
+  background: rgba(5, 150, 105, 0.12);
+  color: #047857;
+}
+
+.blogpress-status--setup {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--browser-accent);
+}
+
+.blogpress-quality {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.blogpress-quality__level {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 10px;
+  background: var(--browser-panel-elevated);
+  border: 1px solid var(--browser-panel-border);
+  font-weight: 700;
+}
+
+.blogpress-quality__label {
+  font-size: 0.9rem;
+  color: var(--browser-muted);
+}
+
+.blogpress-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: var(--browser-panel-elevated);
+  border: 1px solid var(--browser-panel-border);
+}
+
+.blogpress-badge--active {
+  background: rgba(5, 150, 105, 0.12);
+  border-color: rgba(5, 150, 105, 0.35);
+  color: #047857;
+}
+
+.blogpress-badge--setup {
+  background: var(--browser-accent-soft);
+  border-color: var(--browser-accent);
+  color: var(--browser-accent);
+}
+
+.blogpress-badge--tone-blazing {
+  background: rgba(249, 115, 22, 0.14);
+  border-color: rgba(249, 115, 22, 0.32);
+  color: #ea580c;
+}
+
+.blogpress-badge--tone-surging {
+  background: rgba(14, 165, 233, 0.14);
+  border-color: rgba(14, 165, 233, 0.3);
+  color: #0284c7;
+}
+
+.blogpress-badge--tone-trending,
+.blogpress-badge--tone-steady {
+  background: rgba(37, 99, 235, 0.12);
+  border-color: rgba(37, 99, 235, 0.28);
+  color: var(--browser-accent);
+}
+
+.blogpress-badge--tone-cooling,
+.blogpress-badge--tone-dormant {
+  background: rgba(148, 163, 184, 0.15);
+  border-color: rgba(148, 163, 184, 0.28);
+  color: var(--browser-muted);
+}
+
+.blogpress-empty,
+.blogpress-view--locked {
+  display: grid;
+  gap: 1rem;
+  justify-items: start;
+  padding: 2rem;
+  border-radius: var(--browser-radius-lg);
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  box-shadow: var(--browser-shadow-card);
+}
+
+.blogpress-empty__message {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--browser-muted);
+}
+
+.blogpress-detail-grid {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+.blogpress-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.2rem;
+  border-radius: 16px;
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  box-shadow: var(--browser-shadow-soft);
+}
+
+.blogpress-panel h2,
+.blogpress-panel h3 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.blogpress-panel__lead {
+  margin: 0;
+  font-weight: 600;
+}
+
+.blogpress-panel__note,
+.blogpress-panel__hint,
+.blogpress-panel__warning,
+.blogpress-panel__range {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--browser-muted);
+}
+
+.blogpress-panel__warning {
+  color: var(--browser-danger);
+}
+
+.blogpress-progress {
+  width: 100%;
+  height: 0.6rem;
+  border-radius: 999px;
+  background: var(--browser-panel-elevated);
+  overflow: hidden;
+}
+
+.blogpress-progress__fill {
+  height: 100%;
+  background: var(--browser-accent);
+  transition: width 220ms ease;
+}
+
+.blogpress-stats {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  margin: 0;
+}
+
+.blogpress-stats dt {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--browser-subtle);
+}
+
+.blogpress-stats dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.blogpress-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.blogpress-list__item {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.9rem;
+}
+
+.blogpress-list__label {
+  font-weight: 600;
+}
+
+.blogpress-list__value {
+  color: var(--browser-muted);
+}
+
+.blogpress-action-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.blogpress-action {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  background: var(--browser-panel-elevated);
+  border: 1px solid var(--browser-panel-border);
+}
+
+.blogpress-action__label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.blogpress-action__meta {
+  color: var(--browser-muted);
+  font-size: 0.82rem;
+}
+
+.blogpress-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  font-weight: 600;
+}
+
+.blogpress-select {
+  font: inherit;
+  border-radius: 12px;
+  border: 1px solid var(--browser-panel-border);
+  padding: 0.6rem 0.75rem;
+  background: var(--browser-panel-elevated);
+}
+
+.blogpress-pricing__intro,
+.blogpress-pricing__section,
+.blogpress-blueprint {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 1.4rem;
+  border-radius: var(--browser-radius-lg);
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  box-shadow: var(--browser-shadow-soft);
+}
+
+.blogpress-pricing__intro h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.blogpress-pricing__grid {
+  display: grid;
+  gap: 1.1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.blogpress-plan {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem 1.2rem;
+  border-radius: 14px;
+  background: var(--browser-panel-elevated);
+  border: 1px solid var(--browser-panel-border);
+}
+
+.blogpress-plan__range {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.9rem;
+}
+
+.blogpress-requirements {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--browser-muted);
+  font-size: 0.9rem;
+}
+
+.blogpress-blueprint h2 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.blogpress-blueprint p {
+  margin: 0;
+  color: var(--browser-muted);
+}
+
+.blogpress-view--blueprint,
+.blogpress-view--pricing {
+  gap: 1.6rem;
+}
+
+.blogpress-view--detail {
+  gap: 1.6rem;
+}
+
+@media (max-width: 720px) {
+  .blogpress__header {
+    padding: 1.2rem;
+  }
+
+  .blogpress-table th,
+  .blogpress-table td {
+    padding: 0.6rem 0.7rem;
+  }
+
+  .blogpress-detail-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.learnly {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.learnly__hero {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.14), rgba(59, 130, 246, 0.05));
+  border: 1px solid rgba(37, 99, 235, 0.16);
+  border-radius: var(--browser-radius-lg);
+  padding: 2.4rem;
+  display: grid;
+  gap: 1.6rem;
+}
+
+.learnly__title h1 {
+  margin: 0 0 0.5rem;
+  font-size: 2rem;
+}
+
+.learnly__title p {
+  margin: 0;
+  color: var(--browser-muted);
+  max-width: 48ch;
+}
+
+.learnly-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.learnly-metric {
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-md);
+  padding: 1rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  box-shadow: var(--browser-shadow-soft);
+}
+
+.learnly-metric__label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--browser-subtle);
+}
+
+.learnly-metric__value {
+  font-size: 1.45rem;
+}
+
+.learnly-metric__note {
+  font-size: 0.9rem;
+  color: var(--browser-muted);
+}
+
+.learnly-tabs {
+  display: flex;
+  gap: 0.75rem;
+  border-bottom: 1px solid var(--browser-panel-border);
+  padding-bottom: 0.75rem;
+}
+
+.learnly-tab {
+  border: none;
+  background: rgba(148, 163, 184, 0.12);
+  border-radius: var(--browser-radius-pill);
+  padding: 0.55rem 1.1rem;
+  font: inherit;
+  font-weight: 600;
+  color: var(--browser-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  transition: background 160ms ease, color 160ms ease, box-shadow 160ms ease;
+}
+
+.learnly-tab:hover,
+.learnly-tab:focus-visible {
+  color: var(--browser-accent);
+  outline: none;
+  box-shadow: 0 0 0 2px var(--browser-accent-soft);
+}
+
+.learnly-tab.is-active {
+  background: var(--browser-accent);
+  color: #fff;
+  box-shadow: 0 10px 22px rgba(37, 99, 235, 0.26);
+}
+
+:root[data-browser-theme="night"] .learnly-tab.is-active {
+  color: var(--browser-text);
+}
+
+.learnly-tab__badge {
+  background: rgba(255, 255, 255, 0.22);
+  border-radius: var(--browser-radius-pill);
+  padding: 0.1rem 0.5rem;
+  font-size: 0.8rem;
+}
+
+.learnly-view {
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+}
+
+.learnly-view--free {
+  gap: 1.2rem;
+}
+
+.learnly-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.learnly-filter__button {
+  border: 1px solid var(--browser-panel-border);
+  background: var(--browser-panel);
+  color: var(--browser-muted);
+  font: inherit;
+  padding: 0.45rem 0.9rem;
+  border-radius: var(--browser-radius-pill);
+  cursor: pointer;
+  transition: background 160ms ease, border-color 160ms ease, color 160ms ease;
+}
+
+.learnly-filter__button:hover,
+.learnly-filter__button:focus-visible {
+  color: var(--browser-accent);
+  border-color: var(--browser-accent);
+  outline: none;
+}
+
+.learnly-filter__button.is-active {
+  background: var(--browser-accent);
+  border-color: var(--browser-accent);
+  color: #fff;
+}
+
+:root[data-browser-theme="night"] .learnly-filter__button.is-active {
+  color: var(--browser-text);
+}
+
+.learnly-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.4rem;
+}
+
+.learnly-free-intro {
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  padding: 1.2rem 1.4rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.learnly-free-intro h2 {
+  margin: 0;
+}
+
+.learnly-free-intro p {
+  margin: 0;
+  color: var(--browser-muted);
+}
+
+.learnly-card {
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  padding: 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+}
+
+.learnly-card--free {
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.12), rgba(59, 130, 246, 0.04));
+  border-color: rgba(16, 185, 129, 0.45);
+}
+
+.learnly-card:hover,
+.learnly-card:focus-within {
+  transform: translateY(-4px);
+  border-color: rgba(37, 99, 235, 0.35);
+  box-shadow: var(--browser-shadow-card);
+}
+
+.learnly-card--free:hover,
+.learnly-card--free:focus-within {
+  border-color: rgba(16, 185, 129, 0.6);
+}
+
+.learnly-card__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.learnly-card--free .learnly-badge {
+  background: rgba(16, 185, 129, 0.18);
+  color: #047857;
+}
+
+.learnly-badge {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--browser-accent);
+  border-radius: var(--browser-radius-pill);
+  padding: 0.25rem 0.6rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.learnly-card__title {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.learnly-card__summary {
+  margin: 0;
+  color: var(--browser-muted);
+  line-height: 1.5;
+}
+
+.learnly-card__unlock {
+  margin: 0;
+  font-weight: 600;
+  color: #047857;
+}
+
+:root[data-browser-theme="night"] .learnly-card--free {
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.2), rgba(59, 130, 246, 0.1));
+  border-color: rgba(16, 185, 129, 0.55);
+}
+
+:root[data-browser-theme="night"] .learnly-card--free .learnly-badge {
+  color: #bbf7d0;
+}
+
+:root[data-browser-theme="night"] .learnly-card__unlock {
+  color: #bbf7d0;
+}
+
+.learnly-card__stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.4rem 1rem;
+  margin: 0;
+}
+
+.learnly-card__stats dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--browser-subtle);
+}
+
+.learnly-card__stats dd {
+  margin: 0 0 0.4rem;
+  font-weight: 600;
+}
+
+.learnly-card__actions {
+  margin-top: auto;
+}
+
+.learnly-button {
+  border: none;
+  border-radius: var(--browser-radius-pill);
+  font: inherit;
+  font-weight: 600;
+  padding: 0.55rem 1.3rem;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease, background 160ms ease, color 160ms ease;
+}
+
+.learnly-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.learnly-button--primary {
+  background: var(--browser-accent);
+  color: #fff;
+  box-shadow: 0 12px 26px rgba(37, 99, 235, 0.28);
+}
+
+.learnly-card--free .learnly-button--primary {
+  background: #10b981;
+  box-shadow: 0 12px 28px rgba(16, 185, 129, 0.32);
+}
+
+.learnly-button--primary:hover:not(:disabled),
+.learnly-button--primary:focus-visible:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(37, 99, 235, 0.32);
+  outline: none;
+}
+
+.learnly-card--free .learnly-button--primary:hover:not(:disabled),
+.learnly-card--free .learnly-button--primary:focus-visible:not(:disabled) {
+  box-shadow: 0 16px 32px rgba(16, 185, 129, 0.36);
+}
+
+.learnly-button--ghost {
+  background: rgba(148, 163, 184, 0.14);
+  color: var(--browser-muted);
+}
+
+.learnly-button--ghost:hover:not(:disabled),
+.learnly-button--ghost:focus-visible:not(:disabled) {
+  color: var(--browser-accent);
+  outline: none;
+}
+
+.learnly-button--large {
+  font-size: 1rem;
+  padding: 0.85rem 2.6rem;
+}
+
+.learnly-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.learnly-progress__label {
+  font-size: 0.9rem;
+  color: var(--browser-muted);
+}
+
+.learnly-progress__bar {
+  height: 0.5rem;
+  border-radius: var(--browser-radius-pill);
+  background: rgba(148, 163, 184, 0.3);
+  overflow: hidden;
+}
+
+.learnly-progress__bar span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(37, 99, 235, 0.85), rgba(59, 130, 246, 0.65));
+}
+
+.learnly-empty {
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  border-radius: var(--browser-radius-lg);
+  padding: 1.8rem;
+  text-align: center;
+  color: var(--browser-muted);
+}
+
+.learnly-back {
+  border: none;
+  background: transparent;
+  color: var(--browser-accent);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  align-self: flex-start;
+}
+
+.learnly-detail__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.learnly-detail__summary {
+  margin: 0;
+  color: var(--browser-muted);
+  line-height: 1.6;
+}
+
+.learnly-detail__highlights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.learnly-highlight {
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-md);
+  padding: 1rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.learnly-highlight__label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--browser-subtle);
+}
+
+.learnly-highlight__value {
+  font-size: 1.1rem;
+}
+
+.learnly-detail__body {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.learnly-detail__section h3 {
+  margin: 0 0 0.35rem;
+}
+
+.learnly-detail__list {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.4rem;
+  color: var(--browser-muted);
+}
+
+.learnly-detail__cta {
+  display: flex;
+  gap: 1rem;
+}
+
+.learnly-my-courses__intro {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.learnly-my-courses__intro p {
+  margin: 0;
+  color: var(--browser-muted);
+}
+
+.learnly-enrollment-list {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.learnly-enrollment {
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.learnly-enrollment__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.learnly-enrollment__header h3 {
+  margin: 0;
+}
+
+.learnly-enrollment__status {
+  padding: 0.3rem 0.8rem;
+  border-radius: var(--browser-radius-pill);
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--browser-accent);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.learnly-enrollment__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.4rem 1.4rem;
+  margin: 0;
+}
+
+.learnly-enrollment__stats dt {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--browser-subtle);
+}
+
+.learnly-enrollment__stats dd {
+  margin: 0 0 0.4rem;
+  font-weight: 600;
+}
+
+.learnly-enrollment__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.learnly-faq {
+  display: grid;
+  gap: 1rem;
+}
+
+.learnly-faq__item {
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-md);
+  padding: 1.2rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.learnly-faq__item h3 {
+  margin: 0;
+}
+
+.learnly-faq__item p {
+  margin: 0;
+  color: var(--browser-muted);
+}
+
+@media (max-width: 720px) {
+  .learnly__hero {
+    padding: 1.8rem;
+  }
+
+  .learnly-card__stats {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+
+  .learnly-detail__cta {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .learnly-enrollment__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+}
+
+/* ShopStack marketplace */
+.shopstack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.8rem;
+}
+
+.shopstack__header {
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  padding: 1.6rem;
+  box-shadow: var(--browser-shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.shopstack__title-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.2rem;
+}
+
+.shopstack__title-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  max-width: 42rem;
+}
+
+.shopstack__title {
+  margin: 0;
+  font-size: 2rem;
+  letter-spacing: -0.02em;
+}
+
+.shopstack__note {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.98rem;
+}
+
+.shopstack-summary {
+  margin: 0;
+  color: var(--browser-muted);
+  font-weight: 600;
+}
+
+.shopstack-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.shopstack-tab {
+  background: transparent;
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-pill);
+  color: var(--browser-muted);
+  cursor: pointer;
+  font-weight: 600;
+  padding: 0.55rem 1.2rem;
+  transition: background 160ms ease, color 160ms ease, border-color 160ms ease;
+}
+
+.shopstack-tab.is-active {
+  background: var(--browser-accent);
+  border-color: var(--browser-accent);
+  color: #fff;
+  box-shadow: var(--browser-shadow-focus);
+}
+
+.shopstack__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+}
+
+.shopstack__layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.8fr) minmax(0, 1.1fr);
+  gap: 1.8rem;
+  align-items: flex-start;
+}
+
+.shopstack-catalog {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.shopstack-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.shopstack-search {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-md);
+  padding: 0.55rem 0.9rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.shopstack-search__icon {
+  font-size: 1rem;
+  opacity: 0.7;
+}
+
+.shopstack-search input {
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font-size: 1rem;
+  width: 100%;
+}
+
+.shopstack-search input:focus {
+  outline: none;
+}
+
+.shopstack-categories {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.shopstack-chip {
+  background: transparent;
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-pill);
+  padding: 0.45rem 1rem;
+  font-size: 0.92rem;
+  color: var(--browser-muted);
+  cursor: pointer;
+  transition: background 160ms ease, color 160ms ease, border-color 160ms ease;
+}
+
+.shopstack-chip.is-active {
+  background: var(--browser-accent-soft);
+  border-color: var(--browser-accent);
+  color: var(--browser-accent);
+}
+
+.shopstack-grid {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+}
+
+.shopstack-card {
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-md);
+  box-shadow: var(--browser-shadow-card);
+  padding: 1.2rem 1.3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+  cursor: pointer;
+}
+
+.shopstack-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--browser-shadow-soft);
+}
+
+.shopstack-card.is-active {
+  border-color: var(--browser-accent);
+}
+
+.shopstack-card.is-locked {
+  opacity: 0.7;
+}
+
+.shopstack-card.is-owned {
+  border-color: var(--browser-positive);
+}
+
+.shopstack-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.shopstack-card__titleblock {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.shopstack-card__title {
+  margin: 0;
+  font-size: 1.18rem;
+}
+
+.shopstack-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.shopstack-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border-radius: var(--browser-radius-pill);
+  padding: 0.25rem 0.6rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: var(--browser-surface);
+  color: var(--browser-muted);
+}
+
+.shopstack-badge--tech {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--browser-accent);
+}
+
+.shopstack-badge--boost {
+  background: rgba(59, 130, 246, 0.12);
+  color: #2563eb;
+}
+
+.shopstack-badge--unlock {
+  background: rgba(5, 150, 105, 0.12);
+  color: var(--browser-positive);
+}
+
+.shopstack-badge--category,
+.shopstack-badge--family {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.shopstack-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--browser-radius-pill);
+  padding: 0.35rem 0.75rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.shopstack-status--ready {
+  background: var(--browser-accent);
+  color: #fff;
+}
+
+.shopstack-status--owned {
+  background: rgba(5, 150, 105, 0.18);
+  color: var(--browser-positive);
+}
+
+.shopstack-status--unaffordable {
+  background: rgba(239, 68, 68, 0.14);
+  color: var(--browser-danger);
+}
+
+.shopstack-status--locked {
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--browser-muted);
+}
+
+.shopstack-card__description {
+  margin: 0;
+  color: var(--browser-muted);
+  min-height: 3rem;
+}
+
+.shopstack-card__price {
+  font-size: 1.05rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.shopstack-card__highlights {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  color: var(--browser-muted);
+  font-size: 0.92rem;
+}
+
+.shopstack-card__actions {
+  margin-top: auto;
+}
+
+.shopstack-button {
+  appearance: none;
+  border: 1px solid transparent;
+  border-radius: var(--browser-radius-pill);
+  cursor: pointer;
+  font-weight: 700;
+  padding: 0.55rem 1.1rem;
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+}
+
+.shopstack-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.shopstack-button--primary,
+.shopstack-card__buy:not(:disabled) {
+  background: var(--browser-accent);
+  color: #fff;
+  box-shadow: var(--browser-shadow-focus);
+}
+
+.shopstack-card__buy:disabled {
+  background: rgba(148, 163, 184, 0.2);
+  color: var(--browser-muted);
+}
+
+.shopstack-detail {
+  position: sticky;
+  top: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  padding: 1.6rem;
+  box-shadow: var(--browser-shadow-soft);
+  max-height: calc(100vh - 8rem);
+  overflow-y: auto;
+}
+
+.shopstack-detail__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.shopstack-detail__breadcrumbs {
+  margin: 0;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: var(--browser-subtle);
+}
+
+.shopstack-detail__title {
+  margin: 0;
+  font-size: 1.7rem;
+  letter-spacing: -0.01em;
+}
+
+.shopstack-detail__tagline {
+  margin: 0;
+  color: var(--browser-muted);
+}
+
+.shopstack-detail__price-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.shopstack-detail__price {
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.shopstack-detail__affordability {
+  color: var(--browser-muted);
+  font-size: 0.95rem;
+}
+
+.shopstack-detail__status-row {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.shopstack-detail__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.shopstack-detail__section > h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.shopstack-detail__highlights,
+.shopstack-detail__specs {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--browser-muted);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.shopstack-detail__requirements {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.shopstack-detail__requirement {
+  display: flex;
+  gap: 0.55rem;
+  align-items: flex-start;
+  color: var(--browser-muted);
+}
+
+.shopstack-detail__requirement-icon {
+  font-weight: 700;
+  color: var(--browser-muted);
+}
+
+.shopstack-detail__requirement.is-met .shopstack-detail__requirement-icon {
+  color: var(--browser-positive);
+}
+
+.shopstack-detail__cta {
+  align-self: flex-start;
+}
+
+.shopstack-detail__empty {
+  text-align: center;
+  color: var(--browser-muted);
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.shopstack-empty {
+  margin: 0;
+  padding: 1rem 1.2rem;
+  background: rgba(148, 163, 184, 0.18);
+  border-radius: var(--browser-radius-md);
+  color: var(--browser-muted);
+  text-align: center;
+}
+
+.shopstack-purchases {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.shopstack-purchase {
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-md);
+  padding: 1.2rem 1.4rem;
+  box-shadow: var(--browser-shadow-card);
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.shopstack-purchase__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.shopstack-purchase__title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.shopstack-purchase__meta {
+  margin: 0;
+  font-size: 0.92rem;
+  color: var(--browser-muted);
+}
+
+.shopstack-purchase__description {
+  margin: 0;
+  color: var(--browser-muted);
+}
+
+.shopstack-purchase__highlights {
+  list-style: none;
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--browser-muted);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.shopstack-pricing {
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  padding: 1.5rem;
+  box-shadow: var(--browser-shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.shopstack-pricing__intro {
+  color: var(--browser-muted);
+}
+
+.shopstack-pricing__intro h3 {
+  margin: 0 0 0.5rem;
+}
+
+.shopstack-pricing__faq {
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.shopstack-pricing__faq dt {
+  font-weight: 700;
+}
+
+.shopstack-pricing__faq dd {
+  margin: 0;
+  color: var(--browser-muted);
+}
+
+@media (max-width: 1200px) {
+  .shopstack__layout {
+    grid-template-columns: 1fr;
+  }
+
+  .shopstack-detail {
+    position: static;
+    max-height: none;
+  }
+}
+
+/* VideoTube styles */
+.videotube {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.videotube__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.videotube__masthead {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.85rem;
+}
+
+.videotube__title h1 {
+  margin: 0;
+  font-size: 1.55rem;
+}
+
+.videotube__title p {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.95rem;
+}
+
+.videotube-tabs {
+  display: flex;
+  gap: 0.6rem;
+  padding: 0.35rem 0;
+  border-bottom: 1px solid var(--browser-panel-border);
+}
+
+.videotube-tab {
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-weight: 600;
+  background: var(--browser-surface-muted);
+  color: var(--browser-text-subtle);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.videotube-tab:hover,
+.videotube-tab:focus-visible {
+  border-color: var(--browser-border-strong);
+  color: var(--browser-text-strong);
+}
+
+.videotube-tab.is-active {
+  background: var(--browser-primary-surface);
+  color: var(--browser-primary-text);
+  border-color: transparent;
+}
+
+.videotube__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.videotube-button {
+  border-radius: 0.65rem;
+  padding: 0.55rem 1.1rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.videotube-button--primary {
+  background: var(--browser-primary-surface);
+  color: var(--browser-primary-text);
+  box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.08);
+}
+
+.videotube-button--primary:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 0.5rem 1.2rem rgba(0, 0, 0, 0.1);
+}
+
+.videotube-button--secondary {
+  background: transparent;
+  color: var(--browser-text-strong);
+  border-color: var(--browser-border-strong);
+}
+
+.videotube-button--ghost {
+  background: transparent;
+  color: var(--browser-text-strong);
+  border-color: var(--browser-border-muted);
+}
+
+.videotube-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.videotube-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+.videotube-stats__card {
+  background: var(--browser-surface-muted);
+  border-radius: 1rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.videotube-stats__card span {
+  font-size: 0.8rem;
+  color: var(--browser-text-subtle);
+}
+
+.videotube-stats__card strong {
+  font-size: 1.15rem;
+  color: var(--browser-text-strong);
+}
+
+.videotube-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  background: var(--browser-surface-base);
+  border-radius: 1rem;
+  overflow: hidden;
+}
+
+.videotube-table th,
+.videotube-table td {
+  padding: 0.9rem 1rem;
+  text-align: left;
+}
+
+.videotube-table thead th {
+  background: var(--browser-surface-muted);
+  font-size: 0.85rem;
+  color: var(--browser-text-subtle);
+}
+
+.videotube-table tbody tr {
+  border-bottom: 1px solid var(--browser-border-muted);
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.videotube-table tbody tr:hover {
+  background: var(--browser-surface-muted);
+}
+
+.videotube-table tbody tr.is-selected {
+  background: var(--browser-primary-surface-transparent, rgba(73, 94, 255, 0.08));
+}
+
+.videotube-table__cell--label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.videotube-status {
+  font-size: 0.75rem;
+  color: var(--browser-text-subtle);
+}
+
+.videotube-table__cell--actions {
+  text-align: right;
+}
+
+.videotube-table__empty {
+  text-align: center;
+  padding: 2.5rem 1rem;
+  color: var(--browser-text-subtle);
+}
+
+.videotube-quality {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.videotube-quality__level {
+  font-weight: 700;
+  color: var(--browser-text-strong);
+}
+
+.videotube-quality__bar {
+  position: relative;
+  background: var(--browser-border-muted);
+  height: 0.4rem;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.videotube-quality__fill {
+  position: absolute;
+  inset: 0;
+  width: calc(var(--videotube-quality, 0) * 1%);
+  background: linear-gradient(90deg, var(--browser-primary-surface), var(--browser-accent-surface));
+}
+
+.videotube-quality__summary {
+  font-size: 0.75rem;
+  color: var(--browser-text-subtle);
+}
+
+.videotube-niche {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  background: var(--browser-surface-muted);
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--browser-text-strong);
+}
+
+.videotube-niche[data-tone*='blazing'] {
+  background: rgba(255, 94, 132, 0.15);
+  color: #ff3b6b;
+}
+
+.videotube-niche[data-tone*='surging'],
+.videotube-niche[data-tone*='warm'] {
+  background: rgba(255, 165, 0, 0.15);
+  color: #ff7a00;
+}
+
+.videotube-niche[data-tone*='cool'],
+.videotube-niche[data-tone*='cold'] {
+  background: rgba(66, 153, 225, 0.18);
+  color: #2b6cb0;
+}
+
+.videotube-niche--large {
+  font-size: 1rem;
+}
+
+.videotube-view {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.videotube-panel {
+  background: var(--browser-surface-base);
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.06);
+}
+
+.videotube-panel h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.videotube-panel__lead {
+  font-weight: 600;
+  margin: 0;
+}
+
+.videotube-panel__note,
+.videotube-panel__hint {
+  margin: 0;
+  color: var(--browser-text-subtle);
+  font-size: 0.85rem;
+}
+
+.videotube-panel__hint {
+  font-style: italic;
+}
+
+.videotube-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.videotube-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.85rem;
+}
+
+.videotube-list--payout li {
+  font-variant-numeric: tabular-nums;
+}
+
+.videotube-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.videotube-input,
+.videotube-select {
+  border-radius: 0.65rem;
+  border: 1px solid var(--browser-border-muted);
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
+  background: var(--browser-surface-base);
+  color: var(--browser-text-strong);
+}
+
+.videotube-action-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.videotube-action {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.videotube-action__label {
+  font-weight: 600;
+}
+
+.videotube-action__meta {
+  grid-column: 1 / 2;
+  font-size: 0.8rem;
+  color: var(--browser-text-subtle);
+}
+
+.videotube-progress {
+  position: relative;
+  height: 0.6rem;
+  background: var(--browser-border-muted);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.videotube-progress__fill {
+  position: absolute;
+  inset: 0;
+  width: calc(var(--videotube-progress, 0) * 1%);
+  background: linear-gradient(90deg, var(--browser-primary-surface), var(--browser-accent-surface));
+}
+
+.videotube-detail__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.videotube-detail__header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.videotube-rename {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.videotube-rename label {
+  display: none;
+}
+
+.videotube-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+.videotube-stats-grid dt {
+  font-size: 0.8rem;
+  color: var(--browser-text-subtle);
+}
+
+.videotube-stats-grid dd {
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.videotube-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
+}
+
+.videotube-empty {
+  margin: 0;
+  padding: 2rem;
+  text-align: center;
+  background: var(--browser-surface-muted);
+  border-radius: 1rem;
+  color: var(--browser-text-subtle);
+}
+
+.videotube-create {
+  background: var(--browser-surface-base);
+  border-radius: 1.5rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 14px 48px rgba(15, 23, 42, 0.08);
+}
+
+.videotube-create__form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.videotube-requirements {
+  list-style: disc;
+  margin: 0 0 0 1rem;
+  color: var(--browser-text-subtle);
+  font-size: 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.videotube-analytics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
+}
+
+.videotube-view--locked {
+  align-items: center;
+}
+
+:root[data-browser-theme="night"] .videotube-table thead th {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+:root[data-browser-theme="night"] .videotube-stats__card {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+:root[data-browser-theme="night"] .videotube-table tbody tr:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+:root[data-browser-theme="night"] .videotube-panel {
+  background: rgba(19, 26, 40, 0.85);
+}
+
+
+.shopily {
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+}
+
+.shopily-topbar {
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  box-shadow: var(--browser-shadow-soft);
+  padding: 1.35rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.shopily-topbar__row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.shopily-topbar__title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.shopily-topbar__title h1 {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.shopily-topbar__title p {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.95rem;
+}
+
+.shopily-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  padding-top: 0.55rem;
+  border-top: 1px solid var(--browser-panel-border);
+}
+
+.shopily-nav__button {
+  position: relative;
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-pill);
+  background: rgba(148, 163, 184, 0.12);
+  color: inherit;
+  font-weight: 600;
+  padding: 0.45rem 1rem;
+  transition: border-color 160ms ease, background 160ms ease, box-shadow 160ms ease;
+}
+
+.shopily-nav__button.is-active {
+  border-color: var(--browser-accent);
+  background: var(--browser-accent-soft);
+  box-shadow: var(--browser-shadow-focus);
+}
+
+.shopily-nav__button:hover {
+  border-color: var(--browser-accent);
+}
+
+.shopily-nav__badge {
+  margin-left: 0.5rem;
+  padding: 0.1rem 0.55rem;
+  background: var(--browser-accent);
+  color: #fff;
+  border-radius: var(--browser-radius-pill);
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
+.shopily-topbar__actions {
+  display: flex;
+  gap: 0.65rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.shopily-button {
+  border: none;
+  border-radius: var(--browser-radius-pill);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease, color 160ms ease;
+}
+
+.shopily-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+}
+
+.shopily-button--primary {
+  background: var(--browser-accent);
+  color: #fff;
+  padding: 0.65rem 1.4rem;
+  box-shadow: var(--browser-shadow-card);
+}
+
+.shopily-button--primary:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: var(--browser-shadow-focus);
+}
+
+.shopily-button--secondary {
+  background: rgba(148, 163, 184, 0.16);
+  color: inherit;
+  padding: 0.55rem 1.2rem;
+}
+
+.shopily-button--secondary:not(:disabled):hover {
+  background: rgba(37, 99, 235, 0.18);
+}
+
+.shopily-button--ghost {
+  background: transparent;
+  color: var(--browser-accent);
+  padding: 0.45rem 1.1rem;
+}
+
+.shopily-button--ghost:hover {
+  background: rgba(37, 99, 235, 0.12);
+}
+
+.shopily-button--link {
+  background: transparent;
+  color: var(--browser-muted);
+  padding: 0.45rem 0.9rem;
+  text-decoration: underline;
+}
+
+.shopily-button--link:hover {
+  color: var(--browser-accent);
+}
+
+.shopily-hero {
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  padding: 1.75rem;
+  display: grid;
+  gap: 1.5rem;
+  box-shadow: var(--browser-shadow-soft);
+}
+
+.shopily-hero__body h2 {
+  margin: 0 0 0.6rem;
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.shopily-hero__body p {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 1rem;
+}
+
+.shopily-hero__cta {
+  margin-top: 1.2rem;
+}
+
+.shopily-metrics {
+  display: grid;
+  gap: 1rem;
+  margin: 0;
+}
+
+.shopily-metric {
+  padding: 1rem 1.25rem;
+  border-radius: var(--browser-radius);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(148, 163, 184, 0.08);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.shopily-metric__label {
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--browser-subtle);
+}
+
+.shopily-metric__value {
+  font-size: 1.35rem;
+  font-weight: 700;
+}
+
+.shopily-metric__note {
+  font-size: 0.9rem;
+  color: var(--browser-muted);
+}
+
+.shopily-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.shopily-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  box-shadow: var(--browser-shadow-soft);
+  overflow: hidden;
+}
+
+.shopily-table th,
+.shopily-table td {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.shopily-table th {
+  background: rgba(148, 163, 184, 0.12);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--browser-subtle);
+}
+
+.shopily-table tbody tr:hover {
+  background: rgba(37, 99, 235, 0.08);
+  cursor: pointer;
+}
+
+.shopily-table tbody tr.is-selected {
+  background: rgba(37, 99, 235, 0.16);
+}
+
+.shopily-table__cell--label {
+  font-weight: 600;
+}
+
+.shopily-table__cell--actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.shopily-table__empty {
+  text-align: center;
+  padding: 2.5rem 1rem;
+  color: var(--browser-muted);
+}
+
+.shopily-niche {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.shopily-niche__name {
+  font-weight: 600;
+}
+
+.shopily-niche__trend {
+  font-size: 0.85rem;
+  color: var(--browser-muted);
+}
+
+.shopily-detail {
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  padding: 1.5rem;
+  box-shadow: var(--browser-shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.shopily-detail__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.shopily-detail__header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.shopily-detail__empty {
+  text-align: center;
+  color: var(--browser-muted);
+  padding: 2rem 1rem;
+}
+
+.shopily-status {
+  padding: 0.35rem 0.8rem;
+  border-radius: var(--browser-radius-pill);
+  font-size: 0.85rem;
+  font-weight: 600;
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--browser-muted);
+}
+
+.shopily-status[data-state='active'] {
+  background: rgba(37, 211, 102, 0.18);
+  color: #047857;
+}
+
+.shopily-status[data-state='setup'] {
+  background: rgba(250, 204, 21, 0.22);
+  color: #92400e;
+}
+
+.shopily-panel {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: var(--browser-radius);
+  padding: 1.1rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.shopily-panel h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.shopily-panel__note {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.95rem;
+}
+
+.shopily-panel__lead {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.shopily-panel__hint {
+  margin: 0;
+  color: var(--browser-subtle);
+  font-size: 0.85rem;
+}
+
+.shopily-panel__warning {
+  margin: 0;
+  background: rgba(239, 68, 68, 0.12);
+  color: #991b1b;
+  padding: 0.6rem 0.8rem;
+  border-radius: var(--browser-radius);
+  font-weight: 600;
+}
+
+.shopily-progress {
+  width: 100%;
+  height: 8px;
+  border-radius: var(--browser-radius-pill);
+  background: rgba(148, 163, 184, 0.3);
+  overflow: hidden;
+}
+
+.shopily-progress__fill {
+  width: calc(var(--shopily-progress, 0) * 1%);
+  height: 100%;
+  background: var(--browser-accent);
+}
+
+.shopily-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.shopily-select {
+  border-radius: var(--browser-radius);
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  padding: 0.55rem 0.75rem;
+  background: rgba(148, 163, 184, 0.08);
+  font-size: 0.95rem;
+}
+
+.shopily-stats {
+  display: grid;
+  gap: 0.4rem;
+  margin: 0;
+}
+
+.shopily-stats__row {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.shopily-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.shopily-list__item {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.shopily-list__label {
+  color: var(--browser-muted);
+}
+
+.shopily-list__value {
+  font-weight: 600;
+}
+
+.shopily-action-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.shopily-action {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.shopily-action__label {
+  font-weight: 600;
+}
+
+.shopily-action__meta {
+  color: var(--browser-muted);
+  font-size: 0.85rem;
+}
+
+.shopily-view {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.shopily-upgrades__intro {
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  padding: 1.5rem;
+  box-shadow: var(--browser-shadow-soft);
+}
+
+.shopily-upgrades__intro h2 {
+  margin: 0 0 0.4rem;
+}
+
+.shopily-upgrades__intro p {
+  margin: 0;
+  color: var(--browser-muted);
+}
+
+.shopily-upgrades__layout {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+  align-items: start;
+}
+
+.shopily-upgrades__catalog {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.shopily-upgrades {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+}
+
+.shopily-upgrade {
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: var(--browser-radius-lg);
+  padding: 1.3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  background: var(--browser-panel);
+  box-shadow: var(--browser-shadow-soft);
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.shopily-upgrade[data-status='ready'] {
+  border-color: rgba(34, 197, 94, 0.35);
+}
+
+.shopily-upgrade[data-status='owned'] {
+  opacity: 0.78;
+}
+
+.shopily-upgrade.is-active {
+  border-color: var(--browser-accent, rgba(59, 130, 246, 0.6));
+  box-shadow: 0 14px 32px -18px rgba(59, 130, 246, 0.35);
+  transform: translateY(-2px);
+}
+
+.shopily-upgrade:focus-visible {
+  outline: 2px solid var(--browser-accent, rgba(59, 130, 246, 0.7));
+  outline-offset: 3px;
+}
+
+.shopily-upgrade__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.shopily-upgrade__badge {
+  padding: 0.25rem 0.7rem;
+  background: rgba(37, 99, 235, 0.18);
+  border-radius: var(--browser-radius-pill);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.shopily-upgrade__summary {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.95rem;
+}
+
+.shopily-upgrade__highlights {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.45rem;
+  font-size: 0.9rem;
+  color: var(--browser-muted);
+}
+
+.shopily-upgrade__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.shopily-upgrade__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.shopily-upgrade__price {
+  margin: 0;
+  font-weight: 700;
+}
+
+.shopily-upgrade__status {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.9rem;
+}
+
+.shopily-upgrade__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.shopily-upgrade-detail {
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  padding: 1.6rem;
+  box-shadow: var(--browser-shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  min-height: 100%;
+}
+
+.shopily-upgrade-detail__empty {
+  margin: 0;
+  color: var(--browser-muted);
+  text-align: center;
+}
+
+.shopily-upgrade-detail__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.shopily-upgrade-detail__title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.shopily-upgrade-detail__title h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.shopily-upgrade-detail__tag {
+  align-self: flex-start;
+  padding: 0.25rem 0.7rem;
+  background: rgba(37, 99, 235, 0.18);
+  border-radius: var(--browser-radius-pill);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.shopily-upgrade-detail__blurb {
+  margin: 0;
+  color: var(--browser-muted);
+}
+
+.shopily-upgrade-detail__price {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  align-items: flex-end;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.shopily-upgrade-detail__price span {
+  color: var(--browser-muted);
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.shopily-upgrade-detail__status-row {
+  display: flex;
+  gap: 0.8rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.shopily-upgrade-detail__badge {
+  padding: 0.25rem 0.8rem;
+  border-radius: var(--browser-radius-pill);
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.shopily-upgrade-detail__badge--owned {
+  background: rgba(129, 140, 248, 0.18);
+  color: #312e81;
+}
+
+.shopily-upgrade-detail__badge--ready {
+  background: rgba(74, 222, 128, 0.2);
+  color: #166534;
+}
+
+.shopily-upgrade-detail__badge--unaffordable {
+  background: rgba(248, 113, 113, 0.18);
+  color: #7f1d1d;
+}
+
+.shopily-upgrade-detail__badge--locked {
+  background: rgba(148, 163, 184, 0.18);
+  color: #475569;
+}
+
+.shopily-upgrade-detail__note {
+  margin: 0;
+  color: var(--browser-muted);
+}
+
+.shopily-upgrade-detail__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.shopily-upgrade-detail__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.shopily-upgrade-detail__section h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.shopily-upgrade-detail__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.55rem;
+  color: var(--browser-muted);
+  font-size: 0.95rem;
+}
+
+.shopily-upgrade-detail__requirements {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.shopily-upgrade-detail__requirement {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  color: var(--browser-muted);
+}
+
+.shopily-upgrade-detail__requirement.is-met {
+  color: #166534;
+}
+
+.shopily-upgrade-detail__requirement-icon {
+  font-weight: 700;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.shopily-upgrade-detail__requirement-text {
+  line-height: 1.4;
+}
+
+@media (max-width: 1100px) {
+  .shopily-upgrades__layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .shopily-upgrade-detail__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .shopily-upgrade-detail__price {
+    align-items: flex-start;
+  }
+}
+
+.shopily-empty {
+  text-align: center;
+  color: var(--browser-muted);
+  padding: 2rem 1rem;
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+}
+
+.shopily-pricing__intro {
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  padding: 1.6rem;
+  box-shadow: var(--browser-shadow-soft);
+}
+
+.shopily-pricing__intro h2 {
+  margin: 0 0 0.4rem;
+}
+
+.shopily-pricing__intro p {
+  margin: 0;
+  color: var(--browser-muted);
+}
+
+.shopily-pricing {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.shopily-plan {
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: var(--browser-radius);
+  padding: 1.3rem;
+  background: var(--browser-panel);
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  box-shadow: var(--browser-shadow-soft);
+}
+
+.shopily-plan__header h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.shopily-plan__summary {
+  margin: 0;
+  color: var(--browser-muted);
+}
+
+.shopily-plan__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.shopily-plan__item {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.shopily-plan__label {
+  color: var(--browser-muted);
+}
+
+.shopily-plan__value {
+  font-weight: 600;
+}
+
+@media (min-width: 768px) {
+  .shopily-topbar__row {
+    align-items: center;
+    flex-wrap: nowrap;
+  }
+
+  .shopily-metrics {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .shopily-grid {
+    grid-template-columns: minmax(0, 1.75fr) minmax(0, 1fr);
+  }
+}
+
+
+.trends-app {
+  display: flex;
+  flex-direction: column;
+  gap: 1.9rem;
+}
+
+.trends-app__header {
+  display: grid;
+  gap: 1rem;
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  padding: 1.3rem 1.5rem;
+  box-shadow: var(--browser-shadow-soft);
+}
+
+@media (min-width: 768px) {
+  .trends-app__header {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+  }
+}
+
+.trends-app__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.trends-app__title {
+  margin: 0;
+  font-size: 1.45rem;
+  font-weight: 700;
+}
+
+.trends-app__tagline {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.95rem;
+}
+
+.trends-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.trends-search,
+.trends-select {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+  color: var(--browser-muted);
+}
+
+.trends-search input,
+.trends-select select {
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius);
+  padding: 0.5rem 0.75rem;
+  font-size: 0.95rem;
+  background: var(--browser-panel);
+  color: var(--browser-text);
+  box-shadow: var(--browser-shadow-soft);
+}
+
+.trends-search input:focus,
+.trends-select select:focus {
+  outline: none;
+  border-color: var(--browser-accent);
+  box-shadow: var(--browser-shadow-focus);
+}
+
+.trends-toggle-group {
+  display: flex;
+  gap: 0.4rem;
+  padding: 0.3rem;
+  background: var(--browser-accent-soft);
+  border-radius: var(--browser-radius-pill);
+}
+
+.trends-toggle-group button {
+  border: none;
+  background: transparent;
+  padding: 0.4rem 1rem;
+  border-radius: var(--browser-radius-pill);
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--browser-muted);
+  cursor: pointer;
+  transition: background 160ms ease, color 160ms ease, box-shadow 160ms ease;
+}
+
+.trends-toggle-group button.is-active {
+  background: var(--browser-accent);
+  color: #fff;
+  box-shadow: var(--browser-shadow-soft);
+}
+
+.trends-toggle-group button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.trends-overview {
+  display: grid;
+  gap: 1.1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.trends-overview__card {
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  box-shadow: var(--browser-shadow-soft);
+}
+
+.trends-overview__icon {
+  font-size: 1.35rem;
+}
+
+.trends-overview__label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.7rem;
+  color: var(--browser-subtle);
+}
+
+.trends-overview__value {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--browser-text);
+}
+
+.trends-overview__note {
+  color: var(--browser-muted);
+  font-size: 0.9rem;
+}
+
+.trends-grid-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.trends-grid-section__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+
+.trends-grid-section__header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.trends-grid-section__meta {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.9rem;
+}
+
+.trends-grid {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.trends-grid__empty {
+  margin: 0;
+  padding: 1.6rem;
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius);
+  color: var(--browser-muted);
+  text-align: center;
+}
+
+.trends-grid__footer {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.9rem;
+}
+
+.trends-card {
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius);
+  padding: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  box-shadow: var(--browser-shadow-soft);
+}
+
+.trends-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.trends-card__title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.trends-card__name {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.trends-card__score {
+  font-size: 0.85rem;
+  color: var(--browser-subtle);
+  font-weight: 600;
+}
+
+.trends-card__watch {
+  border: none;
+  background: transparent;
+  color: var(--browser-subtle);
+  font-size: 1.15rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 160ms ease, transform 160ms ease;
+}
+
+.trends-card__watch:is(:hover, :focus-visible) {
+  color: var(--browser-accent);
+  transform: scale(1.1);
+}
+
+.trends-card__watch[aria-pressed='true'] {
+  color: var(--browser-accent);
+}
+
+.trends-card__sparkline {
+  width: 100%;
+  height: 56px;
+  stroke: var(--browser-accent);
+  stroke-width: 2;
+  fill: none;
+}
+
+.trends-card__sparkline path:first-of-type {
+  fill: var(--browser-accent-soft);
+  stroke: none;
+}
+
+.trends-card__sparkline path:last-of-type {
+  fill: none;
+  stroke: currentColor;
+}
+
+.trends-card__stats,
+.trends-card__extra {
+  display: grid;
+  gap: 0.6rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.trends-card__extra {
+  border-top: 1px solid var(--browser-panel-border);
+  padding-top: 0.6rem;
+}
+
+.trends-card__stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.trends-card__stat-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--browser-subtle);
+}
+
+.trends-card__stat-value {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--browser-text);
+}
+
+.trends-card__empire {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.9rem;
+}
+
+.trends-watchlist {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.trends-watchlist__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.trends-watchlist__header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.trends-watchlist__meta {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.9rem;
+}
+
+.trends-watchlist__grid {
+  display: grid;
+  gap: 1.1rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.trends-watchlist__empty {
+  margin: 0;
+  padding: 1.6rem;
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius);
+  color: var(--browser-muted);
+  text-align: center;
+}
+
+.trends-app__footer {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+.serverhub {
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+  padding: 1.75rem 2rem 2.25rem;
+}
+
+.serverhub-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  box-shadow: var(--browser-shadow-soft);
+  padding: 1.35rem 1.6rem;
+}
+
+.serverhub-header__intro {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.serverhub-header__title {
+  margin: 0;
+  font-size: 1.45rem;
+  font-weight: 700;
+}
+
+.serverhub-header__subtitle {
+  margin: 0;
+  color: var(--browser-muted);
+  font-size: 0.95rem;
+}
+
+.serverhub-header__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.55rem;
+  min-inline-size: 240px;
+}
+
+.serverhub-header__meta {
+  margin: 0;
+  color: var(--browser-subtle);
+  font-size: 0.85rem;
+  flex: 1 1 100%;
+  text-align: right;
+}
+
+.serverhub-button {
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-pill);
+  background: var(--browser-panel);
+  color: inherit;
+  font-weight: 600;
+  padding: 0.5rem 1.1rem;
+  cursor: pointer;
+  transition: background 160ms ease, color 160ms ease, border-color 160ms ease,
+    box-shadow 160ms ease, transform 160ms ease;
+}
+
+.serverhub-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+}
+
+.serverhub-button--primary {
+  background: var(--browser-accent);
+  border-color: var(--browser-accent);
+  color: #fff;
+  box-shadow: var(--browser-shadow-focus);
+}
+
+.serverhub-button--primary:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: var(--browser-shadow-card);
+}
+
+.serverhub-button--quiet {
+  background: rgba(148, 163, 184, 0.16);
+  border-color: transparent;
+  color: inherit;
+}
+
+.serverhub-button--quiet:not(:disabled):hover {
+  background: rgba(37, 99, 235, 0.18);
+  color: var(--browser-accent);
+}
+
+.serverhub-button--ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--browser-muted);
+}
+
+.serverhub-button--ghost:not(:disabled):hover {
+  color: var(--browser-accent);
+  background: rgba(37, 99, 235, 0.12);
+}
+
+.serverhub-button--compact {
+  padding: 0.4rem 0.85rem;
+  font-size: 0.85rem;
+}
+
+.serverhub-button.is-active {
+  background: rgba(37, 99, 235, 0.18);
+  color: var(--browser-accent);
+  box-shadow: var(--browser-shadow-focus);
+}
+
+.serverhub-kpis {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.serverhub-kpi {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-md);
+  box-shadow: var(--browser-shadow-soft);
+  padding: 1rem 1.2rem;
+}
+
+.serverhub-kpi__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--browser-subtle);
+}
+
+.serverhub-kpi__value {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--browser-text);
+}
+
+.serverhub-kpi__note {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--browser-muted);
+}
+
+.serverhub-nav {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  box-shadow: var(--browser-shadow-soft);
+  padding: 0.55rem 0.75rem;
+}
+
+.serverhub-nav__button {
+  position: relative;
+  border: none;
+  border-radius: var(--browser-radius-pill);
+  background: transparent;
+  color: var(--browser-muted);
+  font-weight: 600;
+  padding: 0.45rem 1rem;
+  cursor: pointer;
+  transition: background 160ms ease, color 160ms ease, box-shadow 160ms ease;
+}
+
+.serverhub-nav__button.is-active {
+  background: rgba(37, 99, 235, 0.16);
+  color: var(--browser-accent);
+  box-shadow: var(--browser-shadow-focus);
+}
+
+.serverhub-nav__button:hover {
+  color: var(--browser-accent);
+}
+
+.serverhub-nav__badge {
+  margin-left: 0.45rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: var(--browser-radius-pill);
+  background: var(--browser-accent);
+  color: #fff;
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
+.serverhub-view {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.serverhub-view--apps {
+  gap: 1.35rem;
+}
+
+.serverhub-layout {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  align-items: start;
+}
+
+.serverhub-table-wrapper {
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  box-shadow: var(--browser-shadow-soft);
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+}
+
+.serverhub-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  min-width: 760px;
+}
+
+.serverhub-table__heading {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--browser-subtle);
+  text-align: left;
+  padding: 0.75rem 1.1rem;
+  background: var(--browser-panel-elevated);
+  border-bottom: 1px solid var(--browser-panel-border);
+}
+
+.serverhub-table__row {
+  position: relative;
+  transition: background 160ms ease;
+}
+
+.serverhub-table__row:hover {
+  background: rgba(148, 163, 184, 0.08);
+  cursor: pointer;
+}
+
+.serverhub-table__row.is-selected::before {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  inset-inline-start: 0;
+  inline-size: 4px;
+  background: var(--browser-accent);
+}
+
+.serverhub-table__cell {
+  padding: 0.9rem 1.1rem;
+  border-bottom: 1px solid var(--browser-panel-border);
+  vertical-align: top;
+  font-size: 0.95rem;
+}
+
+.serverhub-table__cell--actions {
+  width: 240px;
+}
+
+.serverhub-table__cell--name {
+  min-width: 200px;
+}
+
+.serverhub-table__cell--niche {
+  min-width: 220px;
+}
+
+.serverhub-table__cell--status {
+  width: 140px;
+}
+
+.serverhub-table__link {
+  border: none;
+  background: transparent;
+  padding: 0;
+  color: var(--browser-accent);
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+.serverhub-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: var(--browser-muted);
+}
+
+.serverhub-status::before {
+  content: '';
+  inline-size: 0.55rem;
+  block-size: 0.55rem;
+  border-radius: 999px;
+  background: var(--browser-muted);
+}
+
+.serverhub-status[data-state='active'] {
+  color: var(--browser-positive);
+}
+
+.serverhub-status[data-state='active']::before {
+  background: var(--browser-positive);
+}
+
+.serverhub-status[data-state='inactive']::before,
+.serverhub-status[data-state='setup']::before {
+  background: rgba(148, 163, 184, 0.6);
+}
+
+.serverhub-status[data-state='offline'] {
+  color: var(--browser-danger);
+}
+
+.serverhub-status[data-state='offline']::before {
+  background: var(--browser-danger);
+}
+
+.serverhub-niche__name {
+  display: block;
+  font-weight: 600;
+}
+
+.serverhub-niche__note {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--browser-muted);
+}
+
+.serverhub-niche__locked {
+  font-size: 0.85rem;
+  color: var(--browser-subtle);
+}
+
+.serverhub-select--inline {
+  padding: 0.4rem 0.65rem;
+  font-size: 0.85rem;
+}
+
+.serverhub-action-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.serverhub-empty {
+  padding: 2.2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: var(--browser-muted);
+}
+
+.serverhub-sidebar {
+  background: var(--browser-panel);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-lg);
+  box-shadow: var(--browser-shadow-soft);
+  padding: 1.5rem 1.65rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.35rem;
+}
+
+.serverhub-detail__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.serverhub-detail__header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.serverhub-detail__tabs {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.serverhub-detail__tab {
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-pill);
+  background: rgba(148, 163, 184, 0.14);
+  color: inherit;
+  font-weight: 600;
+  padding: 0.4rem 1rem;
+  cursor: default;
+}
+
+.serverhub-detail__tab.is-active {
+  border-color: var(--browser-accent);
+  background: rgba(37, 99, 235, 0.18);
+  color: var(--browser-accent);
+}
+
+.serverhub-detail__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  background: var(--browser-panel-elevated);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-md);
+  padding: 1.2rem 1.3rem;
+}
+
+.serverhub-detail__stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.serverhub-detail__stat-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--browser-subtle);
+}
+
+.serverhub-detail__stat-value {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--browser-text);
+}
+
+.serverhub-detail__stat-note {
+  font-size: 0.85rem;
+  color: var(--browser-muted);
+}
+
+.serverhub-detail__grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.serverhub-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  background: var(--browser-panel-elevated);
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-md);
+  padding: 1rem 1.15rem;
+  box-shadow: var(--browser-shadow-soft);
+}
+
+.serverhub-panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.serverhub-panel h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.serverhub-panel__badge {
+  padding: 0.2rem 0.6rem;
+  border-radius: var(--browser-radius-pill);
+  background: rgba(37, 99, 235, 0.16);
+  color: var(--browser-accent);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.serverhub-panel__lead {
+  margin: 0;
+  font-weight: 600;
+}
+
+.serverhub-panel__hint {
+  margin: 0;
+  color: var(--browser-subtle);
+  font-size: 0.9rem;
+}
+
+.serverhub-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 600;
+}
+
+.serverhub-select {
+  padding: 0.55rem 0.75rem;
+  border-radius: var(--browser-radius-pill);
+  border: 1px solid var(--browser-panel-border);
+  background: var(--browser-panel);
+}
+
+.serverhub-breakdown {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.serverhub-breakdown__item {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.serverhub-breakdown__label {
+  color: var(--browser-text);
+  font-weight: 600;
+}
+
+.serverhub-breakdown__value {
+  color: var(--browser-muted);
+}
+
+.serverhub-progress {
+  position: relative;
+  height: 0.6rem;
+  border-radius: var(--browser-radius-pill);
+  background: rgba(37, 99, 235, 0.12);
+  overflow: hidden;
+}
+
+.serverhub-progress__fill {
+  position: absolute;
+  inset: 0;
+  width: calc(var(--serverhub-progress, 0) * 1%);
+  background: var(--browser-accent);
+  border-radius: inherit;
+}
+
+.serverhub-action-console {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.serverhub-action-console__button {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-md);
+  background: var(--browser-panel);
+  font-weight: 600;
+  padding: 0.75rem 1.1rem;
+  cursor: pointer;
+  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease,
+    background 160ms ease;
+}
+
+.serverhub-action-console__button:not(:disabled):hover {
+  border-color: var(--browser-accent);
+  box-shadow: var(--browser-shadow-soft);
+  transform: translateY(-1px);
+}
+
+.serverhub-action-console__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.serverhub-action-console__label {
+  font-size: 0.95rem;
+}
+
+.serverhub-action-console__meta {
+  font-size: 0.85rem;
+  color: var(--browser-muted);
+}
+
+.serverhub-upgrades__intro,
+.serverhub-pricing__intro {
+  padding: 1.25rem 1.5rem 0;
+}
+
+.serverhub-upgrades__intro h2,
+.serverhub-pricing__intro h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1.25rem;
+}
+
+.serverhub-upgrades__intro p,
+.serverhub-pricing__intro p {
+  margin: 0;
+  color: var(--browser-muted);
+}
+
+.serverhub-upgrades {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+  padding: 0 1.5rem 1.5rem;
+}
+
+.serverhub-upgrade {
+  padding: 1.15rem;
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-md);
+  background: var(--browser-panel-elevated);
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.serverhub-upgrade[data-status='owned'] {
+  opacity: 0.7;
+}
+
+.serverhub-upgrade__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.serverhub-upgrade__badge {
+  padding: 0.2rem 0.55rem;
+  border-radius: var(--browser-radius-pill);
+  background: var(--browser-accent-soft);
+  color: var(--browser-accent);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.serverhub-upgrade__summary,
+.serverhub-upgrade__note,
+.serverhub-upgrade__status {
+  margin: 0;
+  color: var(--browser-subtle);
+  font-size: 0.95rem;
+}
+
+.serverhub-upgrade__price {
+  margin: 0;
+  font-weight: 600;
+}
+
+.serverhub-pricing {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+  padding: 0 1.5rem 1.5rem;
+}
+
+.serverhub-plan {
+  padding: 1.15rem;
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-md);
+  background: var(--browser-panel-elevated);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.serverhub-plan__summary {
+  margin: 0;
+  color: var(--browser-muted);
+}
+
+.serverhub-plan__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.serverhub-plan__item {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  border-top: 1px dashed var(--browser-panel-border);
+  padding-top: 0.5rem;
+}
+
+.serverhub-plan__label {
+  font-weight: 600;
+}
+
+.serverhub-plan__value {
+  color: var(--browser-subtle);
+  text-align: right;
+}
+
+.serverhub-detail__empty {
+  color: var(--browser-subtle);
+  text-align: center;
+}
+
+@media (max-width: 1080px) {
+  .serverhub {
+    padding: 1.5rem 1.35rem 2rem;
+  }
+
+  .serverhub-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .serverhub-nav {
+    align-self: stretch;
+  }
+}
+
+@media (max-width: 720px) {
+  .serverhub {
+    padding: 1.25rem 1rem 1.75rem;
+  }
+
+  .serverhub-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .serverhub-header__actions {
+    justify-content: flex-start;
+  }
+
+  .serverhub-table__cell--actions {
+    width: auto;
+  }
+
+  .serverhub-action-group {
+    flex-direction: column;
+  }
+}
+


### PR DESCRIPTION
## Summary
- split the browser stylesheet into module directories for base, components, widgets, workspaces, and overlays
- add a build script that concatenates the modules into styles/browser.css and run it from npm run build:css/prepare
- document the generated CSS workflow for contributors

## Testing
- npm run build:css

------
https://chatgpt.com/codex/tasks/task_e_68e066043d2c832cb256797119fd7024