### PR TITLE
Refine VideoTube header layout

### DIFF
--- a/src/ui/views/browser/components/common/renderWorkspaceHeader.js
+++ b/src/ui/views/browser/components/common/renderWorkspaceHeader.js
@@ -93,54 +93,71 @@ export function renderWorkspaceHeader(options = {}) {
     actions,
     nav,
     theme: themeOverride = {},
-    description
+    description,
+    layout = {}
   } = options;
 
   const theme = { ...DEFAULT_THEME, ...themeOverride };
   const header = document.createElement('header');
   header.className = className || theme.header;
 
+  let intro;
+  let introContent;
+
   if (title || subtitle || meta || badges?.length) {
-    const intro = document.createElement('div');
-    intro.className = theme.intro;
+    intro = document.createElement('div');
+    intro.className = layout.introClassName || theme.intro;
+
+    introContent = intro;
+    if (layout.titleGroupClass) {
+      const titleGroup = document.createElement('div');
+      titleGroup.className = layout.titleGroupClass;
+      intro.appendChild(titleGroup);
+      introContent = titleGroup;
+    }
 
     if (title) {
       const heading = document.createElement('h1');
       heading.className = theme.title;
       appendContent(heading, title);
-      intro.appendChild(heading);
+      introContent.appendChild(heading);
     }
 
     if (subtitle) {
       const subheading = document.createElement('p');
       subheading.className = theme.subtitle;
       appendContent(subheading, subtitle);
-      intro.appendChild(subheading);
+      introContent.appendChild(subheading);
     }
 
     const badgeList = renderBadges(badges, theme);
     if (badgeList) {
-      intro.appendChild(badgeList);
+      introContent.appendChild(badgeList);
     }
 
     if (meta || description) {
       const metaNode = document.createElement('p');
       metaNode.className = theme.meta;
       appendContent(metaNode, meta ?? description ?? '');
-      intro.appendChild(metaNode);
+      introContent.appendChild(metaNode);
     }
 
     header.appendChild(intro);
   }
 
+  let actionsRow = null;
   if (Array.isArray(actions) && actions.length) {
-    const actionsRow = document.createElement('div');
+    actionsRow = document.createElement('div');
     actionsRow.className = theme.actions;
     actions.forEach(action => {
       if (!action) return;
       actionsRow.appendChild(createActionButton(action, theme));
     });
-    header.appendChild(actionsRow);
+    if (layout.wrapIntroWithActions && intro) {
+      intro.appendChild(actionsRow);
+    } else {
+      header.appendChild(actionsRow);
+    }
   }
 
   const navNode = resolveNavConfig(nav, theme);

--- a/src/ui/views/browser/components/videotube/createVideoTubeWorkspace.js
+++ b/src/ui/views/browser/components/videotube/createVideoTubeWorkspace.js
@@ -148,29 +148,6 @@ export function createVideoTubeWorkspace(overrides = {}) {
     header(model, state, context) {
       return buildHeader(model, state, context);
     },
-    afterRender({ mount }) {
-      if (!mount) return;
-      const header = mount.querySelector('.videotube__header');
-      if (!header) return;
-      const masthead = header.querySelector('.videotube__masthead');
-      const title = header.querySelector('.videotube__title');
-      const actions = header.querySelector('.videotube__actions');
-      if (title) {
-        const wrapper = masthead || document.createElement('div');
-        if (!masthead) {
-          wrapper.className = 'videotube__masthead';
-        }
-        if (!wrapper.contains(title)) {
-          wrapper.appendChild(title);
-        }
-        if (actions && !wrapper.contains(actions)) {
-          wrapper.appendChild(actions);
-        }
-        if (!masthead) {
-          header.insertBefore(wrapper, header.firstChild);
-        }
-      }
-    },
     views: [
       {
         id: VIEW_DASHBOARD,

--- a/src/ui/views/browser/components/videotube/header.js
+++ b/src/ui/views/browser/components/videotube/header.js
@@ -10,9 +10,16 @@ export function createVideoTubeHeader() {
 
     return {
       className: 'videotube__header',
+      layout: {
+        introClassName: 'videotube__masthead',
+        titleGroupClass: 'videotube__title',
+        wrapIntroWithActions: true
+      },
       theme: {
         header: 'videotube__header',
-        intro: 'videotube__title',
+        intro: 'videotube__masthead',
+        title: 'videotube__title-heading',
+        subtitle: 'videotube__subtitle',
         actions: 'videotube__actions',
         actionButton: 'videotube-button',
         nav: 'videotube-tabs',

--- a/styles/workspaces/videotube.css
+++ b/styles/workspaces/videotube.css
@@ -19,12 +19,18 @@
   gap: 0.85rem;
 }
 
-.videotube__title h1 {
+.videotube__title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.videotube__title-heading {
   margin: 0;
   font-size: 1.55rem;
 }
 
-.videotube__title p {
+.videotube__subtitle {
   margin: 0;
   color: var(--browser-muted);
   font-size: 0.95rem;

--- a/tests/ui/workspaces/videoTubeWorkspacePresenter.test.js
+++ b/tests/ui/workspaces/videoTubeWorkspacePresenter.test.js
@@ -97,6 +97,13 @@ test('createVideoTubeWorkspace wires table selection and actions', async t => {
   assert.ok(header, 'workspace header should render');
   assert.match(header.textContent, /VideoTube Studio/, 'expected VideoTube title');
 
+  const masthead = header.querySelector('.videotube__masthead');
+  assert.ok(masthead, 'header should render masthead wrapper');
+  assert.ok(
+    masthead.querySelector('.videotube__actions'),
+    'masthead should group primary actions with title'
+  );
+
   const navButtons = [...mount.querySelectorAll('.videotube-tab')];
   assert.equal(navButtons.length, 3, 'nav renders dashboard, detail, and analytics views');
   assert.deepEqual(


### PR DESCRIPTION
## Summary
- teach the shared workspace header renderer how to group intro content with actions when requested
- update the VideoTube header factory to emit the masthead/action layout directly and drop the presenter afterRender hack
- refresh VideoTube header styling and tests to match the new structure

## Testing
- npm test -- tests/ui/workspaces/videoTubeWorkspacePresenter.test.js


------
https://chatgpt.com/codex/tasks/task_e_68e13b782630832c90646ad3525fb8bc