### PR TITLE
Refactor workspace renderers to share initialization logic

### DIFF
--- a/src/ui/views/browser/apps/digishelf.js
+++ b/src/ui/views/browser/apps/digishelf.js
@@ -1,35 +1,19 @@
 import digishelfApp from '../components/digishelf.js';
-import { setWorkspacePath } from '../layoutPresenter.js';
-import { getPageByType } from './pageLookup.js';
+import { createWorkspaceRenderer } from '../utils/workspaceFactories.js';
 
-export default function renderDigishelf(context = {}, definitions = [], model = {}) {
-  const page = getPageByType('digishelf');
-  if (!page) return null;
-
-  const refs = context.ensurePageContent?.(page, ({ body }) => {
-    if (!body.querySelector('[data-role="digishelf-root"]')) {
-      body.innerHTML = '';
-      const wrapper = document.createElement('div');
-      wrapper.dataset.role = 'digishelf-root';
-      body.appendChild(wrapper);
-    }
-  });
-  if (!refs) return null;
-
-  const mount = refs.body.querySelector('[data-role="digishelf-root"]');
-  if (!mount) return null;
-
-  const handleRouteChange = path => {
-    setWorkspacePath(page.id, path);
-  };
-  const summary = digishelfApp.render(model, {
+const renderDigishelfWorkspace = createWorkspaceRenderer({
+  pageType: 'digishelf',
+  mountRole: 'digishelf-root',
+  renderApp: (model, options) => digishelfApp.render(model, options),
+  buildRenderOptions: ({ mount, page, definitions, onRouteChange }) => ({
     mount,
     page,
     definitions,
-    onRouteChange: handleRouteChange,
-  });
-  const path = summary?.urlPath || '';
-  setWorkspacePath(page.id, path);
-  const meta = summary?.meta || model?.summary?.meta || 'Publish your first resource';
-  return { id: page.id, meta, urlPath: path };
+    onRouteChange,
+  }),
+  fallbackMeta: 'Publish your first resource',
+});
+
+export default function renderDigishelf(context = {}, definitions = [], model = {}) {
+  return renderDigishelfWorkspace(context, definitions, model);
 }

--- a/src/ui/views/browser/apps/shopily.js
+++ b/src/ui/views/browser/apps/shopily.js
@@ -1,30 +1,13 @@
 import shopilyApp from '../components/shopily.js';
-import { setWorkspacePath } from '../layoutPresenter.js';
-import { getPageByType } from './pageLookup.js';
+import { createWorkspaceRenderer } from '../utils/workspaceFactories.js';
+
+const renderShopilyWorkspace = createWorkspaceRenderer({
+  pageType: 'shopily',
+  mountRole: 'shopily-root',
+  renderApp: (model, options) => shopilyApp.render(model, options),
+  fallbackMeta: 'Launch your first store',
+});
 
 export default function renderShopily(context = {}, definitions = [], model = {}) {
-  const page = getPageByType('shopily');
-  if (!page) return null;
-
-  const refs = context.ensurePageContent?.(page, ({ body }) => {
-    if (!body.querySelector('[data-role="shopily-root"]')) {
-      body.innerHTML = '';
-      const wrapper = document.createElement('div');
-      wrapper.dataset.role = 'shopily-root';
-      body.appendChild(wrapper);
-    }
-  });
-  if (!refs) return null;
-
-  const mount = refs.body.querySelector('[data-role="shopily-root"]');
-  if (!mount) return null;
-
-  const handleRouteChange = path => {
-    setWorkspacePath(page.id, path);
-  };
-  const summary = shopilyApp.render(model, { mount, page, onRouteChange: handleRouteChange });
-  const path = summary?.urlPath || '';
-  setWorkspacePath(page.id, path);
-  const meta = summary?.meta || model?.summary?.meta || 'Launch your first store';
-  return { id: page.id, meta, urlPath: path };
+  return renderShopilyWorkspace(context, definitions, model);
 }

--- a/src/ui/views/browser/apps/upgrades.js
+++ b/src/ui/views/browser/apps/upgrades.js
@@ -1,36 +1,21 @@
 import shopstackApp from '../components/shopstack/index.js';
-import { setWorkspacePath } from '../layoutPresenter.js';
-import { getPageByType } from './pageLookup.js';
+import { createWorkspaceRenderer } from '../utils/workspaceFactories.js';
 
-export default function renderUpgrades(context = {}, definitions = [], models = {}) {
-  const page = getPageByType('upgrades');
-  if (!page) return null;
-
-  const refs = context.ensurePageContent?.(page, ({ body }) => {
-    if (!body.querySelector('[data-role="shopstack-root"]')) {
-      body.innerHTML = '';
-      const wrapper = document.createElement('div');
-      wrapper.dataset.role = 'shopstack-root';
-      body.appendChild(wrapper);
-    }
-  });
-  if (!refs) return null;
-
-  const mount = refs.body.querySelector('[data-role="shopstack-root"]');
-  if (!mount) return null;
-
-  const handleRouteChange = path => {
-    setWorkspacePath(page.id, path);
-  };
-
-  const summary = shopstackApp.render(models, {
+const renderShopstackWorkspace = createWorkspaceRenderer({
+  pageType: 'upgrades',
+  mountRole: 'shopstack-root',
+  renderApp: (models, options) => shopstackApp.render(models, options),
+  buildRenderOptions: ({ mount, page, definitions, onRouteChange }) => ({
     mount,
     page,
     definitions,
-    onRouteChange: handleRouteChange
-  });
-  const path = summary?.urlPath || '';
-  setWorkspacePath(page.id, path);
-  const meta = summary?.meta || models?.overview?.note || 'Browse upgrades for upcoming boosts';
-  return { id: page.id, meta, urlPath: path };
+    onRouteChange,
+  }),
+  deriveMeta: ({ summary, model, fallback }) =>
+    summary?.meta || model?.overview?.note || model?.summary?.meta || fallback || '',
+  fallbackMeta: 'Browse upgrades for upcoming boosts',
+});
+
+export default function renderUpgrades(context = {}, definitions = [], models = {}) {
+  return renderShopstackWorkspace(context, definitions, models);
 }

--- a/src/ui/views/browser/utils/workspaceFactories.js
+++ b/src/ui/views/browser/utils/workspaceFactories.js
@@ -1,0 +1,87 @@
+import { setWorkspacePath } from '../layoutPresenter.js';
+import { getPageByType } from '../apps/pageLookup.js';
+
+function ensureWorkspaceMount({ body, role }) {
+  if (!body) return null;
+  let mount = body.querySelector(`[data-role="${role}"]`);
+  if (!mount) {
+    body.innerHTML = '';
+    mount = document.createElement('div');
+    mount.dataset.role = role;
+    body.appendChild(mount);
+  }
+  return mount;
+}
+
+function defaultDeriveMeta({ summary, model, fallback }) {
+  return summary?.meta || model?.summary?.meta || fallback || '';
+}
+
+export function createWorkspaceRenderer({
+  pageType,
+  mountRole,
+  renderApp,
+  buildRenderOptions,
+  deriveMeta = defaultDeriveMeta,
+  prepareBody,
+  fallbackMeta,
+}) {
+  if (!pageType) throw new Error('createWorkspaceRenderer requires a pageType');
+  if (!mountRole) throw new Error('createWorkspaceRenderer requires a mountRole');
+  if (typeof renderApp !== 'function') throw new Error('createWorkspaceRenderer requires a renderApp function');
+
+  return function renderWorkspace(context = {}, definitions = [], model = {}) {
+    const page = getPageByType(pageType);
+    if (!page) return null;
+
+    const refs = context.ensurePageContent?.(page, ({ body }) => {
+      const mount = ensureWorkspaceMount({ body, role: mountRole });
+      if (mount && typeof prepareBody === 'function') {
+        prepareBody({
+          body,
+          mount,
+          page,
+          context,
+          definitions,
+          model,
+        });
+      }
+    });
+    if (!refs) return null;
+
+    const mount = refs.body.querySelector(`[data-role="${mountRole}"]`);
+    if (!mount) return null;
+
+    const handleRouteChange = path => {
+      setWorkspacePath(page.id, path);
+    };
+
+    const renderOptions = typeof buildRenderOptions === 'function'
+      ? buildRenderOptions({
+          context,
+          definitions,
+          model,
+          page,
+          mount,
+          onRouteChange: handleRouteChange,
+        })
+      : { mount, page, onRouteChange: handleRouteChange };
+
+    const summary = renderApp(model, renderOptions);
+    const path = summary?.urlPath || '';
+    setWorkspacePath(page.id, path);
+
+    const meta = deriveMeta({
+      summary,
+      model,
+      definitions,
+      page,
+      context,
+      fallback: fallbackMeta,
+    });
+
+    return { id: page.id, meta, urlPath: path };
+  };
+}
+
+export { ensureWorkspaceMount };


### PR DESCRIPTION
## Summary
- add a workspace renderer factory that mounts shared browser workspace scaffolding
- refactor the digishelf, shopily, and shopstack presenters to use the shared helper and retain meta fallbacks

## Testing
- npm test -- tests/ui/workspaces/shopStackWorkspacePresenter.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e11b376df0832c872c0455f8c3cdc6