### PR TITLE
Ensure player panel refreshes after selling assets

### DIFF
--- a/src/game/assets/actions.js
+++ b/src/game/assets/actions.js
@@ -19,7 +19,7 @@ import { instanceLabel } from './details.js';
 import { getAssetMetricId } from './helpers.js';
 import { markDirty } from '../../ui/invalidation.js';
 
-const ASSET_CORE_UI_SECTIONS = ['dashboard', 'headerAction', 'cards'];
+const ASSET_CORE_UI_SECTIONS = ['dashboard', 'headerAction', 'cards', 'player'];
 
 function getEffectiveSetupHours(definition) {
   const base = Number(definition.setup?.hoursPerDay) || 0;


### PR DESCRIPTION
## Summary
- include the player panel when assets mark their core UI sections as dirty after a sale
- extend the UI integration flow to cover selling a zero-income asset and ensure the player panel refreshes

## Testing
- npm test -- tests/ui/update.integration.test.js
- node - <<'NODE' ... (manual zero-income sale check)
NODE

------
https://chatgpt.com/codex/tasks/task_e_68e1375c07c8832cae480a62565b3cbd