### PR TITLE
Remove default export from asset workspace presenter

### DIFF
--- a/src/ui/views/browser/utils/createAssetWorkspace.js
+++ b/src/ui/views/browser/utils/createAssetWorkspace.js
@@ -265,6 +265,3 @@ export function createAssetWorkspacePresenter(config = {}) {
   };
 }
 
-export default {
-  createAssetWorkspacePresenter
-};


### PR DESCRIPTION
## Summary
- remove the unused default export wrapper from createAssetWorkspacePresenter
- keep all consumers on the named export and confirm no default imports remain

## Testing
- npm test -- tests/ui/workspaces/assetWorkspacePresenter.test.js tests/ui/workspaces/shopStackWorkspacePresenter.test.js tests/ui/workspaces/videoTubeWorkspacePresenter.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e129f7eac8832cbf8ecbfffa20819c