### PR TITLE
Refactor Timodoro workspace to use shared renderer

### DIFF
--- a/src/ui/views/browser/apps/timodoro/ui.js
+++ b/src/ui/views/browser/apps/timodoro/ui.js
@@ -1,8 +1,14 @@
+import { appendContent } from '../../components/common/domHelpers.js';
 import { createStat } from '../../components/widgets.js';
 
-let elements = null;
+const COMPLETED_GROUPS = [
+  { key: 'hustles', label: 'Hustles', empty: 'No hustles wrapped yet.' },
+  { key: 'education', label: 'Education', empty: 'No study blocks logged yet.' },
+  { key: 'upkeep', label: 'Upkeep', empty: 'No upkeep tackled yet.' },
+  { key: 'upgrades', label: 'Upgrades', empty: 'No upgrade pushes finished yet.' }
+];
 
-function createCard(title, summary) {
+function createCard({ title, summary }) {
   const card = document.createElement('article');
   card.className = 'browser-card timodoro-card';
 
@@ -11,13 +17,13 @@ function createCard(title, summary) {
 
   const heading = document.createElement('h2');
   heading.className = 'browser-card__title';
-  heading.textContent = title;
+  appendContent(heading, title);
   header.appendChild(heading);
 
   if (summary) {
     const description = document.createElement('p');
     description.className = 'browser-card__summary';
-    description.textContent = summary;
+    appendContent(description, summary);
     header.appendChild(description);
   }
 
@@ -25,268 +31,270 @@ function createCard(title, summary) {
   return card;
 }
 
-function renderList(list, entries, emptyText) {
-  if (!list) return;
-  list.innerHTML = '';
-  if (!entries.length) {
-    const empty = document.createElement('li');
-    empty.className = 'timodoro-list__empty';
-    empty.textContent = emptyText;
-    list.appendChild(empty);
-    return;
+function createEmptyItem(className, message) {
+  const empty = document.createElement('li');
+  empty.className = className;
+  appendContent(empty, message);
+  return empty;
+}
+
+function createTaskList(entries = [], emptyText, datasetKey) {
+  const list = document.createElement('ul');
+  list.className = 'timodoro-list timodoro-list--tasks';
+  if (datasetKey) {
+    list.dataset.role = datasetKey;
+  }
+
+  if (!Array.isArray(entries) || entries.length === 0) {
+    list.appendChild(createEmptyItem('timodoro-list__empty', emptyText));
+    return list;
   }
 
   entries.forEach(entry => {
+    if (!entry) return;
     const item = document.createElement('li');
     item.className = 'timodoro-list__item';
 
     const name = document.createElement('span');
     name.className = 'timodoro-list__name';
-    name.textContent = entry.name;
+    appendContent(name, entry.name ?? '');
 
     const meta = document.createElement('span');
     meta.className = 'timodoro-list__meta';
-    meta.textContent = entry.detail;
+    appendContent(meta, entry.detail ?? '');
 
     item.append(name, meta);
     list.appendChild(item);
   });
+
+  return list;
 }
 
-function renderCompletedGroups(lists = {}, groupedEntries = {}) {
-  const groups = [
-    { key: 'hustles', empty: 'No hustles wrapped yet.' },
-    { key: 'education', empty: 'No study blocks logged yet.' },
-    { key: 'upkeep', empty: 'No upkeep tackled yet.' },
-    { key: 'upgrades', empty: 'No upgrade pushes finished yet.' }
-  ];
+function createCompletedSection(completedGroups = {}) {
+  const section = document.createElement('section');
+  section.className = 'timodoro-section';
 
-  groups.forEach(({ key, empty }) => {
-    const list = lists?.[key];
-    const entries = Array.isArray(groupedEntries?.[key]) ? groupedEntries[key] : [];
-    renderList(list, entries, empty);
+  const heading = document.createElement('h3');
+  heading.className = 'timodoro-section__title';
+  appendContent(heading, 'Completed today');
+
+  const groupsWrapper = document.createElement('div');
+  groupsWrapper.className = 'timodoro-section__groups';
+
+  COMPLETED_GROUPS.forEach(groupConfig => {
+    const group = document.createElement('section');
+    group.className = 'timodoro-subsection';
+
+    const title = document.createElement('h4');
+    title.className = 'timodoro-subsection__title';
+    appendContent(title, groupConfig.label);
+
+    const entries = Array.isArray(completedGroups[groupConfig.key])
+      ? completedGroups[groupConfig.key]
+      : [];
+    const list = createTaskList(entries, groupConfig.empty, `timodoro-completed-${groupConfig.key}`);
+
+    group.append(title, list);
+    groupsWrapper.appendChild(group);
   });
+
+  section.append(heading, groupsWrapper);
+  return section;
 }
 
-function renderBreakdown(list, entries) {
-  if (!list) return;
-  list.innerHTML = '';
-  if (!entries.length) {
-    const empty = document.createElement('li');
-    empty.className = 'timodoro-breakdown__empty';
-    empty.textContent = 'No hours tracked yet.';
-    list.appendChild(empty);
-    return;
+function createRecurringCard(model = {}) {
+  const card = createCard({
+    title: 'Recurring / Assistant Work',
+    summary: 'Upkeep, maintenance, and study sessions auto-logged for you.'
+  });
+
+  const list = createTaskList(
+    Array.isArray(model.recurringEntries) ? model.recurringEntries : [],
+    model.recurringEmpty || 'No upkeep logged yet. Assistants will report here.',
+    'timodoro-recurring'
+  );
+
+  card.appendChild(list);
+  return card;
+}
+
+function createBreakdownList(entries = []) {
+  const list = document.createElement('ul');
+  list.className = 'timodoro-list timodoro-list--breakdown';
+  list.dataset.role = 'timodoro-breakdown';
+
+  if (!Array.isArray(entries) || entries.length === 0) {
+    list.appendChild(createEmptyItem('timodoro-breakdown__empty', 'No hours tracked yet.'));
+    return list;
   }
 
   entries.forEach(entry => {
+    if (!entry) return;
     const item = document.createElement('li');
     item.className = 'timodoro-breakdown__item';
 
     const label = document.createElement('span');
     label.className = 'timodoro-breakdown__label';
-    label.textContent = entry.label;
+    appendContent(label, entry.label ?? '');
 
     const value = document.createElement('span');
     value.className = 'timodoro-breakdown__value';
-    value.textContent = entry.value;
+    appendContent(value, entry.value ?? '');
 
     item.append(label, value);
     list.appendChild(item);
   });
+
+  return list;
 }
 
-function renderSummaryStats(list, entries) {
-  if (!list) return;
-  list.innerHTML = '';
+function createSummaryList(entries = []) {
+  const list = document.createElement('ul');
+  list.className = 'timodoro-list timodoro-list--stats';
+  list.dataset.role = 'timodoro-stats';
+
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return list;
+  }
+
   entries.forEach(entry => {
+    if (!entry) return;
     const item = document.createElement('li');
     item.className = 'timodoro-stats__item';
 
     const label = document.createElement('span');
     label.className = 'timodoro-stats__label';
-    label.textContent = entry.label;
+    appendContent(label, entry.label ?? '');
 
     const value = document.createElement('span');
     value.className = 'timodoro-stats__value';
-    value.textContent = entry.value;
+    appendContent(value, entry.value ?? '');
 
     item.append(label, value);
 
     if (entry.note) {
       const note = document.createElement('span');
       note.className = 'timodoro-stats__note';
-      note.textContent = entry.note;
+      appendContent(note, entry.note);
       item.appendChild(note);
     }
 
     list.appendChild(item);
   });
+
+  return list;
 }
 
-export function ensureElements(body) {
-  if (!body) return null;
-  let root = body.querySelector('[data-role="timodoro-root"]');
-  if (!root) {
-    body.innerHTML = '';
+function createSnapshotCard(model = {}) {
+  const card = createCard({
+    title: 'Today’s Snapshot',
+    summary: 'Where your hustle hours landed.'
+  });
 
-    root = document.createElement('div');
-    root.className = 'timodoro';
-    root.dataset.role = 'timodoro-root';
+  const stats = document.createElement('div');
+  stats.className = 'browser-card__stats';
 
-    const header = document.createElement('header');
-    header.className = 'timodoro__header';
+  const availableLabel = model.hoursAvailableLabel || '0h';
+  const spentLabel = model.hoursSpentLabel || '0h';
 
-    const title = document.createElement('h1');
-    title.className = 'timodoro__title';
-    title.textContent = 'TimoDoro';
-
-    const subtitle = document.createElement('p');
-    subtitle.className = 'timodoro__subtitle';
-    subtitle.textContent = 'Track your hustle hours and assistant work.';
-
-    header.append(title, subtitle);
-
-    const grid = document.createElement('div');
-    grid.className = 'timodoro__grid';
-
-    const taskColumn = document.createElement('div');
-    taskColumn.className = 'timodoro__column timodoro__column--tasks';
-
-    const summaryColumn = document.createElement('div');
-    summaryColumn.className = 'timodoro__column timodoro__column--summary';
-
-    const taskCard = createCard('Task Log', 'Celebrate today’s finished focus blocks.');
-
-    const completedSection = document.createElement('section');
-    completedSection.className = 'timodoro-section';
-    const completedHeading = document.createElement('h3');
-    completedHeading.className = 'timodoro-section__title';
-    completedHeading.textContent = 'Completed today';
-    const completedGroups = document.createElement('div');
-    completedGroups.className = 'timodoro-section__groups';
-
-    const groupDefinitions = [
-      { key: 'hustles', label: 'Hustles' },
-      { key: 'education', label: 'Education' },
-      { key: 'upkeep', label: 'Upkeep' },
-      { key: 'upgrades', label: 'Upgrades' }
-    ];
-
-    const completedLists = {};
-
-    groupDefinitions.forEach(({ key, label }) => {
-      const group = document.createElement('section');
-      group.className = 'timodoro-subsection';
-
-      const heading = document.createElement('h4');
-      heading.className = 'timodoro-subsection__title';
-      heading.textContent = label;
-
-      const list = document.createElement('ul');
-      list.className = 'timodoro-list timodoro-list--tasks';
-      list.dataset.role = `timodoro-completed-${key}`;
-
-      group.append(heading, list);
-      completedGroups.appendChild(group);
-      completedLists[key] = list;
-    });
-
-    completedSection.append(completedHeading, completedGroups);
-
-    taskCard.append(completedSection);
-
-    const recurringCard = createCard('Recurring / Assistant Work', 'Upkeep, maintenance, and study sessions auto-logged for you.');
-    const recurringList = document.createElement('ul');
-    recurringList.className = 'timodoro-list timodoro-list--tasks';
-    recurringList.dataset.role = 'timodoro-recurring';
-    recurringCard.appendChild(recurringList);
-
-    taskColumn.append(taskCard, recurringCard);
-
-    const snapshotCard = createCard('Today’s Snapshot', 'Where your hustle hours landed.');
-    const stats = document.createElement('div');
-    stats.className = 'browser-card__stats';
-    const availableStat = createStat('Hours available', '0h');
-    const availableValue = availableStat.querySelector('.browser-card__stat-value');
-    const spentStat = createStat('Hours spent', '0h');
-    const spentValue = spentStat.querySelector('.browser-card__stat-value');
-    if (availableValue) {
-      availableValue.dataset.role = 'timodoro-hours-available';
-    }
-    if (spentValue) {
-      spentValue.dataset.role = 'timodoro-hours-spent';
-    }
-    stats.append(availableStat, spentStat);
-
-    const breakdownList = document.createElement('ul');
-    breakdownList.className = 'timodoro-list timodoro-list--breakdown';
-    breakdownList.dataset.role = 'timodoro-breakdown';
-
-    snapshotCard.append(stats, breakdownList);
-
-    const summaryCard = createCard('Summary Stats', 'Totals for today’s push.');
-    const summaryList = document.createElement('ul');
-    summaryList.className = 'timodoro-list timodoro-list--stats';
-    summaryList.dataset.role = 'timodoro-stats';
-    summaryCard.appendChild(summaryList);
-
-    summaryColumn.append(snapshotCard, summaryCard);
-
-    grid.append(taskColumn, summaryColumn);
-    root.append(header, grid);
-    body.appendChild(root);
-
-    elements = {
-      root,
-      completedLists,
-      recurringList,
-      breakdownList,
-      summaryList,
-      availableValue,
-      spentValue
-    };
-    return elements;
+  const availableStat = createStat('Hours available', availableLabel);
+  const availableValue = availableStat.querySelector('.browser-card__stat-value');
+  if (availableValue) {
+    availableValue.dataset.role = 'timodoro-hours-available';
   }
 
-  elements = {
-    root,
-    completedLists: {
-      hustles: root.querySelector('[data-role="timodoro-completed-hustles"]'),
-      education: root.querySelector('[data-role="timodoro-completed-education"]'),
-      upkeep: root.querySelector('[data-role="timodoro-completed-upkeep"]'),
-      upgrades: root.querySelector('[data-role="timodoro-completed-upgrades"]')
-    },
-    recurringList: root.querySelector('[data-role="timodoro-recurring"]'),
-    breakdownList: root.querySelector('[data-role="timodoro-breakdown"]'),
-    summaryList: root.querySelector('[data-role="timodoro-stats"]'),
-    availableValue: root.querySelector('[data-role="timodoro-hours-available"]'),
-    spentValue: root.querySelector('[data-role="timodoro-hours-spent"]')
-  };
-  return elements;
+  const spentStat = createStat('Hours spent', spentLabel);
+  const spentValue = spentStat.querySelector('.browser-card__stat-value');
+  if (spentValue) {
+    spentValue.dataset.role = 'timodoro-hours-spent';
+  }
+
+  stats.append(availableStat, spentStat);
+
+  const breakdown = createBreakdownList(Array.isArray(model.breakdownEntries) ? model.breakdownEntries : []);
+
+  card.append(stats, breakdown);
+  return card;
 }
 
-export function renderView(dom, viewModel = {}) {
-  if (!dom) return;
-  const {
-    completedGroups = {},
-    recurringEntries = [],
-    summaryEntries = [],
-    breakdownEntries = [],
-    hoursAvailableLabel = '0h',
-    hoursSpentLabel = '0h',
-    recurringEmpty = 'No upkeep logged yet. Assistants will report here.'
-  } = viewModel;
+function createTaskColumn(model = {}) {
+  const column = document.createElement('div');
+  column.className = 'timodoro__column timodoro__column--tasks';
 
-  if (dom.availableValue) {
-    dom.availableValue.textContent = hoursAvailableLabel;
-  }
-  if (dom.spentValue) {
-    dom.spentValue.textContent = hoursSpentLabel;
-  }
+  const taskCard = createCard({
+    title: 'Task Log',
+    summary: 'Celebrate today’s finished focus blocks.'
+  });
 
-  renderBreakdown(dom.breakdownList, breakdownEntries);
-  renderCompletedGroups(dom.completedLists, completedGroups);
-  renderList(dom.recurringList, recurringEntries, recurringEmpty);
-  renderSummaryStats(dom.summaryList, summaryEntries);
+  taskCard.appendChild(createCompletedSection(model.completedGroups));
+  column.append(taskCard, createRecurringCard(model));
+
+  return column;
 }
+
+function createSummaryColumn(model = {}) {
+  const column = document.createElement('div');
+  column.className = 'timodoro__column timodoro__column--summary';
+
+  column.append(
+    createSnapshotCard(model),
+    (() => {
+      const card = createCard({
+        title: 'Summary Stats',
+        summary: 'Totals for today’s push.'
+      });
+      card.appendChild(createSummaryList(Array.isArray(model.summaryEntries) ? model.summaryEntries : []));
+      return card;
+    })()
+  );
+
+  return column;
+}
+
+function createHeader() {
+  const header = document.createElement('header');
+  header.className = 'timodoro__header';
+
+  const title = document.createElement('h1');
+  title.className = 'timodoro__title';
+  appendContent(title, 'TimoDoro');
+
+  const subtitle = document.createElement('p');
+  subtitle.className = 'timodoro__subtitle';
+  appendContent(subtitle, 'Track your hustle hours and assistant work.');
+
+  header.append(title, subtitle);
+  return header;
+}
+
+function createLayout(model = {}) {
+  const fragment = document.createDocumentFragment();
+  fragment.appendChild(createHeader());
+
+  const grid = document.createElement('div');
+  grid.className = 'timodoro__grid';
+
+  grid.append(createTaskColumn(model), createSummaryColumn(model));
+  fragment.appendChild(grid);
+
+  return fragment;
+}
+
+function render(model = {}, context = {}) {
+  const { mount } = context;
+  const summary = { meta: model?.meta || 'Productivity ready' };
+
+  if (!mount) {
+    return summary;
+  }
+
+  mount.innerHTML = '';
+  mount.className = 'timodoro';
+  mount.dataset.role = mount.dataset.role || 'timodoro-root';
+  mount.appendChild(createLayout(model));
+
+  return summary;
+}
+
+export { render };
+export default { render };


### PR DESCRIPTION
## Summary
- wrap the Timodoro workspace with the shared workspace renderer and allow injecting pre-built view models
- rebuild the Timodoro UI component as a stateless renderer that uses shared DOM helpers and mounts into the provided root
- update the Timodoro workspace tests to cover the new renderer contract and metadata handling

## Testing
- npm test -- tests/ui/workspaces/timodoroWorkspacePresenter.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e16a7e72f0832c9f8fe57f8a566181