### PR TITLE
Add GitLab Pages deployment pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,13 @@ pages:
       - node_modules/
   script:
     - npm ci
-    - npm run build
+    - |
+      if [ -n "${CI_PAGES_URL}" ]; then
+        BASE_PATH="$(node -e 'const url = new URL(process.env.CI_PAGES_URL); const path = url.pathname.endsWith("/") ? url.pathname : url.pathname + "/"; process.stdout.write(path);')"
+      else
+        BASE_PATH="/${CI_PROJECT_NAME}/"
+      fi
+      npm run build -- --base "${BASE_PATH}"
     - rm -rf public
     - cp -r dist public
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,21 @@
+stages:
+  - deploy
+
+pages:
+  image: node:20
+  stage: deploy
+  cache:
+    key: ${CI_COMMIT_REF_SLUG}
+    paths:
+      - node_modules/
+  script:
+    - npm ci
+    - npm run build
+    - rm -rf public
+    - cp -r dist public
+  artifacts:
+    paths:
+      - public
+    expire_in: 1 week
+  only:
+    - main

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,5 @@ pages:
   artifacts:
     paths:
       - public
-    expire_in: 1 week
   only:
     - main

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ Each asset supports multiple instances, tracks setup progress, and rolls a daily
 3. Start the Vite development server with `npm run dev` and follow the command output to open the local URL in your browser.
 4. Build a production bundle with `npm run build`. Preview the output locally with `npm run preview`.
 
+## GitLab Pages Deployment Flow
+1. Push or merge to the `main` branch to trigger the GitLab Pages pipeline defined in `.gitlab-ci.yml`.
+2. The `pages` job runs on a Node 20 image, installs dependencies with `npm ci`, builds the Vite bundle, and copies the compiled output from `dist/` into a freshly created `public/` directory.
+3. The `public/` directory is uploaded as a job artifact so GitLab Pages can publish the site at your project’s Pages URL. Cached `node_modules/` data is reused between pipeline runs to keep installs snappy.
+4. If you need to update the deployment, repeat the process with another push to `main`; GitLab Pages will replace the previously published bundle once the pipeline finishes.
+
 ## Styling Workflow
 - The browser shell now links each modular stylesheet directly. Edit the files under `styles/base/`, `styles/components/`, `styles/widgets/`, `styles/workspaces/`, and `styles/overlays/` and the Vite dev server will hot-reload the updates.
 - Maintain the documented load order (base → components → widgets → workspaces → overlays) when adding new modules. Update the `<head>` of `index.html` with any additional `<link rel="stylesheet">` entries so the cascade remains intact.


### PR DESCRIPTION
## Summary
- add a GitLab CI configuration that builds the Vite bundle and publishes it through GitLab Pages
- document the GitLab Pages deployment flow in the README for future contributors

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68e15c5663b4832ca4e1569081b95373