### PR TITLE
Remove unused UI exports

### DIFF
--- a/src/ui/cards/model/skillLocks.js
+++ b/src/ui/cards/model/skillLocks.js
@@ -87,7 +87,3 @@ export function getWorkspaceLockByCourse(courseId) {
     courseName: courseDefinition?.name || config.courseName || null
   };
 }
-
-export function getWorkspaceSkillLockConfig(workspaceId) {
-  return WORKSPACE_SKILL_LOCKS[workspaceId] || null;
-}

--- a/src/ui/views/browser/layoutPresenter.js
+++ b/src/ui/views/browser/layoutPresenter.js
@@ -389,10 +389,6 @@ const layoutPresenter = {
 
 export default layoutPresenter;
 
-export function navigateToWorkspace(pageId, options) {
-  openWorkspace(pageId, options);
-}
-
 export function setWorkspacePath(pageId, path) {
   setWorkspacePathDom(pageId, path);
   if (navigationController.getCurrentPage() === pageId) {


### PR DESCRIPTION
## Summary
- remove the unused `getWorkspaceSkillLockConfig` helper from the skill lock model
- drop the unused `navigateToWorkspace` export from the browser layout presenter

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e087039e4c832c81653ebf0a725ffb