### PR TITLE
Hook VideoTube navigation to in-game address bar

### DIFF
--- a/src/ui/views/browser/apps/videotube.js
+++ b/src/ui/views/browser/apps/videotube.js
@@ -1,4 +1,5 @@
 import videotubeApp from '../components/videotube.js';
+import { setWorkspacePath } from '../layoutPresenter.js';
 import { getPageByType } from './pageLookup.js';
 
 export default function renderVideoTube(context = {}, definitions = [], model = {}) {
@@ -18,7 +19,20 @@ export default function renderVideoTube(context = {}, definitions = [], model = 
   const mount = refs.body.querySelector('[data-role="videotube-root"]');
   if (!mount) return null;
 
-  const summary = videotubeApp.render(model, { mount, page, definitions });
+  const handleRouteChange = path => {
+    setWorkspacePath(page.id, path);
+  };
+
+  const summary = videotubeApp.render(model, {
+    mount,
+    page,
+    definitions,
+    onRouteChange: handleRouteChange
+  });
+
+  const path = summary?.urlPath || '';
+  setWorkspacePath(page.id, path);
+
   const meta = summary?.meta || model?.summary?.meta || 'Launch your first video';
-  return { id: page.id, meta };
+  return { id: page.id, meta, urlPath: path };
 }

--- a/src/ui/views/browser/components/videotube/createVideoTubeWorkspace.js
+++ b/src/ui/views/browser/components/videotube/createVideoTubeWorkspace.js
@@ -19,6 +19,22 @@ const VIEW_DETAIL = 'detail';
 const VIEW_CREATE = 'create';
 const VIEW_ANALYTICS = 'analytics';
 
+function derivePath(state = {}) {
+  switch (state.view) {
+    case VIEW_ANALYTICS:
+      return 'analytics';
+    case VIEW_DETAIL: {
+      const videoId = state.selectedVideoId;
+      return videoId ? `videos/${videoId}` : 'videos';
+    }
+    case VIEW_CREATE:
+      return 'create';
+    case VIEW_DASHBOARD:
+    default:
+      return 'dashboard';
+  }
+}
+
 const formatCurrency = amount =>
   baseFormatCurrency(amount, { precision: 'integer', clampZero: true });
 const formatPercent = value =>
@@ -120,6 +136,7 @@ export function createVideoTubeWorkspace() {
     state: { view: VIEW_DASHBOARD, selectedVideoId: null },
     ensureSelection: ensureSelectedVideo,
     deriveSummary,
+    derivePath,
     renderLocked: renderLockedState,
     isLocked: model => !model?.definition,
     header(model, state, context) {


### PR DESCRIPTION
## Summary
- derive explicit URL paths for VideoTube dashboard, detail, analytics, and create views so navigation updates the browser address bar
- forward route change notifications from the VideoTube workspace to the in-game browser shell and persist the current path

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0ff427b50832c8ee08b13e0022290