### PR TITLE
Fix ServerHub navigation wiring

### DIFF
--- a/src/ui/views/browser/apps/serverhub.js
+++ b/src/ui/views/browser/apps/serverhub.js
@@ -20,5 +20,6 @@ export default function renderServerHub(context = {}, definitions = [], model = 
 
   const summary = serverhubApp.render(model, { mount, page, definitions });
   const meta = summary?.meta || model?.summary?.meta || 'Launch your first micro SaaS';
-  return { id: page.id, meta };
+  const urlPath = summary?.urlPath || '';
+  return { id: page.id, meta, urlPath };
 }

--- a/src/ui/views/browser/components/serverhub.js
+++ b/src/ui/views/browser/components/serverhub.js
@@ -182,6 +182,18 @@ function deriveSummary(model = {}) {
   return { meta };
 }
 
+function derivePath(state = {}) {
+  switch (state.view) {
+    case VIEW_UPGRADES:
+      return 'upgrades';
+    case VIEW_PRICING:
+      return 'pricing';
+    case VIEW_APPS:
+    default:
+      return '';
+  }
+}
+
 let presenter;
 
 const renderAppsView = createAppsView({
@@ -207,6 +219,7 @@ presenter = createAssetWorkspacePresenter({
   state: { view: VIEW_APPS, selectedAppId: null },
   ensureSelection,
   deriveSummary,
+  derivePath,
   renderLocked: renderLockedState,
   isLocked: model => !model?.definition,
   header(model, state, { setView }) {
@@ -219,16 +232,6 @@ presenter = createAssetWorkspacePresenter({
         disabled: launch.disabled,
         ...(reasons.length ? { title: reasons.join('\n') } : {}),
         onClick: () => handleLaunch(presenter)
-      },
-      {
-        label: 'Pricing',
-        className: `serverhub-button serverhub-button--quiet${state.view === VIEW_PRICING ? ' is-active' : ''}`,
-        onClick: () => setView(VIEW_PRICING)
-      },
-      {
-        label: 'Upgrades',
-        className: `serverhub-button serverhub-button--quiet${state.view === VIEW_UPGRADES ? ' is-active' : ''}`,
-        onClick: () => setView(VIEW_UPGRADES)
       }
     ];
 
@@ -291,7 +294,8 @@ presenter = createAssetWorkspacePresenter({
 function render(model, context = {}) {
   const summary = presenter.render(model, context);
   const meta = summary?.meta || 'Launch your first micro SaaS';
-  return { meta };
+  const urlPath = summary?.urlPath || '';
+  return { meta, urlPath };
 }
 
 export default {


### PR DESCRIPTION
## Summary
- remove the redundant Pricing and Upgrades buttons from the ServerHub action bar
- add path derivation so ServerHub tabs stay in sync with the global workspace navigation
- surface the derived URL path to the app summary returned to the browser shell

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e069c1e738832c9febbcbe83f70263