### PR TITLE
Refactor card quality helper logic

### DIFF
--- a/src/ui/cards/model/sharedQuality.js
+++ b/src/ui/cards/model/sharedQuality.js
@@ -1,0 +1,137 @@
+import { formatHours, formatMoney } from '../../../core/helpers.js';
+import {
+  canPerformQualityAction,
+  getNextQualityLevel,
+  getQualityActionAvailability,
+  getQualityActionUsage,
+  getQualityTracks
+} from '../../../game/assets/quality.js';
+
+export function clampNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+export function buildMilestoneProgress(definition, instance, options = {}) {
+  const { maxedSummary, readySummary } = options;
+  const quality = instance?.quality || {};
+  const level = Math.max(0, clampNumber(quality.level));
+  const nextLevel = getNextQualityLevel(definition, level);
+  const tracks = getQualityTracks(definition);
+  const progress = quality.progress || {};
+
+  if (!nextLevel?.requirements) {
+    return {
+      level,
+      percent: 1,
+      summary: maxedSummary || 'Maxed out — milestone ready for future tuning.',
+      nextLevel: null,
+      steps: []
+    };
+  }
+
+  let totalGoal = 0;
+  let totalCurrent = 0;
+  const steps = [];
+
+  Object.entries(nextLevel.requirements).forEach(([key, rawGoal]) => {
+    const goal = Math.max(0, clampNumber(rawGoal));
+    if (goal <= 0) return;
+    const current = Math.max(0, clampNumber(progress?.[key]));
+    const capped = Math.min(current, goal);
+    totalGoal += goal;
+    totalCurrent += capped;
+    const track = tracks?.[key] || {};
+    const label = track.shortLabel || track.label || key;
+    steps.push({
+      key,
+      label,
+      current: capped,
+      goal
+    });
+  });
+
+  const percent = totalGoal > 0 ? Math.min(1, totalCurrent / totalGoal) : 1;
+  const summary = steps.length
+    ? steps.map(step => `${step.current}/${step.goal} ${step.label}`).join(' • ')
+    : readySummary || 'No requirements — milestone ready to trigger.';
+
+  return {
+    level,
+    percent,
+    summary,
+    nextLevel,
+    steps
+  };
+}
+
+export function buildActionSnapshot(definition, instance, action, state, options = {}) {
+  const {
+    lockedReason = 'Requires an upgrade first.',
+    limitReason = 'Daily limit reached — try again tomorrow.',
+    inactiveCopy = remaining => remaining > 0
+      ? `Launch finishes in ${remaining} day${remaining === 1 ? '' : 's'}`
+      : 'Launch prep wrapping up soon',
+    decorate
+  } = options;
+
+  const timeCost = Math.max(0, clampNumber(action.time));
+  const moneyCost = Math.max(0, clampNumber(action.cost));
+  const usage = getQualityActionUsage(definition, instance, action);
+  const availability = getQualityActionAvailability(definition, instance, action, state);
+  const unlocked = Boolean(availability?.unlocked);
+  const canRun = canPerformQualityAction(definition, instance, action, state);
+  const tracks = getQualityTracks(definition);
+  let disabledReason = '';
+
+  if (instance.status !== 'active') {
+    const remaining = Math.max(0, clampNumber(instance.daysRemaining));
+    disabledReason = inactiveCopy(remaining, { definition, instance, action, state }) || '';
+  } else if (!unlocked) {
+    disabledReason = availability?.reason || lockedReason;
+  } else if ((usage?.remainingUses ?? Infinity) <= 0) {
+    disabledReason = limitReason;
+  } else if (timeCost > 0 && state.timeLeft < timeCost) {
+    disabledReason = `Need ${formatHours(timeCost)} free.`;
+  } else if (moneyCost > 0 && state.money < moneyCost) {
+    disabledReason = `Need $${formatMoney(moneyCost)} on hand.`;
+  }
+
+  const baseSnapshot = {
+    id: action.id,
+    label: action.label || 'Quality push',
+    time: timeCost,
+    cost: moneyCost,
+    available: canRun,
+    unlocked,
+    usage,
+    disabledReason,
+    skills: action.skills || []
+  };
+
+  if (typeof decorate === 'function') {
+    const extras = decorate({
+      definition,
+      instance,
+      action,
+      state,
+      tracks,
+      timeCost,
+      moneyCost,
+      usage,
+      availability,
+      baseSnapshot
+    });
+    if (extras && typeof extras === 'object') {
+      return { ...baseSnapshot, ...extras };
+    }
+  }
+
+  return baseSnapshot;
+}
+
+export default {
+  clampNumber,
+  buildMilestoneProgress,
+  buildActionSnapshot
+};

--- a/src/ui/cards/model/videotube.js
+++ b/src/ui/cards/model/videotube.js
@@ -1,4 +1,4 @@
-import { ensureArray, formatHours, formatMoney } from '../../../core/helpers.js';
+import { ensureArray, formatMoney } from '../../../core/helpers.js';
 import { getAssetState, getState } from '../../../core/state.js';
 import { instanceLabel } from '../../../game/assets/details.js';
 import { formatMaintenanceSummary } from '../../../game/assets/maintenance.js';
@@ -8,129 +8,23 @@ import {
   getInstanceNicheInfo
 } from '../../../game/assets/niches.js';
 import {
-  canPerformQualityAction,
   getInstanceQualityRange,
-  getNextQualityLevel,
-  getQualityActionAvailability,
-  getQualityActionUsage,
   getQualityActions,
-  getQualityLevel,
-  getQualityTracks
+  getQualityLevel
 } from '../../../game/assets/quality.js';
 import { setAssetInstanceName } from '../../../game/assets/actions.js';
 import { describeAssetLaunchAvailability } from './assets.js';
 import { registerModelBuilder } from '../modelBuilderRegistry.js';
 import { buildSkillLock } from './skillLocks.js';
-
-function clampNumber(value) {
-  const number = Number(value);
-  return Number.isFinite(number) ? number : 0;
-}
+import {
+  clampNumber,
+  buildActionSnapshot,
+  buildMilestoneProgress
+} from './sharedQuality.js';
 
 function formatCurrency(amount) {
   return `$${formatMoney(Math.max(0, Math.round(Number(amount) || 0)))}`;
 }
-
-function buildMilestoneProgress(definition, instance) {
-  const quality = instance?.quality || {};
-  const level = Math.max(0, clampNumber(quality.level));
-  const nextLevel = getNextQualityLevel(definition, level);
-  const tracks = getQualityTracks(definition);
-  const progress = quality.progress || {};
-
-  if (!nextLevel?.requirements) {
-    return {
-      level,
-      percent: 1,
-      summary: 'Maxed out — production is at peak polish.',
-      nextLevel: null,
-      steps: []
-    };
-  }
-
-  let totalGoal = 0;
-  let totalCurrent = 0;
-  const steps = [];
-
-  Object.entries(nextLevel.requirements).forEach(([key, rawGoal]) => {
-    const goal = Math.max(0, clampNumber(rawGoal));
-    if (goal <= 0) return;
-    const current = Math.max(0, clampNumber(progress?.[key]));
-    const capped = Math.min(current, goal);
-    totalGoal += goal;
-    totalCurrent += capped;
-    const track = tracks?.[key] || {};
-    const label = track.shortLabel || track.label || key;
-    steps.push({
-      key,
-      label,
-      current: capped,
-      goal
-    });
-  });
-
-  const percent = totalGoal > 0 ? Math.min(1, totalCurrent / totalGoal) : 1;
-  const summary = steps.length
-    ? steps.map(step => `${step.current}/${step.goal} ${step.label}`).join(' • ')
-    : 'No requirements — milestone ready to fire.';
-
-  return {
-    level,
-    percent,
-    summary,
-    nextLevel,
-    steps
-  };
-}
-
-function buildActionSnapshot(definition, instance, action, state) {
-  const timeCost = Math.max(0, clampNumber(action.time));
-  const moneyCost = Math.max(0, clampNumber(action.cost));
-  const usage = getQualityActionUsage(definition, instance, action);
-  const availability = getQualityActionAvailability(definition, instance, action, state);
-  const unlocked = Boolean(availability?.unlocked);
-  const canRun = canPerformQualityAction(definition, instance, action, state);
-  let disabledReason = '';
-  const tracks = getQualityTracks(definition);
-  const track = action.progressKey ? tracks?.[action.progressKey] : null;
-  const rawAmount = typeof action.progressAmount === 'function'
-    ? action.progressAmount({ definition, instance })
-    : Number(action.progressAmount);
-  const effectAmount = Number.isFinite(rawAmount) && rawAmount !== 0 ? rawAmount : 1;
-  const effect = track
-    ? `+${effectAmount} ${track.shortLabel || track.label}`
-    : 'Boosts quality momentum';
-
-  if (instance.status !== 'active') {
-    const remaining = Math.max(0, clampNumber(instance.daysRemaining));
-    disabledReason = remaining > 0
-      ? `Launch wraps in ${remaining} day${remaining === 1 ? '' : 's'}`
-      : 'Launch finishing up soon';
-  } else if (!unlocked) {
-    disabledReason = availability?.reason || 'Requires an upgrade first.';
-  } else if (usage.remainingUses <= 0) {
-    disabledReason = 'Daily limit hit — try again tomorrow.';
-  } else if (timeCost > 0 && state.timeLeft < timeCost) {
-    disabledReason = `Need ${formatHours(timeCost)} free.`;
-  } else if (moneyCost > 0 && state.money < moneyCost) {
-    disabledReason = `Need $${formatMoney(moneyCost)} on hand.`;
-  }
-
-  return {
-    id: action.id,
-    label: action.label || 'Quality push',
-    time: timeCost,
-    cost: moneyCost,
-    available: canRun,
-    unlocked,
-    usage,
-    disabledReason,
-    skills: action.skills || [],
-    description: action.description || '',
-    effect
-  };
-}
-
 function calculateAveragePayout(instance, state) {
   if (!instance || instance.status !== 'active') {
     return 0;
@@ -226,10 +120,33 @@ function buildVideoInstances(definition, state) {
     const averagePayout = calculateAveragePayout(instance, state);
     const qualityLevel = Math.max(0, clampNumber(instance?.quality?.level));
     const qualityInfo = getQualityLevel(definition, qualityLevel);
-    const milestone = buildMilestoneProgress(definition, instance);
+    const milestone = buildMilestoneProgress(definition, instance, {
+      maxedSummary: 'Maxed out — production is at peak polish.',
+      readySummary: 'No requirements — milestone ready to fire.'
+    });
     const qualityRange = getInstanceQualityRange(definition, instance);
     const payoutBreakdown = buildPayoutBreakdown(instance);
-    const actionSnapshots = actions.map(action => buildActionSnapshot(definition, instance, action, state));
+    const actionSnapshots = actions.map(action => buildActionSnapshot(definition, instance, action, state, {
+      limitReason: 'Daily limit hit — try again tomorrow.',
+      inactiveCopy: remaining => remaining > 0
+        ? `Launch wraps in ${remaining} day${remaining === 1 ? '' : 's'}`
+        : 'Launch finishing up soon',
+      decorate: ({ action: entry, instance: assetInstance, definition: assetDefinition, tracks }) => {
+        const track = entry.progressKey ? tracks?.[entry.progressKey] : null;
+        const rawAmount = typeof entry.progressAmount === 'function'
+          ? entry.progressAmount({ definition: assetDefinition, instance: assetInstance })
+          : Number(entry.progressAmount);
+        const effectAmount = Number.isFinite(rawAmount) && rawAmount !== 0 ? rawAmount : 1;
+        const effect = track
+          ? `+${effectAmount} ${track.shortLabel || track.label}`
+          : 'Boosts quality momentum';
+
+        return {
+          description: entry.description || '',
+          effect
+        };
+      }
+    }));
     const quickAction = actionSnapshots.find(entry => entry.available) || actionSnapshots[0] || null;
     const nicheInfo = getInstanceNicheInfo(instance, state);
     const niche = nicheInfo


### PR DESCRIPTION
## Summary
- add a shared quality helper module for clamping, milestone progress, and action snapshot logic
- update the ServerHub, DigiShelf, and VideoTube card models to consume the shared helpers while keeping their bespoke messaging

## Testing
- npm test -- tests/ui/cards

------
https://chatgpt.com/codex/tasks/task_e_68e1374abd28832cb9861eb5f6099d7a