### PR TITLE
Refactor workspace lock helper to manage mounting

### DIFF
--- a/src/ui/views/browser/components/blogpress.js
+++ b/src/ui/views/browser/components/blogpress.js
@@ -22,6 +22,15 @@ const INITIAL_STATE = {
   selectedBlogId: null
 };
 
+const LOCK_THEME = {
+  container: 'blogpress-view',
+  locked: 'blogpress-view--locked',
+  message: 'blogpress-empty__message',
+  label: 'This workspace'
+};
+
+const LOCK_FALLBACK_MESSAGE = 'BlogPress unlocks once the Personal Blog blueprint is discovered.';
+
 const formatCurrency = amount => baseFormatCurrency(amount, { precision: 'integer', clampZero: true });
 
 const { describeSetupSummary, describeUpkeepSummary } = createCurrencyLifecycleSummary({
@@ -223,23 +232,6 @@ function renderViews(model, state = INITIAL_STATE) {
   }
 }
 
-function renderLockedWorkspace(model = {}, mount) {
-  if (!mount) return;
-  mount.innerHTML = '';
-  mount.appendChild(
-    renderWorkspaceLock({
-      theme: {
-        container: 'blogpress-view',
-        locked: 'blogpress-view--locked',
-        message: 'blogpress-empty__message',
-        label: 'This workspace'
-      },
-      lock: model.lock,
-      fallbackMessage: 'BlogPress unlocks once the Personal Blog blueprint is discovered.'
-    })
-  );
-}
-
 function deriveWorkspaceSummary(model = {}) {
   const summary = model?.summary;
   return summary && typeof summary === 'object' ? summary : {};
@@ -275,7 +267,12 @@ const presenter = createTabbedWorkspacePresenter({
   className: 'blogpress',
   state: { ...INITIAL_STATE },
   ensureSelection: ensureSelectedBlog,
-  renderLocked: renderLockedWorkspace,
+  renderLocked: (model = {}, mount) =>
+    renderWorkspaceLock(mount, {
+      theme: LOCK_THEME,
+      lock: model.lock,
+      fallbackMessage: LOCK_FALLBACK_MESSAGE
+    }),
   renderHeader,
   renderViews,
   deriveSummary: deriveWorkspaceSummary,

--- a/src/ui/views/browser/components/common/renderWorkspaceLock.js
+++ b/src/ui/views/browser/components/common/renderWorkspaceLock.js
@@ -1,4 +1,19 @@
-export function renderWorkspaceLock({ theme = {}, lock = null, fallbackMessage = '' } = {}) {
+function isElement(value) {
+  return value && typeof value === 'object' && value.nodeType === 1;
+}
+
+export function renderWorkspaceLock(target, options = {}) {
+  let mount;
+  let config;
+
+  if (isElement(target)) {
+    mount = target;
+    config = options || {};
+  } else {
+    config = target || {};
+  }
+
+  const { theme = {}, lock = null, fallbackMessage = '' } = config;
   const containerTag = theme.containerTag || 'section';
   const container = document.createElement(containerTag);
   const containerClasses = [];
@@ -30,5 +45,11 @@ export function renderWorkspaceLock({ theme = {}, lock = null, fallbackMessage =
   }
 
   container.appendChild(message);
+
+  if (mount) {
+    mount.innerHTML = '';
+    mount.appendChild(container);
+  }
+
   return container;
 }

--- a/src/ui/views/browser/components/digishelf/index.js
+++ b/src/ui/views/browser/components/digishelf/index.js
@@ -29,6 +29,15 @@ import renderInventoryTable from './inventoryTable.js';
 import renderDetailPane from './detailPane.js';
 import renderPricingCards from './pricingCards.js';
 
+const LOCK_THEME = {
+  container: 'digishelf',
+  locked: 'digishelf--locked',
+  message: 'digishelf-empty',
+  label: 'DigiShelf'
+};
+
+const LOCK_FALLBACK_MESSAGE = 'DigiShelf unlocks once the digital asset blueprints are discovered.';
+
 function clampNumber(value) {
   const number = Number(value);
   return Number.isFinite(number) ? number : 0;
@@ -153,23 +162,6 @@ function syncNavigation({ mount, state }) {
   });
 }
 
-function renderLockedWorkspace(model = {}, mount) {
-  if (!mount) return;
-  mount.innerHTML = '';
-  mount.appendChild(
-    renderWorkspaceLock({
-      theme: {
-        container: 'digishelf',
-        locked: 'digishelf--locked',
-        message: 'digishelf-empty',
-        label: 'DigiShelf'
-      },
-      lock: model.lock,
-      fallbackMessage: 'DigiShelf unlocks once the digital asset blueprints are discovered.'
-    })
-  );
-}
-
 function deriveWorkspaceSummary(model = {}) {
   const summary = typeof model?.summary === 'object' && model.summary
     ? { ...model.summary }
@@ -188,7 +180,12 @@ const presenter = createTabbedWorkspacePresenter({
   deriveSummary: deriveWorkspaceSummary,
   renderHeader,
   renderViews,
-  renderLocked: renderLockedWorkspace,
+  renderLocked: (model = {}, mount) =>
+    renderWorkspaceLock(mount, {
+      theme: LOCK_THEME,
+      lock: model.lock,
+      fallbackMessage: LOCK_FALLBACK_MESSAGE
+    }),
   syncNavigation,
   isLocked: model => Boolean(model?.lock)
 });

--- a/src/ui/views/browser/components/serverhub.js
+++ b/src/ui/views/browser/components/serverhub.js
@@ -18,6 +18,15 @@ const VIEW_APPS = 'apps';
 const VIEW_UPGRADES = 'upgrades';
 const VIEW_PRICING = 'pricing';
 
+const LOCK_THEME = {
+  container: 'serverhub',
+  locked: 'serverhub--locked',
+  message: 'serverhub-empty',
+  label: 'This console'
+};
+
+const LOCK_FALLBACK_MESSAGE = 'ServerHub unlocks once the SaaS Micro-App blueprint is discovered.';
+
 const formatCurrency = amount => baseFormatCurrency(amount, { precision: 'integer', clampZero: true });
 const formatNetCurrency = amount => baseFormatNetCurrency(amount, { precision: 'integer' });
 const formatPercent = value => baseFormatPercent(value, { nullFallback: '—', signDisplay: 'always' });
@@ -154,23 +163,6 @@ function handleNicheSelect(instanceId, value) {
   selectServerHubNiche('saas', instanceId, value);
 }
 
-function renderLockedState(model = {}, mount) {
-  if (!mount) return;
-  mount.innerHTML = '';
-  mount.appendChild(
-    renderWorkspaceLock({
-      theme: {
-        container: 'serverhub',
-        locked: 'serverhub--locked',
-        message: 'serverhub-empty',
-        label: 'This console'
-      },
-      lock: model.lock,
-      fallbackMessage: 'ServerHub unlocks once the SaaS Micro-App blueprint is discovered.'
-    })
-  );
-}
-
 function deriveSummary(model = {}) {
   const summary = model.summary;
   const isSummaryObject = summary && typeof summary === 'object' && !Array.isArray(summary);
@@ -226,7 +218,12 @@ presenter = createAssetWorkspacePresenter({
   ensureSelection,
   deriveSummary,
   derivePath,
-  renderLocked: renderLockedState,
+  renderLocked: (model = {}, mount) =>
+    renderWorkspaceLock(mount, {
+      theme: LOCK_THEME,
+      lock: model.lock,
+      fallbackMessage: LOCK_FALLBACK_MESSAGE
+    }),
   isLocked: model => !model?.definition,
   header(model, state, { setView }) {
     const launch = model.launch || {};

--- a/src/ui/views/browser/utils/createConfiguredAssetWorkspace.js
+++ b/src/ui/views/browser/utils/createConfiguredAssetWorkspace.js
@@ -74,14 +74,11 @@ function createLockRenderer(lockConfig = {}) {
   const { theme, fallbackMessage } = lockConfig;
   return (model = {}, mount) => {
     if (!mount) return;
-    mount.innerHTML = '';
-    mount.appendChild(
-      renderWorkspaceLock({
-        theme,
-        lock: model.lock,
-        fallbackMessage
-      })
-    );
+    renderWorkspaceLock(mount, {
+      theme,
+      lock: model.lock,
+      fallbackMessage
+    });
   };
 }
 


### PR DESCRIPTION
## Summary
- teach renderWorkspaceLock to optionally mount itself into a provided element
- update asset workspace lock renderer to reuse the helper mounting logic
- reuse the shared helper in BlogPress, DigiShelf, and ServerHub presenters with consistent copy

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1470e3ab4832ca06c25b00515f24b