### PR TITLE
Ensure asset rename refreshes player view

### DIFF
--- a/src/game/assets/actions.js
+++ b/src/game/assets/actions.js
@@ -194,7 +194,7 @@ export function setAssetInstanceName(assetId, instanceId, name) {
       delete instance.customName;
     }
     changed = true;
-    markDirty('cards');
+    markDirty(['cards', 'player']);
 
     const labelBase = definition.singular || definition.name || 'Asset';
     const fallbackLabel = `${labelBase} #${index + 1}`;


### PR DESCRIPTION
## Summary
- refresh both asset cards and player profile UI when renaming an asset instance so titles stay synchronized

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1375e0b50832ca1dd6868f8a29602