### PR TITLE
Ensure niche reassignment refreshes dashboard analytics

### DIFF
--- a/src/game/assets/niches.js
+++ b/src/game/assets/niches.js
@@ -256,7 +256,7 @@ export function assignInstanceToNiche(assetId, instanceId, nicheId) {
     }
     changed = true;
 
-    markDirty(['cards', 'dashboard']);
+    markDirty({ cards: true, dashboard: true });
 
     const labelBase = assetDefinition.singular || assetDefinition.name || 'Asset';
     const label = `${labelBase} #${index + 1}`;


### PR DESCRIPTION
## Summary
- mark dashboard and cards sections dirty before logging when an instance changes niches so the UI refreshes immediately
- expand the dashboard update integration coverage to exercise niche reassignment and confirm board/highlight data updates

## Testing
- npm test -- tests/ui/update.integration.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e11b1e43ac832cba8050b9791d1612