### PR TITLE
Ensure knowledge track advancement refreshes study panels

### DIFF
--- a/src/game/requirements/orchestrator.js
+++ b/src/game/requirements/orchestrator.js
@@ -218,7 +218,7 @@ export function createRequirementsOrchestrator({
     }
 
     if (completedToday.length || stalled.length) {
-      markDirty('cards');
+      markDirty(STUDY_DIRTY_SECTIONS);
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure advancing knowledge tracks marks the shared study dirty sections so the dashboard and player panels refresh alongside cards

## Testing
- npm test
- node <<'NODE' ... (manual advance of knowledge track)


------
https://chatgpt.com/codex/tasks/task_e_68e1472c4d20832c95625eb1654a30cb