### PR TITLE
Ensure study rollover invalidates study surfaces

### DIFF
--- a/src/game/requirements/orchestrator.js
+++ b/src/game/requirements/orchestrator.js
@@ -3,7 +3,7 @@ import { formatList, formatMoney } from '../../core/helpers.js';
 import { markDirty } from '../../ui/invalidation.js';
 
 export const MIN_MANUAL_BUFFER_HOURS = Math.max(2, Math.round(DEFAULT_DAY_HOURS * 0.25));
-const STUDY_DIRTY_SECTIONS = Object.freeze(['cards', 'dashboard', 'player']);
+export const STUDY_DIRTY_SECTIONS = Object.freeze(['cards', 'dashboard', 'player']);
 
 export function createRequirementsOrchestrator({
   getState,


### PR DESCRIPTION
## Summary
- export the shared study invalidation section list from the requirements orchestrator
- extend requirements tests to assert knowledge track completions refresh study-related panels
- add coverage for day rollover stalls and completions invalidating the dashboard and player widgets

## Testing
- npm test -- tests/requirements.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e14db4c77c832ca54890ef4e3823c5