### PR TITLE
Refine workspace exports and drop unused helpers

### DIFF
--- a/src/core/logAutoReadTypes.js
+++ b/src/core/logAutoReadTypes.js
@@ -7,12 +7,3 @@ export function isAutoReadType(type) {
   const normalized = type.toLowerCase();
   return AUTO_READ_TYPES.some(entry => String(entry).toLowerCase() === normalized);
 }
-
-export function getAutoReadTypes() {
-  return AUTO_READ_TYPES.slice();
-}
-
-export default {
-  isAutoReadType,
-  getAutoReadTypes
-};

--- a/src/ui/cards/model/hustles.js
+++ b/src/ui/cards/model/hustles.js
@@ -2,7 +2,7 @@ import { getState } from '../../../core/state.js';
 import { formatHours, formatMoney } from '../../../core/helpers.js';
 import { describeHustleRequirements, getHustleDailyUsage } from '../../../game/hustles/helpers.js';
 
-export function buildHustleModels(definitions = [], helpers = {}) {
+function buildHustleModels(definitions = [], helpers = {}) {
   const {
     getState: getStateFn = getState,
     describeRequirements = describeHustleRequirements,

--- a/src/ui/cards/model/upgrades.js
+++ b/src/ui/cards/model/upgrades.js
@@ -215,7 +215,7 @@ export function describeUpgradeStatus({ purchased, ready, affordable, disabled }
   return 'Progress for this soon';
 }
 
-export function buildUpgradeModels(definitions = [], helpers = {}) {
+function buildUpgradeModels(definitions = [], helpers = {}) {
   const { getState: getStateFn = getState } = helpers;
   const state = getStateFn();
   const categories = buildUpgradeCategories(definitions).map(category => ({

--- a/src/ui/layout/preferenceAdapters.js
+++ b/src/ui/layout/preferenceAdapters.js
@@ -105,9 +105,4 @@ function ensureDefaultPreferenceAdapters() {
   defaultsRegistered = true;
 }
 
-export {
-  registerPreferenceAdapter,
-  getPreferenceAdapters,
-  resetPreferenceAdapters,
-  ensureDefaultPreferenceAdapters
-};
+export { getPreferenceAdapters, resetPreferenceAdapters, ensureDefaultPreferenceAdapters };

--- a/src/ui/views/browser/apps/blogpress.js
+++ b/src/ui/views/browser/apps/blogpress.js
@@ -1,4 +1,4 @@
-import blogpressApp from '../components/blogpress.js';
+import renderBlogpressWorkspace from '../components/blogpress.js';
 import { setWorkspacePath } from '../layoutPresenter.js';
 import { getPageByType } from './pageLookup.js';
 
@@ -22,7 +22,7 @@ export default function renderBlogpress(context = {}, definitions = [], model = 
   const handleRouteChange = path => {
     setWorkspacePath(page.id, path);
   };
-  const summary = blogpressApp.render(model, { mount, page, onRouteChange: handleRouteChange });
+  const summary = renderBlogpressWorkspace(model, { mount, page, onRouteChange: handleRouteChange });
   const path = summary?.urlPath || '';
   setWorkspacePath(page.id, path);
   const meta = summary?.meta || model?.summary?.meta || 'Launch your first blog';

--- a/src/ui/views/browser/apps/digishelf.js
+++ b/src/ui/views/browser/apps/digishelf.js
@@ -1,4 +1,4 @@
-import digishelfApp from '../components/digishelf.js';
+import renderDigishelfWorkspace from '../components/digishelf.js';
 import { setWorkspacePath } from '../layoutPresenter.js';
 import { getPageByType } from './pageLookup.js';
 
@@ -22,7 +22,7 @@ export default function renderDigishelf(context = {}, definitions = [], model = 
   const handleRouteChange = path => {
     setWorkspacePath(page.id, path);
   };
-  const summary = digishelfApp.render(model, {
+  const summary = renderDigishelfWorkspace(model, {
     mount,
     page,
     definitions,

--- a/src/ui/views/browser/apps/education.js
+++ b/src/ui/views/browser/apps/education.js
@@ -1,4 +1,4 @@
-import learnlyApp from '../components/learnly.js';
+import renderLearnlyWorkspace from '../components/learnly.js';
 import { setWorkspacePath } from '../layoutPresenter.js';
 import { getPageByType } from './pageLookup.js';
 
@@ -24,7 +24,12 @@ export default function renderEducation(context = {}, definitions = [], model = 
     setWorkspacePath(page.id, path);
   };
 
-  const summary = learnlyApp.render(model, { mount, page, definitions, onRouteChange: handleRouteChange });
+  const summary = renderLearnlyWorkspace(model, {
+    mount,
+    page,
+    definitions,
+    onRouteChange: handleRouteChange
+  });
   const path = summary?.urlPath || '';
   setWorkspacePath(page.id, path);
   const meta = summary?.meta || 'Browse the catalog';

--- a/src/ui/views/browser/apps/finance/ledger.js
+++ b/src/ui/views/browser/apps/finance/ledger.js
@@ -24,7 +24,7 @@ export function createBankSection(title, note) {
   return { section, body };
 }
 
-export function createLedgerColumn(title, entries = [], direction = 'in') {
+function createLedgerColumn(title, entries = [], direction = 'in') {
   const column = document.createElement('article');
   column.className = `bankapp-ledger__column bankapp-ledger__column--${direction}`;
 

--- a/src/ui/views/browser/apps/finance/summaryCards.js
+++ b/src/ui/views/browser/apps/finance/summaryCards.js
@@ -61,7 +61,3 @@ export function renderSummaryFootnote(model = {}) {
   return footnote;
 }
 
-export default {
-  renderSummaryCards,
-  renderSummaryFootnote
-};

--- a/src/ui/views/browser/apps/serverhub.js
+++ b/src/ui/views/browser/apps/serverhub.js
@@ -1,4 +1,4 @@
-import serverhubApp from '../components/serverhub.js';
+import renderServerHubWorkspace from '../components/serverhub.js';
 import { setWorkspacePath } from '../layoutPresenter.js';
 import { getPageByType } from './pageLookup.js';
 
@@ -23,7 +23,7 @@ export default function renderServerHub(context = {}, definitions = [], model = 
     setWorkspacePath(page.id, path);
   };
 
-  const summary = serverhubApp.render(model, {
+  const summary = renderServerHubWorkspace(model, {
     mount,
     page,
     definitions,

--- a/src/ui/views/browser/apps/shopily.js
+++ b/src/ui/views/browser/apps/shopily.js
@@ -1,4 +1,4 @@
-import shopilyApp from '../components/shopily.js';
+import renderShopilyWorkspace from '../components/shopily.js';
 import { setWorkspacePath } from '../layoutPresenter.js';
 import { getPageByType } from './pageLookup.js';
 
@@ -22,7 +22,7 @@ export default function renderShopily(context = {}, definitions = [], model = {}
   const handleRouteChange = path => {
     setWorkspacePath(page.id, path);
   };
-  const summary = shopilyApp.render(model, { mount, page, onRouteChange: handleRouteChange });
+  const summary = renderShopilyWorkspace(model, { mount, page, onRouteChange: handleRouteChange });
   const path = summary?.urlPath || '';
   setWorkspacePath(page.id, path);
   const meta = summary?.meta || model?.summary?.meta || 'Launch your first store';

--- a/src/ui/views/browser/components/blogpress.js
+++ b/src/ui/views/browser/components/blogpress.js
@@ -297,8 +297,6 @@ function setView(view, options = {}) {
   presenter.render(presenter.getModel());
 }
 
-export function render(model = {}, context = {}) {
+export default function renderBlogpressWorkspace(model = {}, context = {}) {
   return presenter.render(model, context);
 }
-
-export default { render };

--- a/src/ui/views/browser/components/common/domHelpers.js
+++ b/src/ui/views/browser/components/common/domHelpers.js
@@ -28,9 +28,4 @@ function appendContent(target, content) {
   }
 }
 
-export { isNodeLike, appendContent };
-
-export default {
-  isNodeLike,
-  appendContent
-};
+export { appendContent };

--- a/src/ui/views/browser/components/common/navBuilders.js
+++ b/src/ui/views/browser/components/common/navBuilders.js
@@ -10,7 +10,7 @@ function applyActiveState(button, isActive, activeClassName, withAriaPressed) {
   }
 }
 
-export function createNavButton({
+function createNavButton({
   className,
   label,
   view,

--- a/src/ui/views/browser/components/common/renderDetailPanel.js
+++ b/src/ui/views/browser/components/common/renderDetailPanel.js
@@ -260,7 +260,3 @@ export function renderDetailPanel(options = {}) {
 
   return container;
 }
-
-export default {
-  renderDetailPanel
-};

--- a/src/ui/views/browser/components/common/renderInstanceTable.js
+++ b/src/ui/views/browser/components/common/renderInstanceTable.js
@@ -193,7 +193,3 @@ export function renderInstanceTable(options = {}) {
   container.appendChild(table);
   return container;
 }
-
-export default {
-  renderInstanceTable
-};

--- a/src/ui/views/browser/components/common/renderKpiGrid.js
+++ b/src/ui/views/browser/components/common/renderKpiGrid.js
@@ -77,7 +77,3 @@ export function renderKpiGrid(options = {}) {
   section.appendChild(grid);
   return section;
 }
-
-export default {
-  renderKpiGrid
-};

--- a/src/ui/views/browser/components/common/renderWorkspaceHeader.js
+++ b/src/ui/views/browser/components/common/renderWorkspaceHeader.js
@@ -150,7 +150,3 @@ export function renderWorkspaceHeader(options = {}) {
 
   return header;
 }
-
-export default {
-  renderWorkspaceHeader
-};

--- a/src/ui/views/browser/components/digishelf/index.js
+++ b/src/ui/views/browser/components/digishelf/index.js
@@ -221,10 +221,6 @@ function handlePlanSelect(planId) {
   presenter.render(model);
 }
 
-function render(model = {}, context = {}) {
+export default function renderDigishelfWorkspace(model = {}, context = {}) {
   return presenter.render(model, context);
 }
-
-export default { render };
-
-export { render };

--- a/src/ui/views/browser/components/digishelf/state.js
+++ b/src/ui/views/browser/components/digishelf/state.js
@@ -116,17 +116,3 @@ export function getSelectedInstance(state = initialState, model = {}) {
   return instances.find(entry => entry.id === id) || instances[0] || null;
 }
 
-export default {
-  VIEW_EBOOKS,
-  VIEW_STOCK,
-  VIEW_PRICING,
-  initialState,
-  ensureSelection,
-  reduceSetView,
-  reduceToggleLaunch,
-  reduceOpenLaunch,
-  reduceSelectInstance,
-  derivePath,
-  getSelectedCollection,
-  getSelectedInstance
-};

--- a/src/ui/views/browser/components/learnly.js
+++ b/src/ui/views/browser/components/learnly.js
@@ -2,8 +2,6 @@ import { createLearnlyWorkspace } from './learnly/createLearnlyWorkspace.js';
 
 const workspace = createLearnlyWorkspace();
 
-export function render(model = {}, context = {}) {
+export default function renderLearnlyWorkspace(model = {}, context = {}) {
   return workspace.render(model, context);
 }
-
-export default { render };

--- a/src/ui/views/browser/components/learnly/constants.js
+++ b/src/ui/views/browser/components/learnly/constants.js
@@ -16,11 +16,3 @@ export const CATEGORY_DEFINITIONS = [
   { id: 'general', label: 'Multidisciplinary', skills: [] }
 ];
 
-export default {
-  VIEW_CATALOG,
-  VIEW_DETAIL,
-  VIEW_MY_COURSES,
-  VIEW_PRICING,
-  VIEW_FREE,
-  CATEGORY_DEFINITIONS
-};

--- a/src/ui/views/browser/components/learnly/context.js
+++ b/src/ui/views/browser/components/learnly/context.js
@@ -171,8 +171,3 @@ export function buildContext(model = {}, definitions = []) {
   return { courses, catalogCourses, freeCourses, courseMap, categories, summary };
 }
 
-export default {
-  buildContext,
-  createEmptyContext,
-  describeSkills
-};

--- a/src/ui/views/browser/components/learnly/createLearnlyWorkspace.js
+++ b/src/ui/views/browser/components/learnly/createLearnlyWorkspace.js
@@ -10,6 +10,3 @@ export function createLearnlyWorkspace() {
   };
 }
 
-export default {
-  createLearnlyWorkspace
-};

--- a/src/ui/views/browser/components/learnly/createLearnlyWorkspacePresenter.js
+++ b/src/ui/views/browser/components/learnly/createLearnlyWorkspacePresenter.js
@@ -65,6 +65,3 @@ export function createLearnlyWorkspacePresenter() {
   };
 }
 
-export default {
-  createLearnlyWorkspacePresenter
-};

--- a/src/ui/views/browser/components/learnly/handlers.js
+++ b/src/ui/views/browser/components/learnly/handlers.js
@@ -95,6 +95,3 @@ export function createLearnlyHandlers({ presenter, rerender }) {
   return handlers;
 }
 
-export default {
-  createLearnlyHandlers
-};

--- a/src/ui/views/browser/components/learnly/reducers.js
+++ b/src/ui/views/browser/components/learnly/reducers.js
@@ -61,9 +61,3 @@ export function deriveWorkspacePath(state = {}) {
   return 'catalog';
 }
 
-export default {
-  INITIAL_STATE,
-  ensureSelectedCourse,
-  deriveSummaryFromContext,
-  deriveWorkspacePath
-};

--- a/src/ui/views/browser/components/learnly/views/shared/courseCard.js
+++ b/src/ui/views/browser/components/learnly/views/shared/courseCard.js
@@ -109,4 +109,3 @@ export function createCourseCard({
   return card;
 }
 
-export default createCourseCard;

--- a/src/ui/views/browser/components/learnly/views/shared/enrollmentCard.js
+++ b/src/ui/views/browser/components/learnly/views/shared/enrollmentCard.js
@@ -71,4 +71,3 @@ export function createEnrollmentCard({ course, formatters, handlers, sourceTab }
   return card;
 }
 
-export default createEnrollmentCard;

--- a/src/ui/views/browser/components/learnly/views/shared/progressBar.js
+++ b/src/ui/views/browser/components/learnly/views/shared/progressBar.js
@@ -23,4 +23,3 @@ export function createProgressBar(course) {
   return wrapper;
 }
 
-export default createProgressBar;

--- a/src/ui/views/browser/components/learnly/views/workspaceView.js
+++ b/src/ui/views/browser/components/learnly/views/workspaceView.js
@@ -126,7 +126,3 @@ export function renderLearnlyView({ state, context, handlers, formatters, descri
   }
 }
 
-export default {
-  renderLearnlyHeader,
-  renderLearnlyView
-};

--- a/src/ui/views/browser/components/serverhub.js
+++ b/src/ui/views/browser/components/serverhub.js
@@ -297,13 +297,9 @@ presenter = createAssetWorkspacePresenter({
   ]
 });
 
-function render(model, context = {}) {
+export default function renderServerHubWorkspace(model, context = {}) {
   const summary = presenter.render(model, context);
   const meta = summary?.meta || 'Launch your first micro SaaS';
   const urlPath = summary?.urlPath || '';
   return { meta, urlPath };
 }
-
-export default {
-  render
-};

--- a/src/ui/views/browser/components/serverhub/views/apps/actionConsole.js
+++ b/src/ui/views/browser/components/serverhub/views/apps/actionConsole.js
@@ -33,7 +33,7 @@ function createActionButton(action, label, instanceId, helpers) {
   return button;
 }
 
-export function renderActionConsole(instance, helpers) {
+function renderActionConsole(instance, helpers) {
   const section = document.createElement('section');
   section.className = 'serverhub-panel serverhub-panel--actions';
 

--- a/src/ui/views/browser/components/serverhub/views/apps/appsTable.js
+++ b/src/ui/views/browser/components/serverhub/views/apps/appsTable.js
@@ -153,7 +153,3 @@ export function mapAppsTable(instances, state, helpers = {}) {
     emptyState: createEmptyState(helpers)
   };
 }
-
-export default {
-  mapAppsTable
-};

--- a/src/ui/views/browser/components/serverhub/views/apps/detailSidebar.js
+++ b/src/ui/views/browser/components/serverhub/views/apps/detailSidebar.js
@@ -130,7 +130,3 @@ export function mapDetailSidebar(model = {}, state = {}, helpers = {}) {
     sections: mapDetailSections(selected, helpers)
   };
 }
-
-export default {
-  mapDetailSidebar
-};

--- a/src/ui/views/browser/components/serverhub/views/apps/nicheSelector.js
+++ b/src/ui/views/browser/components/serverhub/views/apps/nicheSelector.js
@@ -104,8 +104,3 @@ export function renderNichePanel(instance, helpers) {
   section.appendChild(field);
   return section;
 }
-
-export default {
-  renderNicheCell,
-  renderNichePanel
-};

--- a/src/ui/views/browser/components/serverhub/views/apps/payoutBreakdown.js
+++ b/src/ui/views/browser/components/serverhub/views/apps/payoutBreakdown.js
@@ -1,6 +1,6 @@
 import { ensureArray } from '../../../../../../../core/helpers.js';
 
-export function renderPayoutBreakdown(instance, { formatCurrency, formatPercent }) {
+function renderPayoutBreakdown(instance, { formatCurrency, formatPercent }) {
   const section = document.createElement('section');
   section.className = 'serverhub-panel';
 

--- a/src/ui/views/browser/components/serverhub/views/apps/qualityPanel.js
+++ b/src/ui/views/browser/components/serverhub/views/apps/qualityPanel.js
@@ -1,4 +1,4 @@
-export function renderQualityPanel(instance) {
+function renderQualityPanel(instance) {
   if (!instance.milestone) {
     return null;
   }

--- a/src/ui/views/browser/components/serverhub/views/appsView.js
+++ b/src/ui/views/browser/components/serverhub/views/appsView.js
@@ -128,7 +128,3 @@ export function createAppsView(options = {}) {
     return section;
   };
 }
-
-export default {
-  createAppsView
-};

--- a/src/ui/views/browser/components/serverhub/views/pricingView.js
+++ b/src/ui/views/browser/components/serverhub/views/pricingView.js
@@ -73,7 +73,3 @@ export function createPricingView({ formatCurrency, formatHours }) {
     return container;
   };
 }
-
-export default {
-  createPricingView
-};

--- a/src/ui/views/browser/components/serverhub/views/upgradesView.js
+++ b/src/ui/views/browser/components/serverhub/views/upgradesView.js
@@ -110,7 +110,3 @@ export function createUpgradesView({ formatCurrency }) {
     return container;
   };
 }
-
-export default {
-  createUpgradesView
-};

--- a/src/ui/views/browser/components/shopily/createShopilyWorkspace.js
+++ b/src/ui/views/browser/components/shopily/createShopilyWorkspace.js
@@ -222,6 +222,4 @@ export function createShopilyWorkspacePresenter() {
   return presenter;
 }
 
-export default {
-  createShopilyWorkspacePresenter
-};
+export default createShopilyWorkspacePresenter;

--- a/src/ui/views/browser/components/shopily/helpers/upgrades.js
+++ b/src/ui/views/browser/components/shopily/helpers/upgrades.js
@@ -2,14 +2,14 @@ import { ensureArray } from '../../../../../../core/helpers.js';
 import { getAssetState, getState, getUpgradeState } from '../../../../../../core/state.js';
 import { getAssetDefinition, getUpgradeDefinition } from '../../../../../../core/state/registry.js';
 
-export const UPGRADE_STATUS_TONES = {
+const UPGRADE_STATUS_TONES = {
   owned: 'owned',
   ready: 'ready',
   unaffordable: 'unaffordable',
   locked: 'locked'
 };
 
-export function formatKeyLabel(key) {
+function formatKeyLabel(key) {
   if (!key) return '';
   return String(key)
     .replace(/([a-z])([A-Z])/g, '$1 $2')
@@ -17,7 +17,7 @@ export function formatKeyLabel(key) {
     .replace(/^./, char => char.toUpperCase());
 }
 
-export function formatSlotLabel(slot, amount) {
+function formatSlotLabel(slot, amount) {
   const label = formatKeyLabel(slot);
   const value = Math.abs(Number(amount) || 0);
   const rounded = Number.isInteger(value) ? value : Number(value.toFixed(2));
@@ -25,7 +25,7 @@ export function formatSlotLabel(slot, amount) {
   return `${rounded} ${label} slot${plural}`;
 }
 
-export function formatSlotMap(map) {
+function formatSlotMap(map) {
   if (!map || typeof map !== 'object') return '';
   return Object.entries(map)
     .map(([slot, amount]) => formatSlotLabel(slot, amount))
@@ -76,7 +76,7 @@ function isRequirementMet(requirement) {
   }
 }
 
-export function formatRequirementHtml(requirement) {
+function formatRequirementHtml(requirement) {
   if (!requirement) return 'Requires: <strong>Prerequisites</strong>';
   if (requirement.detail) return requirement.detail;
   switch (requirement.type) {
@@ -121,7 +121,7 @@ export function collectDetailStrings(definition) {
     .filter(Boolean);
 }
 
-export function describeEffectSummary(effects = {}, affects = {}) {
+function describeEffectSummary(effects = {}, affects = {}) {
   const effectParts = [];
   Object.entries(effects).forEach(([effect, value]) => {
     const numeric = Number(value);
@@ -178,16 +178,3 @@ export function collectUpgradeHighlights(upgrade) {
   return highlights;
 }
 
-export default {
-  UPGRADE_STATUS_TONES,
-  describeUpgradeSnapshotTone,
-  describeUpgradeAffordability,
-  getRequirementEntries,
-  collectUpgradeHighlights,
-  collectDetailStrings,
-  describeEffectSummary,
-  formatKeyLabel,
-  formatSlotLabel,
-  formatSlotMap,
-  formatRequirementHtml
-};

--- a/src/ui/views/browser/components/shopily/index.js
+++ b/src/ui/views/browser/components/shopily/index.js
@@ -2,12 +2,6 @@ import { createShopilyWorkspacePresenter } from './createShopilyWorkspace.js';
 
 const presenter = createShopilyWorkspacePresenter();
 
-function render(model = {}, context = {}) {
+export default function renderShopilyWorkspace(model = {}, context = {}) {
   return presenter.render(model, context);
 }
-
-export default {
-  render
-};
-
-export { render };


### PR DESCRIPTION
## Summary
- remove unused exports like `getAutoReadTypes` and default helper wrappers that were no longer referenced
- standardize workspace modules to export render functions directly and update browser app entry points accordingly
- prune unused helper constants and default objects from shared UI utilities and Shopily upgrade helpers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e11b88edac832cb9ecf6112be410c6