### PR TITLE
Limit nav builders exports to tabs

### DIFF
--- a/src/ui/views/browser/components/common/navBuilders.js
+++ b/src/ui/views/browser/components/common/navBuilders.js
@@ -10,7 +10,7 @@ function applyActiveState(button, isActive, activeClassName, withAriaPressed) {
   }
 }
 
-export function createNavButton({
+function createNavButton({
   className,
   label,
   view,


### PR DESCRIPTION
## Summary
- remove the standalone createNavButton export so only createNavTabs is public

## Testing
- node --test tests/ui/update.integration.test.js
- node --test tests/ui/views/browser/layout/navigation.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e13cc606d0832c9dfc2fa304d860d2