### PR TITLE
Fix bank widget responsive layout

### DIFF
--- a/styles/widgets/bank.css
+++ b/styles/widgets/bank.css
@@ -98,3 +98,19 @@
 .bank-widget__chip[data-tone='in'] .bank-widget__chip-value {
   color: var(--browser-positive);
 }
+
+@media (max-width: 680px) {
+  .bank-widget__highlights {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .bank-widget__column {
+    justify-items: center;
+  }
+
+  .bank-widget__column--left,
+  .bank-widget__column--right {
+    align-self: stretch;
+    text-align: center;
+  }
+}

--- a/styles/workspaces/workspaces.css
+++ b/styles/workspaces/workspaces.css
@@ -1,8 +1,3 @@
-    align-self: stretch;
-    text-align: center;
-  }
-}
-
 .digishelf {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- remove orphaned declarations from the top of the workspaces stylesheet
- restore the bank widget's small-screen media query so its columns stack and align correctly

## Testing
- npm run build:css
- Manually verified the bank widget layout at a 520px viewport

------
https://chatgpt.com/codex/tasks/task_e_68e07bdf4448832cbc4b1c588c3fbdf3