### PR TITLE
Rework Timodoro ToDo layout

### DIFF
--- a/tests/ui/workspaces/timodoroWorkspacePresenter.test.js
+++ b/tests/ui/workspaces/timodoroWorkspacePresenter.test.js
@@ -94,7 +94,7 @@ test('timodoro component renders layout and populates lists', t => {
   assert.ok(tabs[0].classList.contains('is-active'), 'TODO tab active by default');
 
   const todoItems = [
-    ...mount.querySelectorAll('[data-role="timodoro-todo"] .timodoro-list__item')
+    ...mount.querySelectorAll('[data-role="timodoro-todo-hustle"] .timodoro-list__item')
   ];
   assert.equal(todoItems.length, 1, 'todo tab renders active backlog');
   assert.equal(todoItems[0].querySelector('.timodoro-list__name')?.textContent, 'Draft pitch deck');
@@ -102,6 +102,11 @@ test('timodoro component renders layout and populates lists', t => {
     todoItems[0].querySelector('.timodoro-list__meta')?.textContent.includes('Cost $120'),
     'todo item includes cost detail'
   );
+
+  const upgradeEmpty = mount
+    .querySelector('[data-role="timodoro-todo-upgrade"] .timodoro-list__empty');
+  assert.ok(upgradeEmpty, 'upgrade lane renders empty state');
+  assert.equal(upgradeEmpty.textContent, 'Queue an upgrade to keep momentum.');
 
   tabs[1].click();
 


### PR DESCRIPTION
## Summary
- group Timodoro ToDo tasks by focus lane with updated card copy and default visibility tweaks
- rename the Done tab card and ensure the proper panel is shown when switching tabs
- update the Timodoro workspace test to reflect the new grouped backlog layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e17955a36c832c8a0d9bf45465e0d3