### PR TITLE
Refactor workspace lock rendering helper

### DIFF
--- a/src/ui/views/browser/components/blogpress.js
+++ b/src/ui/views/browser/components/blogpress.js
@@ -6,7 +6,7 @@ import { createCurrencyLifecycleSummary } from '../utils/lifecycleSummaries.js';
 import { showLaunchConfirmation } from '../utils/launchDialog.js';
 import { createTabbedWorkspacePresenter } from '../utils/createTabbedWorkspacePresenter.js';
 import { createNavTabs } from './common/navBuilders.js';
-import { renderWorkspaceLock } from './common/renderWorkspaceLock.js';
+import { createWorkspaceLockRenderer } from './common/renderWorkspaceLock.js';
 import renderHomeView from './blogpress/views/homeView.js';
 import renderDetailView from './blogpress/views/detailView.js';
 import renderPricingView from './blogpress/views/pricingView.js';
@@ -263,16 +263,16 @@ function syncNavigation({ mount, state }) {
   });
 }
 
+const renderLocked = createWorkspaceLockRenderer({
+  theme: LOCK_THEME,
+  fallbackMessage: LOCK_FALLBACK_MESSAGE
+});
+
 const presenter = createTabbedWorkspacePresenter({
   className: 'blogpress',
   state: { ...INITIAL_STATE },
   ensureSelection: ensureSelectedBlog,
-  renderLocked: (model = {}, mount) =>
-    renderWorkspaceLock(mount, {
-      theme: LOCK_THEME,
-      lock: model.lock,
-      fallbackMessage: LOCK_FALLBACK_MESSAGE
-    }),
+  renderLocked,
   renderHeader,
   renderViews,
   deriveSummary: deriveWorkspaceSummary,

--- a/src/ui/views/browser/components/common/renderWorkspaceLock.js
+++ b/src/ui/views/browser/components/common/renderWorkspaceLock.js
@@ -53,3 +53,41 @@ export function renderWorkspaceLock(target, options = {}) {
 
   return container;
 }
+
+export function createWorkspaceLockRenderer(options = {}) {
+  const {
+    theme = {},
+    fallbackMessage = '',
+    selectLock,
+    selectTheme,
+    selectFallback
+  } = options;
+
+  const resolveLock = typeof selectLock === 'function'
+    ? (model, context) => selectLock(model, context)
+    : (model => model?.lock);
+
+  const resolveTheme = typeof selectTheme === 'function'
+    ? (model, context) => selectTheme(model, context) || {}
+    : () => theme || {};
+
+  const resolveFallback = typeof selectFallback === 'function'
+    ? (model, context) => selectFallback(model, context)
+    : () => fallbackMessage;
+
+  return (model = {}, mount, context) => {
+    if (!isElement(mount)) {
+      return null;
+    }
+
+    const lock = resolveLock(model, context);
+    const themeConfig = resolveTheme(model, context);
+    const fallback = resolveFallback(model, context);
+
+    return renderWorkspaceLock(mount, {
+      theme: themeConfig,
+      lock,
+      fallbackMessage: fallback
+    });
+  };
+}

--- a/src/ui/views/browser/components/digishelf/index.js
+++ b/src/ui/views/browser/components/digishelf/index.js
@@ -8,7 +8,7 @@ import { formatCurrency as baseFormatCurrency } from '../../utils/formatting.js'
 import { createCurrencyLifecycleSummary } from '../../utils/lifecycleSummaries.js';
 import { showLaunchConfirmation } from '../../utils/launchDialog.js';
 import { createTabbedWorkspacePresenter } from '../../utils/createTabbedWorkspacePresenter.js';
-import { renderWorkspaceLock } from '../common/renderWorkspaceLock.js';
+import { createWorkspaceLockRenderer } from '../common/renderWorkspaceLock.js';
 import {
   VIEW_EBOOKS,
   VIEW_STOCK,
@@ -172,6 +172,11 @@ function deriveWorkspaceSummary(model = {}) {
   return summary;
 }
 
+const renderLocked = createWorkspaceLockRenderer({
+  theme: LOCK_THEME,
+  fallbackMessage: LOCK_FALLBACK_MESSAGE
+});
+
 const presenter = createTabbedWorkspacePresenter({
   className: 'digishelf',
   state: { ...initialState },
@@ -180,12 +185,7 @@ const presenter = createTabbedWorkspacePresenter({
   deriveSummary: deriveWorkspaceSummary,
   renderHeader,
   renderViews,
-  renderLocked: (model = {}, mount) =>
-    renderWorkspaceLock(mount, {
-      theme: LOCK_THEME,
-      lock: model.lock,
-      fallbackMessage: LOCK_FALLBACK_MESSAGE
-    }),
+  renderLocked,
   syncNavigation,
   isLocked: model => Boolean(model?.lock)
 });

--- a/src/ui/views/browser/components/serverhub.js
+++ b/src/ui/views/browser/components/serverhub.js
@@ -8,6 +8,7 @@ import {
 import { createCurrencyLifecycleSummary } from '../utils/lifecycleSummaries.js';
 import { showLaunchConfirmation } from '../utils/launchDialog.js';
 import { createAssetWorkspaceConfig } from '../utils/createAssetWorkspaceConfig.js';
+import { createWorkspaceLockRenderer } from './common/renderWorkspaceLock.js';
 import { createAppsView } from './serverhub/views/appsView.js';
 import { createUpgradesView } from './serverhub/views/upgradesView.js';
 import { createPricingView } from './serverhub/views/pricingView.js';
@@ -24,6 +25,11 @@ const LOCK_THEME = {
 };
 
 const LOCK_FALLBACK_MESSAGE = 'ServerHub unlocks once the SaaS Micro-App blueprint is discovered.';
+
+const renderLocked = createWorkspaceLockRenderer({
+  theme: LOCK_THEME,
+  fallbackMessage: LOCK_FALLBACK_MESSAGE
+});
 
 const formatCurrency = amount => baseFormatCurrency(amount, { precision: 'integer', clampZero: true });
 const formatNetCurrency = amount => baseFormatNetCurrency(amount, { precision: 'integer' });
@@ -193,10 +199,7 @@ presenter = createAssetWorkspaceConfig({
   ensureSelection,
   deriveSummary,
   derivePath,
-  lock: {
-    theme: LOCK_THEME,
-    fallbackMessage: LOCK_FALLBACK_MESSAGE
-  },
+  renderLocked,
   actions: {
     selectNiche: selectServerHubNiche
   },

--- a/src/ui/views/browser/utils/createConfiguredAssetWorkspace.js
+++ b/src/ui/views/browser/utils/createConfiguredAssetWorkspace.js
@@ -1,5 +1,5 @@
 import { createAssetWorkspacePresenter } from './createAssetWorkspace.js';
-import { renderWorkspaceLock } from '../components/common/renderWorkspaceLock.js';
+import { createWorkspaceLockRenderer } from '../components/common/renderWorkspaceLock.js';
 import { performQualityAction as defaultPerformQualityAction } from '../../../../game/assets/index.js';
 
 function noop() {}
@@ -71,15 +71,7 @@ function createLockRenderer(lockConfig = {}) {
   if (!lockConfig || typeof lockConfig !== 'object') {
     return undefined;
   }
-  const { theme, fallbackMessage } = lockConfig;
-  return (model = {}, mount) => {
-    if (!mount) return;
-    renderWorkspaceLock(mount, {
-      theme,
-      lock: model.lock,
-      fallbackMessage
-    });
-  };
+  return createWorkspaceLockRenderer(lockConfig);
 }
 
 function createViewRenderer(viewDefinition = {}, helpers) {


### PR DESCRIPTION
## Summary
- add a reusable `createWorkspaceLockRenderer` helper that mounts lock messaging
- update Blogpress, DigiShelf, and ServerHub presenters to use the shared lock renderer
- route configured asset workspaces through the helper so lock themes stay consistent

## Testing
- npm test -- tests/ui/workspaces/assetWorkspacePresenter.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e14cc00304832c8d4523aa95f23eb1