### PR TITLE
Ensure game loop fallback renders UI when dirty set is empty

### DIFF
--- a/src/game/loop.js
+++ b/src/game/loop.js
@@ -14,7 +14,7 @@ export function startGameLoop() {
   setInterval(runGameLoop, 1000);
 }
 
-function runGameLoop() {
+export function runGameLoop() {
   const now = Date.now();
   for (const hustle of HUSTLES) {
     if (typeof hustle.process === 'function') {
@@ -50,6 +50,8 @@ function runGameLoop() {
   const dirtySections = consumeDirty();
   if (Object.keys(dirtySections).length > 0) {
     updateUI(dirtySections);
+  } else {
+    updateUI();
   }
 
   if (now - lastAutosave >= AUTOSAVE_INTERVAL_MS) {


### PR DESCRIPTION
## Summary
- call the UI update fallback from the game loop when no dirty sections are present
- export the loop runner for testing and cover the clean-cycle scenario with an integration test

## Testing
- npm test -- tests/ui/update.integration.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e0fd2e0e20832ca51691f264300654