### PR TITLE
Refactor card launch descriptors

### DIFF
--- a/src/ui/cards/model/digishelf.js
+++ b/src/ui/cards/model/digishelf.js
@@ -4,7 +4,6 @@ import { formatMaintenanceSummary } from '../../../game/assets/maintenance.js';
 import {
   assignInstanceToNiche
 } from '../../../game/assets/niches.js';
-import { describeAssetLaunchAvailability } from './assets.js';
 import { registerModelBuilder } from '../modelBuilderRegistry.js';
 import { buildSkillLock } from './skillLocks.js';
 import {
@@ -12,7 +11,8 @@ import {
   buildMilestoneProgress
 } from './sharedQuality.js';
 import {
-  buildDefaultSummary
+  buildDefaultSummary,
+  createLaunchDescriptor
 } from './sharedAssetInstances.js';
 import createAssetInstanceSnapshots from './createAssetInstanceSnapshots.js';
 
@@ -74,28 +74,6 @@ function buildInstances(definition, state) {
   });
 }
 
-function buildLaunch(definition, state) {
-  const availability = describeAssetLaunchAvailability(definition, state);
-  const launchAction = definition.action || null;
-  if (!launchAction) {
-    return {
-      label: `Launch ${definition.singular || definition.name || 'resource'}`,
-      disabled: availability.disabled,
-      availability,
-      onClick: null
-    };
-  }
-
-  return {
-    label: typeof launchAction.label === 'function' ? launchAction.label(state) : launchAction.label,
-    disabled: typeof launchAction.disabled === 'function'
-      ? launchAction.disabled(state)
-      : Boolean(launchAction.disabled),
-    availability,
-    onClick: launchAction.onClick || null
-  };
-}
-
 function buildPlan(definition, state, copy) {
   const setup = definition?.setup || {};
   const maintenance = definition?.maintenance || {};
@@ -141,7 +119,9 @@ function buildModelForDefinition(definition, state, copy) {
     fallbackLabel: definition.singular || definition.name || 'resource',
     includeNeedsUpkeep: true
   });
-  const launch = buildLaunch(definition, state);
+  const launch = createLaunchDescriptor(definition, state, {
+    fallbackLabel: `Launch ${definition.singular || definition.name || 'resource'}`
+  });
   const plan = buildPlan(definition, state, copy);
 
   return {

--- a/src/ui/cards/model/shopily.js
+++ b/src/ui/cards/model/shopily.js
@@ -13,11 +13,11 @@ import {
   getQualityTracks
 } from '../../../game/assets/quality.js';
 import { getUpgradeSnapshot, describeUpgradeStatus } from './upgrades.js';
-import { describeAssetLaunchAvailability } from './assets.js';
 import { registerModelBuilder } from '../modelBuilderRegistry.js';
 import { buildSkillLock } from './skillLocks.js';
 import {
-  buildDefaultSummary
+  buildDefaultSummary,
+  createLaunchDescriptor
 } from './sharedAssetInstances.js';
 import createAssetInstanceSnapshots from './createAssetInstanceSnapshots.js';
 
@@ -274,23 +274,9 @@ function buildShopilyModel(assetDefinitions = [], upgradeDefinitions = [], state
   const metrics = buildMetrics(instances, definition);
   const pricing = buildPricing(definition, state);
   const upgrades = extractRelevantUpgrades(upgradeDefinitions, state);
-  const availability = describeAssetLaunchAvailability(definition, state);
-  const launchAction = definition.action || null;
-  const launch = launchAction
-    ? {
-        label: typeof launchAction.label === 'function' ? launchAction.label(state) : launchAction.label,
-        disabled: typeof launchAction.disabled === 'function'
-          ? launchAction.disabled(state)
-          : Boolean(launchAction.disabled),
-        availability,
-        onClick: launchAction.onClick || null
-      }
-    : {
-        label: 'Launch Dropshipping Store',
-        disabled: availability.disabled,
-        availability,
-        onClick: null
-      };
+  const launch = createLaunchDescriptor(definition, state, {
+    fallbackLabel: 'Launch Dropshipping Store'
+  });
 
   return {
     definition,


### PR DESCRIPTION
## Summary
- add a shared `createLaunchDescriptor` helper that normalizes launch metadata
- update the Serverhub, Digishelf, and Shopily card models to reuse the shared launch helper

## Testing
- npm test -- tests/ui/cardsModel.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e175856b34832c974fb4b16b3f0ee9