### PR TITLE
Refactor BlogPress model formatting

### DIFF
--- a/src/ui/blogpress/blogModel.js
+++ b/src/ui/blogpress/blogModel.js
@@ -1,0 +1,104 @@
+import { ensureArray } from '../../core/helpers.js';
+import { getAssetState, getState } from '../../core/state.js';
+import { formatMaintenanceSummary } from '../../game/assets/maintenance.js';
+import createAssetInstanceSnapshots from '../cards/model/createAssetInstanceSnapshots.js';
+import { buildDefaultSummary, mapNicheOptions } from '../cards/model/sharedAssetInstances.js';
+import { clampNumber, buildMilestoneProgress } from '../cards/model/sharedQuality.js';
+
+const SUMMARY_OPTIONS = {
+  fallbackLabel: 'blog',
+  includeNeedsUpkeep: true,
+  setupMeta: 'Launch prep in progress'
+};
+
+const MILESTONE_COPY = {
+  maxedSummary: 'Maxed out — future milestones queued for future builds.',
+  readySummary: 'No requirements — quality milestone is ready to trigger.'
+};
+
+function resolveAssetState(definition, state, selector) {
+  if (typeof selector === 'function') {
+    const custom = selector(definition?.id, state);
+    if (custom) {
+      return custom;
+    }
+  }
+  if (!definition) {
+    return { instances: [] };
+  }
+  const assetState = getAssetState(definition.id, state);
+  if (assetState && typeof assetState === 'object') {
+    return assetState;
+  }
+  return { instances: [] };
+}
+
+export function summarizeBlogpressInstances(instances = []) {
+  return buildDefaultSummary(ensureArray(instances), SUMMARY_OPTIONS);
+}
+
+function decorateInstanceSnapshot(snapshot, instance, state) {
+  const createdOnDay = Math.max(0, clampNumber(instance?.createdOnDay));
+  const currentDay = Math.max(1, clampNumber(state?.day) || 1);
+  const daysActive = instance.status === 'active' && createdOnDay > 0
+    ? Math.max(1, currentDay - createdOnDay + 1)
+    : 0;
+  const estimatedSpend = Math.max(0, clampNumber(snapshot.lifetimeSpend));
+  const lifetimeIncome = Math.max(0, clampNumber(snapshot.lifetimeIncome));
+  return {
+    ...snapshot,
+    daysActive,
+    estimatedSpend,
+    lifetimeNet: lifetimeIncome - estimatedSpend,
+    payoutBreakdown: snapshot.payoutBreakdown || { entries: [], total: 0 }
+  };
+}
+
+function buildActionMetadata(instances = []) {
+  return ensureArray(instances).map(instance => ({
+    id: instance.id,
+    quickAction: instance.quickAction || null,
+    actions: ensureArray(instance.actions)
+  }));
+}
+
+export function formatBlogpressModel(definition, state = getState(), options = {}) {
+  const mapNiches = typeof options.mapNiches === 'function' ? options.mapNiches : mapNicheOptions;
+  if (!definition) {
+    return {
+      definition: null,
+      instances: [],
+      summary: summarizeBlogpressInstances([]),
+      nicheOptions: [],
+      actionMetadata: []
+    };
+  }
+
+  const assetState = resolveAssetState(definition, state, options.selectAssetState);
+  const nicheOptions = mapNiches(definition, state);
+  const maintenanceSummary = formatMaintenanceSummary(definition);
+
+  const snapshots = createAssetInstanceSnapshots(definition, state, {
+    selectAssetState: () => assetState,
+    maintenanceSummary,
+    getNicheOptions: () => nicheOptions,
+    buildMilestone: (def, instance, ctxState) =>
+      buildMilestoneProgress(def, instance, MILESTONE_COPY),
+    quickActionSelector: actions => actions.find(entry => entry.available) || actions[0] || null,
+    decorate: (snapshot, { instance, state: snapshotState }) =>
+      decorateInstanceSnapshot(snapshot, instance, snapshotState)
+  });
+
+  const summary = summarizeBlogpressInstances(snapshots);
+  const actionMetadata = buildActionMetadata(snapshots);
+
+  return {
+    definition,
+    instances: snapshots,
+    summary,
+    nicheOptions,
+    actionMetadata
+  };
+}
+
+export default formatBlogpressModel;

--- a/src/ui/cards/model/blogpress.js
+++ b/src/ui/cards/model/blogpress.js
@@ -1,126 +1,11 @@
-import { ensureArray, formatHours, formatMoney } from '../../../core/helpers.js';
-import { getAssetState, getState } from '../../../core/state.js';
-import { instanceLabel } from '../../../game/assets/details.js';
-import { formatMaintenanceSummary } from '../../../game/assets/maintenance.js';
-import {
-  assignInstanceToNiche,
-  getInstanceNicheInfo
-} from '../../../game/assets/niches.js';
-import {
-  canPerformQualityAction,
-  getInstanceQualityRange,
-  getNextQualityLevel,
-  getQualityActionAvailability,
-  getQualityActionUsage,
-  getQualityActions,
-  getQualityLevel,
-  getQualityTracks
-} from '../../../game/assets/quality.js';
+import { ensureArray } from '../../../core/helpers.js';
+import { getState } from '../../../core/state.js';
+import { assignInstanceToNiche } from '../../../game/assets/niches.js';
 import { describeAssetLaunchAvailability } from './assets.js';
 import { registerModelBuilder } from '../modelBuilderRegistry.js';
 import { buildSkillLock } from './skillLocks.js';
-import {
-  calculateAveragePayout,
-  describeInstanceStatus,
-  estimateLifetimeSpend,
-  buildPayoutBreakdown,
-  mapNicheOptions,
-  buildDefaultSummary
-} from './sharedAssetInstances.js';
-
-function clampNumber(value) {
-  const number = Number(value);
-  return Number.isFinite(number) ? number : 0;
-}
-
-function buildMilestoneProgress(definition, instance) {
-  const quality = instance?.quality || {};
-  const level = Math.max(0, clampNumber(quality.level));
-  const nextLevel = getNextQualityLevel(definition, level);
-  const tracks = getQualityTracks(definition);
-  const progress = quality.progress || {};
-
-  if (!nextLevel?.requirements) {
-    return {
-      level,
-      percent: 1,
-      summary: 'Maxed out — future milestones queued for future builds.',
-      nextLevel: null,
-      steps: []
-    };
-  }
-
-  let totalGoal = 0;
-  let totalCurrent = 0;
-  const steps = [];
-
-  Object.entries(nextLevel.requirements).forEach(([key, rawGoal]) => {
-    const goal = Math.max(0, clampNumber(rawGoal));
-    if (goal <= 0) return;
-    const current = Math.max(0, clampNumber(progress?.[key]));
-    const capped = Math.min(current, goal);
-    totalGoal += goal;
-    totalCurrent += capped;
-    const track = tracks?.[key] || {};
-    const label = track.shortLabel || track.label || key;
-    steps.push({
-      key,
-      label,
-      current: capped,
-      goal
-    });
-  });
-
-  const percent = totalGoal > 0 ? Math.min(1, totalCurrent / totalGoal) : 1;
-  const summary = steps.length
-    ? steps.map(step => `${step.current}/${step.goal} ${step.label}`).join(' • ')
-    : 'No requirements — quality milestone is ready to trigger.';
-
-  return {
-    level,
-    percent,
-    summary,
-    nextLevel,
-    steps
-  };
-}
-
-function buildActionSnapshot(definition, instance, action, state) {
-  const timeCost = Math.max(0, clampNumber(action.time));
-  const moneyCost = Math.max(0, clampNumber(action.cost));
-  const usage = getQualityActionUsage(definition, instance, action);
-  const availability = getQualityActionAvailability(definition, instance, action, state);
-  const unlocked = Boolean(availability?.unlocked);
-  const canRun = canPerformQualityAction(definition, instance, action, state);
-  let disabledReason = '';
-
-  if (instance.status !== 'active') {
-    const remaining = Math.max(0, clampNumber(instance.daysRemaining));
-    disabledReason = remaining > 0
-      ? `Launch finishes in ${remaining} day${remaining === 1 ? '' : 's'}`
-      : 'Launch prep wrapping up soon';
-  } else if (!unlocked) {
-    disabledReason = availability?.reason || 'Requires an upgrade first.';
-  } else if (usage.remainingUses <= 0) {
-    disabledReason = 'Daily limit reached — try again tomorrow.';
-  } else if (timeCost > 0 && state.timeLeft < timeCost) {
-    disabledReason = `Need ${formatHours(timeCost)} free.`;
-  } else if (moneyCost > 0 && state.money < moneyCost) {
-    disabledReason = `Need $${formatMoney(moneyCost)} on hand.`;
-  }
-
-  return {
-    id: action.id,
-    label: action.label || 'Quality push',
-    time: timeCost,
-    cost: moneyCost,
-    available: canRun,
-    unlocked,
-    usage,
-    disabledReason,
-    skills: action.skills || []
-  };
-}
+import formatBlogpressModel, { summarizeBlogpressInstances } from '../../blogpress/blogModel.js';
+import { clampNumber } from './sharedQuality.js';
 
 function extractRelevantUpgrades(upgrades = []) {
   return ensureArray(upgrades)
@@ -141,77 +26,7 @@ function extractRelevantUpgrades(upgrades = []) {
     }));
 }
 
-function buildBlogInstances(definition, state) {
-  const assetState = getAssetState('blog', state) || { instances: [] };
-  const instances = ensureArray(assetState.instances);
-  const actions = getQualityActions(definition);
-  const nicheOptions = mapNicheOptions(definition, state);
-  const maintenance = formatMaintenanceSummary(definition);
-
-  return instances.map((instance, index) => {
-    const label = instanceLabel(definition, index);
-    const status = describeInstanceStatus(instance, definition);
-    const averagePayout = calculateAveragePayout(instance, state);
-    const lifetimeIncome = Math.max(0, clampNumber(instance.totalIncome));
-    const estimatedSpend = estimateLifetimeSpend(definition, instance, state);
-    const lifetimeNet = lifetimeIncome - estimatedSpend;
-    const createdOnDay = Math.max(0, clampNumber(instance?.createdOnDay));
-    const currentDay = Math.max(1, clampNumber(state?.day) || 1);
-    const daysActive = instance.status === 'active' && createdOnDay > 0
-      ? Math.max(1, currentDay - createdOnDay + 1)
-      : 0;
-    const qualityLevel = Math.max(0, clampNumber(instance?.quality?.level));
-    const qualityInfo = getQualityLevel(definition, qualityLevel);
-    const milestone = buildMilestoneProgress(definition, instance);
-    const qualityRange = getInstanceQualityRange(definition, instance);
-    const payoutBreakdown = buildPayoutBreakdown(instance);
-    const actionSnapshots = actions.map(action => buildActionSnapshot(definition, instance, action, state));
-    const quickAction = actionSnapshots.find(entry => entry.available) || actionSnapshots[0] || null;
-    const nicheInfo = getInstanceNicheInfo(instance, state);
-    const niche = nicheInfo
-      ? {
-          id: nicheInfo.definition?.id || '',
-          name: nicheInfo.definition?.name || nicheInfo.definition?.id || '',
-          summary: nicheInfo.popularity?.summary || '',
-          label: nicheInfo.popularity?.label || '',
-          multiplier: nicheInfo.popularity?.multiplier || 1,
-          score: clampNumber(nicheInfo.popularity?.score),
-          delta: Number.isFinite(Number(nicheInfo.popularity?.delta))
-            ? Number(nicheInfo.popularity.delta)
-            : null
-        }
-      : null;
-
-    return {
-      id: instance.id,
-      label,
-      status,
-      latestPayout: Math.max(0, clampNumber(instance.lastIncome)),
-      averagePayout,
-      lifetimeIncome,
-      estimatedSpend,
-      lifetimeNet,
-      maintenanceFunded: Boolean(instance.maintenanceFundedToday),
-      pendingIncome: Math.max(0, clampNumber(instance.pendingIncome)),
-      daysActive,
-      qualityLevel,
-      qualityInfo: qualityInfo || null,
-      qualityRange,
-      milestone,
-      payoutBreakdown,
-      actions: actionSnapshots,
-      quickAction,
-      niche,
-      nicheLocked: Boolean(instance.nicheId),
-      nicheOptions,
-      maintenance,
-      definition,
-      instance
-    };
-  });
-}
-
-function buildPricing(definition, upgrades = [], state) {
+function buildPricing(definition, upgrades = [], state, { nicheOptions = [] } = {}) {
   const setup = definition?.setup || {};
   const maintenance = definition?.maintenance || {};
   const quality = definition?.quality || {};
@@ -231,7 +46,9 @@ function buildPricing(definition, upgrades = [], state) {
     cost: Math.max(0, clampNumber(action.cost))
   }));
   const upgradesList = extractRelevantUpgrades(upgrades);
-  const nicheOptions = mapNicheOptions(definition, state).sort((a, b) => b.score - a.score);
+  const sortedNiches = ensureArray(nicheOptions)
+    .slice()
+    .sort((a, b) => (b?.score || 0) - (a?.score || 0));
 
   return {
     setup,
@@ -239,17 +56,39 @@ function buildPricing(definition, upgrades = [], state) {
     levels,
     actions,
     upgrades: upgradesList,
-    topNiches: nicheOptions.slice(0, 3),
-    nicheCount: nicheOptions.length
+    topNiches: sortedNiches.slice(0, 3),
+    nicheCount: sortedNiches.length
   };
 }
 
-function buildSummary(instances = []) {
-  return buildDefaultSummary(instances, {
-    fallbackLabel: 'blog',
-    includeNeedsUpkeep: true,
-    setupMeta: 'Launch prep in progress'
-  });
+function buildLaunchAction(definition, state) {
+  const availability = describeAssetLaunchAvailability(definition, state);
+  const launchAction = definition?.action || null;
+  if (!launchAction) {
+    return {
+      label: 'Launch Blog',
+      disabled: availability.disabled,
+      onClick: null,
+      availability
+    };
+  }
+
+  const resolveActionLabel = value =>
+    typeof value === 'function' ? value(state) : value;
+
+  return {
+    label: resolveActionLabel(launchAction.label),
+    disabled: typeof launchAction.disabled === 'function'
+      ? launchAction.disabled(state)
+      : Boolean(launchAction.disabled),
+    onClick: launchAction.onClick || null,
+    availability
+  };
+}
+
+function buildEmptySummary(meta) {
+  const summary = summarizeBlogpressInstances([]);
+  return { ...summary, meta };
 }
 
 function buildBlogpressModel(assetDefinitions = [], upgradeDefinitions = [], state = getState()) {
@@ -258,7 +97,7 @@ function buildBlogpressModel(assetDefinitions = [], upgradeDefinitions = [], sta
     return {
       definition: null,
       instances: [],
-      summary: { total: 0, active: 0, setup: 0, needsUpkeep: 0, meta: 'BlogPress locked' },
+      summary: buildEmptySummary('BlogPress locked'),
       pricing: null,
       launch: null
     };
@@ -269,38 +108,24 @@ function buildBlogpressModel(assetDefinitions = [], upgradeDefinitions = [], sta
     return {
       definition: null,
       instances: [],
-      summary: { total: 0, active: 0, setup: 0, needsUpkeep: 0, meta: lock.meta },
+      summary: buildEmptySummary(lock.meta),
       pricing: null,
       launch: null,
       lock
     };
   }
 
-  const instances = buildBlogInstances(definition, state);
-  const summary = buildSummary(instances);
-  const pricing = buildPricing(definition, upgradeDefinitions, state);
-  const availability = describeAssetLaunchAvailability(definition, state);
-  const launchAction = definition.action || null;
-  const launch = launchAction
-    ? {
-        label: typeof launchAction.label === 'function' ? launchAction.label(state) : launchAction.label,
-        disabled: typeof launchAction.disabled === 'function' ? launchAction.disabled(state) : Boolean(launchAction.disabled),
-        onClick: launchAction.onClick || null,
-        availability
-      }
-    : {
-        label: 'Launch Blog',
-        disabled: availability.disabled,
-        onClick: null,
-        availability
-      };
+  const { instances, summary, nicheOptions, actionMetadata } = formatBlogpressModel(definition, state);
+  const pricing = buildPricing(definition, upgradeDefinitions, state, { nicheOptions });
+  const launch = buildLaunchAction(definition, state);
 
   return {
     definition,
     instances,
     summary,
     pricing,
-    launch
+    launch,
+    actionMetadata
   };
 }
 

--- a/src/ui/views/browser/components/blogpress.js
+++ b/src/ui/views/browser/components/blogpress.js
@@ -8,6 +8,7 @@ import { createTabbedWorkspacePresenter } from '../utils/createTabbedWorkspacePr
 import { createNavTabs } from './common/navBuilders.js';
 import { createWorkspaceLockRenderer } from './common/renderWorkspaceLock.js';
 import { getWorkspaceLockTheme } from './common/workspaceLockThemes.js';
+import { summarizeBlogpressInstances } from '../../../blogpress/blogModel.js';
 import renderHomeView from './blogpress/views/homeView.js';
 import renderDetailView from './blogpress/views/detailView.js';
 import renderPricingView from './blogpress/views/pricingView.js';
@@ -230,8 +231,13 @@ function renderViews(model, state = INITIAL_STATE) {
 }
 
 function deriveWorkspaceSummary(model = {}) {
-  const summary = model?.summary;
-  return summary && typeof summary === 'object' ? summary : {};
+  if (model?.summary && typeof model.summary === 'object') {
+    return model.summary;
+  }
+  if (Array.isArray(model.instances)) {
+    return summarizeBlogpressInstances(model.instances);
+  }
+  return summarizeBlogpressInstances([]);
 }
 
 function deriveWorkspacePath(state = {}) {

--- a/tests/ui/blogpressModel.test.js
+++ b/tests/ui/blogpressModel.test.js
@@ -1,0 +1,76 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import formatBlogpressModel, { summarizeBlogpressInstances } from '../../src/ui/blogpress/blogModel.js';
+import blogDefinition from '../../src/game/assets/definitions/blog.js';
+
+test('formatBlogpressModel returns enriched blog data', () => {
+  const state = {
+    day: 5,
+    timeLeft: 12,
+    money: 240,
+    assets: {}
+  };
+
+  const assetState = {
+    instances: [
+      {
+        id: 'blog-1',
+        status: 'active',
+        createdOnDay: 2,
+        totalIncome: 180,
+        lastIncome: 36,
+        pendingIncome: 12,
+        maintenanceFundedToday: true,
+        quality: { level: 2, progress: { posts: 6, seo: 2 } },
+        dailyUsage: { writePost: 0 },
+        lastIncomeBreakdown: { entries: [{ id: 'base', label: 'Base', amount: 30 }] },
+        nicheId: 'personalFinance'
+      },
+      {
+        id: 'blog-2',
+        status: 'setup',
+        daysCompleted: 1,
+        daysRemaining: 2,
+        totalIncome: 0,
+        pendingIncome: 0,
+        maintenanceFundedToday: false,
+        quality: { level: 0, progress: {} }
+      }
+    ]
+  };
+  state.assets.blog = assetState;
+
+  const nicheOptions = [
+    { id: 'personalFinance', name: 'Personal Finance', label: 'Trending', summary: 'Hot', multiplier: 1.2, score: 82 },
+    { id: 'healthWellness', name: 'Health & Wellness', label: 'Steady', summary: 'Chill', multiplier: 1, score: 60 }
+  ];
+
+  const result = formatBlogpressModel(blogDefinition, state, {
+    selectAssetState: () => assetState,
+    mapNiches: () => nicheOptions
+  });
+
+  assert.equal(result.summary.total, 2, 'counts total blogs');
+  assert.equal(result.summary.active, 1, 'counts active blogs');
+  assert.equal(result.summary.needsUpkeep, 0, 'tracks funded upkeep');
+  assert.deepEqual(result.nicheOptions, nicheOptions, 'reuses mapped niche options');
+  assert.equal(result.instances.length, 2, 'builds instance snapshots');
+
+  const first = result.instances[0];
+  assert.ok(first.quickAction, 'selects quick action for active blogs');
+  assert.equal(first.quickAction.id, 'writePost', 'prefers available actions');
+  assert.equal(first.daysActive, 4, 'derives days active from state');
+  assert.equal(result.actionMetadata.length, 2, 'builds action metadata list');
+  const actionMeta = result.actionMetadata.find(entry => entry.id === 'blog-1');
+  assert.ok(actionMeta, 'includes action metadata for each blog');
+  assert.equal(actionMeta.quickAction?.id, 'writePost', 'mirrors quick action in metadata');
+});
+
+test('summarizeBlogpressInstances tracks upkeep needs', () => {
+  const summary = summarizeBlogpressInstances([
+    { id: 'blog-1', status: { id: 'active' }, maintenanceFunded: false },
+    { id: 'blog-2', status: { id: 'active' }, maintenanceFunded: true }
+  ]);
+  assert.equal(summary.total, 2);
+  assert.equal(summary.needsUpkeep, 1);
+});


### PR DESCRIPTION
## Summary
- add a shared BlogPress formatter that builds instance snapshots, summary data, and action metadata
- update the card model and browser workspace to consume the shared formatter and reuse the summary helper
- add unit tests covering the BlogPress formatter contract

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e18589aff0832cbc75e99582a52bf8