### PR TITLE
Ensure niche reassignment refreshes player panel

### DIFF
--- a/src/game/assets/niches.js
+++ b/src/game/assets/niches.js
@@ -256,7 +256,7 @@ export function assignInstanceToNiche(assetId, instanceId, nicheId) {
     }
     changed = true;
 
-    markDirty({ cards: true, dashboard: true });
+    markDirty({ cards: true, dashboard: true, player: true });
 
     const labelBase = assetDefinition.singular || assetDefinition.name || 'Asset';
     const label = `${labelBase} #${index + 1}`;

--- a/tests/ui/update.integration.test.js
+++ b/tests/ui/update.integration.test.js
@@ -413,7 +413,7 @@ test('state mutators mark dirty sections and drive partial UI refreshes', { conc
   assert.strictEqual(updatedInstance?.nicheId, targetNicheId, 'expected instance to adopt the chosen niche');
   assert.ok(callCounts.dashboard > 0, 'expected dashboard to refresh when changing an asset niche');
   assert.ok(callCounts.cards > 0, 'expected cards presenter to refresh when changing an asset niche');
-  assert.strictEqual(callCounts.player, 0, 'expected player panel to remain untouched for niche change');
+  assert.ok(callCounts.player > 0, 'expected player panel to refresh immediately for niche change');
   assert.strictEqual(callCounts.skills, 0, 'expected skills widget to remain untouched for niche change');
   assert.strictEqual(callCounts.header, 0, 'expected header action to remain untouched for niche change');
   const reassignedSummary = summaryModule.computeDailySummary(state);


### PR DESCRIPTION
## Summary
- mark the player section dirty when reassigning an asset niche so the About You panel reflects the change immediately
- extend the UI regression test to assert the player presenter refreshes after a niche change

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e14042e194832c978da2561c0af895