### PR TITLE
Clean up ShopStack detail helper exports

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,7 @@
 - Content tracks lean on schema builders for courses, upgrades, and passive assets; boosts and events reuse the shared multi-day engine.
 - Passive income, education, and hustles remain tuned around upkeep-first scheduling so players stay in control of daily hours.
 - Routine hustle payouts and quality work logs now auto-dismiss so the notification bell spotlights urgent alerts.
-- ShopStack workspace trims unused detail builders to keep presenter imports lean.
+- ShopStack workspace trims unused detail builders—`buildDetailView` and the old `detailBuilders.js` helper are gone, with `detail/index.js` re-exporting the focused helpers directly.
 
 ## Recent Highlights
 - Passive assets gained Quality 4–5 payout milestones with clearer upkeep cues.

--- a/src/ui/views/browser/components/shopstack/detail/index.js
+++ b/src/ui/views/browser/components/shopstack/detail/index.js
@@ -1,9 +1,22 @@
-export * from './formatting.js';
-export * from './effects.js';
-export * from './requirements.js';
-export * from './requirementList.js';
-export * from './highlights.js';
-export * from './sections.js';
-export * from './statusHeader.js';
-export * from './cta.js';
-export * from './view.js';
+export {
+  formatPrice,
+  formatKeyLabel,
+  describeTargetScope,
+  formatSlotLabel,
+  formatSlotMap,
+  stripHtml
+} from './formatting.js';
+export { describeEffectSummary } from './effects.js';
+export { getRequirementEntries } from './requirements.js';
+export { buildRequirementList } from './requirementList.js';
+export { buildHighlights } from './highlights.js';
+export { collectDetailStrings, buildDetailSections } from './sections.js';
+export {
+  describeStatus,
+  createBadge,
+  createStatusBadge,
+  createDetailHeader,
+  createDetailPricing
+} from './statusHeader.js';
+export { createDetailCta } from './cta.js';
+export { createEmptyDetail } from './view.js';


### PR DESCRIPTION
## Summary
- replace the wildcard ShopStack detail exports with explicit helpers now that buildDetailView/detailBuilders are retired
- update the changelog entry to spell out the helper removals for documentation

## Testing
- node --test tests/ui/workspaces

## Manual Testing
- not run (environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68e11b39b11c832cafa9b77bf59581e6