### PR TITLE
Hook ServerHub workspace routes into address bar

### DIFF
--- a/src/ui/views/browser/apps/serverhub.js
+++ b/src/ui/views/browser/apps/serverhub.js
@@ -1,4 +1,5 @@
 import serverhubApp from '../components/serverhub.js';
+import { setWorkspacePath } from '../layoutPresenter.js';
 import { getPageByType } from './pageLookup.js';
 
 export default function renderServerHub(context = {}, definitions = [], model = {}) {
@@ -18,8 +19,19 @@ export default function renderServerHub(context = {}, definitions = [], model = 
   const mount = refs.body.querySelector('[data-role="serverhub-root"]');
   if (!mount) return null;
 
-  const summary = serverhubApp.render(model, { mount, page, definitions });
-  const meta = summary?.meta || model?.summary?.meta || 'Launch your first micro SaaS';
+  const handleRouteChange = path => {
+    setWorkspacePath(page.id, path);
+  };
+
+  const summary = serverhubApp.render(model, {
+    mount,
+    page,
+    definitions,
+    onRouteChange: handleRouteChange
+  });
+
   const urlPath = summary?.urlPath || '';
+  setWorkspacePath(page.id, urlPath);
+  const meta = summary?.meta || model?.summary?.meta || 'Launch your first micro SaaS';
   return { id: page.id, meta, urlPath };
 }

--- a/src/ui/views/browser/components/serverhub.js
+++ b/src/ui/views/browser/components/serverhub.js
@@ -183,14 +183,20 @@ function deriveSummary(model = {}) {
 }
 
 function derivePath(state = {}) {
-  switch (state.view) {
+  const view = state?.view;
+  switch (view) {
     case VIEW_UPGRADES:
       return 'upgrades';
     case VIEW_PRICING:
       return 'pricing';
     case VIEW_APPS:
-    default:
-      return '';
+    default: {
+      const appId = state?.selectedAppId;
+      if (appId != null && appId !== '') {
+        return `apps/${appId}`;
+      }
+      return 'apps';
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- wire the ServerHub workspace renderer to update the internal browser address bar when navigation or selection changes
- derive ServerHub URL paths for apps, upgrades, pricing, and selected app detail routes so the address bar reflects the active view

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1016c2284832cb0a4fb8f2c5b5361