### PR TITLE
Centralize workspace lock themes across presenters

### DIFF
--- a/src/ui/views/browser/components/blogpress.js
+++ b/src/ui/views/browser/components/blogpress.js
@@ -7,6 +7,7 @@ import { showLaunchConfirmation } from '../utils/launchDialog.js';
 import { createTabbedWorkspacePresenter } from '../utils/createTabbedWorkspacePresenter.js';
 import { createNavTabs } from './common/navBuilders.js';
 import { createWorkspaceLockRenderer } from './common/renderWorkspaceLock.js';
+import { getWorkspaceLockTheme } from './common/workspaceLockThemes.js';
 import renderHomeView from './blogpress/views/homeView.js';
 import renderDetailView from './blogpress/views/detailView.js';
 import renderPricingView from './blogpress/views/pricingView.js';
@@ -22,14 +23,10 @@ const INITIAL_STATE = {
   selectedBlogId: null
 };
 
-const LOCK_THEME = {
-  container: 'blogpress-view',
-  locked: 'blogpress-view--locked',
-  message: 'blogpress-empty__message',
-  label: 'This workspace'
-};
-
-const LOCK_FALLBACK_MESSAGE = 'BlogPress unlocks once the Personal Blog blueprint is discovered.';
+const {
+  theme: BLOGPRESS_LOCK_THEME,
+  fallbackMessage: BLOGPRESS_LOCK_FALLBACK_MESSAGE
+} = getWorkspaceLockTheme('blogpress');
 
 const formatCurrency = amount => baseFormatCurrency(amount, { precision: 'integer', clampZero: true });
 
@@ -264,8 +261,8 @@ function syncNavigation({ mount, state }) {
 }
 
 const renderLocked = createWorkspaceLockRenderer({
-  theme: LOCK_THEME,
-  fallbackMessage: LOCK_FALLBACK_MESSAGE
+  theme: BLOGPRESS_LOCK_THEME,
+  fallbackMessage: BLOGPRESS_LOCK_FALLBACK_MESSAGE
 });
 
 const presenter = createTabbedWorkspacePresenter({

--- a/src/ui/views/browser/components/common/workspaceLockThemes.js
+++ b/src/ui/views/browser/components/common/workspaceLockThemes.js
@@ -1,0 +1,78 @@
+const lock = (theme, fallbackMessage) =>
+  Object.freeze({ theme: Object.freeze(theme), fallbackMessage });
+
+export const WORKSPACE_LOCK_THEMES = new Map([
+  [
+    'blogpress',
+    lock(
+      {
+        container: 'blogpress-view',
+        locked: 'blogpress-view--locked',
+        message: 'blogpress-empty__message',
+        label: 'This workspace'
+      },
+      'BlogPress unlocks once the Personal Blog blueprint is discovered.'
+    )
+  ],
+  [
+    'digishelf',
+    lock(
+      {
+        container: 'digishelf',
+        locked: 'digishelf--locked',
+        message: 'digishelf-empty',
+        label: 'DigiShelf'
+      },
+      'DigiShelf unlocks once the digital asset blueprints are discovered.'
+    )
+  ],
+  [
+    'shopily',
+    lock(
+      {
+        container: 'shopily',
+        locked: 'shopily--locked',
+        message: 'shopily-empty',
+        label: 'Shopily'
+      },
+      'Shopily unlocks once the Dropshipping blueprint is discovered.'
+    )
+  ],
+  [
+    'serverhub',
+    lock(
+      {
+        container: 'serverhub',
+        locked: 'serverhub--locked',
+        message: 'serverhub-empty',
+        label: 'This console'
+      },
+      'ServerHub unlocks once the SaaS Micro-App blueprint is discovered.'
+    )
+  ],
+  [
+    'videotube',
+    lock(
+      {
+        container: 'videotube-view',
+        locked: 'videotube-view--locked',
+        message: 'videotube-empty',
+        label: 'This workspace'
+      },
+      'VideoTube unlocks once the Vlog blueprint is discovered.'
+    )
+  ]
+]);
+
+export function getWorkspaceLockTheme(id) {
+  const config = WORKSPACE_LOCK_THEMES.get(id);
+  if (!config) {
+    return { theme: {}, fallbackMessage: '' };
+  }
+  return {
+    theme: { ...config.theme },
+    fallbackMessage: config.fallbackMessage
+  };
+}
+
+export default WORKSPACE_LOCK_THEMES;

--- a/src/ui/views/browser/components/digishelf/index.js
+++ b/src/ui/views/browser/components/digishelf/index.js
@@ -9,6 +9,7 @@ import { createCurrencyLifecycleSummary } from '../../utils/lifecycleSummaries.j
 import { showLaunchConfirmation } from '../../utils/launchDialog.js';
 import { createTabbedWorkspacePresenter } from '../../utils/createTabbedWorkspacePresenter.js';
 import { createWorkspaceLockRenderer } from '../common/renderWorkspaceLock.js';
+import { getWorkspaceLockTheme } from '../common/workspaceLockThemes.js';
 import {
   VIEW_EBOOKS,
   VIEW_STOCK,
@@ -29,14 +30,10 @@ import renderInventoryTable from './inventoryTable.js';
 import renderDetailPane from './detailPane.js';
 import renderPricingCards from './pricingCards.js';
 
-const LOCK_THEME = {
-  container: 'digishelf',
-  locked: 'digishelf--locked',
-  message: 'digishelf-empty',
-  label: 'DigiShelf'
-};
-
-const LOCK_FALLBACK_MESSAGE = 'DigiShelf unlocks once the digital asset blueprints are discovered.';
+const {
+  theme: DIGISHELF_LOCK_THEME,
+  fallbackMessage: DIGISHELF_LOCK_FALLBACK_MESSAGE
+} = getWorkspaceLockTheme('digishelf');
 
 function clampNumber(value) {
   const number = Number(value);
@@ -173,8 +170,8 @@ function deriveWorkspaceSummary(model = {}) {
 }
 
 const renderLocked = createWorkspaceLockRenderer({
-  theme: LOCK_THEME,
-  fallbackMessage: LOCK_FALLBACK_MESSAGE
+  theme: DIGISHELF_LOCK_THEME,
+  fallbackMessage: DIGISHELF_LOCK_FALLBACK_MESSAGE
 });
 
 const presenter = createTabbedWorkspacePresenter({

--- a/src/ui/views/browser/components/serverhub.js
+++ b/src/ui/views/browser/components/serverhub.js
@@ -14,6 +14,7 @@ import {
   withNavTheme
 } from '../utils/assetWorkspaceRegistry.js';
 import { createWorkspaceLockRenderer } from './common/renderWorkspaceLock.js';
+import { getWorkspaceLockTheme } from './common/workspaceLockThemes.js';
 import { createAppsView } from './serverhub/views/appsView.js';
 import { createUpgradesView } from './serverhub/views/upgradesView.js';
 import { createPricingView } from './serverhub/views/pricingView.js';
@@ -22,18 +23,14 @@ const VIEW_APPS = 'apps';
 const VIEW_UPGRADES = 'upgrades';
 const VIEW_PRICING = 'pricing';
 
-const LOCK_THEME = {
-  container: 'serverhub',
-  locked: 'serverhub--locked',
-  message: 'serverhub-empty',
-  label: 'This console'
-};
-
-const LOCK_FALLBACK_MESSAGE = 'ServerHub unlocks once the SaaS Micro-App blueprint is discovered.';
+const {
+  theme: SERVERHUB_LOCK_THEME,
+  fallbackMessage: SERVERHUB_LOCK_FALLBACK_MESSAGE
+} = getWorkspaceLockTheme('serverhub');
 
 const renderLocked = createWorkspaceLockRenderer({
-  theme: LOCK_THEME,
-  fallbackMessage: LOCK_FALLBACK_MESSAGE
+  theme: SERVERHUB_LOCK_THEME,
+  fallbackMessage: SERVERHUB_LOCK_FALLBACK_MESSAGE
 });
 
 const formatCurrency = amount => baseFormatCurrency(amount, { precision: 'integer', clampZero: true });

--- a/src/ui/views/browser/components/shopily/createShopilyWorkspace.js
+++ b/src/ui/views/browser/components/shopily/createShopilyWorkspace.js
@@ -13,6 +13,7 @@ import {
   withNavTheme
 } from '../../utils/assetWorkspaceRegistry.js';
 import { selectShopilyNiche } from '../../../../cards/model/index.js';
+import { getWorkspaceLockTheme } from '../common/workspaceLockThemes.js';
 import {
   VIEW_DASHBOARD,
   VIEW_UPGRADES,
@@ -43,6 +44,11 @@ const {
     upkeepFallback: 'No upkeep'
   }
 });
+
+const {
+  theme: SHOPILY_LOCK_THEME,
+  fallbackMessage: SHOPILY_LOCK_FALLBACK_MESSAGE
+} = getWorkspaceLockTheme('shopily');
 
 function deriveWorkspaceSummary(model = {}) {
   const summary = typeof model?.summary === 'object' && model.summary ? { ...model.summary } : {};
@@ -119,13 +125,8 @@ const { createPresenter: createShopilyWorkspacePresenter } = registerAssetWorksp
     deriveSummary: deriveWorkspaceSummary,
     derivePath,
     lock: {
-      theme: {
-        container: 'shopily',
-        locked: 'shopily--locked',
-        message: 'shopily-empty',
-        label: 'Shopily'
-      },
-      fallbackMessage: 'Shopily unlocks once the Dropshipping blueprint is discovered.'
+      theme: SHOPILY_LOCK_THEME,
+      fallbackMessage: SHOPILY_LOCK_FALLBACK_MESSAGE
     },
     actions: {
       selectNiche: selectShopilyNiche

--- a/src/ui/views/browser/components/videotube/createVideoTubeWorkspace.js
+++ b/src/ui/views/browser/components/videotube/createVideoTubeWorkspace.js
@@ -7,6 +7,7 @@ import {
   formatPercent as baseFormatPercent
 } from '../../utils/formatting.js';
 import { registerAssetWorkspace, createActionDelegates } from '../../utils/assetWorkspaceRegistry.js';
+import { getWorkspaceLockTheme } from '../common/workspaceLockThemes.js';
 import { createVideoTubeHeader } from './header.js';
 import { createDashboardView } from './views/dashboardView.js';
 import { createDetailView } from './views/detailView.js';
@@ -67,6 +68,11 @@ const buildHeader = createVideoTubeHeader();
 let presenter;
 let renameAssetInstance = setAssetInstanceName;
 
+const {
+  theme: VIDEOTUBE_LOCK_THEME,
+  fallbackMessage: VIDEOTUBE_LOCK_FALLBACK_MESSAGE
+} = getWorkspaceLockTheme('videotube');
+
 function showVideoDetail(videoId) {
   if (!videoId || !presenter) return;
   presenter.updateState(state => ({ ...state, selectedVideoId: videoId }));
@@ -87,13 +93,8 @@ const videoTubeWorkspaceRegistration = registerAssetWorkspace({
   deriveSummary,
   derivePath,
   lock: {
-    theme: {
-      container: 'videotube-view',
-      locked: 'videotube-view--locked',
-      message: 'videotube-empty',
-      label: 'This workspace'
-    },
-    fallbackMessage: 'VideoTube unlocks once the Vlog blueprint is discovered.'
+    theme: VIDEOTUBE_LOCK_THEME,
+    fallbackMessage: VIDEOTUBE_LOCK_FALLBACK_MESSAGE
   },
   actions: {
     performQualityAction,

--- a/workspace-locks/workspaceLockThemes.test.js
+++ b/workspace-locks/workspaceLockThemes.test.js
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+import {
+  WORKSPACE_LOCK_THEMES,
+  getWorkspaceLockTheme
+} from '../src/ui/views/browser/components/common/workspaceLockThemes.js';
+import { createWorkspaceLockRenderer } from '../src/ui/views/browser/components/common/renderWorkspaceLock.js';
+
+const WORKSPACE_IDS = ['blogpress', 'digishelf', 'shopily', 'serverhub', 'videotube'];
+
+function assertString(value, message) {
+  assert.equal(typeof value, 'string', message);
+  assert.ok(value.length > 0, message);
+}
+
+test('workspace lock themes expose consistent structure', () => {
+  for (const id of WORKSPACE_IDS) {
+    const config = WORKSPACE_LOCK_THEMES.get(id);
+    assert.ok(config, `expected lock config for ${id}`);
+
+    const { theme, fallbackMessage } = config;
+    assert.ok(theme && typeof theme === 'object', `theme should be an object for ${id}`);
+    assertString(fallbackMessage, `fallback message missing for ${id}`);
+
+    for (const key of ['container', 'locked', 'message', 'label']) {
+      assertString(theme[key], `theme.${key} missing for ${id}`);
+    }
+  }
+});
+
+test('workspace lock renderer uses shared fallback copy', t => {
+  const dom = new JSDOM('<div id="mount"></div>');
+  const { document } = dom.window;
+  const mount = document.getElementById('mount');
+
+  globalThis.window = dom.window;
+  globalThis.document = document;
+  globalThis.HTMLElement = dom.window.HTMLElement;
+
+  t.after(() => {
+    dom.window.close();
+    delete globalThis.window;
+    delete globalThis.document;
+    delete globalThis.HTMLElement;
+  });
+
+  for (const id of WORKSPACE_IDS) {
+    const { theme, fallbackMessage } = getWorkspaceLockTheme(id);
+    const renderLocked = createWorkspaceLockRenderer({ theme, fallbackMessage });
+    renderLocked({}, mount);
+
+    const messageSelector = theme.message ? `.${theme.message}` : theme.messageTag || 'p';
+    const messageElement = mount.querySelector(messageSelector);
+    assert.ok(messageElement, `rendered message element for ${id}`);
+    assert.equal(
+      messageElement.textContent,
+      fallbackMessage,
+      `fallback copy should render for ${id}`
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add a shared `workspaceLockThemes` map for the blogpress, digishelf, shopily, serverhub, and videotube workspaces
- update each workspace presenter to pull its lock theme and fallback copy from the shared map
- cover the shared lock themes with workspace lock renderer tests

## Testing
- npm test -- workspace-locks

------
https://chatgpt.com/codex/tasks/task_e_68e171bad98c832c857f48d05b70ad9f