### PR TITLE
Remove workspace paths default export

### DIFF
--- a/src/ui/views/browser/utils/workspacePaths.js
+++ b/src/ui/views/browser/utils/workspacePaths.js
@@ -42,6 +42,3 @@ export function createWorkspacePathController({ derivePath, listener: initialLis
   };
 }
 
-export default {
-  createWorkspacePathController
-};


### PR DESCRIPTION
## Summary
- remove the unused default export from the workspace path controller module

## Testing
- node --test tests/ui/workspaces/shopStackWorkspacePresenter.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e129f52d40832c87969e296e970fcf