### PR TITLE
Modularize apps widget helpers

### DIFF
--- a/src/ui/views/browser/widgets/apps/dragHandlers.js
+++ b/src/ui/views/browser/widgets/apps/dragHandlers.js
@@ -1,0 +1,127 @@
+function createDragHandlers({
+  elementsRef,
+  getSortMode,
+  canSort,
+  onSwap
+}) {
+  let dragSourceId = null;
+
+  function getList() {
+    return elementsRef()?.list || null;
+  }
+
+  function clearDragState() {
+    dragSourceId = null;
+    const list = getList();
+    if (!list) return;
+    list.querySelectorAll('.apps-widget__tile').forEach(tile => {
+      tile.classList.remove('is-dragging');
+      tile.classList.remove('is-drop-target');
+    });
+  }
+
+  function handleDragStart(event) {
+    if (!getSortMode()) {
+      event.preventDefault();
+      return;
+    }
+    const list = getList();
+    if (!list) return;
+    const tile = event.target.closest('.apps-widget__tile');
+    if (!tile || !list.contains(tile)) return;
+    const siteId = tile.dataset.siteTarget;
+    if (!siteId) return;
+    dragSourceId = siteId;
+    tile.classList.add('is-dragging');
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = 'move';
+      event.dataTransfer.setData('text/plain', siteId);
+    }
+  }
+
+  function handleDragEnter(event) {
+    if (!getSortMode()) return;
+    const list = getList();
+    if (!list) return;
+    const tile = event.target.closest('.apps-widget__tile');
+    if (!tile || !list.contains(tile)) return;
+    const siteId = tile.dataset.siteTarget;
+    if (!siteId || siteId === dragSourceId) return;
+    tile.classList.add('is-drop-target');
+  }
+
+  function handleDragOver(event) {
+    if (!getSortMode()) return;
+    const list = getList();
+    if (!list) return;
+    const tile = event.target.closest('.apps-widget__tile');
+    if (!tile || !list.contains(tile)) return;
+    const siteId = tile.dataset.siteTarget;
+    if (!siteId || siteId === dragSourceId) return;
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'move';
+    }
+  }
+
+  function handleDragLeave(event) {
+    if (!getSortMode()) return;
+    const list = getList();
+    if (!list) return;
+    const tile = event.target.closest('.apps-widget__tile');
+    if (!tile || !list.contains(tile)) return;
+    const siteId = tile.dataset.siteTarget;
+    if (!siteId || siteId === dragSourceId) return;
+    tile.classList.remove('is-drop-target');
+  }
+
+  function handleDrop(event) {
+    if (!getSortMode()) return;
+    const list = getList();
+    if (!list) return;
+    const tile = event.target.closest('.apps-widget__tile');
+    if (!tile || !list.contains(tile)) return;
+    event.preventDefault();
+    const targetId = tile.dataset.siteTarget;
+    if (!targetId || targetId === dragSourceId) {
+      clearDragState();
+      return;
+    }
+    onSwap(dragSourceId, targetId);
+    clearDragState();
+  }
+
+  function handleDragEnd() {
+    clearDragState();
+  }
+
+  function updateDraggableState() {
+    const list = getList();
+    if (!list) return;
+    const allowSort = getSortMode() && canSort();
+    list.querySelectorAll('.apps-widget__tile').forEach(tile => {
+      tile.draggable = allowSort;
+      if (allowSort) {
+        tile.setAttribute('aria-disabled', 'true');
+      } else {
+        tile.removeAttribute('aria-disabled');
+      }
+    });
+    if (!allowSort) {
+      clearDragState();
+    }
+  }
+
+  return {
+    clearDragState,
+    handleDragStart,
+    handleDragEnter,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+    handleDragEnd,
+    updateDraggableState
+  };
+}
+
+export { createDragHandlers };

--- a/src/ui/views/browser/widgets/apps/index.js
+++ b/src/ui/views/browser/widgets/apps/index.js
@@ -1,0 +1,3 @@
+export * from './storageController.js';
+export * from './renderingHelpers.js';
+export * from './dragHandlers.js';

--- a/src/ui/views/browser/widgets/apps/renderingHelpers.js
+++ b/src/ui/views/browser/widgets/apps/renderingHelpers.js
@@ -1,0 +1,84 @@
+function getSummaryMap(summaries = []) {
+  return new Map(summaries.map(entry => [entry?.id, entry]));
+}
+
+function isPageLocked(meta = '') {
+  return /lock/i.test(meta || '');
+}
+
+function describeTooltip(page, summary) {
+  const parts = [];
+  if (page?.tagline) {
+    parts.push(page.tagline);
+  }
+  if (summary?.meta) {
+    parts.push(summary.meta);
+  }
+  return parts.join(' — ');
+}
+
+function describeAriaLabel(page, summary) {
+  const parts = [page?.label || 'Workspace'];
+  if (page?.tagline) {
+    parts.push(page.tagline);
+  }
+  if (summary?.meta) {
+    parts.push(summary.meta);
+  }
+  return parts.join('. ');
+}
+
+function renderEmptyState({ listElement, emptyText, noteElement, noteText }) {
+  if (!listElement) return;
+  listElement.innerHTML = '';
+  const empty = document.createElement('li');
+  empty.className = 'apps-widget__empty';
+  empty.textContent = emptyText;
+  listElement.appendChild(empty);
+  if (noteElement) {
+    noteElement.textContent = noteText;
+  }
+}
+
+function createTileElement(page, summary) {
+  const item = document.createElement('li');
+  item.className = 'apps-widget__item';
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'apps-widget__tile';
+  button.dataset.siteTarget = page.id;
+
+  const tooltip = describeTooltip(page, summary);
+  if (tooltip) {
+    button.title = tooltip;
+  }
+  button.setAttribute('aria-label', describeAriaLabel(page, summary));
+  button.setAttribute('aria-pressed', 'false');
+
+  const icon = document.createElement('span');
+  icon.className = 'apps-widget__icon';
+  icon.textContent = page.icon || '✨';
+
+  const label = document.createElement('span');
+  label.className = 'apps-widget__label';
+
+  const name = document.createElement('span');
+  name.className = 'apps-widget__name';
+  name.textContent = page.label;
+
+  label.appendChild(name);
+  button.append(icon, label);
+  item.appendChild(button);
+
+  return item;
+}
+
+export {
+  getSummaryMap,
+  isPageLocked,
+  describeTooltip,
+  describeAriaLabel,
+  renderEmptyState,
+  createTileElement
+};

--- a/src/ui/views/browser/widgets/apps/storageController.js
+++ b/src/ui/views/browser/widgets/apps/storageController.js
@@ -1,0 +1,73 @@
+const STORAGE_KEY = 'browser.apps.order';
+
+function getStorage() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    return window.localStorage || null;
+  } catch (error) {
+    return null;
+  }
+}
+
+function loadSortOrder(storageKey = STORAGE_KEY) {
+  const storage = getStorage();
+  if (!storage) return [];
+  try {
+    const stored = JSON.parse(storage.getItem(storageKey));
+    if (Array.isArray(stored)) {
+      return stored.filter(id => typeof id === 'string' && id);
+    }
+  } catch (error) {
+    return [];
+  }
+  return [];
+}
+
+function persistSortOrder(order = [], storageKey = STORAGE_KEY) {
+  const storage = getStorage();
+  if (!storage) return;
+  try {
+    if (Array.isArray(order) && order.length) {
+      storage.setItem(storageKey, JSON.stringify(order));
+    } else {
+      storage.removeItem(storageKey);
+    }
+  } catch (error) {
+    // Ignore persistence errors to keep the widget responsive.
+  }
+}
+
+function getOrderedIds(availableIds = [], storedOrder = []) {
+  const uniqueIds = Array.from(new Set(availableIds.filter(Boolean)));
+  if (!uniqueIds.length) return [];
+  const filtered = Array.isArray(storedOrder)
+    ? storedOrder.filter(id => uniqueIds.includes(id))
+    : [];
+  const missing = uniqueIds.filter(id => !filtered.includes(id));
+  return [...filtered, ...missing];
+}
+
+function getOrderedPages(pages = [], storedOrder = []) {
+  const map = new Map();
+  pages.forEach(page => {
+    if (page?.id) {
+      map.set(page.id, page);
+    }
+  });
+  const orderedIds = getOrderedIds(
+    pages.map(page => page?.id),
+    storedOrder
+  );
+  return orderedIds.map(id => map.get(id)).filter(Boolean);
+}
+
+export {
+  STORAGE_KEY,
+  getStorage,
+  loadSortOrder,
+  persistSortOrder,
+  getOrderedIds,
+  getOrderedPages
+};


### PR DESCRIPTION
## Summary
- split the apps widget into dedicated storage, rendering, and drag controller helpers
- re-export the helper modules from a central index for future reuse
- update the widget implementation to compose the new helpers without changing its public API

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e13d16493c832cb3f68e1e77aeafae