### PR TITLE
Refactor trends presenter into modular components

### DIFF
--- a/src/ui/views/browser/components/trends/overview.js
+++ b/src/ui/views/browser/components/trends/overview.js
@@ -1,0 +1,83 @@
+export const DEFAULT_OVERVIEW = {
+  topBoost: { title: 'No boosts yet', note: 'Run hustles to reveal positive swings.' },
+  biggestDrop: { title: 'Stable so far', note: 'Downtrends will appear here.' },
+  bestPayout: { title: 'No payout spikes yet', note: 'Assign ventures to chase multipliers.' },
+  activeCount: { value: 0, note: 'Activate a venture to start the count.' }
+};
+
+export function computeOverview(entries = []) {
+  if (!entries.length) return DEFAULT_OVERVIEW;
+
+  const byImpactDesc = entries
+    .filter(entry => Number.isFinite(Number(entry.trendImpact)))
+    .slice()
+    .sort((a, b) => Number(b.trendImpact) - Number(a.trendImpact));
+  const positive = byImpactDesc.filter(entry => Number(entry.trendImpact) > 0);
+  const negative = entries
+    .filter(entry => Number(entry.trendImpact) < 0)
+    .slice()
+    .sort((a, b) => Number(a.trendImpact) - Number(b.trendImpact));
+  const bestPayout = entries
+    .slice()
+    .sort((a, b) => (Number(b.popularity?.multiplier) || 1) - (Number(a.popularity?.multiplier) || 1))[0];
+  const activeCount = entries.filter(entry => entry.assetCount > 0).length;
+
+  return {
+    topBoost: positive[0] || null,
+    biggestDrop: negative[0] || null,
+    bestPayout: bestPayout || null,
+    activeCount: { value: activeCount }
+  };
+}
+
+export function updateOverview(entries = [], overviewRefs = {}, { formatPercent, formatSignedCurrency } = {}) {
+  const overview = computeOverview(entries);
+
+  const renderEntry = (target, entry, fallback) => {
+    if (!target) return;
+    if (!entry) {
+      target.value.textContent = fallback?.title || '—';
+      target.note.textContent = fallback?.note || '';
+      return;
+    }
+
+    const name = entry.definition?.name || 'Untitled niche';
+    if (typeof entry === 'object' && 'value' in entry && !entry.definition) {
+      const countValue = Number(entry.value) || 0;
+      target.value.textContent = String(countValue);
+      target.note.textContent = countValue > 0
+        ? entry.note || (countValue === 1 ? 'Active niche today.' : 'Active niches today.')
+        : DEFAULT_OVERVIEW.activeCount.note;
+      return;
+    }
+
+    const impact = Number(entry.trendImpact) || 0;
+    const delta = Number(entry.popularity?.delta);
+    const multiplier = Number(entry.popularity?.multiplier) || 1;
+    const payoutText = formatPercent ? formatPercent(multiplier - 1) : '';
+    target.value.textContent = name;
+
+    if (impact > 0) {
+      const impactText = formatSignedCurrency ? formatSignedCurrency(impact) : impact;
+      target.note.textContent = `${impactText} impact${payoutText ? ` • ${payoutText} payouts` : ''}`;
+    } else if (impact < 0) {
+      const impactText = formatSignedCurrency ? formatSignedCurrency(impact) : impact;
+      target.note.textContent = `${impactText} impact`;
+    } else if (Number.isFinite(delta)) {
+      target.note.textContent = `${delta > 0 ? '+' : ''}${delta} pts momentum`;
+    } else {
+      target.note.textContent = payoutText;
+    }
+  };
+
+  renderEntry(overviewRefs.topBoost, overview.topBoost, DEFAULT_OVERVIEW.topBoost);
+  renderEntry(overviewRefs.biggestDrop, overview.biggestDrop, DEFAULT_OVERVIEW.biggestDrop);
+  renderEntry(overviewRefs.bestPayout, overview.bestPayout, DEFAULT_OVERVIEW.bestPayout);
+
+  if (overviewRefs.activeCount) {
+    const value = Number(overview.activeCount?.value) || 0;
+    overviewRefs.activeCount.value.textContent = String(value);
+    const label = value === 1 ? 'Active niche today.' : 'Active niches today.';
+    overviewRefs.activeCount.note.textContent = value ? label : DEFAULT_OVERVIEW.activeCount.note;
+  }
+}

--- a/src/ui/views/browser/components/trends/sparkline.js
+++ b/src/ui/views/browser/components/trends/sparkline.js
@@ -1,0 +1,81 @@
+const HISTORY_LENGTH = 7;
+
+export function clampScore(value) {
+  if (!Number.isFinite(value)) return null;
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function createSparklineSeries(popularity = {}) {
+  const history = Array.isArray(popularity.history)
+    ? popularity.history
+        .map(clampScore)
+        .filter(value => value !== null)
+    : [];
+
+  if (history.length >= 2) {
+    const trimmed = history.slice(-HISTORY_LENGTH);
+    if (trimmed.length >= 2) {
+      return trimmed;
+    }
+  }
+
+  const score = clampScore(popularity.score);
+  const previous = clampScore(popularity.previousScore);
+  const length = HISTORY_LENGTH;
+
+  if (score === null && previous === null) {
+    return Array.from({ length }, () => 0);
+  }
+
+  const start = previous !== null ? previous : score ?? 0;
+  const end = score !== null ? score : start;
+
+  return Array.from({ length }, (_, index) => {
+    const t = length === 1 ? 1 : index / (length - 1);
+    return start + (end - start) * t;
+  });
+}
+
+export function buildSparkline(popularity = {}) {
+  const values = createSparklineSeries(popularity);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const height = 42;
+  const width = 160;
+  const range = Math.max(1, max - min);
+  const hasSlope = values.some(value => value !== values[0]);
+  const NS = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(NS, 'svg');
+  svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+  svg.setAttribute('preserveAspectRatio', 'none');
+  svg.classList.add('trends-card__sparkline');
+
+  if (!hasSlope) {
+    const line = document.createElementNS(NS, 'path');
+    const y = height / 2;
+    line.setAttribute('d', `M0 ${y} L${width} ${y}`);
+    line.setAttribute('vector-effect', 'non-scaling-stroke');
+    svg.appendChild(line);
+    return svg;
+  }
+
+  const points = values.map((value, index) => {
+    const x = (index / (values.length - 1)) * width;
+    const y = height - ((value - min) / range) * height;
+    return { x, y };
+  });
+
+  const path = document.createElementNS(NS, 'path');
+  const pathData = points
+    .map(({ x, y }, index) => `${index === 0 ? 'M' : 'L'}${x} ${y}`)
+    .join(' ');
+  path.setAttribute('d', pathData);
+  path.setAttribute('vector-effect', 'non-scaling-stroke');
+
+  const area = document.createElementNS(NS, 'path');
+  const areaData = `M0 ${height} ${pathData} L${width} ${height} Z`;
+  area.setAttribute('d', areaData);
+
+  svg.append(area, path);
+  return svg;
+}

--- a/src/ui/views/browser/components/trends/state.js
+++ b/src/ui/views/browser/components/trends/state.js
@@ -1,0 +1,82 @@
+export const filterState = {
+  sort: 'momentum',
+  view: 'all',
+  search: '',
+  rawSearch: ''
+};
+
+let rootNode = null;
+let refs = null;
+let currentModel = null;
+
+function ensureRefs() {
+  if (refs) return refs;
+  refs = {
+    header: {
+      searchInput: null,
+      sortSelect: null,
+      viewButtons: {}
+    },
+    overview: {
+      topBoost: {},
+      biggestDrop: {},
+      bestPayout: {},
+      activeCount: {}
+    },
+    grid: {
+      container: null,
+      empty: null,
+      footer: null,
+      meta: null
+    },
+    watchlist: {
+      container: null,
+      section: null,
+      empty: null,
+      meta: null
+    },
+    footerNote: null
+  };
+  return refs;
+}
+
+export function getRefs() {
+  return ensureRefs();
+}
+
+export function ensureRoot(mount, buildLayout) {
+  if (!rootNode) {
+    rootNode = document.createElement('div');
+    rootNode.className = 'trends-app';
+    buildLayout(rootNode);
+  }
+
+  if (rootNode.parentElement !== mount) {
+    mount.innerHTML = '';
+    mount.appendChild(rootNode);
+  }
+
+  return rootNode;
+}
+
+export function getCurrentModel() {
+  return currentModel;
+}
+
+export function setCurrentModel(model) {
+  currentModel = model;
+}
+
+export function getWatchlistCount() {
+  return currentModel?.watchlistCount || 0;
+}
+
+export function updateEntryWatchlist(nicheId, watchlisted) {
+  if (!nicheId || !currentModel?.entries) return;
+  currentModel.entries.forEach(entry => {
+    if (entry?.id === nicheId) {
+      entry.watchlisted = watchlisted;
+    }
+  });
+  currentModel.watchlistCount = currentModel.entries.filter(entry => entry.watchlisted).length;
+}


### PR DESCRIPTION
## Summary
- extract the trends presenter's state management into a dedicated module and centralize shared references
- move sparkline generation and overview aggregation into focused helpers for reuse
- update the trends presenter to use the new modules while keeping the existing UI wiring intact

## Testing
- npm test -- tests/ui/views/browser/cardsPresenter.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e11658169c832c8c4d16094f23c841