### PR TITLE
Implement UI partial invalidation pipeline

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Browser chrome gains a partial invalidation system so background ticks and actions only refresh the dashboard, cards, and widgets that actually changed.
 - Knowledge tracks retune advanced business courses with longer sessions, higher tuitions, and refreshed hustle/asset bonuses while Free Course jumpstarts shift to 4h/day intensives.
 - Learnly adds a Free Courses tab stocked with XP-rich jumpstarts that unlock BlogPress, VideoTube, DigiShelf, Shopily, and ServerHub once you hit level 1 in their focus skill.
 - Passive income and upgrade completion notifications now arrive pre-read, and the welcome-back alert no longer appears so the tray only spotlights actionable events.

--- a/docs/features/ui-partial-invalidation.md
+++ b/docs/features/ui-partial-invalidation.md
@@ -1,0 +1,16 @@
+# UI Partial Invalidation
+
+## Goals
+- Reduce unnecessary DOM churn by only updating dashboard, cards, and widgets that actually changed during a tick or action.
+- Provide a shared helper that gameplay systems can use to flag dirty sections without knowing how the UI renders them.
+- Keep the existing full-refresh path available so complex flows can opt-in without refactors.
+
+## Player Impact
+- Smoother interface updates during background ticks because idle sections no longer rerender every second.
+- Lower chance of flicker in cards, dashboard summaries, and header controls when nothing changed.
+- Faster response when chained actions trigger follow-up updates, maintaining the upbeat, responsive tone of the shell.
+
+## Tuning Notes
+- `markDirty(section)` accepts `dashboard`, `player`, `skillsWidget`, `headerAction`, and `cards`; callers can also pass arrays or maps of sections.
+- `consumeDirty()` clears the pending set and should be called immediately before `updateUI` so sections are not updated twice.
+- When no sections are flagged, callers should fall back to a full refresh by omitting options so late-joining systems stay accurate.

--- a/src/game/actions.js
+++ b/src/game/actions.js
@@ -1,10 +1,16 @@
 import { saveState } from '../core/storage.js';
 import { updateUI } from '../ui/update.js';
+import { consumeDirty } from '../ui/invalidation.js';
 
 export function executeAction(effect) {
   if (typeof effect === 'function') {
     effect();
   }
-  updateUI();
+  const dirtySections = consumeDirty();
+  if (Object.keys(dirtySections).length > 0) {
+    updateUI(dirtySections);
+  } else {
+    updateUI();
+  }
   saveState();
 }

--- a/src/game/loop.js
+++ b/src/game/loop.js
@@ -2,6 +2,7 @@ import { AUTOSAVE_INTERVAL_MS } from '../core/constants.js';
 import { saveState } from '../core/storage.js';
 import { HUSTLES } from './hustles.js';
 import { updateUI } from '../ui/update.js';
+import { consumeDirty, markAllDirty, markDirty } from '../ui/invalidation.js';
 
 let lastAutosave = Date.now();
 
@@ -15,19 +16,40 @@ export function startGameLoop() {
 
 function runGameLoop() {
   const now = Date.now();
-  let uiDirty = false;
-
   for (const hustle of HUSTLES) {
     if (typeof hustle.process === 'function') {
       const result = hustle.process(now, false);
-      if (result?.changed) {
-        uiDirty = true;
+      if (!result) {
+        continue;
+      }
+
+      if (typeof result === 'boolean') {
+        if (result) {
+          markAllDirty();
+        }
+        continue;
+      }
+
+      if (typeof result === 'object') {
+        let flagged = false;
+        for (const [section, value] of Object.entries(result)) {
+          if (section === 'changed') continue;
+          if (value) {
+            markDirty(section, true);
+            flagged = true;
+          }
+        }
+
+        if (!flagged && result.changed) {
+          markAllDirty();
+        }
       }
     }
   }
 
-  if (uiDirty) {
-    updateUI();
+  const dirtySections = consumeDirty();
+  if (Object.keys(dirtySections).length > 0) {
+    updateUI(dirtySections);
   }
 
   if (now - lastAutosave >= AUTOSAVE_INTERVAL_MS) {

--- a/src/ui/invalidation.js
+++ b/src/ui/invalidation.js
@@ -1,0 +1,63 @@
+const ALL_UI_SECTIONS = Object.freeze([
+  'dashboard',
+  'player',
+  'skillsWidget',
+  'headerAction',
+  'cards'
+]);
+
+const dirtySections = new Set();
+
+function markEntry(section, flag = true) {
+  if (!section) return;
+  if (flag) {
+    dirtySections.add(section);
+  } else {
+    dirtySections.delete(section);
+  }
+}
+
+export function markDirty(sectionOrMap, flag = true) {
+  if (typeof sectionOrMap === 'string') {
+    markEntry(sectionOrMap, flag);
+    return;
+  }
+
+  if (Array.isArray(sectionOrMap)) {
+    sectionOrMap.forEach(section => markEntry(section, true));
+    return;
+  }
+
+  if (sectionOrMap && typeof sectionOrMap === 'object') {
+    for (const [section, value] of Object.entries(sectionOrMap)) {
+      if (section === 'changed') continue;
+      markEntry(section, Boolean(value));
+    }
+  }
+}
+
+export function markAllDirty() {
+  ALL_UI_SECTIONS.forEach(section => dirtySections.add(section));
+}
+
+export function consumeDirty() {
+  if (dirtySections.size === 0) {
+    return {};
+  }
+
+  const result = {};
+  dirtySections.forEach(section => {
+    result[section] = true;
+  });
+  dirtySections.clear();
+  return result;
+}
+
+export { ALL_UI_SECTIONS };
+
+export default {
+  markDirty,
+  markAllDirty,
+  consumeDirty,
+  ALL_UI_SECTIONS
+};


### PR DESCRIPTION
## Summary
- add a shared UI invalidation helper and teach `updateUI` to respect partial refresh flags
- wire the hustle loop, lifecycle flows, and action runner to merge dirty sections before updating the UI
- document the new behaviour and cover it with an integration test that ensures untouched presenters remain idle during partial updates

## Testing
- npm test
- Manual testing: not run (automated environment)


------
https://chatgpt.com/codex/tasks/task_e_68e07277c888832c8f78a061cb699b98