### PR TITLE
Remove unused UI exports and builder helpers

### DIFF
--- a/src/ui/cards/model/index.js
+++ b/src/ui/cards/model/index.js
@@ -1,35 +1,17 @@
-import buildAssetModels, {
-  getAssetGroupLabel,
-  getAssetGroupId,
-  getAssetGroupNote,
-  describeAssetLaunchAvailability
-} from './assets.js';
+import buildAssetModels from './assets.js';
 import buildHustleModels from './hustles.js';
-import buildUpgradeModels, {
-  getUpgradeCategory,
-  getUpgradeFamily,
-  getCategoryCopy,
-  getFamilyCopy,
-  buildUpgradeCategories,
-  getUpgradeSnapshot,
-  describeUpgradeStatus
-} from './upgrades.js';
-import buildEducationModels, { buildSkillRewards, resolveTrack } from './education.js';
+import buildUpgradeModels from './upgrades.js';
+import buildEducationModels from './education.js';
 import buildFinanceModel from './finance/index.js';
+import { selectNiche as selectBlogpressNiche } from './blogpress.js';
+import { selectNiche as selectVideoTubeNiche } from './videotube.js';
 import {
-  formatLabelFromKey,
-  describeAssetCardSummary,
-  formatInstanceUpkeep
-} from '../utils.js';
-import buildBlogpressModel, { selectNiche as selectBlogpressNiche } from './blogpress.js';
-import buildVideoTubeModel, { selectNiche as selectVideoTubeNiche } from './videotube.js';
-import buildDigishelfModel, {
   selectDigishelfNiche,
   getQuickActionIds as getDigishelfQuickActionIds
 } from './digishelf.js';
-import buildShopilyModel, { selectNiche as selectShopilyNiche } from './shopily.js';
+import { selectNiche as selectShopilyNiche } from './shopily.js';
 import buildTrendsModel from './trends.js';
-import buildServerHubModel, { selectServerHubNiche } from './serverhub.js';
+import { selectServerHubNiche } from './serverhub.js';
 import { ensureDefaultBuilders, registerModelBuilder } from '../modelBuilderRegistry.js';
 
 function registerDefaultCardBuilders() {
@@ -64,36 +46,15 @@ ensureDefaultBuilders(registerDefaultCardBuilders);
 
 export {
   buildAssetModels,
-  getAssetGroupLabel,
-  getAssetGroupId,
-  getAssetGroupNote,
-  describeAssetLaunchAvailability,
   buildHustleModels,
   buildUpgradeModels,
-  getUpgradeCategory,
-  getUpgradeFamily,
-  getCategoryCopy,
-  getFamilyCopy,
-  buildUpgradeCategories,
-  getUpgradeSnapshot,
-  describeUpgradeStatus,
   buildEducationModels,
-  buildSkillRewards,
-  resolveTrack,
   buildFinanceModel,
-  formatLabelFromKey,
-  describeAssetCardSummary,
-  formatInstanceUpkeep,
-  buildBlogpressModel,
   selectBlogpressNiche,
-  buildVideoTubeModel,
   selectVideoTubeNiche,
-  buildDigishelfModel,
   selectDigishelfNiche,
   getDigishelfQuickActionIds,
-  buildShopilyModel,
   selectShopilyNiche,
   buildTrendsModel,
-  buildServerHubModel,
   selectServerHubNiche
 };

--- a/src/ui/cards/model/skillLocks.js
+++ b/src/ui/cards/model/skillLocks.js
@@ -1,7 +1,7 @@
 import { getSkillDefinition } from '../../../game/skills/data.js';
 import { KNOWLEDGE_TRACKS } from '../../../game/requirements.js';
 
-export const WORKSPACE_SKILL_LOCKS = {
+const WORKSPACE_SKILL_LOCKS = {
   blogpress: {
     workspaceLabel: 'BlogPress',
     skillId: 'writing',
@@ -88,6 +88,3 @@ export function getWorkspaceLockByCourse(courseId) {
   };
 }
 
-export function getWorkspaceSkillLockConfig(workspaceId) {
-  return WORKSPACE_SKILL_LOCKS[workspaceId] || null;
-}

--- a/src/ui/cards/modelBuilderRegistry.js
+++ b/src/ui/cards/modelBuilderRegistry.js
@@ -20,10 +20,6 @@ function registerModelBuilder(key, builder, { isDefault = false } = {}) {
   return () => builders.delete(normalizedKey);
 }
 
-function unregisterModelBuilder(key) {
-  builders.delete(key);
-}
-
 function getModelBuilderEntries() {
   return Array.from(builders.entries());
 }
@@ -34,15 +30,6 @@ function buildModelMap(registries, context = {}) {
     models[key] = builder(registries, context);
   });
   return models;
-}
-
-function resetModelBuilders() {
-  builders.clear();
-  defaultsRegistered = false;
-}
-
-function hasRegisteredBuilders() {
-  return builders.size > 0;
 }
 
 function ensureDefaultBuilders(registerDefaults) {
@@ -57,10 +44,6 @@ function ensureDefaultBuilders(registerDefaults) {
 
 export {
   registerModelBuilder,
-  unregisterModelBuilder,
-  getModelBuilderEntries,
   buildModelMap,
-  resetModelBuilders,
-  hasRegisteredBuilders,
   ensureDefaultBuilders
 };

--- a/src/ui/cards/presenters/shared.js
+++ b/src/ui/cards/presenters/shared.js
@@ -4,7 +4,7 @@ function isPlainObject(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
-export function normalizeRegistries(registries = {}) {
+function normalizeRegistries(registries = {}) {
   const normalized = isPlainObject(registries) ? { ...registries } : {};
   REGISTRY_KEYS.forEach(key => {
     const value = registries?.[key];
@@ -53,10 +53,3 @@ export function updateCollections(payload = {}, adapters = {}, options = {}) {
   return { registries: normalizedRegistries, models };
 }
 
-const sharedCollections = {
-  normalizeRegistries,
-  renderCollections,
-  updateCollections
-};
-
-export default sharedCollections;

--- a/src/ui/cards/utils.js
+++ b/src/ui/cards/utils.js
@@ -35,8 +35,3 @@ export function formatInstanceUpkeep(definition) {
   return parts.join(' • ');
 }
 
-export default {
-  formatLabelFromKey,
-  describeAssetCardSummary,
-  formatInstanceUpkeep
-};

--- a/src/ui/dashboard/formatters.js
+++ b/src/ui/dashboard/formatters.js
@@ -5,12 +5,7 @@ export function clampNumber(value) {
   return Number.isFinite(numeric) ? numeric : 0;
 }
 
-export function clampScore(value) {
-  if (!Number.isFinite(value)) return null;
-  return Math.max(0, Math.min(100, Math.round(value)));
-}
-
-export function getMetricLabel(entry = {}) {
+function getMetricLabel(entry = {}) {
   return entry.label
     || entry?.definition?.label
     || entry?.definition?.name
@@ -18,7 +13,7 @@ export function getMetricLabel(entry = {}) {
     || 'Metric';
 }
 
-export function extractIconPrefix(label) {
+function extractIconPrefix(label) {
   if (typeof label !== 'string') return '';
   const match = label.match(/^([^\w]*)/u);
   return match ? match[1].trim() : '';
@@ -65,7 +60,7 @@ export function formatPayoutEntries(entries = []) {
   });
 }
 
-export function formatSpendEntries(entries = []) {
+function formatSpendEntries(entries = []) {
   return entries.map(entry => {
     const amount = clampNumber(entry?.amount);
     return {
@@ -79,7 +74,7 @@ export function formatSpendEntries(entries = []) {
   });
 }
 
-export function formatStudyEntries(entries = []) {
+function formatStudyEntries(entries = []) {
   return entries.map(entry => {
     const hours = clampNumber(entry?.hoursPerDay);
     const remaining = Math.max(0, clampNumber(entry?.remainingDays));
@@ -121,16 +116,3 @@ export function formatPercent(value) {
   return `${sign}${percent}%`;
 }
 
-export default {
-  clampNumber,
-  clampScore,
-  getMetricLabel,
-  extractIconPrefix,
-  formatTimeEntries,
-  formatPayoutEntries,
-  formatSpendEntries,
-  formatStudyEntries,
-  buildSummaryPresentations,
-  describeDelta,
-  formatPercent
-};

--- a/src/ui/dashboard/knowledge.js
+++ b/src/ui/dashboard/knowledge.js
@@ -30,7 +30,7 @@ export function computeStudyProgress(state = {}) {
   return { percent, summary };
 }
 
-export function buildStudyEnrollmentSuggestions(state = {}) {
+function buildStudyEnrollmentSuggestions(state = {}) {
   const suggestions = [];
 
   if (!state || typeof state !== 'object') {
@@ -121,8 +121,3 @@ export function buildStudyEnrollmentActionModel(state = {}) {
   };
 }
 
-export default {
-  computeStudyProgress,
-  buildStudyEnrollmentSuggestions,
-  buildStudyEnrollmentActionModel
-};

--- a/src/ui/dashboard/model.js
+++ b/src/ui/dashboard/model.js
@@ -284,10 +284,3 @@ export function buildDashboardViewModel(state, summary = {}) {
 
 export { buildQuickActionModel, buildAssetActionModel, buildStudyEnrollmentActionModel };
 
-export default {
-  buildDashboardViewModel,
-  buildDailySummaries,
-  buildQuickActions,
-  buildAssetUpgradeRecommendations,
-  buildStudyEnrollmentActionModel
-};

--- a/src/ui/dashboard/passiveIncome.js
+++ b/src/ui/dashboard/passiveIncome.js
@@ -233,6 +233,3 @@ export function buildDailySummaries(state = {}, summary = {}) {
   };
 }
 
-export default {
-  buildDailySummaries
-};

--- a/src/ui/dashboard/quickActions.js
+++ b/src/ui/dashboard/quickActions.js
@@ -280,9 +280,3 @@ export function buildAssetActionModel(state = {}) {
   };
 }
 
-export default {
-  buildQuickActions,
-  buildAssetUpgradeRecommendations,
-  buildQuickActionModel,
-  buildAssetActionModel
-};

--- a/src/ui/headerAction/index.js
+++ b/src/ui/headerAction/index.js
@@ -123,7 +123,3 @@ export function renderHeaderAction(model) {
   presenter?.renderAction?.(model);
 }
 
-export default {
-  initHeaderActionControls,
-  renderHeaderAction
-};

--- a/src/ui/headerAction/model.js
+++ b/src/ui/headerAction/model.js
@@ -37,7 +37,7 @@ function normalizeQuickAction(entry) {
   };
 }
 
-export function selectHeaderAction(state) {
+function selectHeaderAction(state) {
   const assetActions = buildAssetUpgradeRecommendations(state)
     .map(normalizeAssetRecommendation)
     .filter(Boolean)
@@ -80,4 +80,3 @@ export function buildHeaderActionModel(state) {
   };
 }
 
-export default buildHeaderActionModel;

--- a/src/ui/invalidation.js
+++ b/src/ui/invalidation.js
@@ -55,9 +55,3 @@ export function consumeDirty() {
 
 export { ALL_UI_SECTIONS };
 
-export default {
-  markDirty,
-  markAllDirty,
-  consumeDirty,
-  ALL_UI_SECTIONS
-};


### PR DESCRIPTION
## Summary
- prune unused exports from the cards model aggregator and skill lock helpers
- drop dead registry utilities and default exports across dashboard and header modules
- simplify dashboard formatter internals while keeping public API intact

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e087da91a4832cb63a284ea892554e