### PR TITLE
Refactor todo widget state and DOM helpers

### DIFF
--- a/src/ui/views/browser/widgets/todoDom.js
+++ b/src/ui/views/browser/widgets/todoDom.js
@@ -1,0 +1,272 @@
+function toArray(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (!value) {
+    return [];
+  }
+  if (typeof value.forEach === 'function' && typeof value.length === 'number') {
+    return Array.from(value);
+  }
+  return [];
+}
+
+function prepareElements(widgetElements = {}) {
+  const elements = { ...widgetElements };
+
+  if (!elements.listWrapper && elements.container?.querySelector) {
+    const wrapper = elements.container.querySelector('.todo-widget__list-wrapper');
+    if (wrapper) {
+      elements.listWrapper = wrapper;
+    }
+  }
+
+  if (elements.focusButtons) {
+    elements.focusButtons = toArray(elements.focusButtons);
+  } else if (elements.focusGroup?.querySelectorAll) {
+    const buttons = elements.focusGroup.querySelectorAll('[data-focus]');
+    if (buttons?.length) {
+      elements.focusButtons = Array.from(buttons);
+    }
+  } else {
+    elements.focusButtons = [];
+  }
+
+  if (elements.doneHeading) {
+    elements.doneHeading.hidden = true;
+  }
+
+  return elements;
+}
+
+function bindEndDay(button, handler) {
+  if (!button || button.dataset.bound === 'true') return;
+  if (typeof handler !== 'function') return;
+
+  button.addEventListener('click', handler);
+  button.dataset.bound = 'true';
+}
+
+function syncFocusButtons(buttons = [], activeMode) {
+  buttons.forEach(button => {
+    if (!button?.dataset) return;
+    const mode = button.dataset.focus;
+    const isActive = mode === activeMode;
+    button.classList.toggle('is-active', isActive);
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+  });
+}
+
+function bindFocusControls(buttons = [], onFocusChange, activeMode) {
+  if (!Array.isArray(buttons) || !buttons.length) {
+    return;
+  }
+
+  buttons.forEach(button => {
+    if (!button || button.dataset.focusBound === 'true') return;
+    button.addEventListener('click', () => {
+      const mode = button.dataset.focus;
+      if (typeof onFocusChange === 'function') {
+        onFocusChange(mode);
+      }
+    });
+    button.dataset.focusBound = 'true';
+  });
+
+  syncFocusButtons(buttons, activeMode);
+}
+
+function applyScrollerLimit(listWrapper, model = {}) {
+  if (!listWrapper?.style) return;
+
+  const limit = Number(model?.scroller?.limit);
+  if (!Number.isFinite(limit) || limit <= 0) {
+    listWrapper.style.removeProperty('--todo-widget-max-height');
+    listWrapper.style.removeProperty('--todo-widget-row-height');
+    return;
+  }
+
+  const rows = Math.max(1, Math.floor(limit));
+  const rowHeight = Number(model?.scroller?.rowHeight);
+  if (Number.isFinite(rowHeight) && rowHeight > 0) {
+    listWrapper.style.setProperty('--todo-widget-row-height', `${rowHeight}rem`);
+  } else {
+    listWrapper.style.removeProperty('--todo-widget-row-height');
+  }
+  const maxHeight = `calc(var(--todo-widget-row-height, 4.5rem) * ${rows})`;
+  listWrapper.style.setProperty('--todo-widget-max-height', maxHeight);
+}
+
+function renderHours(elements = {}, model = {}, formatHours) {
+  if (typeof formatHours !== 'function') return;
+
+  if (elements.availableValue) {
+    const available = Number(model.hoursAvailable);
+    const label = model.hoursAvailableLabel
+      || formatHours(Number.isFinite(available) ? Math.max(0, available) : 0);
+    elements.availableValue.textContent = label || '0h';
+  }
+
+  if (elements.spentValue) {
+    const spent = Number(model.hoursSpent);
+    const label = model.hoursSpentLabel
+      || formatHours(Number.isFinite(spent) ? Math.max(0, spent) : 0);
+    elements.spentValue.textContent = label || '0h';
+  }
+}
+
+function updateNote(note, model = {}, pendingCount = 0) {
+  if (!note) return;
+
+  if (pendingCount > 0) {
+    note.textContent = pendingCount === 1
+      ? '1 task ready to trigger.'
+      : `${pendingCount} tasks ready to trigger.`;
+    return;
+  }
+
+  note.textContent = model.emptyMessage || 'Queue a hustle or upgrade to add new tasks.';
+}
+
+function createTask(entry, model, onComplete) {
+  const item = document.createElement('li');
+  item.className = 'todo-widget__item';
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'todo-widget__task';
+  button.setAttribute('aria-label', `${entry.title} ${entry.meta}`.trim());
+
+  const checkbox = document.createElement('span');
+  checkbox.className = 'todo-widget__checkbox';
+  checkbox.textContent = '✓';
+
+  const content = document.createElement('div');
+  content.className = 'todo-widget__content';
+
+  const title = document.createElement('span');
+  title.className = 'todo-widget__title';
+  title.textContent = entry.title;
+  content.appendChild(title);
+
+  if (entry.meta) {
+    const meta = document.createElement('span');
+    meta.className = 'todo-widget__meta';
+    meta.textContent = entry.meta;
+    content.appendChild(meta);
+  }
+
+  button.addEventListener('click', () => {
+    if (button.getAttribute('aria-disabled') === 'true') return;
+    button.setAttribute('aria-disabled', 'true');
+    button.classList.add('is-complete');
+
+    const completed = typeof onComplete === 'function' ? onComplete(entry, model) : false;
+    if (!completed) {
+      button.removeAttribute('aria-disabled');
+      button.classList.remove('is-complete');
+    }
+  });
+
+  button.append(checkbox, content);
+  item.appendChild(button);
+  return item;
+}
+
+function renderPending(list, entries = [], model, onComplete) {
+  if (!list) return;
+
+  list.innerHTML = '';
+  entries.forEach(entry => {
+    const task = createTask(entry, model, onComplete);
+    list.appendChild(task);
+  });
+}
+
+function renderEmptyState(list, message, onEndDay) {
+  if (!list) return;
+
+  list.innerHTML = '';
+  const empty = document.createElement('li');
+  empty.className = 'todo-widget__empty';
+
+  const text = document.createElement('span');
+  text.className = 'todo-widget__empty-text';
+  text.textContent = message || 'No quick wins queued. Check upgrades or ventures.';
+  empty.appendChild(text);
+
+  if (typeof onEndDay === 'function') {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'todo-widget__empty-action';
+    button.textContent = 'End Day';
+    bindEndDay(button, onEndDay);
+    empty.appendChild(button);
+  }
+
+  list.appendChild(empty);
+}
+
+function renderCompleted(list, heading, entries = [], formatDuration) {
+  if (!list) return;
+
+  const sorted = [...entries].sort((a, b) => b.completedAt - a.completedAt);
+  list.innerHTML = '';
+
+  if (heading) {
+    heading.hidden = sorted.length === 0;
+  }
+
+  if (!sorted.length) {
+    const placeholder = document.createElement('li');
+    placeholder.className = 'todo-widget__empty';
+    placeholder.textContent = 'Nothing checked off yet.';
+    list.appendChild(placeholder);
+    return;
+  }
+
+  sorted.forEach(entry => {
+    const item = document.createElement('li');
+    item.className = 'todo-widget__done-item';
+
+    const title = document.createElement('span');
+    title.className = 'todo-widget__done-title';
+    title.textContent = entry.title;
+
+    const meta = document.createElement('span');
+    meta.className = 'todo-widget__done-meta';
+    const label = entry.durationText
+      || (typeof formatDuration === 'function' ? formatDuration(entry.durationHours) : '0h');
+    const countLabel = entry.count && entry.count > 1 ? ` ×${entry.count}` : '';
+    meta.textContent = `(${label}${countLabel})`;
+
+    item.append(title, meta);
+    list.appendChild(item);
+  });
+}
+
+export {
+  applyScrollerLimit,
+  bindEndDay,
+  bindFocusControls,
+  prepareElements,
+  renderCompleted,
+  renderEmptyState,
+  renderHours,
+  renderPending,
+  syncFocusButtons,
+  updateNote
+};
+
+export default {
+  applyScrollerLimit,
+  bindEndDay,
+  bindFocusControls,
+  prepareElements,
+  renderCompleted,
+  renderEmptyState,
+  renderHours,
+  renderPending,
+  syncFocusButtons,
+  updateNote
+};

--- a/src/ui/views/browser/widgets/todoState.js
+++ b/src/ui/views/browser/widgets/todoState.js
@@ -1,0 +1,179 @@
+import { formatHours } from '../../../../core/helpers.js';
+
+const focusModes = ['money', 'upgrades', 'balanced'];
+const completedItems = new Map();
+let currentDay = null;
+let focusMode = 'balanced';
+let pendingEntries = [];
+let lastModel = null;
+
+function normalizeDay(day) {
+  const numeric = Number(day);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function resetCompletedForDay(day) {
+  const normalized = normalizeDay(day);
+  if (normalized === null) {
+    if (currentDay !== null) {
+      completedItems.clear();
+      currentDay = null;
+    }
+    return;
+  }
+
+  if (normalized !== currentDay) {
+    completedItems.clear();
+    currentDay = normalized;
+  }
+}
+
+function seedAutoCompletedEntries(entries = [], formatDuration = hours => formatHours(hours || 0)) {
+  if (!Array.isArray(entries) || !entries.length) return;
+
+  entries.forEach((entry, index) => {
+    const id = entry?.id || `auto-${index}`;
+    if (!id) return;
+
+    const existing = completedItems.get(id);
+    const hours = Number(entry?.durationHours);
+    const durationHours = Number.isFinite(hours) && hours > 0 ? hours : 0;
+    const durationText = entry?.durationText || formatDuration(durationHours);
+    const count = Number.isFinite(entry?.count) && entry.count > 0 ? entry.count : 1;
+    const completedAt = existing?.completedAt ?? Date.now();
+
+    completedItems.set(id, {
+      id,
+      title: entry?.title || 'Scheduled work',
+      durationHours,
+      durationText,
+      repeatable: false,
+      remainingRuns: null,
+      count,
+      completedAt
+    });
+  });
+}
+
+function isValidFocusMode(mode) {
+  return focusModes.includes(mode);
+}
+
+function setFocusMode(mode) {
+  const normalized = typeof mode === 'string' ? mode.toLowerCase() : '';
+  if (!isValidFocusMode(normalized) || normalized === focusMode) {
+    return false;
+  }
+
+  focusMode = normalized;
+  return true;
+}
+
+function getFocusMode() {
+  return focusMode;
+}
+
+function getFocusModes() {
+  return [...focusModes];
+}
+
+function setLastModel(model = {}) {
+  lastModel = model;
+}
+
+function getLastModel() {
+  return lastModel;
+}
+
+function setPendingEntries(entries = []) {
+  pendingEntries = Array.isArray(entries) ? entries : [];
+}
+
+function getPendingEntries() {
+  return pendingEntries;
+}
+
+function getCompletion(entryId) {
+  if (!entryId) return null;
+  return completedItems.get(entryId) || null;
+}
+
+function recordCompletion(entry, {
+  durationHours = 0,
+  durationText = '',
+  repeatable = false,
+  remainingRuns = null
+} = {}) {
+  if (!entry?.id) {
+    return null;
+  }
+
+  const existing = completedItems.get(entry.id);
+  const count = existing ? (existing.count || 1) + 1 : 1;
+  const normalizedDuration = Number.isFinite(durationHours) && durationHours > 0 ? durationHours : 0;
+
+  const record = {
+    id: entry.id,
+    title: entry.title,
+    durationHours: normalizedDuration,
+    durationText,
+    repeatable,
+    remainingRuns,
+    count,
+    completedAt: Date.now()
+  };
+
+  completedItems.set(entry.id, record);
+  return record;
+}
+
+function getCompletedEntries() {
+  return Array.from(completedItems.values());
+}
+
+function getEffectiveRemainingRuns(entry = {}, completion) {
+  if (entry?.remainingRuns == null) {
+    return null;
+  }
+
+  const total = Number(entry.remainingRuns);
+  if (!Number.isFinite(total)) {
+    return null;
+  }
+
+  const used = Number(completion?.count);
+  const consumed = Number.isFinite(used) ? Math.max(0, used) : 0;
+  return Math.max(0, total - consumed);
+}
+
+export {
+  getCompletion,
+  getCompletedEntries,
+  getEffectiveRemainingRuns,
+  getFocusMode,
+  getFocusModes,
+  getLastModel,
+  getPendingEntries,
+  recordCompletion,
+  resetCompletedForDay,
+  seedAutoCompletedEntries,
+  setFocusMode,
+  setLastModel,
+  setPendingEntries
+};
+
+export default {
+  getCompletion,
+  getCompletedEntries,
+  getEffectiveRemainingRuns,
+  getFocusMode,
+  getFocusModes,
+  getLastModel,
+  getPendingEntries,
+  recordCompletion,
+  resetCompletedForDay,
+  seedAutoCompletedEntries,
+  setFocusMode,
+  setLastModel,
+  setPendingEntries
+};


### PR DESCRIPTION
## Summary
- extract focus-mode and completion bookkeeping into a dedicated todo state module
- centralize DOM querying and event wiring for the todo widget in a reusable helper
- rework the todo widget presenter to compose the new modules and maintain existing behaviors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e116738e28832ca83f5975d165052f