### PR TITLE
Update workspace docs for browser shell architecture

### DIFF
--- a/docs/features/learnly.md
+++ b/docs/features/learnly.md
@@ -18,3 +18,12 @@ Reimagine the education experience inside the browser shell as a dedicated Learn
 - Pricing Info tab explains tuition, time reservation, and graduation rewards so new players understand how Learnly interacts with their schedule and income.
 - Browser navigation mirrors Learnly’s tabs, mapping the workspace URL to `/catalog`, `/my-courses`, or `/pricing` for easy orientation.
 - The module reuses the existing knowledge track registry so XP rewards, unlocks, and study progress remain in sync with backend systems.
+
+## Workspace Architecture
+- The Learnly workspace is orchestrated by `createTabbedWorkspacePresenter`, which builds tab navigation, hero metrics, and view routing so catalog, free courses, My Courses, detail, and pricing screens share URL segments and state transitions.【F:src/ui/views/browser/components/learnly/createLearnlyWorkspace.js†L378-L502】
+- Tab buttons surface badges for free offerings and active enrollments, while the hero band highlights total catalog size, reserved hours, and current enrollments drawn from the aggregated course context.【F:src/ui/views/browser/components/learnly/createLearnlyWorkspace.js†L278-L319】【F:src/ui/views/browser/components/learnly/views/tabNavigation.js†L3-L37】
+- Course detail pages now include back-navigation tied to the originating tab, skill highlight lists, and CTAs that enroll or deep link into My Courses depending on progress state.【F:src/ui/views/browser/components/learnly/views/detailView.js†L9-L139】【F:src/ui/views/browser/components/learnly/views/detailView.js†L140-L175】
+- My Courses sorts in-progress enrollments to the top and reiterates reserved time and sunk tuition so the daily plan is visible without opening detail views.【F:src/ui/views/browser/components/learnly/views/myCoursesView.js†L4-L55】
+
+## Follow-up Tech Debt
+- Dropping a course still relies on the browser `window.confirm` prompt; swap in the shared shell modal so the experience matches other workspace confirmations and remains themeable.【F:src/ui/views/browser/components/learnly/createLearnlyWorkspace.js†L494-L503】

--- a/docs/features/shopily.md
+++ b/docs/features/shopily.md
@@ -11,6 +11,9 @@ Shopily transforms the classic dropshipping venture interface into a modern SaaS
 - Offer a pricing page with playful copy that explains setup costs, upkeep expectations, and payout ladders using live definition data.
 
 ## Implementation Notes
+- The browser workspace now runs through `createAssetWorkspacePresenter`, wiring the Shopily top bar, launch CTA, and tabbed navigation around the shared Dropshipping model so My Stores, Upgrades, and Pricing stay in sync with the browser shell state and URL segments.【F:src/ui/views/browser/components/shopily/createShopilyWorkspace.js†L160-L218】【F:src/ui/views/browser/components/shopily/state.js†L1-L72】
+- The dashboard view composes a hero banner with live metrics plus a store table and sidebar detail panel, exposing quick upgrade navigation, niche assignment, and quality actions without leaving the workspace.【F:src/ui/views/browser/components/shopily/views/dashboardView.js†L13-L171】【F:src/ui/views/browser/components/shopily/storeDetail.js†L11-L240】
+- The upgrades view mirrors a commerce catalog: cards summarize readiness, while the adjacent detail inspector surfaces highlights, prerequisites, and checkout states powered by upgrade snapshots.【F:src/ui/views/browser/components/shopily/views/upgradesView.js†L19-L120】
 - Reuses `buildShopilyModel` to adapt `getAssetState('dropshipping')`, quality helpers, and upgrade snapshots into a view model consumed by `shopily.js`.
 - Quality actions route through `performQualityAction('dropshipping', …)` so buttons behave identically to the classic dashboard.
 - Niche selection uses `assignInstanceToNiche` under the hood and locks once set.
@@ -19,6 +22,13 @@ Shopily transforms the classic dropshipping venture interface into a modern SaaS
 - The upgrades tab now mirrors a mobile top-up catalog: cards show highlights, cost, readiness tone, and a "View product" action that opens a detail panel with full ShopStack-style specs, requirements, and buy button.
 - High-tier commerce upgrades formerly sold through ShopStack (Fulfillment Automation Suite, Global Supply Mesh, White-Label Alliance) render exclusively here so players manage all storefront boosters in one place.
 - Workspace URLs expose `upgrades/<id>` segments so selecting a product updates the browser shell path and keeps deep links in sync.
+
+## Shell Layout
+- Top navigation badges surface active store counts and upgrade readiness while the launch action persists in the header, matching the rest of the shell workspaces.【F:src/ui/views/browser/components/shopily/createShopilyWorkspace.js†L169-L217】
+- Hero metrics reuse shared KPI builders so currency, ROI, and upkeep figures inherit the shell formatting rules.【F:src/ui/views/browser/components/shopily/views/dashboardView.js†L13-L169】
+
+## UX Follow-ups
+- Disabled launch buttons currently expose gating reasons only through the browser tooltip; surface the same copy inline so players on touch devices understand the block.【F:src/ui/views/browser/components/shopily/createShopilyWorkspace.js†L70-L81】
 
 ## Future Enhancements
 - Add analytics view (daily revenue chart, top modifiers) once the finance history service exposes commerce-specific slices.

--- a/docs/features/videotube.md
+++ b/docs/features/videotube.md
@@ -15,3 +15,13 @@ VideoTube transforms the original vlog asset interface into a full browser works
 - Quick actions respect the existing daily limits/time costs and route through the existing `performQualityAction` API.
 - Launch flow uses the existing asset action, then applies the chosen title/niche with `setAssetInstanceName` and `assignInstanceToNiche` to preserve backend behaviour.
 - Analytics uses live lifetime and latest payout data—no extra history was stored to avoid persistence churn.
+
+## Workspace Architecture
+- `createAssetWorkspacePresenter` drives the VideoTube shell module, wiring dashboard, detail, hidden creation, and analytics views alongside the shared header so navigation state, summaries, and locks remain consistent with other asset workspaces.【F:src/ui/views/browser/components/videotube/createVideoTubeWorkspace.js†L92-L178】
+- The header injects a persistent “Create New Video” action and reuses the shared tab theming so players can swap views without losing context.【F:src/ui/views/browser/components/videotube/header.js†L1-L30】
+- The dashboard view pairs a stats rail with the sortable-like channel table, enabling quick actions, quality previews, and detail navigation directly from the workspace.【F:src/ui/views/browser/components/videotube/views/dashboardView.js†L1-L178】
+- Detail panels support renaming, niche locking, payout breakdowns, and milestone tracking while sharing quick-action hooks with the dashboard for parity.【F:src/ui/views/browser/components/videotube/views/detailView.js†L1-L200】
+- The create view mirrors the classic launch flow but now lives in-shell, summarizing setup/upkeep costs, enforcing availability rules, and calling back into the workspace to focus the newly launched video.【F:src/ui/views/browser/components/videotube/views/createView.js†L1-L104】
+
+## Follow-up Tech Debt
+- The workspace still rewraps header markup manually after render; migrate this layout tweak into the shared header renderer to avoid DOM poking each frame.【F:src/ui/views/browser/components/videotube/createVideoTubeWorkspace.js†L128-L148】


### PR DESCRIPTION
## Summary
- refresh Shopily documentation to describe the tabbed workspace presenter, dashboard layout, and outstanding launch CTA UX debt
- expand Learnly notes with presenter wiring, hero metrics, and follow-up to replace the confirm-style drop dialog
- capture the VideoTube workspace structure, including the in-shell create flow and header adjustments

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e071ddbff8832c96dae5b967b907e6