### PR TITLE
Refactor: prune unused exports across game and UI modules

### DIFF
--- a/src/game/assets/maintenance.js
+++ b/src/game/assets/maintenance.js
@@ -25,9 +25,3 @@ export function maintenanceDetail(definition) {
   return `🛠 Maintenance: <strong>${summary.parts.join(' + ')}</strong>`;
 }
 
-const MaintenanceHelpers = {
-  formatMaintenanceSummary,
-  maintenanceDetail
-};
-
-export default MaintenanceHelpers;

--- a/src/game/assets/niches.js
+++ b/src/game/assets/niches.js
@@ -151,7 +151,7 @@ export function getInstanceNicheInfo(instance, state = getState()) {
   return { definition, popularity };
 }
 
-export function getAssignableNiches(definition) {
+function getAssignableNiches(definition) {
   if (!definition) return [];
   const tags = new Set(Array.isArray(definition.tags) ? definition.tags : []);
   const definitions = getNicheDefinitions();

--- a/src/game/assets/payout.js
+++ b/src/game/assets/payout.js
@@ -231,10 +231,3 @@ export function getIncomeRangeForDisplay(assetId) {
   return getDailyIncomeRange(definition);
 }
 
-const Payout = {
-  getDailyIncomeRange,
-  rollDailyIncome,
-  getIncomeRangeForDisplay
-};
-
-export default Payout;

--- a/src/game/assets/quality.js
+++ b/src/game/assets/quality.js
@@ -121,7 +121,7 @@ function getQualityActionAvailabilityInternal(definition, instance, action, stat
   return { ...availability };
 }
 
-export function getQualityConfig(definition) {
+function getQualityConfig(definition) {
   return definition?.quality || null;
 }
 
@@ -149,7 +149,7 @@ export function getNextQualityLevel(definition, level) {
   return levels.find(entry => entry.level === level + 1) || null;
 }
 
-export function getHighestQualityLevel(definition) {
+function getHighestQualityLevel(definition) {
   const levels = getSortedLevels(definition);
   if (!levels.length) return null;
   return levels.at(-1);
@@ -170,7 +170,7 @@ function meetsRequirements(progress, requirements = {}) {
   return true;
 }
 
-export function calculateEligibleQualityLevel(definition, progress = {}) {
+function calculateEligibleQualityLevel(definition, progress = {}) {
   const levels = getSortedLevels(definition);
   if (!levels.length) return 0;
   let eligible = 0;
@@ -438,9 +438,4 @@ export function getQualityLevelSummary(definition) {
     income: level.income,
     requirements: level.requirements
   }));
-}
-
-export function getQualityNextRequirements(definition, level) {
-  const next = getNextQualityLevel(definition, level);
-  return next?.requirements || null;
 }

--- a/src/game/content/schema/logMessaging.js
+++ b/src/game/content/schema/logMessaging.js
@@ -48,7 +48,7 @@ export function formatSlotMap(map) {
     .join(', ');
 }
 
-export function describeTargetScope(scope) {
+function describeTargetScope(scope) {
   if (!scope || typeof scope !== 'object') return '';
   const tags = ensureArray(scope.tags).map(tag => `#${tag}`);
   const ids = ensureArray(scope.ids);

--- a/src/game/educationEffects.js
+++ b/src/game/educationEffects.js
@@ -70,12 +70,12 @@ function buildBoostIndexes() {
 
 const BOOST_INDEX = buildBoostIndexes();
 
-export function getInstantHustleEducationBonuses(hustleId) {
+function getInstantHustleEducationBonuses(hustleId) {
   if (!hustleId) return [];
   return BOOST_INDEX.byHustle.get(hustleId) || [];
 }
 
-export function getAssetEducationBonuses(assetId) {
+function getAssetEducationBonuses(assetId) {
   if (!assetId) return [];
   return BOOST_INDEX.byAsset.get(assetId) || [];
 }

--- a/src/game/hustles/helpers.js
+++ b/src/game/hustles/helpers.js
@@ -17,12 +17,12 @@ export const BUG_SQUASH_REQUIREMENTS = [{ assetId: 'saas', count: 1 }];
 export const NARRATION_REQUIREMENTS = [{ assetId: 'ebook', count: 1 }];
 export const STREET_PROMO_REQUIREMENTS = [{ assetId: 'blog', count: 2 }];
 
-export function getHustleRequirements(definition) {
+function getHustleRequirements(definition) {
   if (!definition) return [];
   return Array.isArray(definition.requirements) ? definition.requirements : [];
 }
 
-export function normalizeHustleDailyUsage(definition, state = getState()) {
+function normalizeHustleDailyUsage(definition, state = getState()) {
   if (!definition || typeof definition.getDailyUsage !== 'function') {
     const dayFromState = Number(state?.day);
     return {
@@ -49,7 +49,7 @@ export function normalizeHustleDailyUsage(definition, state = getState()) {
   return { limit, used, remaining, day };
 }
 
-export function describeDailyLimit(definition, state = getState()) {
+function describeDailyLimit(definition, state = getState()) {
   const usage = normalizeHustleDailyUsage(definition, state);
   if (!usage || !Number.isFinite(usage.limit) || usage.limit <= 0) return [];
   const { used, remaining, limit } = usage;

--- a/src/game/hustles/knowledgeHustles.js
+++ b/src/game/hustles/knowledgeHustles.js
@@ -9,7 +9,7 @@ import {
 } from '../requirements.js';
 import { describeTrackEducationBonuses } from '../educationEffects.js';
 
-export function createKnowledgeTrackPresenter(track) {
+function createKnowledgeTrackPresenter(track) {
   let cachedSignature = null;
   let cachedViewModel = null;
 

--- a/src/game/requirements.js
+++ b/src/game/requirements.js
@@ -49,16 +49,11 @@ export {
   KNOWLEDGE_TRACKS,
   KNOWLEDGE_REWARDS,
   getKnowledgeProgress,
-  estimateManualMaintenanceReserve,
-  getDefinitionRequirements,
   buildAssetRequirementDescriptor,
-  describeRequirement,
   formatAssetRequirementLabel,
   summarizeAssetRequirements,
   renderAssetRequirementDetail,
   listAssetRequirementDescriptors,
   updateAssetCardLock,
-  isRequirementMet,
-  definitionRequirementsMet,
   assetRequirementsMetById
 };

--- a/src/game/requirements/checks.js
+++ b/src/game/requirements/checks.js
@@ -51,11 +51,3 @@ export function assetRequirementsMetById(id, state = getState()) {
   return definitionRequirementsMet(definition, state);
 }
 
-export default {
-  isEquipmentUnlocked,
-  isKnowledgeComplete,
-  hasExperience,
-  isRequirementMet,
-  definitionRequirementsMet,
-  assetRequirementsMetById
-};

--- a/src/game/requirements/definitionRequirements.js
+++ b/src/game/requirements/definitionRequirements.js
@@ -18,5 +18,3 @@ export function getDefinitionRequirements(definition) {
   return bundle;
 }
 
-export { EMPTY_REQUIREMENTS };
-export default getDefinitionRequirements;

--- a/src/game/requirements/descriptors.js
+++ b/src/game/requirements/descriptors.js
@@ -189,12 +189,3 @@ export function updateAssetCardLock(assetId, card, state = getState()) {
   card.classList.toggle('locked', locked);
 }
 
-export default {
-  buildAssetRequirementDescriptor,
-  describeRequirement,
-  formatAssetRequirementLabel,
-  summarizeAssetRequirements,
-  renderAssetRequirementDetail,
-  listAssetRequirementDescriptors,
-  updateAssetCardLock
-};

--- a/src/game/requirements/knowledgeProgress.js
+++ b/src/game/requirements/knowledgeProgress.js
@@ -30,4 +30,3 @@ export function getKnowledgeProgress(id, target = getState()) {
   return progress;
 }
 
-export default getKnowledgeProgress;

--- a/src/game/requirements/maintenanceReserve.js
+++ b/src/game/requirements/maintenanceReserve.js
@@ -29,4 +29,3 @@ export function estimateManualMaintenanceReserve(state = getState()) {
   return Math.max(0, upkeepDemand);
 }
 
-export default estimateManualMaintenanceReserve;

--- a/src/game/requirements/orchestrator.js
+++ b/src/game/requirements/orchestrator.js
@@ -209,4 +209,3 @@ export function createRequirementsOrchestrator({
   };
 }
 
-export default createRequirementsOrchestrator;

--- a/src/game/schema/metrics.js
+++ b/src/game/schema/metrics.js
@@ -38,7 +38,7 @@ function registerMetric(index, metricId, definition, category, metricType) {
   });
 }
 
-export function attachHustleMetricIds(definition) {
+function attachHustleMetricIds(definition) {
   if (!definition || !definition.id) return definition;
   const metricIds = { ...(definition.metricIds || {}) };
   for (const type of METRIC_TYPES) {
@@ -55,7 +55,7 @@ export function attachHustleMetricIds(definition) {
   return definition;
 }
 
-export function attachAssetMetricIds(definition) {
+function attachAssetMetricIds(definition) {
   if (!definition || !definition.id) return definition;
   const metricIds = { ...(definition.metricIds || {}) };
   const setup = ensureObject(metricIds, 'setup');

--- a/src/game/schema/requirements.js
+++ b/src/game/schema/requirements.js
@@ -88,7 +88,7 @@ function normalizeRequirementEntry(entry) {
   return null;
 }
 
-export function normalizeRequirementConfig(config) {
+function normalizeRequirementConfig(config) {
   const byType = {
     equipment: [],
     knowledge: [],

--- a/src/game/summary/selectors.js
+++ b/src/game/summary/selectors.js
@@ -20,7 +20,7 @@ function normalizeCategory(entryCategory, fallbackCategory) {
   return 'general';
 }
 
-export function selectPassiveAssetSources(state = getState()) {
+function selectPassiveAssetSources(state = getState()) {
   if (!state) return new Map();
   const summaries = new Map();
 

--- a/src/game/upgrades/definitions/index.js
+++ b/src/game/upgrades/definitions/index.js
@@ -817,4 +817,3 @@ export const UPGRADE_DEFINITIONS = [
   }
 ];
 
-export default UPGRADE_DEFINITIONS;

--- a/src/game/upgrades/detailResolvers.js
+++ b/src/game/upgrades/detailResolvers.js
@@ -43,4 +43,3 @@ export function resolveDetailEntry(entry) {
   return null;
 }
 
-export { countActiveInstances, describeKnowledgeProgress };

--- a/src/ui/cards.js
+++ b/src/ui/cards.js
@@ -98,23 +98,3 @@ export function updateAllCards(registries = {}, models) {
   updateSharedCollections(payload, {}, presenterOptions);
 }
 
-export function updateCard(definition) {
-  const presenter = getActiveCardsPresenter();
-  if (presenter?.updateCard) {
-    presenter.updateCard(definition);
-    return;
-  }
-
-  renderSharedCollections();
-}
-
-export function refreshUpgradeSections() {
-  const presenter = getActiveCardsPresenter();
-  if (presenter?.refreshUpgradeSections) {
-    presenter.refreshUpgradeSections();
-    return;
-  }
-
-  renderSharedCollections();
-}
-

--- a/src/ui/cards/model/assets.js
+++ b/src/ui/cards/model/assets.js
@@ -71,7 +71,7 @@ export function describeAssetLaunchAvailability(definition, state = getState()) 
   return { disabled: reasons.length > 0, reasons, hours, cost };
 }
 
-export function buildAssetModels(definitions = [], helpers = {}) {
+function buildAssetModels(definitions = [], helpers = {}) {
   const {
     getState: getStateFn = getState,
     getAssetState: getAssetStateFn = getAssetState

--- a/src/ui/cards/model/education.js
+++ b/src/ui/cards/model/education.js
@@ -68,7 +68,7 @@ export function resolveTrack(definition) {
   };
 }
 
-export function buildEducationModels(definitions = [], helpers = {}) {
+function buildEducationModels(definitions = [], helpers = {}) {
   const {
     getState: getStateFn = getState,
     getKnowledgeProgress: getKnowledgeProgressFn = getKnowledgeProgress,

--- a/src/ui/cards/model/finance/index.js
+++ b/src/ui/cards/model/finance/index.js
@@ -202,7 +202,7 @@ function buildActivityFeed(state) {
     .reverse();
 }
 
-export function buildFinanceModel(registries = {}, helpers = {}, injected = {}) {
+function buildFinanceModel(registries = {}, helpers = {}, injected = {}) {
   const {
     getState: getStateFn = getState,
     computeDailySummary: computeDailySummaryFn = computeDailySummary,

--- a/src/ui/cards/model/finance/ledger.js
+++ b/src/ui/cards/model/finance/ledger.js
@@ -103,7 +103,3 @@ export function buildOutflowLedger(summary = {}) {
   }));
 }
 
-export default {
-  buildInflowLedger,
-  buildOutflowLedger
-};

--- a/src/ui/cards/model/finance/obligations.js
+++ b/src/ui/cards/model/finance/obligations.js
@@ -5,7 +5,7 @@ import { getKnowledgeProgress } from '../../../../game/requirements.js';
 import { buildSkillRewards, resolveTrack } from '../education.js';
 import { ensureArray, toCurrency } from './utils.js';
 
-export function collectUnfundedUpkeep(assetDefinitions = [], state, services = {}) {
+function collectUnfundedUpkeep(assetDefinitions = [], state, services = {}) {
   const {
     getAssetState: getAssetStateFn = getAssetState,
     instanceLabel: instanceLabelFn = instanceLabel
@@ -35,7 +35,7 @@ export function collectUnfundedUpkeep(assetDefinitions = [], state, services = {
   return { total: toCurrency(total), count, entries };
 }
 
-export function collectTuitionCommitments(educationDefinitions = [], state, services = {}) {
+function collectTuitionCommitments(educationDefinitions = [], state, services = {}) {
   const {
     resolveTrack: resolveTrackFn = resolveTrack,
     getKnowledgeProgress: getKnowledgeProgressFn = getKnowledgeProgress,
@@ -129,8 +129,3 @@ export function buildObligations(state, assetDefinitions = [], educationDefiniti
   return { entries, quick };
 }
 
-export default {
-  collectUnfundedUpkeep,
-  collectTuitionCommitments,
-  buildObligations
-};

--- a/src/ui/cards/model/finance/opportunities.js
+++ b/src/ui/cards/model/finance/opportunities.js
@@ -92,9 +92,3 @@ export function buildOpportunitySummary(assets, upgrades, hustles) {
   };
 }
 
-export default {
-  buildAssetOpportunities,
-  buildUpgradeOpportunities,
-  buildHustleOpportunities,
-  buildOpportunitySummary
-};

--- a/src/ui/cards/model/finance/pulse.js
+++ b/src/ui/cards/model/finance/pulse.js
@@ -58,7 +58,3 @@ export function computeTopEarner(summary = {}) {
   return top;
 }
 
-export default {
-  buildPulseSummary,
-  computeTopEarner
-};

--- a/src/ui/cards/model/finance/utils.js
+++ b/src/ui/cards/model/finance/utils.js
@@ -8,7 +8,3 @@ export function ensureArray(value) {
   return Array.isArray(value) ? value : [];
 }
 
-export default {
-  toCurrency,
-  ensureArray
-};


### PR DESCRIPTION
## Summary
- tighten quality, education, and hustle helpers by keeping unused utilities internal and removing dead requirement re-exports
- drop unused default exports throughout the requirements and finance card model layers to shrink the module API surface
- delete obsolete card update helpers so the UI relies on presenter-level entry points only

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68e08251f884832caec025fc43eb0dd4