### PR TITLE
Remove redundant default exports from browser component helpers

### DIFF
--- a/src/ui/views/browser/components/common/renderDetailPanel.js
+++ b/src/ui/views/browser/components/common/renderDetailPanel.js
@@ -261,6 +261,3 @@ export function renderDetailPanel(options = {}) {
   return container;
 }
 
-export default {
-  renderDetailPanel
-};

--- a/src/ui/views/browser/components/common/renderInstanceTable.js
+++ b/src/ui/views/browser/components/common/renderInstanceTable.js
@@ -194,6 +194,3 @@ export function renderInstanceTable(options = {}) {
   return container;
 }
 
-export default {
-  renderInstanceTable
-};

--- a/src/ui/views/browser/components/common/renderKpiGrid.js
+++ b/src/ui/views/browser/components/common/renderKpiGrid.js
@@ -78,6 +78,3 @@ export function renderKpiGrid(options = {}) {
   return section;
 }
 
-export default {
-  renderKpiGrid
-};

--- a/src/ui/views/browser/components/common/renderWorkspaceHeader.js
+++ b/src/ui/views/browser/components/common/renderWorkspaceHeader.js
@@ -151,6 +151,3 @@ export function renderWorkspaceHeader(options = {}) {
   return header;
 }
 
-export default {
-  renderWorkspaceHeader
-};


### PR DESCRIPTION
## Summary
- remove unused default exports from render helper modules so only named exports remain

## Testing
- node --test tests/ui/workspaces
- node --test tests/ui/views/browser/components

------
https://chatgpt.com/codex/tasks/task_e_68e129f257b8832cbdb3a71f20cf8bd1