### PR TITLE
Ensure UI invalidation follows partial updates

### DIFF
--- a/src/game/assets/niches.js
+++ b/src/game/assets/niches.js
@@ -4,6 +4,7 @@ import { getAssetState, getState } from '../../core/state.js';
 import { getAssetDefinition } from '../../core/state/registry.js';
 import { getNicheDefinition, getNicheDefinitions } from './nicheData.js';
 import { NICHE_ANALYTICS_HISTORY_LIMIT } from '../../core/state/niches.js';
+import { markDirty } from '../../ui/invalidation.js';
 
 const POPULARITY_MIN = 25;
 const POPULARITY_MAX = 95;
@@ -216,6 +217,9 @@ export function setNicheWatchlist(nicheId, watchlisted) {
       changed = true;
     }
     data.watchlist = Array.from(list);
+    if (changed) {
+      markDirty('cards');
+    }
   });
   return changed;
 }
@@ -251,6 +255,8 @@ export function assignInstanceToNiche(assetId, instanceId, nicheId) {
       delete instance.nicheId;
     }
     changed = true;
+
+    markDirty('cards');
 
     const labelBase = assetDefinition.singular || assetDefinition.name || 'Asset';
     const label = `${labelBase} #${index + 1}`;

--- a/src/game/assets/quality.js
+++ b/src/game/assets/quality.js
@@ -9,6 +9,7 @@ import { checkDayEnd } from '../lifecycle.js';
 import { recordCostContribution, recordTimeContribution } from '../metrics.js';
 import { spendTime } from '../time.js';
 import { awardSkillProgress } from '../skills/index.js';
+import { markDirty } from '../../ui/invalidation.js';
 
 function ensureUsageMap(instance) {
   if (!instance.dailyUsage || typeof instance.dailyUsage !== 'object') {
@@ -314,6 +315,7 @@ function runQualityAction(definition, instanceId, actionId) {
   }
 
   updateQualityLevel(definition, assetState, instance, quality);
+  markDirty('cards');
 }
 
 function updateQualityLevel(definition, assetState, instance, quality) {

--- a/src/game/assistant.js
+++ b/src/game/assistant.js
@@ -5,6 +5,9 @@ import { spendMoney } from './currency.js';
 import { gainTime } from './time.js';
 import { recordCostContribution } from './metrics.js';
 import { awardSkillProgress } from './skills/index.js';
+import { markDirty } from '../ui/invalidation.js';
+
+const CORE_UI_SECTIONS = ['dashboard', 'player', 'skillsWidget', 'headerAction'];
 
 export const ASSISTANT_CONFIG = {
   hiringCost: 180,
@@ -64,6 +67,7 @@ export function hireAssistant() {
   upgrade.count = currentCount + 1;
   state.bonusTime += ASSISTANT_CONFIG.hoursPerAssistant;
   gainTime(ASSISTANT_CONFIG.hoursPerAssistant);
+  markDirty(CORE_UI_SECTIONS);
   addLog(
     `You hired a virtual assistant! They add +${ASSISTANT_CONFIG.hoursPerAssistant}h and expect $${ASSISTANT_CONFIG.hourlyRate}/hr.`,
     'upgrade'
@@ -85,6 +89,7 @@ export function fireAssistant() {
   upgrade.count = currentCount - 1;
   state.bonusTime = Math.max(0, state.bonusTime - ASSISTANT_CONFIG.hoursPerAssistant);
   state.timeLeft -= ASSISTANT_CONFIG.hoursPerAssistant;
+  markDirty(CORE_UI_SECTIONS);
   addLog(
     `You let an assistant go. Daily support drops by ${ASSISTANT_CONFIG.hoursPerAssistant}h, but payroll eases a bit.`,
     'info'

--- a/src/game/content/schema.js
+++ b/src/game/content/schema.js
@@ -35,6 +35,7 @@ import {
   formatSlotMap,
   logUpgradeBlocked
 } from './schema/logMessaging.js';
+import { markDirty } from '../../ui/invalidation.js';
 
 export { createInstantHustle } from './schema/assetActions.js';
 
@@ -359,6 +360,7 @@ export function createUpgrade(config, hooks = {}) {
             config.logType || 'upgrade'
           );
         }
+        markDirty('cards');
       });
       checkDayEnd();
     }

--- a/src/game/content/schema/assetActions.js
+++ b/src/game/content/schema/assetActions.js
@@ -15,6 +15,7 @@ import {
 import { getHustleEffectMultiplier } from '../../upgrades/effects.js';
 import { applyMetric, normalizeHustleMetrics } from './metrics.js';
 import { logEducationBonusSummary, logHustleBlocked } from './logMessaging.js';
+import { markDirty } from '../../../ui/invalidation.js';
 
 function formatHourDetail(hours, effective) {
   if (!hours) return '⏳ Time: <strong>Instant</strong>';
@@ -291,6 +292,7 @@ export function createInstantHustle(config) {
     }
 
     config.onComplete?.(context);
+    markDirty('cards');
   }
 
   definition.action = {

--- a/src/game/currency.js
+++ b/src/game/currency.js
@@ -2,6 +2,9 @@ import { getState } from '../core/state.js';
 import { addLog } from '../core/log.js';
 import { getElement } from '../ui/elements/registry.js';
 import { flashValue } from '../ui/effects.js';
+import { markDirty } from '../ui/invalidation.js';
+
+const MONEY_UI_SECTIONS = ['dashboard', 'player', 'skillsWidget', 'headerAction'];
 
 export function addMoney(amount, message, type = 'info') {
   const state = getState();
@@ -9,6 +12,7 @@ export function addMoney(amount, message, type = 'info') {
   state.money = Math.max(0, Number(state.money) + Number(amount));
   const moneyNode = getElement('money');
   flashValue(moneyNode);
+  markDirty(MONEY_UI_SECTIONS);
   if (message) {
     addLog(message, type);
   }
@@ -20,4 +24,5 @@ export function spendMoney(amount) {
   state.money = Math.max(0, state.money - amount);
   const moneyNode = getElement('money');
   flashValue(moneyNode, true);
+  markDirty(MONEY_UI_SECTIONS);
 }

--- a/src/game/requirements/orchestrator.js
+++ b/src/game/requirements/orchestrator.js
@@ -1,5 +1,6 @@
 import { DEFAULT_DAY_HOURS } from '../../core/constants.js';
 import { formatList, formatMoney } from '../../core/helpers.js';
+import { markDirty } from '../../ui/invalidation.js';
 
 export const MIN_MANUAL_BUFFER_HOURS = Math.max(2, Math.round(DEFAULT_DAY_HOURS * 0.25));
 
@@ -55,6 +56,8 @@ export function createRequirementsOrchestrator({
 
     allocateDailyStudy({ trackIds: [id], triggeredByEnrollment: true });
 
+    markDirty('cards');
+
     return { success: true };
   }
 
@@ -76,6 +79,8 @@ export function createRequirementsOrchestrator({
     progress.enrolledOnDay = null;
 
     addLog(`You dropped ${track.name}. Tuition stays paid, but your schedule opens back up.`, 'warning');
+
+    markDirty('cards');
 
     return { success: true };
   }
@@ -131,6 +136,10 @@ export function createRequirementsOrchestrator({
     if (studied.length) {
       const prefix = triggeredByEnrollment ? 'Class time booked today for' : 'Study sessions reserved for';
       addLog(`${prefix} ${formatList(studied)}.`, 'info');
+    }
+
+    if (studied.length || reserveSkipped.length || timeSkipped.length) {
+      markDirty('cards');
     }
 
     if (reserveSkipped.length) {
@@ -198,6 +207,10 @@ export function createRequirementsOrchestrator({
     }
     if (stalled.length) {
       addLog(`${formatList(stalled)} did not get study time today. Progress paused.`, 'warning');
+    }
+
+    if (completedToday.length || stalled.length) {
+      markDirty('cards');
     }
   }
 

--- a/src/game/skills/index.js
+++ b/src/game/skills/index.js
@@ -13,6 +13,9 @@ import {
   normalizeSkillList,
   normalizeSkillState
 } from './data.js';
+import { markDirty } from '../../ui/invalidation.js';
+
+const SKILL_UI_SECTIONS = ['dashboard', 'player', 'skillsWidget', 'headerAction'];
 
 const TIME_XP_RATE = 5;
 const MONEY_XP_INTERVAL = 25;
@@ -113,6 +116,10 @@ export function awardSkillProgress({
   character.level = calculateCharacterLevel(character.xp);
   if (character.level > beforeCharacterLevel) {
     logCharacterLevelUp(character.level, label);
+  }
+
+  if (totalAwarded > 0) {
+    markDirty(SKILL_UI_SECTIONS);
   }
 
   return totalAwarded;

--- a/src/game/time.js
+++ b/src/game/time.js
@@ -1,4 +1,7 @@
 import { getState } from '../core/state.js';
+import { markDirty } from '../ui/invalidation.js';
+
+const TIME_UI_SECTIONS = ['dashboard', 'player', 'skillsWidget', 'headerAction'];
 
 export function getTimeCap() {
   const state = getState();
@@ -10,10 +13,12 @@ export function spendTime(hours) {
   const state = getState();
   if (!state) return;
   state.timeLeft -= hours;
+  markDirty(TIME_UI_SECTIONS);
 }
 
 export function gainTime(hours) {
   const state = getState();
   if (!state) return;
   state.timeLeft = Math.min(getTimeCap(), state.timeLeft + hours);
+  markDirty(TIME_UI_SECTIONS);
 }

--- a/tests/ui/update.integration.test.js
+++ b/tests/ui/update.integration.test.js
@@ -190,3 +190,169 @@ test('updateUI skips untouched presenters when sections are clean', { concurrenc
   assert.strictEqual(callCounts.skills, 0, 'expected skills presenter to remain untouched when not flagged');
   assert.strictEqual(callCounts.cards, previousCardCalls, 'expected cards presenter not to re-render without dirty flag');
 });
+
+test('state mutators mark dirty sections and drive partial UI refreshes', { concurrency: false }, async t => {
+  ensureTestDom();
+  const harness = await getGameTestHarness();
+  const state = harness.resetState();
+
+  const viewManager = await import('../../src/ui/viewManager.js');
+  const browserViewModule = await import('../../src/ui/views/browser/index.js');
+  const updateModule = await import('../../src/ui/update.js');
+  const invalidation = await import('../../src/ui/invalidation.js');
+  const assetsActionsModule = await import('../../src/game/assets/actions.js');
+  const skillsModule = await import('../../src/game/skills/index.js');
+
+  const originalView = viewManager.getActiveView();
+  const browserView = browserViewModule.default;
+
+  const callCounts = {
+    dashboard: 0,
+    player: 0,
+    skills: 0,
+    header: 0,
+    cards: 0
+  };
+
+  const stubView = {
+    ...browserView,
+    presenters: {
+      ...browserView.presenters,
+      player: {
+        render: (...args) => {
+          callCounts.player += 1;
+          return browserView.presenters?.player?.render?.(...args);
+        }
+      },
+      skillsWidget: {
+        render: (...args) => {
+          callCounts.skills += 1;
+          return browserView.presenters?.skillsWidget?.render?.(...args);
+        }
+      },
+      headerAction: {
+        ...browserView.presenters?.headerAction,
+        renderAction: (...args) => {
+          callCounts.header += 1;
+          return browserView.presenters?.headerAction?.renderAction?.(...args);
+        }
+      },
+      cards: {
+        ...browserView.presenters?.cards,
+        renderAll: (...args) => {
+          browserView.presenters?.cards?.renderAll?.(...args);
+          return undefined;
+        },
+        update: (...args) => {
+          callCounts.cards += 1;
+          return browserView.presenters?.cards?.update?.(...args);
+        }
+      }
+    },
+    renderDashboard: (...args) => {
+      callCounts.dashboard += 1;
+      return browserView.renderDashboard?.(...args);
+    }
+  };
+
+  viewManager.setActiveView(stubView, document);
+
+  t.after(() => {
+    invalidation.consumeDirty();
+    viewManager.setActiveView(originalView ?? browserView, document);
+  });
+
+  const resetCounts = () => {
+    Object.keys(callCounts).forEach(key => {
+      callCounts[key] = 0;
+    });
+  };
+
+  const expectCoreDirty = dirtyMap => {
+    const keys = Object.keys(dirtyMap).sort();
+    const expected = ['dashboard', 'headerAction', 'player', 'skillsWidget'].sort();
+    assert.deepStrictEqual(keys, expected, 'expected money/time updates to flag core UI presenters');
+    expected.forEach(section => {
+      assert.strictEqual(dirtyMap[section], true, `expected ${section} to be marked dirty`);
+    });
+  };
+
+  // Money changes flag dashboard/player/skills/header presenters.
+  resetCounts();
+  invalidation.consumeDirty();
+  harness.currencyModule.addMoney(25, null);
+  const moneyDirty = invalidation.consumeDirty();
+  expectCoreDirty(moneyDirty);
+  updateModule.updateUI(moneyDirty);
+  assert.ok(callCounts.dashboard > 0, 'expected dashboard to refresh for money change');
+  assert.ok(callCounts.player > 0, 'expected player panel to refresh for money change');
+  assert.ok(callCounts.skills > 0, 'expected skills widget to refresh for money change');
+  assert.ok(callCounts.header > 0, 'expected header action to refresh for money change');
+  assert.strictEqual(callCounts.cards, 0, 'expected cards presenter to stay idle during money update');
+
+  // Time changes mark the same presenters.
+  resetCounts();
+  invalidation.consumeDirty();
+  harness.timeModule.spendTime(1);
+  const timeDirty = invalidation.consumeDirty();
+  expectCoreDirty(timeDirty);
+  updateModule.updateUI(timeDirty);
+  assert.ok(callCounts.dashboard > 0, 'expected dashboard to refresh for time change');
+  assert.ok(callCounts.player > 0, 'expected player panel to refresh for time change');
+  assert.ok(callCounts.skills > 0, 'expected skills widget to refresh for time change');
+  assert.ok(callCounts.header > 0, 'expected header action to refresh for time change');
+  assert.strictEqual(callCounts.cards, 0, 'expected cards presenter to stay idle during time update');
+
+  // Skill progress touches the same core presenters.
+  resetCounts();
+  invalidation.consumeDirty();
+  const xpAwarded = skillsModule.awardSkillProgress({
+    skills: ['writing'],
+    baseXp: 4,
+    state
+  });
+  assert.ok(xpAwarded > 0, 'expected awardSkillProgress to grant experience');
+  const skillDirty = invalidation.consumeDirty();
+  expectCoreDirty(skillDirty);
+  updateModule.updateUI(skillDirty);
+  assert.ok(callCounts.dashboard > 0, 'expected dashboard to refresh for skill progress');
+  assert.ok(callCounts.player > 0, 'expected player panel to refresh for skill progress');
+  assert.ok(callCounts.skills > 0, 'expected skills widget to refresh for skill progress');
+  assert.ok(callCounts.header > 0, 'expected header action to refresh for skill progress');
+  assert.strictEqual(callCounts.cards, 0, 'expected cards presenter to stay idle when only skills update');
+
+  // Launching an asset via executeAction should refresh all five presenters.
+  resetCounts();
+  invalidation.consumeDirty();
+  state.money = 1000;
+  state.timeLeft = 24;
+  const launchable = harness.assetsModule.ASSETS.find(asset => Array.isArray(asset?.skills?.setup) && asset.skills.setup.length);
+  assert.ok(launchable, 'expected to find an asset with setup skills for testing');
+  const launchAction = assetsActionsModule.buildAssetAction(launchable);
+  launchAction.onClick();
+  assert.ok(callCounts.dashboard > 0, 'expected dashboard to refresh when launching asset');
+  assert.ok(callCounts.player > 0, 'expected player panel to refresh when launching asset');
+  assert.ok(callCounts.skills > 0, 'expected skills widget to refresh when launching asset');
+  assert.ok(callCounts.header > 0, 'expected header action to refresh when launching asset');
+  assert.ok(callCounts.cards > 0, 'expected cards presenter to update when launching asset');
+  const postLaunchDirty = invalidation.consumeDirty();
+  assert.deepStrictEqual(postLaunchDirty, {}, 'expected executeAction to consume dirty sections after launch');
+
+  // Selling the newly created instance should also refresh all presenters.
+  const assetState = harness.stateModule.getAssetState(launchable.id, state);
+  const [firstInstance] = assetState.instances;
+  assert.ok(firstInstance, 'expected a launched asset instance for sale test');
+  firstInstance.lastIncome = 48;
+
+  resetCounts();
+  invalidation.consumeDirty();
+  const sold = assetsActionsModule.sellAssetInstance(launchable, firstInstance.id);
+  assert.strictEqual(sold, true, 'expected sellAssetInstance to succeed');
+  assert.ok(callCounts.dashboard > 0, 'expected dashboard to refresh when selling asset');
+  assert.ok(callCounts.player > 0, 'expected player panel to refresh when selling asset');
+  assert.ok(callCounts.skills > 0, 'expected skills widget to refresh when selling asset');
+  assert.ok(callCounts.header > 0, 'expected header action to refresh when selling asset');
+  assert.ok(callCounts.cards > 0, 'expected cards presenter to refresh when selling asset');
+  const postSaleDirty = invalidation.consumeDirty();
+  assert.deepStrictEqual(postSaleDirty, {}, 'expected executeAction to consume dirty sections after sale');
+});


### PR DESCRIPTION
## Summary
- mark money, time, and skill progress helpers as touching the dashboard, player, skills widget, and header action presenters so partial updates stay accurate
- propagate markDirty calls through asset launches/sales, card-affecting helpers, assistant management, and upgrade/knowledge flows to keep cards in sync with state mutations
- extend the UI integration suite to exercise these flows, assert dirty section reporting, and verify presenters are only refreshed when flagged

## Testing
- `npm test -- tests/ui/update.integration.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68e087488768832c9ace11b6d2705722