### PR TITLE
Remove unused ShopStack detail builders module

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@
 - Content tracks lean on schema builders for courses, upgrades, and passive assets; boosts and events reuse the shared multi-day engine.
 - Passive income, education, and hustles remain tuned around upkeep-first scheduling so players stay in control of daily hours.
 - Routine hustle payouts and quality work logs now auto-dismiss so the notification bell spotlights urgent alerts.
+- ShopStack workspace trims unused detail builders to keep presenter imports lean.
 
 ## Recent Highlights
 - Passive assets gained Quality 4–5 payout milestones with clearer upkeep cues.

--- a/src/ui/views/browser/components/shopstack/detailBuilders.js
+++ b/src/ui/views/browser/components/shopstack/detailBuilders.js
@@ -1,5 +1,0 @@
-import * as detail from './detail/index.js';
-
-export * from './detail/index.js';
-
-export default detail;


### PR DESCRIPTION
## Summary
- remove the unused ShopStack detailBuilders module after confirming there are no remaining references
- document the cleanup in the changelog

## Testing
- node --test tests/ui/workspaces/shopStackWorkspacePresenter.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e1158294e8832c8aa5582ae4ea0794