### PR TITLE
Prune unused exports reported by knip

### DIFF
--- a/src/game/assets/niches.js
+++ b/src/game/assets/niches.js
@@ -122,7 +122,7 @@ export function rerollNichePopularity({ force = false } = {}) {
   return data.popularity;
 }
 
-export function getNichePopularity(nicheId, state = getState()) {
+function getNichePopularity(nicheId, state = getState()) {
   if (!nicheId) return null;
   const target = ensureNicheState(state);
   if (!target) return null;

--- a/src/game/requirements/checks.js
+++ b/src/game/requirements/checks.js
@@ -9,7 +9,7 @@ export function isEquipmentUnlocked(id, state = getState()) {
   return Boolean(getUpgradeState(id, state).purchased);
 }
 
-export function isKnowledgeComplete(id, state = getState()) {
+function isKnowledgeComplete(id, state = getState()) {
   if (!id) return true;
   const track = KNOWLEDGE_TRACKS[id];
   if (!track) return true;
@@ -17,7 +17,7 @@ export function isKnowledgeComplete(id, state = getState()) {
   return progress.completed;
 }
 
-export function hasExperience(requirement, state = getState()) {
+function hasExperience(requirement, state = getState()) {
   if (!requirement?.assetId) return true;
   const targetCount = Number(requirement.count) || 0;
   if (targetCount <= 0) return true;

--- a/src/ui/cards/model/assets.js
+++ b/src/ui/cards/model/assets.js
@@ -22,16 +22,16 @@ const ASSET_GROUP_ICONS = {
   Tech: '🚀'
 };
 
-export function getAssetGroupLabel(definition) {
+function getAssetGroupLabel(definition) {
   return definition?.tag?.label || 'Special';
 }
 
-export function getAssetGroupId(definition) {
+function getAssetGroupId(definition) {
   const label = getAssetGroupLabel(definition);
   return label.toLowerCase().replace(/[^a-z0-9]+/g, '-');
 }
 
-export function getAssetGroupNote(label) {
+function getAssetGroupNote(label) {
   return ASSET_GROUP_NOTES[label] || 'Bundle kindred builds together to compare potential at a glance.';
 }
 

--- a/src/ui/cards/model/blogpress.js
+++ b/src/ui/cards/model/blogpress.js
@@ -320,7 +320,7 @@ function buildSummary(instances = []) {
   return { total, active, setup, needsUpkeep, meta };
 }
 
-export default function buildBlogpressModel(assetDefinitions = [], upgradeDefinitions = [], state = getState()) {
+function buildBlogpressModel(assetDefinitions = [], upgradeDefinitions = [], state = getState()) {
   const definition = ensureArray(assetDefinitions).find(entry => entry?.id === 'blog') || null;
   if (!definition) {
     return {

--- a/src/ui/cards/model/digishelf.js
+++ b/src/ui/cards/model/digishelf.js
@@ -385,7 +385,7 @@ function buildOverview(ebookSummary, stockSummary, ebookInstances = [], stockIns
   };
 }
 
-export default function buildDigishelfModel(assetDefinitions = [], state = getState()) {
+function buildDigishelfModel(assetDefinitions = [], state = getState()) {
   const definitionMap = new Map(ensureArray(assetDefinitions).map(definition => [definition?.id, definition]));
   const ebookDefinition = definitionMap.get('ebook') || null;
   const stockDefinition = definitionMap.get('stockPhotos') || null;

--- a/src/ui/cards/model/serverhub.js
+++ b/src/ui/cards/model/serverhub.js
@@ -414,7 +414,7 @@ function buildPricingPlans(definition) {
   ].filter(Boolean);
 }
 
-export default function buildServerHubModel(assetDefinitions = [], upgradeDefinitions = [], state = getState()) {
+function buildServerHubModel(assetDefinitions = [], upgradeDefinitions = [], state = getState()) {
   const definitionMap = new Map(ensureArray(assetDefinitions).map(definition => [definition?.id, definition]));
   const saasDefinition = definitionMap.get('saas') || null;
 

--- a/src/ui/cards/model/shopily.js
+++ b/src/ui/cards/model/shopily.js
@@ -375,7 +375,7 @@ function buildPricing(definition, state) {
   };
 }
 
-export default function buildShopilyModel(assetDefinitions = [], upgradeDefinitions = [], state = getState()) {
+function buildShopilyModel(assetDefinitions = [], upgradeDefinitions = [], state = getState()) {
   const definition = ensureArray(assetDefinitions).find(entry => entry?.id === 'dropshipping') || null;
   if (!definition) {
     return {

--- a/src/ui/cards/model/upgrades.js
+++ b/src/ui/cards/model/upgrades.js
@@ -110,15 +110,15 @@ const UPGRADE_FAMILY_COPY = {
   }
 };
 
-export function getUpgradeCategory(definition) {
+function getUpgradeCategory(definition) {
   return definition?.category || 'misc';
 }
 
-export function getUpgradeFamily(definition) {
+function getUpgradeFamily(definition) {
   return definition?.family || 'general';
 }
 
-export function getCategoryCopy(id) {
+function getCategoryCopy(id) {
   if (UPGRADE_CATEGORY_COPY[id]) {
     return UPGRADE_CATEGORY_COPY[id];
   }
@@ -130,7 +130,7 @@ export function getCategoryCopy(id) {
   };
 }
 
-export function getFamilyCopy(id) {
+function getFamilyCopy(id) {
   if (!id) {
     return UPGRADE_FAMILY_COPY.general;
   }
@@ -143,7 +143,7 @@ export function getFamilyCopy(id) {
   };
 }
 
-export function buildUpgradeCategories(definitions) {
+function buildUpgradeCategories(definitions) {
   const grouped = new Map();
   definitions.forEach(definition => {
     const categoryId = getUpgradeCategory(definition);

--- a/src/ui/cards/model/videotube.js
+++ b/src/ui/cards/model/videotube.js
@@ -378,7 +378,7 @@ function startVideoInstance(definition, options = {}, state = getState()) {
   return newInstance.id;
 }
 
-export default function buildVideoTubeModel(assetDefinitions = [], state = getState()) {
+function buildVideoTubeModel(assetDefinitions = [], state = getState()) {
   const definition = ensureArray(assetDefinitions).find(entry => entry?.id === 'vlog') || null;
   if (!definition) {
     return {

--- a/src/ui/layout/features/eventLog.js
+++ b/src/ui/layout/features/eventLog.js
@@ -28,4 +28,3 @@ export function setupEventLog({ getElement } = {}) {
   });
 }
 
-export default setupEventLog;

--- a/src/ui/layout/features/kpiShortcuts.js
+++ b/src/ui/layout/features/kpiShortcuts.js
@@ -79,4 +79,3 @@ export function setupKpiShortcuts({ getElement } = {}) {
   });
 }
 
-export default setupKpiShortcuts;

--- a/src/ui/layout/features/slideOver.js
+++ b/src/ui/layout/features/slideOver.js
@@ -30,4 +30,3 @@ export function setupSlideOver({ getElement } = {}) {
   slideOver.hidePanel = hide;
 }
 
-export default setupSlideOver;

--- a/src/ui/layout/features/tabs.js
+++ b/src/ui/layout/features/tabs.js
@@ -35,4 +35,3 @@ export function setupTabs({ getElement, onActivate } = {}) {
   return activate;
 }
 
-export default setupTabs;

--- a/src/ui/layout/index.js
+++ b/src/ui/layout/index.js
@@ -10,12 +10,3 @@ export function applyCardFilters(models) {
   layoutController.applyFilters(models);
 }
 
-export function activateShellPanel(panelId) {
-  layoutController.activateShellPanel(panelId);
-}
-
-export default {
-  initLayoutControls,
-  activateShellPanel,
-  applyCardFilters
-};

--- a/src/ui/layout/model.js
+++ b/src/ui/layout/model.js
@@ -275,4 +275,3 @@ export function buildLayoutModel(models = {}) {
   };
 }
 
-export default buildLayoutModel;

--- a/src/ui/log/model.js
+++ b/src/ui/log/model.js
@@ -40,4 +40,3 @@ export function buildLogModel(state) {
   };
 }
 
-export default buildLogModel;

--- a/src/ui/player/model.js
+++ b/src/ui/player/model.js
@@ -190,4 +190,3 @@ export function buildPlayerPanelModel(state = {}) {
   };
 }
 
-export default buildPlayerPanelModel;

--- a/src/ui/skills/helpers.js
+++ b/src/ui/skills/helpers.js
@@ -9,11 +9,11 @@ export function formatXp(value) {
   return numberFormatter.format(Math.max(0, Math.round(Number(value) || 0)));
 }
 
-export function findSkillTier(level) {
+function findSkillTier(level) {
   return SKILL_LEVELS.find(tier => tier.level === level) || SKILL_LEVELS[0];
 }
 
-export function findNextSkillTier(level) {
+function findNextSkillTier(level) {
   return SKILL_LEVELS.find(tier => tier.level === level + 1) || null;
 }
 

--- a/src/ui/skillsWidget/model.js
+++ b/src/ui/skillsWidget/model.js
@@ -24,4 +24,3 @@ export function buildSkillsWidgetModel(state = {}) {
   };
 }
 
-export default buildSkillsWidgetModel;

--- a/src/ui/viewManager.js
+++ b/src/ui/viewManager.js
@@ -22,7 +22,3 @@ export function getActiveView() {
   return activeView;
 }
 
-export default {
-  setActiveView,
-  getActiveView
-};

--- a/src/ui/views/browser/apps/pageLookup.js
+++ b/src/ui/views/browser/apps/pageLookup.js
@@ -4,6 +4,3 @@ export function getPageByType(type) {
   return SERVICE_PAGES.find(entry => entry.type === type) || null;
 }
 
-export default {
-  getPageByType
-};

--- a/src/ui/views/browser/apps/serviceManager.js
+++ b/src/ui/views/browser/apps/serviceManager.js
@@ -54,10 +54,3 @@ export function subscribeToServiceSummaries(listener) {
   };
 }
 
-export default {
-  cachePayload,
-  getCachedPayload,
-  setServiceSummaries,
-  getLatestServiceSummaries,
-  subscribeToServiceSummaries
-};

--- a/src/ui/views/browser/cardsPresenter.js
+++ b/src/ui/views/browser/cardsPresenter.js
@@ -172,21 +172,21 @@ function renderBrowserCollections(registries = {}, models = {}) {
   setServiceSummaries(summaries);
 }
 
-export function renderAll(payload = {}) {
+function renderAll(payload = {}) {
   renderCollections(payload, {
     cache: cacheBrowserPayload,
     render: renderBrowserCollections
   });
 }
 
-export function update(payload = {}) {
+function update(payload = {}) {
   updateCollections(payload, {
     cache: cacheBrowserPayload,
     update: renderBrowserCollections
   });
 }
 
-export function updateCard() {
+function updateCard() {
   const cached = getCachedPayload();
   if (!cached) return;
   renderCollections(cached, {
@@ -195,7 +195,7 @@ export function updateCard() {
   });
 }
 
-export function refreshUpgradeSections() {
+function refreshUpgradeSections() {
   updateCard();
 }
 

--- a/src/ui/views/browser/components/blogpress/views/detailView.js
+++ b/src/ui/views/browser/components/blogpress/views/detailView.js
@@ -1,4 +1,4 @@
-export function createBackButton(onBack = () => {}, label = 'Back to blogs') {
+function createBackButton(onBack = () => {}, label = 'Back to blogs') {
   const button = document.createElement('button');
   button.type = 'button';
   button.className = 'blogpress-button blogpress-button--link';
@@ -7,7 +7,7 @@ export function createBackButton(onBack = () => {}, label = 'Back to blogs') {
   return button;
 }
 
-export function renderOverviewPanel(instance, formatCurrency) {
+function renderOverviewPanel(instance, formatCurrency) {
   const panel = document.createElement('article');
   panel.className = 'blogpress-panel blogpress-panel--overview';
 
@@ -52,7 +52,7 @@ export function renderOverviewPanel(instance, formatCurrency) {
   return panel;
 }
 
-export function renderNichePanel(instance, handlers = {}) {
+function renderNichePanel(instance, handlers = {}) {
   const panel = document.createElement('article');
   panel.className = 'blogpress-panel blogpress-panel--niche';
 
@@ -109,7 +109,7 @@ export function renderNichePanel(instance, handlers = {}) {
   return panel;
 }
 
-export function renderQualityPanel(instance, formatRange) {
+function renderQualityPanel(instance, formatRange) {
   const panel = document.createElement('article');
   panel.className = 'blogpress-panel blogpress-panel--quality';
 
@@ -160,7 +160,7 @@ export function renderQualityPanel(instance, formatRange) {
   return panel;
 }
 
-export function renderIncomePanel(instance, formatCurrency, formatNetCurrency) {
+function renderIncomePanel(instance, formatCurrency, formatNetCurrency) {
   const panel = document.createElement('article');
   panel.className = 'blogpress-panel blogpress-panel--income';
 
@@ -238,7 +238,7 @@ export function renderIncomePanel(instance, formatCurrency, formatNetCurrency) {
   return panel;
 }
 
-export function renderPayoutPanel(instance, formatCurrency) {
+function renderPayoutPanel(instance, formatCurrency) {
   const panel = document.createElement('article');
   panel.className = 'blogpress-panel blogpress-panel--payout';
   const title = document.createElement('h3');
@@ -279,7 +279,7 @@ export function renderPayoutPanel(instance, formatCurrency) {
   return panel;
 }
 
-export function renderActionPanel(instance, handlers = {}, formatHours, formatCurrency) {
+function renderActionPanel(instance, handlers = {}, formatHours, formatCurrency) {
   const panel = document.createElement('article');
   panel.className = 'blogpress-panel blogpress-panel--actions';
   const title = document.createElement('h3');
@@ -333,7 +333,7 @@ export function renderActionPanel(instance, handlers = {}, formatHours, formatCu
   return panel;
 }
 
-export function renderUpkeepPanel(instance) {
+function renderUpkeepPanel(instance) {
   const panel = document.createElement('article');
   panel.className = 'blogpress-panel blogpress-panel--upkeep';
   const title = document.createElement('h3');

--- a/src/ui/views/browser/components/blogpress/views/homeView.js
+++ b/src/ui/views/browser/components/blogpress/views/homeView.js
@@ -1,4 +1,4 @@
-export function renderSummaryBar(model = {}) {
+function renderSummaryBar(model = {}) {
   const summary = document.createElement('div');
   summary.className = 'blogpress-summary';
   const total = model.summary?.total || 0;
@@ -13,7 +13,7 @@ export function renderSummaryBar(model = {}) {
   return summary;
 }
 
-export function createTableCell(content, className) {
+function createTableCell(content, className) {
   const cell = document.createElement('td');
   if (className) {
     cell.className = className;

--- a/src/ui/views/browser/components/shopstack/detailBuilders.js
+++ b/src/ui/views/browser/components/shopstack/detailBuilders.js
@@ -1,5 +1,0 @@
-import * as detail from './detail/index.js';
-
-export * from './detail/index.js';
-
-export default detail;


### PR DESCRIPTION
## Summary
- remove unused shopstack detail builder wrapper
- drop unused default or named exports across UI helpers, layout features, and card models
- keep helper functions internal to their modules so they are not exported unnecessarily

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e111ef3fe8832c8b44ebd38706b5a5