### PR TITLE
Adjust auto-read log types for education payoff messages

### DIFF
--- a/src/core/logAutoReadTypes.js
+++ b/src/core/logAutoReadTypes.js
@@ -1,11 +1,11 @@
-const AUTO_READ_TYPES = Object.freeze(['passive', 'upgrade', 'hustle', 'quality']);
+const AUTO_READ_TYPES = Object.freeze(['passive', 'hustle', 'quality', 'educationPayoff']);
 
 export function isAutoReadType(type) {
   if (typeof type !== 'string' || !type) {
     return false;
   }
   const normalized = type.toLowerCase();
-  return AUTO_READ_TYPES.includes(normalized);
+  return AUTO_READ_TYPES.some(entry => String(entry).toLowerCase() === normalized);
 }
 
 export function getAutoReadTypes() {

--- a/src/game/content/schema/assetActions.js
+++ b/src/game/content/schema/assetActions.js
@@ -14,7 +14,7 @@ import {
 } from '../../educationEffects.js';
 import { getHustleEffectMultiplier } from '../../upgrades/effects.js';
 import { applyMetric, normalizeHustleMetrics } from './metrics.js';
-import { logEducationBonusSummary, logHustleBlocked } from './logMessaging.js';
+import { logEducationPayoffSummary, logHustleBlocked } from './logMessaging.js';
 import { markDirty } from '../../../ui/invalidation.js';
 
 function formatHourDetail(hours, effective) {
@@ -282,7 +282,7 @@ export function createInstantHustle(config) {
 
       if (appliedBonuses.length) {
         const summary = formatEducationBonusSummary(appliedBonuses);
-        logEducationBonusSummary(summary);
+        logEducationPayoffSummary(summary);
       }
     }
 

--- a/src/game/content/schema/logMessaging.js
+++ b/src/game/content/schema/logMessaging.js
@@ -7,9 +7,9 @@ export function logHustleBlocked(reason) {
   addLog(reason, 'warning');
 }
 
-export function logEducationBonusSummary(summary) {
+export function logEducationPayoffSummary(summary) {
   if (!summary) return;
-  addLog(`Your studies kicked in: ${summary}.`, 'info');
+  addLog(`Your studies kicked in: ${summary}.`, 'educationPayoff');
 }
 
 export function logUpgradeBlocked({ context, config, consumes }) {

--- a/src/ui/views/browser/notificationsPresenter.js
+++ b/src/ui/views/browser/notificationsPresenter.js
@@ -7,7 +7,8 @@ const TYPE_LABELS = {
   success: 'Success',
   warning: 'Alert',
   danger: 'Alert',
-  info: 'Update'
+  info: 'Update',
+  educationpayoff: 'Study Boost'
 };
 
 const presenterState = {


### PR DESCRIPTION
## Summary
- make upgrade logs unread by default so upgrade notifications stay visible
- move education bonus summaries to a dedicated educationPayoff log type and auto-read list
- label education payoff notifications as a "Study Boost" in the browser panel

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e117fc4f10832caed579c22020068e