### PR TITLE
Refactor serverhub apps view into modular helpers

### DIFF
--- a/src/ui/views/browser/components/serverhub/views/apps/actionConsole.js
+++ b/src/ui/views/browser/components/serverhub/views/apps/actionConsole.js
@@ -1,0 +1,69 @@
+import { ensureArray } from '../../../../../../../core/helpers.js';
+
+function createActionButton(action, label, instanceId, helpers) {
+  const { onQuickAction, formatCurrency, formatHours } = helpers;
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'serverhub-action-console__button';
+
+  const actionLabel = document.createElement('span');
+  actionLabel.className = 'serverhub-action-console__label';
+  actionLabel.textContent = action.label || label;
+
+  const meta = document.createElement('span');
+  meta.className = 'serverhub-action-console__meta';
+  const timeLabel = Number(action.time) > 0 ? formatHours(action.time) : 'Instant';
+  const costLabel = formatCurrency(action.cost || 0);
+  meta.textContent = `${timeLabel} • ${costLabel}`;
+
+  if (!action.available) {
+    button.disabled = true;
+    if (action.disabledReason) {
+      button.title = action.disabledReason;
+    }
+  }
+
+  button.append(actionLabel, meta);
+  button.addEventListener('click', event => {
+    event.stopPropagation();
+    if (button.disabled) return;
+    onQuickAction(instanceId, action.id);
+  });
+
+  return button;
+}
+
+export function renderActionConsole(instance, helpers) {
+  const section = document.createElement('section');
+  section.className = 'serverhub-panel serverhub-panel--actions';
+
+  const heading = document.createElement('h3');
+  heading.textContent = 'Action console';
+  section.appendChild(heading);
+
+  const list = document.createElement('div');
+  list.className = 'serverhub-action-console';
+
+  const actions = ensureArray(instance.actions);
+  let rendered = 0;
+
+  ensureArray(helpers.actionConsoleOrder).forEach(({ id, label }) => {
+    const action = instance.actionsById?.[id] || actions.find(entry => entry.id === id);
+    if (!action) return;
+    list.appendChild(createActionButton(action, label, instance.id, helpers));
+    rendered += 1;
+  });
+
+  if (!rendered) {
+    const empty = document.createElement('p');
+    empty.className = 'serverhub-panel__hint';
+    empty.textContent = 'Quality actions unlock as your SaaS portfolio grows.';
+    section.appendChild(empty);
+  } else {
+    section.appendChild(list);
+  }
+
+  return section;
+}
+
+export default renderActionConsole;

--- a/src/ui/views/browser/components/serverhub/views/apps/appsTable.js
+++ b/src/ui/views/browser/components/serverhub/views/apps/appsTable.js
@@ -1,0 +1,173 @@
+import { ensureArray } from '../../../../../../../core/helpers.js';
+
+function createQuickAction(instance, actionId, label, { onQuickAction }) {
+  const action = instance?.actionsById?.[actionId]
+    || ensureArray(instance?.actions).find(entry => entry.id === actionId);
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'serverhub-button serverhub-button--quiet serverhub-button--compact';
+  button.textContent = label;
+  if (!action || !action.available) {
+    button.disabled = true;
+  }
+  if (action?.disabledReason) {
+    button.title = action.disabledReason;
+  }
+  button.addEventListener('click', event => {
+    event.stopPropagation();
+    if (button.disabled) return;
+    onQuickAction(instance.id, action?.id || actionId);
+  });
+  return button;
+}
+
+function renderNameCell(instance, { selectInstance }) {
+  const nameButton = document.createElement('button');
+  nameButton.type = 'button';
+  nameButton.className = 'serverhub-table__link';
+  nameButton.textContent = instance.label;
+  nameButton.addEventListener('click', event => {
+    event.stopPropagation();
+    selectInstance(instance.id);
+  });
+  return nameButton;
+}
+
+function renderStatusCell(instance) {
+  const status = document.createElement('span');
+  status.className = 'serverhub-status';
+  status.dataset.state = instance.status?.id || 'setup';
+  status.textContent = instance.status?.label || 'Setup';
+  return status;
+}
+
+function renderActionsCell(instance, helpers) {
+  const { selectInstance } = helpers;
+  const group = document.createElement('div');
+  group.className = 'serverhub-action-group';
+  group.append(
+    createQuickAction(instance, 'shipFeature', 'Scale Up', helpers),
+    createQuickAction(instance, 'improveStability', 'Optimize', helpers)
+  );
+  const details = document.createElement('button');
+  details.type = 'button';
+  details.className = 'serverhub-button serverhub-button--ghost serverhub-button--compact';
+  details.textContent = 'View Details';
+  details.addEventListener('click', event => {
+    event.stopPropagation();
+    selectInstance(instance.id);
+  });
+  group.appendChild(details);
+  return group;
+}
+
+function renderEmptyTable(onLaunch) {
+  const empty = document.createElement('div');
+  empty.className = 'serverhub-empty';
+  const message = document.createElement('p');
+  message.textContent = 'No SaaS apps live yet. Deploy a new instance to kickstart recurring revenue.';
+  empty.appendChild(message);
+  const cta = document.createElement('button');
+  cta.type = 'button';
+  cta.className = 'serverhub-button serverhub-button--primary';
+  cta.textContent = 'Deploy New App';
+  cta.addEventListener('click', async () => {
+    await onLaunch();
+  });
+  empty.appendChild(cta);
+  return empty;
+}
+
+export function createAppsTable({ renderNicheCell }) {
+  const columnRenderers = {
+    name: renderNameCell,
+    status: renderStatusCell,
+    niche: renderNicheCell,
+    payout(instance, { formatCurrency }) {
+      const value = document.createElement('span');
+      value.textContent = formatCurrency(instance.latestPayout);
+      return value;
+    },
+    upkeep(instance, { formatCurrency }) {
+      const value = document.createElement('span');
+      value.textContent = formatCurrency(instance.upkeepCost);
+      return value;
+    },
+    roi(instance, { formatPercent }) {
+      const value = document.createElement('span');
+      value.textContent = formatPercent(instance.roi);
+      return value;
+    },
+    actions: renderActionsCell
+  };
+
+  return function renderAppsTable(instances, state, helpers, updateState) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'serverhub-table-wrapper';
+
+    if (!instances.length) {
+      wrapper.appendChild(renderEmptyTable(helpers.onLaunch));
+      return wrapper;
+    }
+
+    const table = document.createElement('table');
+    table.className = 'serverhub-table';
+
+    const thead = document.createElement('thead');
+    const headRow = document.createElement('tr');
+    helpers.tableColumns.forEach(column => {
+      if (!column) return;
+      const th = document.createElement('th');
+      th.scope = 'col';
+      th.className = column.headerClassName || 'serverhub-table__heading';
+      th.textContent = column.label;
+      headRow.appendChild(th);
+    });
+    thead.appendChild(headRow);
+    table.appendChild(thead);
+
+    const tbody = document.createElement('tbody');
+    instances.forEach(instance => {
+      const row = document.createElement('tr');
+      row.dataset.appId = instance.id;
+      row.className = 'serverhub-table__row';
+      if (instance.id === state.selectedAppId) {
+        row.classList.add('is-selected');
+      }
+
+      const selectInstance = id => {
+        updateState(current => ({ ...current, selectedAppId: id }));
+      };
+
+      helpers.tableColumns.forEach(column => {
+        if (!column) return;
+        const cell = document.createElement('td');
+        cell.className = column.cellClassName
+          ? `serverhub-table__cell ${column.cellClassName}`.trim()
+          : 'serverhub-table__cell';
+        const renderer = columnRenderers[column.renderer] || (value => value);
+        const content = renderer(instance, { ...helpers, selectInstance });
+        if (content != null) {
+          if (typeof content === 'string') {
+            cell.textContent = content;
+          } else {
+            cell.appendChild(content);
+          }
+        }
+        row.appendChild(cell);
+      });
+
+      row.addEventListener('click', () => {
+        selectInstance(instance.id);
+      });
+
+      tbody.appendChild(row);
+    });
+
+    table.appendChild(tbody);
+    wrapper.appendChild(table);
+    return wrapper;
+  };
+}
+
+export default createAppsTable;

--- a/src/ui/views/browser/components/serverhub/views/apps/detailSidebar.js
+++ b/src/ui/views/browser/components/serverhub/views/apps/detailSidebar.js
@@ -1,0 +1,98 @@
+function createStat(label, value, note = '') {
+  const item = document.createElement('div');
+  item.className = 'serverhub-detail__stat';
+
+  const title = document.createElement('span');
+  title.className = 'serverhub-detail__stat-label';
+  title.textContent = label;
+
+  const amount = document.createElement('strong');
+  amount.className = 'serverhub-detail__stat-value';
+  amount.textContent = value;
+
+  item.append(title, amount);
+
+  if (note) {
+    const noteEl = document.createElement('span');
+    noteEl.className = 'serverhub-detail__stat-note';
+    noteEl.textContent = note;
+    item.appendChild(noteEl);
+  }
+
+  return item;
+}
+
+export function renderDetailSidebar(model, state, helpers, config = {}) {
+  const { getSelectedApp } = helpers;
+  const {
+    stats = [],
+    panels = [],
+    footer
+  } = config;
+
+  const aside = document.createElement('aside');
+  aside.className = 'serverhub-sidebar';
+
+  const instance = getSelectedApp(model, state);
+  if (!instance) {
+    const empty = document.createElement('div');
+    empty.className = 'serverhub-detail__empty';
+    empty.textContent = 'Select an app to inspect uptime, payouts, and quality progress.';
+    aside.appendChild(empty);
+    return aside;
+  }
+
+  const header = document.createElement('header');
+  header.className = 'serverhub-detail__header';
+
+  const title = document.createElement('h2');
+  title.textContent = instance.label;
+
+  const status = document.createElement('span');
+  status.className = 'serverhub-status';
+  status.dataset.state = instance.status?.id || 'setup';
+  status.textContent = instance.status?.label || 'Active';
+
+  header.append(title, status);
+
+  const tabs = document.createElement('div');
+  tabs.className = 'serverhub-detail__tabs';
+
+  const overviewTab = document.createElement('button');
+  overviewTab.type = 'button';
+  overviewTab.className = 'serverhub-detail__tab is-active';
+  overviewTab.textContent = 'Overview';
+  overviewTab.disabled = true;
+
+  tabs.appendChild(overviewTab);
+
+  const statsContainer = document.createElement('div');
+  statsContainer.className = 'serverhub-detail__stats';
+  stats.forEach(entry => {
+    const value = entry.getValue(instance, helpers);
+    const note = typeof entry.getNote === 'function' ? entry.getNote(instance, helpers) : entry.note;
+    statsContainer.appendChild(createStat(entry.label, value, note));
+  });
+
+  const panelsContainer = document.createElement('div');
+  panelsContainer.className = 'serverhub-detail__grid';
+  panels.forEach(renderPanel => {
+    const panel = renderPanel(instance, helpers);
+    if (panel) {
+      panelsContainer.appendChild(panel);
+    }
+  });
+
+  aside.append(header, tabs, statsContainer, panelsContainer);
+
+  if (typeof footer === 'function') {
+    const footerNode = footer(instance, helpers);
+    if (footerNode) {
+      aside.appendChild(footerNode);
+    }
+  }
+
+  return aside;
+}
+
+export default renderDetailSidebar;

--- a/src/ui/views/browser/components/serverhub/views/apps/nicheSelector.js
+++ b/src/ui/views/browser/components/serverhub/views/apps/nicheSelector.js
@@ -1,0 +1,111 @@
+import { ensureArray } from '../../../../../../../core/helpers.js';
+
+export function renderNicheCell(instance, { onNicheSelect }) {
+  const fragment = document.createDocumentFragment();
+
+  if (instance.niche) {
+    const name = document.createElement('strong');
+    name.className = 'serverhub-niche__name';
+    name.textContent = instance.niche.name;
+
+    const note = document.createElement('span');
+    note.className = 'serverhub-niche__note';
+    note.textContent = instance.niche.label ? `${instance.niche.label}` : 'Trend data pending';
+
+    fragment.append(name, note);
+    return fragment;
+  }
+
+  if (instance.nicheLocked) {
+    const locked = document.createElement('span');
+    locked.className = 'serverhub-niche__locked';
+    locked.textContent = 'Locked';
+    fragment.appendChild(locked);
+    return fragment;
+  }
+
+  const select = document.createElement('select');
+  select.className = 'serverhub-select serverhub-select--inline';
+  select.ariaLabel = `Assign niche to ${instance.label}`;
+
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = 'Assign niche';
+  select.appendChild(placeholder);
+
+  ensureArray(instance.nicheOptions).forEach(option => {
+    const opt = document.createElement('option');
+    opt.value = option.id;
+    opt.textContent = `${option.name} (${option.label || 'Popularity pending'})`;
+    select.appendChild(opt);
+  });
+
+  select.addEventListener('click', event => event.stopPropagation());
+  select.addEventListener('change', event => {
+    const value = event.target.value;
+    if (!value) return;
+    onNicheSelect(instance.id, value);
+  });
+
+  fragment.appendChild(select);
+  return fragment;
+}
+
+export function renderNichePanel(instance, helpers) {
+  const section = document.createElement('section');
+  section.className = 'serverhub-panel';
+
+  const heading = document.createElement('h3');
+  heading.textContent = 'Niche targeting';
+  section.appendChild(heading);
+
+  if (instance.niche) {
+    const summary = document.createElement('p');
+    summary.className = 'serverhub-panel__lead';
+    const label = instance.niche.label ? `${instance.niche.label} • ` : '';
+    summary.textContent = `${label}${instance.niche.summary || 'Audience details updating daily.'}`;
+    section.appendChild(summary);
+  }
+
+  if (instance.nicheLocked) {
+    const locked = document.createElement('p');
+    locked.className = 'serverhub-panel__hint';
+    locked.textContent = 'Niche locked in — reroll popularity tomorrow for fresh multipliers.';
+    section.appendChild(locked);
+    return section;
+  }
+
+  const field = document.createElement('label');
+  field.className = 'serverhub-field';
+  field.textContent = 'Assign niche';
+
+  const select = document.createElement('select');
+  select.className = 'serverhub-select';
+
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = 'Select a niche';
+  select.appendChild(placeholder);
+
+  ensureArray(instance.nicheOptions).forEach(option => {
+    const opt = document.createElement('option');
+    opt.value = option.id;
+    opt.textContent = `${option.name} (${option.label || 'Popularity pending'})`;
+    select.appendChild(opt);
+  });
+
+  select.addEventListener('change', event => {
+    const value = event.target.value;
+    if (!value) return;
+    helpers.onNicheSelect(instance.id, value);
+  });
+
+  field.appendChild(select);
+  section.appendChild(field);
+  return section;
+}
+
+export default {
+  renderNicheCell,
+  renderNichePanel
+};

--- a/src/ui/views/browser/components/serverhub/views/apps/payoutBreakdown.js
+++ b/src/ui/views/browser/components/serverhub/views/apps/payoutBreakdown.js
@@ -1,0 +1,49 @@
+import { ensureArray } from '../../../../../../../core/helpers.js';
+
+export function renderPayoutBreakdown(instance, { formatCurrency, formatPercent }) {
+  const section = document.createElement('section');
+  section.className = 'serverhub-panel';
+
+  const heading = document.createElement('h3');
+  heading.textContent = 'Payout recap';
+  section.appendChild(heading);
+
+  const total = document.createElement('p');
+  total.className = 'serverhub-panel__lead';
+  total.textContent = `Yesterday: ${formatCurrency(instance.payoutBreakdown?.total || instance.latestPayout)}`;
+  section.appendChild(total);
+
+  const list = document.createElement('ul');
+  list.className = 'serverhub-breakdown';
+
+  const entries = ensureArray(instance.payoutBreakdown?.entries);
+  if (!entries.length) {
+    const item = document.createElement('li');
+    item.textContent = 'Core subscriptions, no modifiers yesterday.';
+    list.appendChild(item);
+  } else {
+    entries.forEach(entry => {
+      const item = document.createElement('li');
+      item.className = 'serverhub-breakdown__item';
+
+      const label = document.createElement('span');
+      label.className = 'serverhub-breakdown__label';
+      label.textContent = entry.label;
+
+      const value = document.createElement('span');
+      value.className = 'serverhub-breakdown__value';
+      const percent = entry.percent !== null && entry.percent !== undefined
+        ? ` (${formatPercent(entry.percent)})`
+        : '';
+      value.textContent = `${formatCurrency(entry.amount)}${percent}`;
+
+      item.append(label, value);
+      list.appendChild(item);
+    });
+  }
+
+  section.appendChild(list);
+  return section;
+}
+
+export default renderPayoutBreakdown;

--- a/src/ui/views/browser/components/serverhub/views/apps/qualityPanel.js
+++ b/src/ui/views/browser/components/serverhub/views/apps/qualityPanel.js
@@ -1,0 +1,41 @@
+export function renderQualityPanel(instance) {
+  if (!instance.milestone) {
+    return null;
+  }
+
+  const section = document.createElement('section');
+  section.className = 'serverhub-panel';
+
+  const heading = document.createElement('div');
+  heading.className = 'serverhub-panel__header';
+
+  const title = document.createElement('h3');
+  title.textContent = 'Quality tier';
+
+  const badge = document.createElement('span');
+  badge.className = 'serverhub-panel__badge';
+  badge.textContent = `Tier ${instance.milestone.level}`;
+
+  heading.append(title, badge);
+  section.appendChild(heading);
+
+  const progress = document.createElement('div');
+  progress.className = 'serverhub-progress';
+  progress.style.setProperty(
+    '--serverhub-progress',
+    String(Math.round((instance.milestone.percent || 0) * 100))
+  );
+
+  const progressFill = document.createElement('span');
+  progressFill.className = 'serverhub-progress__fill';
+  progress.appendChild(progressFill);
+
+  const summary = document.createElement('p');
+  summary.className = 'serverhub-panel__hint';
+  summary.textContent = instance.milestone.summary;
+
+  section.append(progress, summary);
+  return section;
+}
+
+export default renderQualityPanel;

--- a/src/ui/views/browser/components/serverhub/views/appsView.js
+++ b/src/ui/views/browser/components/serverhub/views/appsView.js
@@ -1,4 +1,12 @@
 import { ensureArray } from '../../../../../../core/helpers.js';
+import renderActionConsole from './apps/actionConsole.js';
+import { renderNicheCell, renderNichePanel } from './apps/nicheSelector.js';
+import renderPayoutBreakdown from './apps/payoutBreakdown.js';
+import renderQualityPanel from './apps/qualityPanel.js';
+import renderDetailSidebar from './apps/detailSidebar.js';
+import createAppsTable from './apps/appsTable.js';
+
+const renderAppsTable = createAppsTable({ renderNicheCell });
 
 function formatKpiValue(metric, descriptor, helpers) {
   const { formatCurrency, formatNetCurrency } = helpers;
@@ -17,468 +25,48 @@ function formatKpiValue(metric, descriptor, helpers) {
   }
 }
 
-function createQuickAction(instance, actionId, label, { onQuickAction }) {
-  const action = instance?.actionsById?.[actionId]
-    || ensureArray(instance?.actions).find(entry => entry.id === actionId);
-  const button = document.createElement('button');
-  button.type = 'button';
-  button.className = 'serverhub-button serverhub-button--quiet serverhub-button--compact';
-  button.textContent = label;
-  if (!action || !action.available) {
-    button.disabled = true;
-  }
-  if (action?.disabledReason) {
-    button.title = action.disabledReason;
-  }
-  button.addEventListener('click', event => {
-    event.stopPropagation();
-    if (button.disabled) return;
-    onQuickAction(instance.id, action?.id || actionId);
-  });
-  return button;
-}
-
-function renderNameCell(instance, { selectInstance }) {
-  const nameButton = document.createElement('button');
-  nameButton.type = 'button';
-  nameButton.className = 'serverhub-table__link';
-  nameButton.textContent = instance.label;
-  nameButton.addEventListener('click', event => {
-    event.stopPropagation();
-    selectInstance(instance.id);
-  });
-  return nameButton;
-}
-
-function renderStatusCell(instance) {
-  const status = document.createElement('span');
-  status.className = 'serverhub-status';
-  status.dataset.state = instance.status?.id || 'setup';
-  status.textContent = instance.status?.label || 'Setup';
-  return status;
-}
-
-function renderNicheCell(instance, { onNicheSelect }) {
-  const fragment = document.createDocumentFragment();
-  if (instance.niche) {
-    const name = document.createElement('strong');
-    name.className = 'serverhub-niche__name';
-    name.textContent = instance.niche.name;
-    const note = document.createElement('span');
-    note.className = 'serverhub-niche__note';
-    note.textContent = instance.niche.label
-      ? `${instance.niche.label}`
-      : 'Trend data pending';
-    fragment.append(name, note);
-    return fragment;
-  }
-  if (instance.nicheLocked) {
-    const locked = document.createElement('span');
-    locked.className = 'serverhub-niche__locked';
-    locked.textContent = 'Locked';
-    fragment.appendChild(locked);
-    return fragment;
-  }
-  const select = document.createElement('select');
-  select.className = 'serverhub-select serverhub-select--inline';
-  select.ariaLabel = `Assign niche to ${instance.label}`;
-  const placeholder = document.createElement('option');
-  placeholder.value = '';
-  placeholder.textContent = 'Assign niche';
-  select.appendChild(placeholder);
-  ensureArray(instance.nicheOptions).forEach(option => {
-    const opt = document.createElement('option');
-    opt.value = option.id;
-    opt.textContent = `${option.name} (${option.label || 'Popularity pending'})`;
-    select.appendChild(opt);
-  });
-  select.addEventListener('click', event => event.stopPropagation());
-  select.addEventListener('change', event => {
-    const value = event.target.value;
-    if (!value) return;
-    onNicheSelect(instance.id, value);
-  });
-  fragment.appendChild(select);
-  return fragment;
-}
-
-function renderActionsCell(instance, helpers) {
-  const { selectInstance } = helpers;
-  const group = document.createElement('div');
-  group.className = 'serverhub-action-group';
-  group.append(
-    createQuickAction(instance, 'shipFeature', 'Scale Up', helpers),
-    createQuickAction(instance, 'improveStability', 'Optimize', helpers)
-  );
-  const details = document.createElement('button');
-  details.type = 'button';
-  details.className = 'serverhub-button serverhub-button--ghost serverhub-button--compact';
-  details.textContent = 'View Details';
-  details.addEventListener('click', event => {
-    event.stopPropagation();
-    selectInstance(instance.id);
-  });
-  group.appendChild(details);
-  return group;
-}
-
-const COLUMN_RENDERERS = {
-  name: renderNameCell,
-  status: renderStatusCell,
-  niche: renderNicheCell,
-  payout(instance, { formatCurrency }) {
-    const value = document.createElement('span');
-    value.textContent = formatCurrency(instance.latestPayout);
-    return value;
+const DETAIL_STATS_CONFIG = [
+  {
+    label: 'Daily earnings',
+    getValue: (instance, helpers) => helpers.formatCurrency(instance.latestPayout)
   },
-  upkeep(instance, { formatCurrency }) {
-    const value = document.createElement('span');
-    value.textContent = formatCurrency(instance.upkeepCost);
-    return value;
+  {
+    label: 'Average daily',
+    getValue: (instance, helpers) => helpers.formatCurrency(instance.averagePayout)
   },
-  roi(instance, { formatPercent }) {
-    const value = document.createElement('span');
-    value.textContent = formatPercent(instance.roi);
-    return value;
+  {
+    label: 'Pending income',
+    getValue: (instance, helpers) => helpers.formatCurrency(instance.pendingIncome)
   },
-  actions: renderActionsCell
-};
-
-function createStat(label, value, note = '') {
-  const item = document.createElement('div');
-  item.className = 'serverhub-detail__stat';
-  const title = document.createElement('span');
-  title.className = 'serverhub-detail__stat-label';
-  title.textContent = label;
-  const amount = document.createElement('strong');
-  amount.className = 'serverhub-detail__stat-value';
-  amount.textContent = value;
-  item.append(title, amount);
-  if (note) {
-    const noteEl = document.createElement('span');
-    noteEl.className = 'serverhub-detail__stat-note';
-    noteEl.textContent = note;
-    item.appendChild(noteEl);
+  {
+    label: 'Lifetime revenue',
+    getValue: (instance, helpers) => helpers.formatCurrency(instance.lifetimeIncome)
+  },
+  {
+    label: 'Lifetime spend',
+    getValue: (instance, helpers) => helpers.formatCurrency(instance.lifetimeSpend)
+  },
+  {
+    label: 'Net profit',
+    getValue: (instance, helpers) => helpers.formatNetCurrency(instance.profit)
+  },
+  {
+    label: 'ROI',
+    getValue: (instance, helpers) => helpers.formatPercent(instance.roi)
+  },
+  {
+    label: 'Days live',
+    getValue: instance => `${instance.daysLive} day${instance.daysLive === 1 ? '' : 's'}`
   }
-  return item;
-}
+];
 
-function renderActionConsole(instance, { actionConsoleOrder, onQuickAction, formatCurrency, formatHours }) {
-  const section = document.createElement('section');
-  section.className = 'serverhub-panel serverhub-panel--actions';
-  const heading = document.createElement('h3');
-  heading.textContent = 'Action console';
-  section.appendChild(heading);
+const DETAIL_PANELS = [
+  instance => renderQualityPanel(instance),
+  (instance, helpers) => renderNichePanel(instance, helpers),
+  (instance, helpers) => renderPayoutBreakdown(instance, helpers)
+];
 
-  const list = document.createElement('div');
-  list.className = 'serverhub-action-console';
-
-  const actions = ensureArray(instance.actions);
-  let rendered = 0;
-
-  ensureArray(actionConsoleOrder).forEach(({ id, label }) => {
-    const action = instance.actionsById?.[id] || actions.find(entry => entry.id === id);
-    if (!action) return;
-    const button = document.createElement('button');
-    button.type = 'button';
-    button.className = 'serverhub-action-console__button';
-    const actionLabel = document.createElement('span');
-    actionLabel.className = 'serverhub-action-console__label';
-    actionLabel.textContent = action.label || label;
-    const meta = document.createElement('span');
-    meta.className = 'serverhub-action-console__meta';
-    const timeLabel = Number(action.time) > 0 ? formatHours(action.time) : 'Instant';
-    const costLabel = formatCurrency(action.cost || 0);
-    meta.textContent = `${timeLabel} • ${costLabel}`;
-    if (!action.available) {
-      button.disabled = true;
-      if (action.disabledReason) {
-        button.title = action.disabledReason;
-      }
-    }
-    button.append(actionLabel, meta);
-    button.addEventListener('click', event => {
-      event.stopPropagation();
-      if (button.disabled) return;
-      onQuickAction(instance.id, action.id);
-    });
-    list.appendChild(button);
-    rendered += 1;
-  });
-
-  if (!rendered) {
-    const empty = document.createElement('p');
-    empty.className = 'serverhub-panel__hint';
-    empty.textContent = 'Quality actions unlock as your SaaS portfolio grows.';
-    section.appendChild(empty);
-  } else {
-    section.appendChild(list);
-  }
-
-  return section;
-}
-
-function renderNicheSection(instance, helpers) {
-  const section = document.createElement('section');
-  section.className = 'serverhub-panel';
-  const heading = document.createElement('h3');
-  heading.textContent = 'Niche targeting';
-  section.appendChild(heading);
-
-  if (instance.niche) {
-    const summary = document.createElement('p');
-    summary.className = 'serverhub-panel__lead';
-    const label = instance.niche.label ? `${instance.niche.label} • ` : '';
-    summary.textContent = `${label}${instance.niche.summary || 'Audience details updating daily.'}`;
-    section.appendChild(summary);
-  }
-
-  if (instance.nicheLocked) {
-    const locked = document.createElement('p');
-    locked.className = 'serverhub-panel__hint';
-    locked.textContent = 'Niche locked in — reroll popularity tomorrow for fresh multipliers.';
-    section.appendChild(locked);
-    return section;
-  }
-
-  const field = document.createElement('label');
-  field.className = 'serverhub-field';
-  field.textContent = 'Assign niche';
-  const select = document.createElement('select');
-  select.className = 'serverhub-select';
-  const placeholder = document.createElement('option');
-  placeholder.value = '';
-  placeholder.textContent = 'Select a niche';
-  select.appendChild(placeholder);
-  ensureArray(instance.nicheOptions).forEach(option => {
-    const opt = document.createElement('option');
-    opt.value = option.id;
-    opt.textContent = `${option.name} (${option.label || 'Popularity pending'})`;
-    select.appendChild(opt);
-  });
-  select.addEventListener('change', event => {
-    const value = event.target.value;
-    if (!value) return;
-    helpers.onNicheSelect(instance.id, value);
-  });
-  field.appendChild(select);
-  section.appendChild(field);
-  return section;
-}
-
-function renderPayoutBreakdown(instance, { formatCurrency, formatPercent }) {
-  const section = document.createElement('section');
-  section.className = 'serverhub-panel';
-  const heading = document.createElement('h3');
-  heading.textContent = 'Payout recap';
-  section.appendChild(heading);
-
-  const total = document.createElement('p');
-  total.className = 'serverhub-panel__lead';
-  total.textContent = `Yesterday: ${formatCurrency(instance.payoutBreakdown?.total || instance.latestPayout)}`;
-  section.appendChild(total);
-
-  const list = document.createElement('ul');
-  list.className = 'serverhub-breakdown';
-  const entries = ensureArray(instance.payoutBreakdown?.entries);
-  if (!entries.length) {
-    const item = document.createElement('li');
-    item.textContent = 'Core subscriptions, no modifiers yesterday.';
-    list.appendChild(item);
-  } else {
-    entries.forEach(entry => {
-      const item = document.createElement('li');
-      item.className = 'serverhub-breakdown__item';
-      const label = document.createElement('span');
-      label.className = 'serverhub-breakdown__label';
-      label.textContent = entry.label;
-      const value = document.createElement('span');
-      value.className = 'serverhub-breakdown__value';
-      const percent = entry.percent !== null && entry.percent !== undefined
-        ? ` (${formatPercent(entry.percent)})`
-        : '';
-      value.textContent = `${formatCurrency(entry.amount)}${percent}`;
-      item.append(label, value);
-      list.appendChild(item);
-    });
-  }
-  section.appendChild(list);
-  return section;
-}
-
-function renderQualitySection(instance) {
-  if (!instance.milestone) {
-    return null;
-  }
-  const section = document.createElement('section');
-  section.className = 'serverhub-panel';
-  const heading = document.createElement('div');
-  heading.className = 'serverhub-panel__header';
-  const title = document.createElement('h3');
-  title.textContent = 'Quality tier';
-  const badge = document.createElement('span');
-  badge.className = 'serverhub-panel__badge';
-  badge.textContent = `Tier ${instance.milestone.level}`;
-  heading.append(title, badge);
-  section.appendChild(heading);
-
-  const progress = document.createElement('div');
-  progress.className = 'serverhub-progress';
-  progress.style.setProperty('--serverhub-progress', String(Math.round((instance.milestone.percent || 0) * 100)));
-  const progressFill = document.createElement('span');
-  progressFill.className = 'serverhub-progress__fill';
-  progress.appendChild(progressFill);
-
-  const summary = document.createElement('p');
-  summary.className = 'serverhub-panel__hint';
-  summary.textContent = instance.milestone.summary;
-
-  section.append(progress, summary);
-  return section;
-}
-
-function renderDetailPanel(model, state, helpers) {
-  const aside = document.createElement('aside');
-  aside.className = 'serverhub-sidebar';
-  const instance = helpers.getSelectedApp(model, state);
-  if (!instance) {
-    const empty = document.createElement('div');
-    empty.className = 'serverhub-detail__empty';
-    empty.textContent = 'Select an app to inspect uptime, payouts, and quality progress.';
-    aside.appendChild(empty);
-    return aside;
-  }
-
-  const header = document.createElement('header');
-  header.className = 'serverhub-detail__header';
-  const title = document.createElement('h2');
-  title.textContent = instance.label;
-  const status = document.createElement('span');
-  status.className = 'serverhub-status';
-  status.dataset.state = instance.status?.id || 'setup';
-  status.textContent = instance.status?.label || 'Active';
-  header.append(title, status);
-
-  const tabs = document.createElement('div');
-  tabs.className = 'serverhub-detail__tabs';
-  const overviewTab = document.createElement('button');
-  overviewTab.type = 'button';
-  overviewTab.className = 'serverhub-detail__tab is-active';
-  overviewTab.textContent = 'Overview';
-  overviewTab.disabled = true;
-  tabs.appendChild(overviewTab);
-
-  const stats = document.createElement('div');
-  stats.className = 'serverhub-detail__stats';
-  stats.append(
-    createStat('Daily earnings', helpers.formatCurrency(instance.latestPayout)),
-    createStat('Average daily', helpers.formatCurrency(instance.averagePayout)),
-    createStat('Pending income', helpers.formatCurrency(instance.pendingIncome)),
-    createStat('Lifetime revenue', helpers.formatCurrency(instance.lifetimeIncome)),
-    createStat('Lifetime spend', helpers.formatCurrency(instance.lifetimeSpend)),
-    createStat('Net profit', helpers.formatNetCurrency(instance.profit)),
-    createStat('ROI', helpers.formatPercent(instance.roi)),
-    createStat('Days live', `${instance.daysLive} day${instance.daysLive === 1 ? '' : 's'}`)
-  );
-
-  const panels = document.createElement('div');
-  panels.className = 'serverhub-detail__grid';
-  const quality = renderQualitySection(instance);
-  if (quality) {
-    panels.appendChild(quality);
-  }
-  panels.append(
-    renderNicheSection(instance, helpers),
-    renderPayoutBreakdown(instance, helpers)
-  );
-
-  aside.append(header, tabs, stats, panels, renderActionConsole(instance, helpers));
-  return aside;
-}
-
-function renderEmptyTable(onLaunch) {
-  const empty = document.createElement('div');
-  empty.className = 'serverhub-empty';
-  const message = document.createElement('p');
-  message.textContent = 'No SaaS apps live yet. Deploy a new instance to kickstart recurring revenue.';
-  empty.appendChild(message);
-  const cta = document.createElement('button');
-  cta.type = 'button';
-  cta.className = 'serverhub-button serverhub-button--primary';
-  cta.textContent = 'Deploy New App';
-  cta.addEventListener('click', async () => {
-    await onLaunch();
-  });
-  empty.appendChild(cta);
-  return empty;
-}
-
-function renderAppsTable(instances, state, helpers, updateState) {
-  const wrapper = document.createElement('div');
-  wrapper.className = 'serverhub-table-wrapper';
-
-  if (!instances.length) {
-    wrapper.appendChild(renderEmptyTable(helpers.onLaunch));
-    return wrapper;
-  }
-
-  const table = document.createElement('table');
-  table.className = 'serverhub-table';
-  const thead = document.createElement('thead');
-  const headRow = document.createElement('tr');
-  helpers.tableColumns.forEach(column => {
-    if (!column) return;
-    const th = document.createElement('th');
-    th.scope = 'col';
-    th.className = column.headerClassName || 'serverhub-table__heading';
-    th.textContent = column.label;
-    headRow.appendChild(th);
-  });
-  thead.appendChild(headRow);
-  table.appendChild(thead);
-
-  const tbody = document.createElement('tbody');
-  instances.forEach(instance => {
-    const row = document.createElement('tr');
-    row.dataset.appId = instance.id;
-    row.className = 'serverhub-table__row';
-    if (instance.id === state.selectedAppId) {
-      row.classList.add('is-selected');
-    }
-
-    const selectInstance = id => {
-      updateState(current => ({ ...current, selectedAppId: id }));
-    };
-
-    helpers.tableColumns.forEach(column => {
-      if (!column) return;
-      const cell = document.createElement('td');
-      cell.className = column.cellClassName
-        ? `serverhub-table__cell ${column.cellClassName}`.trim()
-        : 'serverhub-table__cell';
-      const renderer = COLUMN_RENDERERS[column.renderer] || (value => value);
-      const content = renderer(instance, { ...helpers, selectInstance });
-      if (content != null) {
-        if (typeof content === 'string') {
-          cell.textContent = content;
-        } else {
-          cell.appendChild(content);
-        }
-      }
-      row.appendChild(cell);
-    });
-
-    row.addEventListener('click', () => {
-      selectInstance(instance.id);
-    });
-
-    tbody.appendChild(row);
-  });
-
-  table.appendChild(tbody);
-  wrapper.appendChild(table);
-  return wrapper;
-}
+const DETAIL_FOOTER = (instance, helpers) => renderActionConsole(instance, helpers);
 
 function renderMetrics(model, helpers) {
   const metrics = document.createElement('section');
@@ -538,6 +126,12 @@ export function createAppsView(options = {}) {
     getSelectedApp
   };
 
+  const detailConfig = {
+    stats: DETAIL_STATS_CONFIG,
+    panels: DETAIL_PANELS,
+    footer: DETAIL_FOOTER
+  };
+
   return function renderAppsView({ model = {}, state = {}, updateState }) {
     const section = document.createElement('section');
     section.className = 'serverhub-view serverhub-view--apps';
@@ -548,7 +142,7 @@ export function createAppsView(options = {}) {
     const instances = ensureArray(model.instances);
     layout.append(
       renderAppsTable(instances, state, helpers, updateState),
-      renderDetailPanel(model, state, helpers)
+      renderDetailSidebar(model, state, helpers, detailConfig)
     );
 
     section.appendChild(layout);

--- a/tests/ui/views/serverhub/apps/helpers.test.js
+++ b/tests/ui/views/serverhub/apps/helpers.test.js
@@ -1,0 +1,126 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+import renderActionConsole from '../../../../../src/ui/views/browser/components/serverhub/views/apps/actionConsole.js';
+import { renderNicheCell } from '../../../../../src/ui/views/browser/components/serverhub/views/apps/nicheSelector.js';
+import renderDetailSidebar from '../../../../../src/ui/views/browser/components/serverhub/views/apps/detailSidebar.js';
+
+function withDom(callback) {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>');
+  const { document } = dom.window;
+  const previousDocument = globalThis.document;
+  globalThis.document = document;
+  try {
+    callback({ dom, document });
+  } finally {
+    if (previousDocument) {
+      globalThis.document = previousDocument;
+    } else {
+      delete globalThis.document;
+    }
+    dom.window.close();
+  }
+}
+
+test('action console disables unavailable actions and shows reason', () => {
+  withDom(() => {
+    let triggered = false;
+    const instance = {
+      id: 'app-1',
+      actions: [
+        { id: 'shipFeature', label: 'Scale Up', available: false, disabledReason: 'Needs upgrades', time: 2, cost: 100 }
+      ],
+      actionsById: {
+        shipFeature: { id: 'shipFeature', label: 'Scale Up', available: false, disabledReason: 'Needs upgrades', time: 2, cost: 100 }
+      }
+    };
+    const helpers = {
+      actionConsoleOrder: [{ id: 'shipFeature', label: 'Scale Up' }],
+      formatCurrency: value => `$${value}`,
+      formatHours: value => `${value}h`,
+      onQuickAction() {
+        triggered = true;
+      }
+    };
+
+    const section = renderActionConsole(instance, helpers);
+    const button = section.querySelector('button.serverhub-action-console__button');
+    assert.ok(button, 'expected button to render');
+    assert.equal(button.disabled, true);
+    assert.equal(button.title, 'Needs upgrades');
+
+    button.click();
+    assert.equal(triggered, false, 'click should be ignored when disabled');
+  });
+});
+
+test('action console shows hint when no ordered actions are available', () => {
+  withDom(() => {
+    const instance = {
+      id: 'app-1',
+      actions: [],
+      actionsById: {}
+    };
+    const helpers = {
+      actionConsoleOrder: [{ id: 'missing', label: 'Missing' }],
+      formatCurrency: value => `$${value}`,
+      formatHours: value => `${value}h`,
+      onQuickAction: () => {}
+    };
+
+    const section = renderActionConsole(instance, helpers);
+    const hint = section.querySelector('.serverhub-panel__hint');
+    assert.ok(hint, 'expected hint to render');
+    assert.match(hint.textContent, /Quality actions unlock/);
+  });
+});
+
+test('niche selector change triggers callback with selection', () => {
+  withDom(({ dom }) => {
+    const picked = [];
+    const instance = {
+      id: 'app-7',
+      label: 'Test App',
+      nicheOptions: [
+        { id: 'n1', name: 'Creators', label: 'High' },
+        { id: 'n2', name: 'Gamers', label: 'Medium' }
+      ]
+    };
+
+    const fragment = renderNicheCell(instance, {
+      onNicheSelect(appId, nicheId) {
+        picked.push({ appId, nicheId });
+      }
+    });
+
+    const container = dom.window.document.createElement('div');
+    container.appendChild(fragment);
+    const select = container.querySelector('select');
+    assert.ok(select, 'expected select to render for unassigned niche');
+
+    select.value = 'n2';
+    select.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+
+    assert.deepEqual(picked, [{ appId: 'app-7', nicheId: 'n2' }]);
+  });
+});
+
+test('detail sidebar renders empty guidance when no app selected', () => {
+  withDom(() => {
+    const helpers = {
+      getSelectedApp: () => null
+    };
+
+    const aside = renderDetailSidebar(
+      { instances: [] },
+      { selectedAppId: null },
+      helpers,
+      { stats: [], panels: [], footer: null }
+    );
+
+    const empty = aside.querySelector('.serverhub-detail__empty');
+    assert.ok(empty, 'expected empty state to render');
+    assert.match(empty.textContent, /Select an app/);
+  });
+});


### PR DESCRIPTION
## Summary
- extract the serverhub apps action console, niche targeting, payout recap, quality panel, and sidebar logic into dedicated helpers
- reorganize the apps view to use the new helpers via configuration and delegate table rendering to a shared builder
- add DOM-focused unit tests that cover action availability, niche assignment, and empty sidebar states

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e07647b2c8832ca7252315bd4f9d63