### PR TITLE
Sync ShopStack navigation with browser URL

### DIFF
--- a/src/ui/views/browser/apps/upgrades.js
+++ b/src/ui/views/browser/apps/upgrades.js
@@ -1,4 +1,5 @@
 import shopstackApp from '../components/shopstack.js';
+import { setWorkspacePath } from '../layoutPresenter.js';
 import { getPageByType } from './pageLookup.js';
 
 export default function renderUpgrades(context = {}, definitions = [], models = {}) {
@@ -18,7 +19,18 @@ export default function renderUpgrades(context = {}, definitions = [], models = 
   const mount = refs.body.querySelector('[data-role="shopstack-root"]');
   if (!mount) return null;
 
-  const summary = shopstackApp.render(models, { mount, page, definitions });
+  const handleRouteChange = path => {
+    setWorkspacePath(page.id, path);
+  };
+
+  const summary = shopstackApp.render(models, {
+    mount,
+    page,
+    definitions,
+    onRouteChange: handleRouteChange
+  });
+  const path = summary?.urlPath || '';
+  setWorkspacePath(page.id, path);
   const meta = summary?.meta || models?.overview?.note || 'Browse upgrades for upcoming boosts';
-  return { id: page.id, meta };
+  return { id: page.id, meta, urlPath: path };
 }


### PR DESCRIPTION
## Summary
- derive a ShopStack workspace path from the active view, category, and selected upgrade
- notify the browser shell whenever ShopStack navigation changes and expose the path in render summaries
- wire the upgrades app to persist ShopStack paths so the in-game address bar reflects navigation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0fde3d750832c8c551f03752e128d