### PR TITLE
Remove workspace presenter path controller accessor

### DIFF
--- a/src/ui/views/browser/utils/workspacePresenter.js
+++ b/src/ui/views/browser/utils/workspacePresenter.js
@@ -170,10 +170,6 @@ export function createWorkspacePresenter(options = {}) {
     }
   }
 
-  function getPathController() {
-    return pathController;
-  }
-
   function render(nextModel = {}, context = {}) {
     currentModel = isObject(nextModel) ? nextModel : {};
 
@@ -260,8 +256,7 @@ export function createWorkspacePresenter(options = {}) {
     setMount,
     getPage,
     setPage,
-    setRouteChangeListener,
-    getPathController
+    setRouteChangeListener
   };
 }
 


### PR DESCRIPTION
## Summary
- remove the `getPathController` accessor from the workspace presenter public API now that callers rely on route change hooks
- keep internal path controller wiring focused on `onRouteChange`

## Testing
- node --test tests/ui/workspaces

------
https://chatgpt.com/codex/tasks/task_e_68e13cd3a880832cb46cf200846740c5