### PR TITLE
Add tabbed navigation to Timodoro workspace

### DIFF
--- a/src/ui/views/browser/apps/timodoro/model.js
+++ b/src/ui/views/browser/apps/timodoro/model.js
@@ -153,6 +153,8 @@ export function buildTimodoroViewModel(state = {}, summary = {}, todoModel = {})
   const recurringEntries = buildRecurringEntries(summary);
   const summaryEntries = buildSummaryEntries(summary, todoModel, state);
   const breakdownEntries = buildBreakdown(summary, todoModel, state);
+  const todoEntries = Array.isArray(todoModel?.entries) ? todoModel.entries : [];
+  const todoEmptyMessage = todoModel?.emptyMessage;
 
   const availableLabel = todoModel?.hoursAvailableLabel
     || formatHours(Number(todoModel?.hoursAvailable) || Number(state?.timeLeft) || 0);
@@ -169,6 +171,8 @@ export function buildTimodoroViewModel(state = {}, summary = {}, todoModel = {})
     recurringEntries,
     summaryEntries,
     breakdownEntries,
+    todoEntries,
+    todoEmptyMessage,
     hoursAvailableLabel: availableLabel,
     hoursSpentLabel: spentLabel,
     meta

--- a/styles/workspaces/timodoro.css
+++ b/styles/workspaces/timodoro.css
@@ -5,21 +5,51 @@
   gap: 1.8rem;
 }
 
-.timodoro__header {
+.timodoro-tabs {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 1.25rem;
 }
 
-.timodoro__title {
-  margin: 0;
-  font-size: 1.75rem;
+.timodoro-tabs__nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
 }
 
-.timodoro__subtitle {
-  margin: 0;
-  color: var(--browser-muted);
-  font-size: 0.95rem;
+.timodoro-tabs__button {
+  border: 1px solid var(--browser-panel-border);
+  border-radius: var(--browser-radius-pill, 999px);
+  background: rgba(148, 163, 184, 0.14);
+  color: inherit;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.5rem 1.1rem;
+  cursor: pointer;
+  transition: background 160ms ease, color 160ms ease, border-color 160ms ease;
+}
+
+.timodoro-tabs__button.is-active {
+  border-color: var(--browser-accent, rgba(37, 99, 235, 0.7));
+  background: rgba(37, 99, 235, 0.18);
+  color: var(--browser-accent, rgb(37, 99, 235));
+}
+
+.timodoro-tabs__button:focus-visible {
+  outline: 2px solid var(--browser-accent, rgb(37, 99, 235));
+  outline-offset: 2px;
+}
+
+.timodoro-tabs__panels {
+  display: flex;
+  flex-direction: column;
+}
+
+.timodoro-tabs__panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
 .timodoro__grid {

--- a/tests/ui/workspaces/timodoroWorkspacePresenter.test.js
+++ b/tests/ui/workspaces/timodoroWorkspacePresenter.test.js
@@ -56,6 +56,15 @@ test('timodoro component renders layout and populates lists', t => {
 
   const viewModel = {
     meta: '3 tasks logged • 6h logged • $320 earned',
+    todoEntries: [
+      {
+        title: 'Draft pitch deck',
+        durationText: '2h focus',
+        meta: 'Client work',
+        moneyCost: 120
+      }
+    ],
+    todoEmptyMessage: 'Queue a hustle or upgrade to add new tasks.',
     completedGroups: {
       hustles: [{ name: 'Logo sprint', detail: '2h logged' }],
       education: [],
@@ -80,10 +89,29 @@ test('timodoro component renders layout and populates lists', t => {
   assert.equal(summary.meta, viewModel.meta, 'render returns view model meta');
   assert.equal(mount.className, 'timodoro', 'mount receives root class');
 
+  const tabs = [...mount.querySelectorAll('.timodoro-tabs__button')];
+  assert.equal(tabs.length, 2, 'two navigation tabs rendered');
+  assert.ok(tabs[0].classList.contains('is-active'), 'TODO tab active by default');
+
+  const todoItems = [
+    ...mount.querySelectorAll('[data-role="timodoro-todo"] .timodoro-list__item')
+  ];
+  assert.equal(todoItems.length, 1, 'todo tab renders active backlog');
+  assert.equal(todoItems[0].querySelector('.timodoro-list__name')?.textContent, 'Draft pitch deck');
+  assert.ok(
+    todoItems[0].querySelector('.timodoro-list__meta')?.textContent.includes('Cost $120'),
+    'todo item includes cost detail'
+  );
+
+  tabs[1].click();
+
   const available = mount.querySelector('[data-role="timodoro-hours-available"]');
   const spent = mount.querySelector('[data-role="timodoro-hours-spent"]');
   assert.equal(available?.textContent, '4h', 'available hours should update');
   assert.equal(spent?.textContent, '2h', 'spent hours should update');
+
+  const donePanel = mount.querySelector('[data-tab="done"]');
+  assert.equal(donePanel?.hidden, false, 'done tab becomes visible after selecting it');
 
   const hustleItems = [
     ...mount.querySelectorAll('[data-role="timodoro-completed-hustles"] .timodoro-list__item')
@@ -165,13 +193,25 @@ test('buildTimodoroViewModel composes summary, recurring, and meta data', () => 
   const todoModel = {
     hoursAvailable: 3,
     hoursAvailableLabel: '3h ready',
-    hoursSpent: 5
+    hoursSpent: 5,
+    entries: [
+      { title: 'Design Blitz', durationText: '2h focus' }
+    ],
+    emptyMessage: 'Queue something inspiring.'
   };
 
   const viewModel = buildTimodoroViewModel(state, summary, todoModel);
 
   assert.equal(viewModel.hoursAvailableLabel, '3h ready', 'uses provided available label');
   assert.equal(viewModel.hoursSpentLabel, '5h', 'formats supplied hours spent');
+
+  assert.equal(viewModel.todoEntries.length, 1, 'todo entries forwarded from todo model');
+  assert.equal(viewModel.todoEntries[0].title, 'Design Blitz', 'retains source todo data');
+  assert.equal(
+    viewModel.todoEmptyMessage,
+    'Queue something inspiring.',
+    'passes through todo empty state message'
+  );
 
   assert.equal(viewModel.summaryEntries.length, 3, 'summary entries include hours, earnings, time used');
   assert.equal(viewModel.breakdownEntries.length, 3, 'breakdown includes active, upkeep, remaining');


### PR DESCRIPTION
## Summary
- add TODO/DONE navigation tabs to the Timodoro workspace and feed the todo tab from the shared backlog model
- expose todo entries and empty messaging in the Timodoro view model and refresh the UI to render tabs without the legacy header copy
- style the new tab set and update workspace tests to cover the navigation flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e15fc4f3f0832ca08ced83252b3e9a