### PR TITLE
Sync TimoDoro tabs with workspace navigation

### DIFF
--- a/styles/workspaces/timodoro.css
+++ b/styles/workspaces/timodoro.css
@@ -52,6 +52,10 @@
   gap: 1.5rem;
 }
 
+.timodoro-tabs__panel[hidden] {
+  display: none;
+}
+
 .timodoro__grid {
   display: grid;
   gap: 1.5rem;


### PR DESCRIPTION
## Summary
- sync the TimoDoro todo/done tabs with the workspace navigation path so only the selected section is visible
- add CSS to hide inactive tab panels and keep the layout tidy
- extend the TimoDoro workspace tests to cover navigation path changes and hidden states

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e18b675634832c9b19e11ccb24e909