### PR TITLE
Refactor ServerHub apps view to use shared renderers

### DIFF
--- a/src/ui/views/browser/components/serverhub/views/apps/appsTable.js
+++ b/src/ui/views/browser/components/serverhub/views/apps/appsTable.js
@@ -1,0 +1,159 @@
+import { ensureArray } from '../../../../../../../core/helpers.js';
+import { renderNicheCell } from './nicheSelector.js';
+
+const TABLE_THEME = {
+  container: 'asset-table serverhub-table-wrapper',
+  table: 'asset-table__table serverhub-table',
+  headCell: 'asset-table__heading serverhub-table__heading',
+  row: 'asset-table__row serverhub-table__row',
+  cell: 'asset-table__cell serverhub-table__cell',
+  actionsCell: 'asset-table__cell--actions serverhub-table__cell--actions',
+  actions: 'asset-table__actions serverhub-action-group',
+  actionButton: 'serverhub-button serverhub-button--ghost serverhub-button--compact',
+  empty: 'asset-table__empty serverhub-empty'
+};
+
+function mapTableColumns(columns = []) {
+  return ensureArray(columns)
+    .filter(Boolean)
+    .map(column => ({
+      id: column.id,
+      label: column.label,
+      className: column.headerClassName,
+      dataset: column.dataset
+    }));
+}
+
+function createNameCell(instance, selectInstance) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'serverhub-table__link';
+  button.textContent = instance.label;
+  button.addEventListener('click', event => {
+    event.stopPropagation();
+    selectInstance(instance.id);
+  });
+  return button;
+}
+
+function createStatusCell(instance) {
+  const status = document.createElement('span');
+  status.className = 'serverhub-status';
+  status.dataset.state = instance.status?.id || 'setup';
+  status.textContent = instance.status?.label || 'Setup';
+  return status;
+}
+
+function createQuickAction(instance, actionId, label, helpers) {
+  const action = instance?.actionsById?.[actionId]
+    || ensureArray(instance?.actions).find(entry => entry.id === actionId);
+  return {
+    id: actionId,
+    label,
+    className: 'serverhub-button serverhub-button--quiet serverhub-button--compact',
+    disabled: !action || !action.available,
+    title: action?.disabledReason,
+    onSelect(rowId) {
+      if (!helpers.onQuickAction) return;
+      helpers.onQuickAction(rowId, action?.id || actionId);
+    }
+  };
+}
+
+function createRowActions(instance, helpers, selectInstance) {
+  const actions = [
+    createQuickAction(instance, 'shipFeature', 'Scale Up', helpers),
+    createQuickAction(instance, 'improveStability', 'Optimize', helpers),
+    {
+      id: 'viewDetails',
+      label: 'View Details',
+      className: 'serverhub-button serverhub-button--ghost serverhub-button--compact',
+      onSelect(rowId) {
+        selectInstance(rowId);
+      }
+    }
+  ];
+  return actions.filter(Boolean);
+}
+
+const CELL_RENDERERS = {
+  name(instance, { selectInstance }) {
+    return createNameCell(instance, selectInstance);
+  },
+  status(instance) {
+    return createStatusCell(instance);
+  },
+  niche(instance, context) {
+    return renderNicheCell(instance, context.helpers);
+  },
+  payout(instance, context) {
+    return context.helpers.formatCurrency(instance.latestPayout || 0);
+  },
+  upkeep(instance, context) {
+    return context.helpers.formatCurrency(instance.upkeepCost || 0);
+  },
+  roi(instance, context) {
+    return context.helpers.formatPercent(instance.roi);
+  }
+};
+
+function mapInstanceRows(instances, state, helpers, selectInstance) {
+  return ensureArray(instances)
+    .filter(Boolean)
+    .map(instance => {
+      const cells = ensureArray(helpers.tableColumns)
+        .filter(column => column && column.id !== 'actions')
+        .map(column => {
+          const renderer = CELL_RENDERERS[column.renderer] || CELL_RENDERERS[column.id];
+          const content = renderer ? renderer(instance, { helpers, selectInstance }) : instance[column.id];
+          return {
+            className: column.cellClassName,
+            content: content ?? ''
+          };
+        });
+
+      return {
+        id: instance.id,
+        isSelected: instance.id === state.selectedAppId,
+        cells,
+        actions: createRowActions(instance, helpers, selectInstance)
+      };
+    });
+}
+
+function createEmptyState(helpers) {
+  const actions = helpers.onLaunch
+    ? [
+        {
+          id: 'launch-app',
+          label: 'Deploy New App',
+          className: 'serverhub-button serverhub-button--primary',
+          onSelect: () => helpers.onLaunch()
+        }
+      ]
+    : [];
+
+  return {
+    message: 'No SaaS apps live yet. Deploy a new instance to kickstart recurring revenue.',
+    actions
+  };
+}
+
+export function mapAppsTable(instances, state, helpers = {}) {
+  const selectInstance = typeof helpers.selectInstance === 'function'
+    ? helpers.selectInstance
+    : () => {};
+
+  return {
+    theme: TABLE_THEME,
+    columns: mapTableColumns(helpers.tableColumns),
+    rows: mapInstanceRows(instances, state, helpers, selectInstance),
+    selectedId: state?.selectedAppId,
+    onSelect: selectInstance,
+    emptyState: createEmptyState(helpers)
+  };
+}
+
+export default {
+  mapAppsTable
+};

--- a/src/ui/views/browser/components/serverhub/views/apps/detailSidebar.js
+++ b/src/ui/views/browser/components/serverhub/views/apps/detailSidebar.js
@@ -1,0 +1,136 @@
+import renderActionConsole from './actionConsole.js';
+import { renderNichePanel } from './nicheSelector.js';
+import renderPayoutBreakdown from './payoutBreakdown.js';
+import renderQualityPanel from './qualityPanel.js';
+
+const DETAIL_THEME = {
+  container: 'asset-detail serverhub-sidebar',
+  header: 'serverhub-detail__header',
+  title: 'serverhub-detail__title',
+  subtitle: 'serverhub-detail__subtitle',
+  status: 'serverhub-status',
+  tabs: 'serverhub-detail__tabs',
+  stats: 'asset-detail__stats serverhub-detail__stats',
+  stat: 'asset-detail__stat serverhub-detail__stat',
+  statLabel: 'asset-detail__stat-label serverhub-detail__stat-label',
+  statValue: 'asset-detail__stat-value serverhub-detail__stat-value',
+  statNote: 'asset-detail__stat-note serverhub-detail__stat-note',
+  sections: 'asset-detail__sections serverhub-detail__grid',
+  section: 'asset-detail__section serverhub-panel',
+  sectionTitle: 'asset-detail__section-title',
+  sectionBody: 'asset-detail__section-body serverhub-panel__hint',
+  actions: 'asset-detail__actions serverhub-action-group',
+  actionButton: 'serverhub-button serverhub-button--ghost serverhub-button--compact',
+  empty: 'asset-detail__empty serverhub-detail__empty'
+};
+
+const DETAIL_STATS_CONFIG = [
+  {
+    label: 'Daily earnings',
+    getValue: (instance, helpers) => helpers.formatCurrency(instance.latestPayout)
+  },
+  {
+    label: 'Average daily',
+    getValue: (instance, helpers) => helpers.formatCurrency(instance.averagePayout)
+  },
+  {
+    label: 'Pending income',
+    getValue: (instance, helpers) => helpers.formatCurrency(instance.pendingIncome)
+  },
+  {
+    label: 'Lifetime revenue',
+    getValue: (instance, helpers) => helpers.formatCurrency(instance.lifetimeIncome)
+  },
+  {
+    label: 'Lifetime spend',
+    getValue: (instance, helpers) => helpers.formatCurrency(instance.lifetimeSpend)
+  },
+  {
+    label: 'Net profit',
+    getValue: (instance, helpers) => helpers.formatNetCurrency(instance.profit)
+  },
+  {
+    label: 'ROI',
+    getValue: (instance, helpers) => helpers.formatPercent(instance.roi)
+  },
+  {
+    label: 'Days live',
+    getValue: instance => `${instance.daysLive} day${instance.daysLive === 1 ? '' : 's'}`
+  }
+];
+
+const DETAIL_PANELS = [
+  instance => renderQualityPanel(instance),
+  (instance, helpers) => renderNichePanel(instance, helpers),
+  (instance, helpers) => renderPayoutBreakdown(instance, helpers),
+  (instance, helpers) => renderActionConsole(instance, helpers)
+];
+
+function createPanelSection(renderPanel, instance, helpers) {
+  const preview = renderPanel(instance, helpers);
+  if (!preview) {
+    return null;
+  }
+  const className = preview.className || DETAIL_THEME.section;
+  return {
+    className,
+    render: ({ article }) => {
+      const panel = renderPanel(instance, helpers);
+      if (!panel) return;
+      while (panel.firstChild) {
+        article.appendChild(panel.firstChild);
+      }
+    }
+  };
+}
+
+function mapDetailSections(instance, helpers) {
+  return DETAIL_PANELS
+    .map(renderPanel => createPanelSection(renderPanel, instance, helpers))
+    .filter(Boolean);
+}
+
+function mapDetailStats(instance, helpers) {
+  return DETAIL_STATS_CONFIG.map(entry => ({
+    label: entry.label,
+    value: entry.getValue(instance, helpers),
+    note: typeof entry.getNote === 'function' ? entry.getNote(instance, helpers) : entry.note
+  }));
+}
+
+export function mapDetailSidebar(model = {}, state = {}, helpers = {}) {
+  const selected = typeof helpers.getSelectedApp === 'function'
+    ? helpers.getSelectedApp(model, state)
+    : null;
+
+  if (!selected) {
+    return {
+      theme: DETAIL_THEME,
+      className: 'serverhub-sidebar',
+      isEmpty: true,
+      emptyState: {
+        title: 'Select an app',
+        message: 'Choose an app to inspect uptime, payouts, and quality progress.'
+      }
+    };
+  }
+
+  return {
+    theme: DETAIL_THEME,
+    className: 'serverhub-sidebar',
+    header: {
+      title: selected.label,
+      status: {
+        className: 'serverhub-status',
+        dataset: { state: selected.status?.id || 'setup' },
+        label: selected.status?.label || 'Setup'
+      }
+    },
+    stats: mapDetailStats(selected, helpers),
+    sections: mapDetailSections(selected, helpers)
+  };
+}
+
+export default {
+  mapDetailSidebar
+};

--- a/src/ui/views/browser/components/serverhub/views/appsView.js
+++ b/src/ui/views/browser/components/serverhub/views/appsView.js
@@ -1,11 +1,6 @@
-import { renderKpiGrid } from '../../common/renderKpiGrid.js';
-import { renderInstanceTable } from '../../common/renderInstanceTable.js';
-import { renderDetailPanel } from '../../common/renderDetailPanel.js';
 import { ensureArray } from '../../../../../../core/helpers.js';
-import renderActionConsole from './apps/actionConsole.js';
-import { renderNicheCell, renderNichePanel } from './apps/nicheSelector.js';
-import renderPayoutBreakdown from './apps/payoutBreakdown.js';
-import renderQualityPanel from './apps/qualityPanel.js';
+import { mapAppsTable } from './apps/appsTable.js';
+import { mapDetailSidebar } from './apps/detailSidebar.js';
 
 const KPI_THEME = {
   container: 'asset-kpis serverhub-kpis',
@@ -15,39 +10,6 @@ const KPI_THEME = {
   value: 'asset-kpi__value serverhub-kpi__value',
   note: 'asset-kpi__note serverhub-kpi__note',
   empty: 'asset-kpis__empty serverhub-kpis__empty'
-};
-
-const TABLE_THEME = {
-  container: 'asset-table serverhub-table-wrapper',
-  table: 'asset-table__table serverhub-table',
-  headCell: 'asset-table__heading serverhub-table__heading',
-  row: 'asset-table__row serverhub-table__row',
-  cell: 'asset-table__cell serverhub-table__cell',
-  actionsCell: 'asset-table__cell--actions serverhub-table__cell--actions',
-  actions: 'asset-table__actions serverhub-action-group',
-  actionButton: 'serverhub-button serverhub-button--ghost serverhub-button--compact',
-  empty: 'asset-table__empty serverhub-empty'
-};
-
-const DETAIL_THEME = {
-  container: 'asset-detail serverhub-sidebar',
-  header: 'serverhub-detail__header',
-  title: 'serverhub-detail__title',
-  subtitle: 'serverhub-detail__subtitle',
-  status: 'serverhub-status',
-  tabs: 'serverhub-detail__tabs',
-  stats: 'asset-detail__stats serverhub-detail__stats',
-  stat: 'asset-detail__stat serverhub-detail__stat',
-  statLabel: 'asset-detail__stat-label serverhub-detail__stat-label',
-  statValue: 'asset-detail__stat-value serverhub-detail__stat-value',
-  statNote: 'asset-detail__stat-note serverhub-detail__stat-note',
-  sections: 'asset-detail__sections serverhub-detail__grid',
-  section: 'asset-detail__section serverhub-panel',
-  sectionTitle: 'asset-detail__section-title',
-  sectionBody: 'asset-detail__section-body serverhub-panel__hint',
-  actions: 'asset-detail__actions serverhub-action-group',
-  actionButton: 'serverhub-button serverhub-button--ghost serverhub-button--compact',
-  empty: 'asset-detail__empty serverhub-detail__empty'
 };
 
 function formatKpiValue(metric, descriptor, helpers) {
@@ -67,202 +29,23 @@ function formatKpiValue(metric, descriptor, helpers) {
   }
 }
 
-const DETAIL_STATS_CONFIG = [
-  {
-    label: 'Daily earnings',
-    getValue: (instance, helpers) => helpers.formatCurrency(instance.latestPayout)
-  },
-  {
-    label: 'Average daily',
-    getValue: (instance, helpers) => helpers.formatCurrency(instance.averagePayout)
-  },
-  {
-    label: 'Pending income',
-    getValue: (instance, helpers) => helpers.formatCurrency(instance.pendingIncome)
-  },
-  {
-    label: 'Lifetime revenue',
-    getValue: (instance, helpers) => helpers.formatCurrency(instance.lifetimeIncome)
-  },
-  {
-    label: 'Lifetime spend',
-    getValue: (instance, helpers) => helpers.formatCurrency(instance.lifetimeSpend)
-  },
-  {
-    label: 'Net profit',
-    getValue: (instance, helpers) => helpers.formatNetCurrency(instance.profit)
-  },
-  {
-    label: 'ROI',
-    getValue: (instance, helpers) => helpers.formatPercent(instance.roi)
-  },
-  {
-    label: 'Days live',
-    getValue: instance => `${instance.daysLive} day${instance.daysLive === 1 ? '' : 's'}`
-  }
-];
-
-const DETAIL_PANELS = [
-  instance => renderQualityPanel(instance),
-  (instance, helpers) => renderNichePanel(instance, helpers),
-  (instance, helpers) => renderPayoutBreakdown(instance, helpers),
-  (instance, helpers) => renderActionConsole(instance, helpers)
-];
-
 function mapHeroMetrics(summary = {}, helpers) {
   const hero = ensureArray(summary.hero);
-  return hero.map(metric => {
-    if (!metric) return null;
-    const descriptor = helpers.kpiDescriptors.get(metric.id)
-      || helpers.kpiDescriptors.get('default')
-      || {};
-    return {
-      id: metric.id,
-      label: metric.label,
-      note: metric.note,
-      className: 'serverhub-kpi',
-      formatValue: () => formatKpiValue(metric, descriptor, helpers)
-    };
-  }).filter(Boolean);
-}
-
-function mapTableColumns(columns = []) {
-  return columns
-    .filter(Boolean)
-    .map(column => ({
-      id: column.id,
-      label: column.label,
-      className: column.headerClassName
-    }));
-}
-
-function createNameCell(instance, selectInstance) {
-  const button = document.createElement('button');
-  button.type = 'button';
-  button.className = 'serverhub-table__link';
-  button.textContent = instance.label;
-  button.addEventListener('click', event => {
-    event.stopPropagation();
-    selectInstance(instance.id);
-  });
-  return button;
-}
-
-function createStatusCell(instance) {
-  const status = document.createElement('span');
-  status.className = 'serverhub-status';
-  status.dataset.state = instance.status?.id || 'setup';
-  status.textContent = instance.status?.label || 'Setup';
-  return status;
-}
-
-function createCurrencyCell(value, formatter) {
-  return formatter(value || 0);
-}
-
-function createQuickAction(instance, actionId, label, helpers) {
-  const action = instance?.actionsById?.[actionId]
-    || ensureArray(instance?.actions).find(entry => entry.id === actionId);
-  return {
-    id: actionId,
-    label,
-    className: 'serverhub-button serverhub-button--quiet serverhub-button--compact',
-    disabled: !action || !action.available,
-    title: action?.disabledReason,
-    onSelect(rowId) {
-      if (!helpers.onQuickAction) return;
-      helpers.onQuickAction(rowId, action?.id || actionId);
-    }
-  };
-}
-
-function createRowActions(instance, helpers, selectInstance) {
-  const actions = [
-    createQuickAction(instance, 'shipFeature', 'Scale Up', helpers),
-    createQuickAction(instance, 'improveStability', 'Optimize', helpers),
-    {
-      id: 'viewDetails',
-      label: 'View Details',
-      className: 'serverhub-button serverhub-button--ghost serverhub-button--compact',
-      onSelect(rowId) {
-        selectInstance(rowId);
-      }
-    }
-  ];
-  return actions.filter(Boolean);
-}
-
-const CELL_RENDERERS = {
-  name(instance, { selectInstance }) {
-    return createNameCell(instance, selectInstance);
-  },
-  status(instance) {
-    return createStatusCell(instance);
-  },
-  niche(instance, context) {
-    return renderNicheCell(instance, context.helpers);
-  },
-  payout(instance, context) {
-    return createCurrencyCell(instance.latestPayout, context.helpers.formatCurrency);
-  },
-  upkeep(instance, context) {
-    return createCurrencyCell(instance.upkeepCost, context.helpers.formatCurrency);
-  },
-  roi(instance, context) {
-    return context.helpers.formatPercent(instance.roi);
-  }
-};
-
-function mapInstanceRows(instances, state, helpers, updateState) {
-  const selectInstance = id => {
-    updateState(current => ({ ...current, selectedAppId: id }));
-  };
-  return ensureArray(instances)
-    .filter(Boolean)
-    .map(instance => {
-      const cells = ensureArray(helpers.tableColumns)
-        .filter(column => column && column.id !== 'actions')
-        .map(column => {
-          const renderer = CELL_RENDERERS[column.renderer] || CELL_RENDERERS[column.id];
-          const content = renderer ? renderer(instance, { helpers, selectInstance }) : instance[column.id];
-          return {
-            className: column.cellClassName,
-            content: content ?? ''
-          };
-        });
+  return hero
+    .map(metric => {
+      if (!metric) return null;
+      const descriptor = helpers.kpiDescriptors.get(metric.id)
+        || helpers.kpiDescriptors.get('default')
+        || {};
       return {
-        id: instance.id,
-        isSelected: instance.id === state.selectedAppId,
-        cells,
-        actions: createRowActions(instance, helpers, selectInstance)
+        id: metric.id,
+        label: metric.label,
+        note: metric.note,
+        className: 'serverhub-kpi',
+        formatValue: () => formatKpiValue(metric, descriptor, helpers)
       };
-    });
-}
-
-function convertPanelToSection(panel) {
-  if (!panel) return null;
-  const fragment = document.createDocumentFragment();
-  while (panel.firstChild) {
-    fragment.appendChild(panel.firstChild);
-  }
-  return {
-    className: panel.className,
-    content: fragment
-  };
-}
-
-function mapDetailSections(instance, helpers) {
-  return DETAIL_PANELS
-    .map(renderPanel => convertPanelToSection(renderPanel(instance, helpers)))
+    })
     .filter(Boolean);
-}
-
-function mapDetailStats(instance, helpers) {
-  return DETAIL_STATS_CONFIG.map(entry => ({
-    label: entry.label,
-    value: entry.getValue(instance, helpers),
-    note: typeof entry.getNote === 'function' ? entry.getNote(instance, helpers) : entry.note
-  }));
 }
 
 export function createAppsView(options = {}) {
@@ -294,74 +77,52 @@ export function createAppsView(options = {}) {
     getSelectedApp
   };
 
-  return function renderAppsView({ model = {}, state = {}, updateState }) {
+  return function renderAppsView(viewContext = {}) {
+    const {
+      model = {},
+      state = {},
+      updateState,
+      renderKpiGrid,
+      renderInstanceTable,
+      renderDetailPanel
+    } = viewContext;
+
     const section = document.createElement('section');
     section.className = 'serverhub-view serverhub-view--apps';
 
-    section.appendChild(
-      renderKpiGrid({
-        items: mapHeroMetrics(model.summary || {}, helpers),
-        theme: KPI_THEME,
-        emptyState: {
-          message: 'Deploy your first SaaS to see uptime, revenue, and growth KPIs.'
-        }
-      })
-    );
+    if (typeof renderKpiGrid === 'function') {
+      section.appendChild(
+        renderKpiGrid({
+          items: mapHeroMetrics(model.summary || {}, helpers),
+          theme: KPI_THEME,
+          emptyState: {
+            message: 'Deploy your first SaaS to see uptime, revenue, and growth KPIs.'
+          }
+        })
+      );
+    }
 
     const layout = document.createElement('div');
     layout.className = 'serverhub-layout';
-    const instances = ensureArray(model.instances);
 
-    const rows = mapInstanceRows(instances, state, helpers, updateState);
-    const table = renderInstanceTable({
-      theme: TABLE_THEME,
-      columns: mapTableColumns(helpers.tableColumns),
-      rows,
-      selectedId: state.selectedAppId,
-      onSelect: id => {
-        updateState(current => ({ ...current, selectedAppId: id }));
-      },
-      emptyState: {
-        message: 'No SaaS apps live yet. Deploy a new instance to kickstart recurring revenue.',
-        actions: helpers.onLaunch
-          ? [
-              {
-                id: 'launch-app',
-                label: 'Deploy New App',
-                className: 'serverhub-button serverhub-button--primary',
-                onSelect: () => helpers.onLaunch()
-              }
-            ]
-          : []
-      }
+    const selectInstance = typeof updateState === 'function'
+      ? id => updateState(current => ({ ...current, selectedAppId: id }))
+      : () => {};
+
+    const tableConfig = mapAppsTable(ensureArray(model.instances), state, {
+      ...helpers,
+      selectInstance
     });
 
-    const selected = typeof helpers.getSelectedApp === 'function'
-      ? helpers.getSelectedApp(model, state)
-      : null;
+    if (typeof renderInstanceTable === 'function') {
+      layout.appendChild(renderInstanceTable(tableConfig));
+    }
 
-    const detail = renderDetailPanel({
-      theme: DETAIL_THEME,
-      isEmpty: !selected,
-      emptyState: {
-        title: 'Select an app',
-        message: 'Choose an app to inspect uptime, payouts, and quality progress.'
-      },
-      header: selected
-        ? {
-            title: selected.label,
-            status: {
-              className: 'serverhub-status',
-              dataset: { state: selected.status?.id || 'setup' },
-              label: selected.status?.label || 'Setup'
-            }
-          }
-        : undefined,
-      stats: selected ? mapDetailStats(selected, helpers) : [],
-      sections: selected ? mapDetailSections(selected, helpers) : []
-    });
+    const detailConfig = mapDetailSidebar(model, state, helpers);
 
-    layout.append(table, detail);
+    if (typeof renderDetailPanel === 'function') {
+      layout.appendChild(renderDetailPanel(detailConfig));
+    }
 
     section.appendChild(layout);
     return section;


### PR DESCRIPTION
## Summary
- map ServerHub KPI metrics, instance table, and detail sidebar to the shared presenter renderers supplied by the workspace context
- add dedicated mappers for the apps table and sidebar that preserve niche selection and quick-action hooks

## Testing
- npm test
- node --test tests/ui/views/serverhub/apps/helpers.test.js
- Manual testing: not run (not available in CLI environment)


------
https://chatgpt.com/codex/tasks/task_e_68e08643cce0832c8eccf442e7ca2467