### PR TITLE
Ensure watchlist toggles refresh dashboard immediately

### DIFF
--- a/src/game/assets/niches.js
+++ b/src/game/assets/niches.js
@@ -218,7 +218,7 @@ export function setNicheWatchlist(nicheId, watchlisted) {
     }
     data.watchlist = Array.from(list);
     if (changed) {
-      markDirty('cards');
+      markDirty(['cards', 'dashboard']);
     }
   });
   return changed;


### PR DESCRIPTION
## Summary
- mark both the cards and dashboard sections dirty when setNicheWatchlist changes state so watchlist counts refresh instantly

## Testing
- npm test
- Manual: loaded the default registry, set an active view stub, toggled the Tech Innovators watchlist entry, and observed the dashboard watchlist count update immediately alongside a cards presenter update

------
https://chatgpt.com/codex/tasks/task_e_68e1107c0cf8832c8242e091fe2b0148