### PR TITLE
Add prepare workflow to run npm prepare script

### DIFF
--- a/.github/workflows/prepare.yml
+++ b/.github/workflows/prepare.yml
@@ -1,0 +1,20 @@
+name: Run npm run prepare on main branch
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm install
+      - run: npm run prepare


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs dependencies and runs `npm run prepare`
- ensure the prepare script runs on pushes and pull requests to main

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e07855cfa0832c95cafb6f1cbdfa5a