### PR TITLE
Create action registry for dashboard queue

### DIFF
--- a/src/ui/actions/registry.js
+++ b/src/ui/actions/registry.js
@@ -1,0 +1,157 @@
+import { formatHours } from '../../core/helpers.js';
+import { normalizeEntries as normalizeTodoEntries } from '../views/browser/widgets/todoWidget.js';
+
+const providerRegistry = new Map();
+
+function setMetric(target, key, value) {
+  if (value === undefined) return;
+  if (key === 'entries' || key === 'autoCompletedEntries') {
+    return;
+  }
+  if (!Object.prototype.hasOwnProperty.call(target, key)) {
+    target[key] = value;
+    return;
+  }
+  const current = target[key];
+  const isUnset = current === undefined || current === null || (typeof current === 'string' && current.length === 0);
+  if (isUnset) {
+    target[key] = value;
+  }
+}
+
+function toNumber(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : 0;
+}
+
+export function normalizeActionEntries(entries = [], { focusCategory } = {}) {
+  const normalized = normalizeTodoEntries({ entries });
+  if (!focusCategory) {
+    return normalized;
+  }
+  return normalized.map(entry => {
+    if (entry?.focusCategory === focusCategory) {
+      return entry;
+    }
+    if (entry?.focusCategory) {
+      return entry;
+    }
+    return { ...entry, focusCategory };
+  });
+}
+
+export function registerActionProvider(id, provider) {
+  if (typeof id !== 'string' || !id) {
+    return () => {};
+  }
+  if (typeof provider !== 'function') {
+    return () => {};
+  }
+  providerRegistry.set(id, provider);
+  return () => {
+    const existing = providerRegistry.get(id);
+    if (existing === provider) {
+      providerRegistry.delete(id);
+    }
+  };
+}
+
+export function clearActionProviders() {
+  providerRegistry.clear();
+}
+
+export function createAutoCompletedEntries(summary = {}) {
+  const entries = Array.isArray(summary?.timeBreakdown) ? summary.timeBreakdown : [];
+  return entries
+    .map((entry, index) => {
+      const hours = Math.max(0, toNumber(entry?.hours));
+      if (hours <= 0) return null;
+      const category = typeof entry?.category === 'string' ? entry.category.toLowerCase() : '';
+      const tracksMaintenance = category.startsWith('maintenance');
+      const tracksStudy = category.startsWith('study') || category.startsWith('education');
+      if (!tracksMaintenance && !tracksStudy) {
+        return null;
+      }
+
+      const title = entry?.label
+        || entry?.definition?.label
+        || entry?.definition?.name
+        || 'Scheduled work';
+      const key = entry?.key || `${category || 'auto'}-${index}`;
+      return {
+        id: `auto:${key}`,
+        title,
+        durationHours: hours,
+        durationText: formatHours(hours),
+        category
+      };
+    })
+    .filter(Boolean);
+}
+
+export function buildActionQueue({ state, summary } = {}) {
+  const aggregatedMetrics = {};
+  const combinedEntries = [];
+
+  for (const provider of providerRegistry.values()) {
+    if (typeof provider !== 'function') continue;
+    const result = provider({ state: state || {}, summary: summary || {} });
+    if (!result) continue;
+
+    const fallbackFocus = result.focusCategory || null;
+    const entries = Array.isArray(result.entries) ? result.entries : [];
+    entries.forEach((entry, index) => {
+      if (!entry || typeof entry !== 'object') return;
+      if (!entry.id) return;
+      const needsClone = (fallbackFocus && !entry.focusCategory) || !Number.isFinite(entry.orderIndex);
+      const normalized = needsClone ? { ...entry } : entry;
+      if (fallbackFocus && !normalized.focusCategory) {
+        normalized.focusCategory = fallbackFocus;
+      }
+      if (!Number.isFinite(normalized.orderIndex)) {
+        normalized.orderIndex = index;
+      }
+      combinedEntries.push(normalized);
+    });
+
+    if (result.metrics && typeof result.metrics === 'object') {
+      Object.entries(result.metrics).forEach(([key, value]) => {
+        setMetric(aggregatedMetrics, key, value);
+      });
+    }
+  }
+
+  const queue = { entries: combinedEntries };
+  Object.assign(queue, aggregatedMetrics);
+
+  const autoCompletedEntries = createAutoCompletedEntries(summary);
+  if (autoCompletedEntries.length) {
+    queue.autoCompletedEntries = autoCompletedEntries;
+  }
+
+  if (queue.hoursAvailable != null && (queue.hoursAvailableLabel == null || queue.hoursAvailableLabel === '')) {
+    const available = Math.max(0, toNumber(queue.hoursAvailable));
+    queue.hoursAvailable = available;
+    queue.hoursAvailableLabel = formatHours(available);
+  }
+
+  if (queue.hoursSpent != null && (queue.hoursSpentLabel == null || queue.hoursSpentLabel === '')) {
+    const spent = Math.max(0, toNumber(queue.hoursSpent));
+    queue.hoursSpent = spent;
+    queue.hoursSpentLabel = formatHours(spent);
+  }
+
+  if (queue.emptyMessage == null || queue.emptyMessage === '') {
+    queue.emptyMessage = 'Queue a hustle or upgrade to add new tasks.';
+  }
+
+  return queue;
+}
+
+export default {
+  registerActionProvider,
+  clearActionProviders,
+  buildActionQueue,
+  normalizeActionEntries,
+  createAutoCompletedEntries
+};

--- a/src/ui/dashboard/knowledge.js
+++ b/src/ui/dashboard/knowledge.js
@@ -2,6 +2,7 @@ import { formatHours, formatMoney } from '../../core/helpers.js';
 import { clampNumber } from './formatters.js';
 import { getHustles } from '../../game/registryService.js';
 import { KNOWLEDGE_TRACKS, getKnowledgeProgress } from '../../game/requirements.js';
+import { registerActionProvider, normalizeActionEntries } from '../actions/registry.js';
 
 export function computeStudyProgress(state = {}) {
   const tracks = Object.values(KNOWLEDGE_TRACKS);
@@ -120,4 +121,22 @@ export function buildStudyEnrollmentActionModel(state = {}) {
     hoursSpentLabel: formatHours(hoursSpent)
   };
 }
+
+function provideStudyEnrollments({ state } = {}) {
+  const model = buildStudyEnrollmentActionModel(state || {});
+  const { entries = [], ...metrics } = model || {};
+  const normalizedEntries = normalizeActionEntries(entries, { focusCategory: 'study' });
+  return {
+    id: 'dashboard:study-enrollment',
+    focusCategory: 'study',
+    entries: normalizedEntries,
+    metrics
+  };
+}
+
+export function registerStudyEnrollmentProvider() {
+  return registerActionProvider('dashboard:study-enrollment', provideStudyEnrollments);
+}
+
+registerStudyEnrollmentProvider();
 

--- a/src/ui/dashboard/quickActions.js
+++ b/src/ui/dashboard/quickActions.js
@@ -10,6 +10,7 @@ import {
   performQualityAction
 } from '../../game/assets/quality.js';
 import { instanceLabel } from '../../game/assets/details.js';
+import { registerActionProvider, normalizeActionEntries } from '../actions/registry.js';
 
 function getQualitySnapshot(instance = {}) {
   const level = Math.max(0, clampNumber(instance?.quality?.level));
@@ -279,4 +280,39 @@ export function buildAssetActionModel(state = {}) {
     moneyAvailable: clampNumber(state.money)
   };
 }
+
+function provideQuickActions({ state } = {}) {
+  const model = buildQuickActionModel(state || {});
+  const { entries = [], ...metrics } = model || {};
+  const normalizedEntries = normalizeActionEntries(entries, { focusCategory: 'hustle' });
+  return {
+    id: 'dashboard:quick-actions',
+    focusCategory: 'hustle',
+    entries: normalizedEntries,
+    metrics
+  };
+}
+
+function provideAssetUpgrades({ state } = {}) {
+  const model = buildAssetActionModel(state || {});
+  const { entries = [], ...metrics } = model || {};
+  const normalizedEntries = normalizeActionEntries(entries, { focusCategory: 'upgrade' });
+  return {
+    id: 'dashboard:asset-upgrades',
+    focusCategory: 'upgrade',
+    entries: normalizedEntries,
+    metrics
+  };
+}
+
+export function registerQuickActionProvider() {
+  return registerActionProvider('dashboard:quick-actions', provideQuickActions);
+}
+
+export function registerAssetUpgradeProvider() {
+  return registerActionProvider('dashboard:asset-upgrades', provideAssetUpgrades);
+}
+
+registerQuickActionProvider();
+registerAssetUpgradeProvider();
 

--- a/src/ui/views/browser/apps/timodoro.js
+++ b/src/ui/views/browser/apps/timodoro.js
@@ -1,14 +1,9 @@
 import { getState } from '../../../../core/state.js';
 import { computeDailySummary } from '../../../../game/summary.js';
-import {
-  buildQuickActionModel,
-  buildAssetActionModel,
-  buildStudyEnrollmentActionModel
-} from '../../../dashboard/model.js';
-import { composeTodoModel, createAutoCompletedEntries } from '../dashboardPresenter.js';
 import timodoroApp from './timodoro/ui.js';
 import { createWorkspaceRenderer } from '../utils/workspaceFactories.js';
 import { buildTimodoroViewModel } from './timodoro/model.js';
+import { buildActionQueue } from '../../../actions/registry.js';
 
 const renderTimodoroWorkspace = createWorkspaceRenderer({
   pageType: 'timodoro',
@@ -29,11 +24,7 @@ function resolveViewModel(model, state) {
   }
 
   const summary = computeDailySummary(state);
-  const quickActions = buildQuickActionModel(state);
-  const assetActions = buildAssetActionModel(state);
-  const studyActions = buildStudyEnrollmentActionModel(state);
-  const autoEntries = createAutoCompletedEntries(summary);
-  const todoModel = composeTodoModel(quickActions, assetActions, studyActions, autoEntries);
+  const todoModel = buildActionQueue({ state, summary });
 
   return buildTimodoroViewModel(state, summary, todoModel);
 }

--- a/src/ui/views/browser/dashboardPresenter.js
+++ b/src/ui/views/browser/dashboardPresenter.js
@@ -1,170 +1,15 @@
 import { getElement } from '../../elements/registry.js';
-import { formatHours } from '../../../core/helpers.js';
 import todoWidget from './widgets/todoWidget.js';
 import appsWidget from './widgets/appsWidget.js';
 import bankWidget from './widgets/bankWidget.js';
 import notificationsPresenter from './notificationsPresenter.js';
+import { buildActionQueue } from '../../actions/registry.js';
 
 const widgetModules = {
   todo: todoWidget,
   apps: appsWidget,
   bank: bankWidget
 };
-
-function toNumber(value, fallback = 0) {
-  const numeric = Number(value);
-  return Number.isFinite(numeric) ? numeric : fallback;
-}
-
-function createUpgradeTodoEntries(entries = []) {
-  const list = Array.isArray(entries) ? entries.filter(Boolean) : [];
-  return list.map((entry, index) => {
-    const hours = Math.max(0, toNumber(entry?.durationHours, toNumber(entry?.timeCost)));
-    const durationText = entry?.durationText || formatHours(hours);
-    const moneyCost = Math.max(0, toNumber(entry?.moneyCost));
-    const metaParts = [entry?.subtitle, entry?.meta].filter(Boolean);
-    const rawRemaining = Number(entry?.remaining);
-    const upgradeRemaining = Number.isFinite(rawRemaining) ? Math.max(0, rawRemaining) : null;
-    return {
-      id: entry?.id || `upgrade-${index}`,
-      title: entry?.title || 'Upgrade',
-      meta: metaParts.join(' • '),
-      onClick: typeof entry?.onClick === 'function' ? entry.onClick : null,
-      durationHours: hours,
-      durationText,
-      moneyCost,
-      repeatable: Boolean(entry?.repeatable),
-      remainingRuns: entry?.remainingRuns ?? null,
-      focusCategory: 'upgrade',
-      upgradeRemaining,
-      orderIndex: index
-    };
-  });
-}
-
-function createEnrollmentTodoEntries(entries = []) {
-  const list = Array.isArray(entries) ? entries.filter(Boolean) : [];
-  return list.map((entry, index) => {
-    const hours = Math.max(0, toNumber(entry?.durationHours, toNumber(entry?.timeCost)));
-    const durationText = entry?.durationText || formatHours(hours);
-    const moneyCost = Math.max(0, toNumber(entry?.moneyCost));
-    const metaParts = [entry?.subtitle, entry?.meta].filter(Boolean);
-    return {
-      id: entry?.id || `study-${index}`,
-      title: entry?.title || 'Study Track',
-      meta: metaParts.join(' • '),
-      onClick: typeof entry?.onClick === 'function' ? entry.onClick : null,
-      durationHours: hours,
-      durationText,
-      moneyCost,
-      repeatable: Boolean(entry?.repeatable),
-      remainingRuns: entry?.remainingRuns ?? null,
-      focusCategory: 'study',
-      orderIndex: index
-    };
-  });
-}
-
-export function composeTodoModel(
-  quickActions = {},
-  assetActions = {},
-  enrollmentActions = {},
-  autoCompletedEntries = []
-) {
-  const quickEntries = Array.isArray(quickActions?.entries)
-    ? quickActions.entries.filter(Boolean).map((entry, index) => ({
-      ...entry,
-      focusCategory: entry?.focusCategory || 'hustle',
-      orderIndex: Number.isFinite(entry?.orderIndex) ? entry.orderIndex : index
-    }))
-    : [];
-  const upgradeEntries = createUpgradeTodoEntries(assetActions?.entries);
-  const enrollmentEntries = createEnrollmentTodoEntries(enrollmentActions?.entries);
-  const entries = [...quickEntries, ...upgradeEntries, ...enrollmentEntries];
-
-  const model = { ...(quickActions || {}) };
-  model.entries = entries;
-  model.emptyMessage = quickActions?.emptyMessage
-    || assetActions?.emptyMessage
-    || enrollmentActions?.emptyMessage
-    || 'Queue a hustle or upgrade to add new tasks.';
-
-  if (Array.isArray(autoCompletedEntries) && autoCompletedEntries.length) {
-    model.autoCompletedEntries = autoCompletedEntries.filter(Boolean);
-  } else if (model.autoCompletedEntries) {
-    delete model.autoCompletedEntries;
-  }
-
-  if (quickActions?.scroller || assetActions?.scroller || enrollmentActions?.scroller) {
-    model.scroller = quickActions?.scroller || assetActions?.scroller || enrollmentActions?.scroller;
-  } else if (model.scroller) {
-    delete model.scroller;
-  }
-
-  if (model.hoursAvailable == null && assetActions?.hoursAvailable != null) {
-    model.hoursAvailable = assetActions.hoursAvailable;
-  }
-  if (model.hoursAvailable == null && enrollmentActions?.hoursAvailable != null) {
-    model.hoursAvailable = enrollmentActions.hoursAvailable;
-  }
-  if (model.hoursSpent == null && assetActions?.hoursSpent != null) {
-    model.hoursSpent = assetActions.hoursSpent;
-  }
-  if (model.hoursSpent == null && enrollmentActions?.hoursSpent != null) {
-    model.hoursSpent = enrollmentActions.hoursSpent;
-  }
-  if (!model.hoursAvailableLabel && model.hoursAvailable != null) {
-    const available = toNumber(model.hoursAvailable);
-    model.hoursAvailableLabel = formatHours(Math.max(0, available));
-  }
-  if (!model.hoursSpentLabel && model.hoursSpent != null) {
-    const spent = toNumber(model.hoursSpent);
-    model.hoursSpentLabel = formatHours(Math.max(0, spent));
-  }
-
-  if (model.moneyAvailable == null) {
-    const moneySources = [
-      quickActions?.moneyAvailable,
-      assetActions?.moneyAvailable,
-      enrollmentActions?.moneyAvailable
-    ];
-    const sourced = moneySources.find(value => value != null);
-    if (sourced != null) {
-      model.moneyAvailable = sourced;
-    }
-  }
-
-  return model;
-}
-
-export function createAutoCompletedEntries(summary = {}) {
-  const entries = Array.isArray(summary?.timeBreakdown) ? summary.timeBreakdown : [];
-  return entries
-    .map((entry, index) => {
-      const hours = Math.max(0, toNumber(entry?.hours));
-      if (hours <= 0) return null;
-      const category = typeof entry?.category === 'string' ? entry.category.toLowerCase() : '';
-      const tracksMaintenance = category.startsWith('maintenance');
-      const tracksStudy = category.startsWith('study') || category.startsWith('education');
-      if (!tracksMaintenance && !tracksStudy) {
-        return null;
-      }
-
-      const title = entry?.label
-        || entry?.definition?.label
-        || entry?.definition?.name
-        || 'Scheduled work';
-      const key = entry?.key || `${category || 'auto'}-${index}`;
-      return {
-        id: `auto:${key}`,
-        title,
-        durationHours: hours,
-        durationText: formatHours(hours),
-        category
-      };
-    })
-    .filter(Boolean);
-}
 
 function getWidgetMounts() {
   return getElement('homepageWidgets') || {};
@@ -182,16 +27,10 @@ function ensureWidget(key) {
   return module;
 }
 
-function renderTodo(quickActions = {}, assetActions = {}, enrollmentActions = {}, summary = {}) {
+function renderTodo(state = {}, summary = {}) {
   const widget = ensureWidget('todo');
   if (!widget) return;
-  const autoCompletedEntries = createAutoCompletedEntries(summary);
-  const model = composeTodoModel(
-    quickActions,
-    assetActions,
-    enrollmentActions,
-    autoCompletedEntries
-  );
+  const model = buildActionQueue({ state, summary });
   widget.render(model);
 }
 
@@ -208,12 +47,7 @@ function renderBank(context = {}) {
 function renderDashboard(viewModel = {}, context = {}) {
   if (!viewModel) return;
   notificationsPresenter.render(viewModel.eventLog || {});
-  renderTodo(
-    viewModel.quickActions || {},
-    viewModel.assetActions || {},
-    viewModel.studyActions || {},
-    context?.summary || {}
-  );
+  renderTodo(context?.state || {}, context?.summary || {});
   renderApps(context);
   renderBank(context);
 }

--- a/src/ui/views/browser/widgets/todoWidget.js
+++ b/src/ui/views/browser/widgets/todoWidget.js
@@ -59,7 +59,7 @@ function getAvailableMoney(model = {}) {
   return Math.max(0, available);
 }
 
-function normalizeEntries(model = {}) {
+export function normalizeEntries(model = {}) {
   const entries = Array.isArray(model.entries) ? model.entries : [];
   return entries
     .map((entry, index) => {

--- a/tests/ui/actions/registry.test.js
+++ b/tests/ui/actions/registry.test.js
@@ -1,0 +1,137 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildActionQueue,
+  registerActionProvider,
+  clearActionProviders,
+  normalizeActionEntries
+} from '../../../src/ui/actions/registry.js';
+import {
+  registerQuickActionProvider,
+  registerAssetUpgradeProvider
+} from '../../../src/ui/dashboard/quickActions.js';
+import { registerStudyEnrollmentProvider } from '../../../src/ui/dashboard/knowledge.js';
+
+function restoreDefaultProviders() {
+  clearActionProviders();
+  registerQuickActionProvider();
+  registerAssetUpgradeProvider();
+  registerStudyEnrollmentProvider();
+}
+
+test('action registry coordinates providers and auto-complete entries', async t => {
+  await t.test('aggregates provider entries and metrics', () => {
+    clearActionProviders();
+    t.after(() => {
+      restoreDefaultProviders();
+    });
+
+    registerActionProvider('test:hustle', () => ({
+      id: 'test:hustle',
+      focusCategory: 'hustle',
+      entries: normalizeActionEntries([
+        {
+          id: 'alpha',
+          title: 'Alpha Gig',
+          durationHours: 2,
+          payout: 80,
+          payoutText: '$80'
+        }
+      ], { focusCategory: 'hustle' }),
+      metrics: {
+        hoursAvailable: 4
+      }
+    }));
+
+    registerActionProvider('test:upgrade', () => ({
+      id: 'test:upgrade',
+      focusCategory: 'upgrade',
+      entries: normalizeActionEntries([
+        {
+          id: 'beta',
+          title: 'Beta Upgrade',
+          durationHours: 1,
+          moneyCost: 150
+        }
+      ], { focusCategory: 'upgrade' }),
+      metrics: {
+        moneyAvailable: 200,
+        emptyMessage: 'Beta queue ready when you are.'
+      }
+    }));
+
+    const queue = buildActionQueue({ state: {}, summary: {} });
+
+    assert.equal(queue.entries.length, 2);
+    const hustle = queue.entries.find(entry => entry.id === 'alpha');
+    const upgrade = queue.entries.find(entry => entry.id === 'beta');
+    assert.ok(hustle);
+    assert.ok(upgrade);
+    assert.equal(hustle.focusCategory, 'hustle');
+    assert.equal(upgrade.focusCategory, 'upgrade');
+    assert.equal(queue.hoursAvailable, 4);
+    assert.equal(queue.hoursAvailableLabel, '4h');
+    assert.equal(queue.moneyAvailable, 200);
+    assert.equal(queue.emptyMessage, 'Beta queue ready when you are.');
+  });
+
+  await t.test('normalization helper preserves duration and meta', () => {
+    clearActionProviders();
+    t.after(() => {
+      restoreDefaultProviders();
+    });
+
+    registerActionProvider('test:study', () => ({
+      id: 'test:study',
+      focusCategory: 'study',
+      entries: normalizeActionEntries([
+        {
+          id: 'study-1',
+          title: 'Deep Dive',
+          timeCost: 1.5,
+          moneyCost: 75
+        }
+      ], { focusCategory: 'study' }),
+      metrics: {}
+    }));
+
+    const queue = buildActionQueue({ state: {}, summary: {} });
+    assert.equal(queue.entries.length, 1);
+    const entry = queue.entries[0];
+    assert.equal(entry.focusCategory, 'study');
+    assert.equal(entry.durationText, '1.5h');
+    assert.equal(entry.moneyCost, 75);
+    assert.ok(entry.meta.includes('1.5h'));
+  });
+
+  await t.test('auto-completed entries merge into queue model', () => {
+    clearActionProviders();
+    t.after(() => {
+      restoreDefaultProviders();
+    });
+
+    registerActionProvider('test:auto', () => ({
+      id: 'test:auto',
+      focusCategory: 'hustle',
+      entries: normalizeActionEntries([], { focusCategory: 'hustle' }),
+      metrics: {}
+    }));
+
+    const summary = {
+      timeBreakdown: [
+        { key: 'maint', category: 'Maintenance', hours: 2, label: 'Workshop upkeep' },
+        { key: 'study', category: 'Study', hours: 1, label: 'Night classes' },
+        { key: 'other', category: 'Exploration', hours: 3, label: 'Doodles' }
+      ]
+    };
+
+    const queue = buildActionQueue({ state: {}, summary });
+    assert.ok(Array.isArray(queue.autoCompletedEntries));
+    assert.equal(queue.autoCompletedEntries.length, 2);
+    const ids = queue.autoCompletedEntries.map(entry => entry.id);
+    assert.ok(ids.includes('auto:maint'));
+    assert.ok(ids.includes('auto:study'));
+    const upkeep = queue.autoCompletedEntries.find(entry => entry.id === 'auto:maint');
+    assert.equal(upkeep.durationText, '2h');
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared action registry that normalizes provider output and builds the todo queue
- hook existing quick, asset upgrade, and study builders into the registry and update the dashboard/timodoro presenters
- cover provider registration, normalization, and auto-complete behavior with new registry unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e176e015e8832cb4746cfafd2bf551