### PR TITLE
Refactor blogpress formatting into shared model

### DIFF
--- a/src/ui/blogpress/blogModel.js
+++ b/src/ui/blogpress/blogModel.js
@@ -1,0 +1,139 @@
+import { ensureArray } from '../../core/helpers.js';
+import { getAssetState, getState } from '../../core/state.js';
+import { instanceLabel } from '../../game/assets/details.js';
+import { formatMaintenanceSummary } from '../../game/assets/maintenance.js';
+import { getInstanceNicheInfo } from '../../game/assets/niches.js';
+import { getQualityActions } from '../../game/assets/quality/actions.js';
+import {
+  getInstanceQualityRange,
+  getQualityLevel
+} from '../../game/assets/quality/levels.js';
+import {
+  calculateAveragePayout,
+  describeInstanceStatus,
+  estimateLifetimeSpend,
+  buildPayoutBreakdown,
+  mapNicheOptions,
+  buildDefaultSummary
+} from '../cards/model/sharedAssetInstances.js';
+import {
+  clampNumber,
+  buildMilestoneProgress as createMilestoneProgress,
+  buildActionSnapshot
+} from '../cards/model/sharedQuality.js';
+
+function buildMilestoneProgress(definition, instance) {
+  return createMilestoneProgress(definition, instance, {
+    maxedSummary: 'Maxed out — future milestones queued for future builds.',
+    readySummary: 'No requirements — quality milestone is ready to trigger.'
+  });
+}
+
+function formatInstance(definition, instance, index, state, shared) {
+  const status = describeInstanceStatus(instance, definition);
+  const averagePayout = calculateAveragePayout(instance, state);
+  const lifetimeIncome = Math.max(0, clampNumber(instance.totalIncome));
+  const estimatedSpend = estimateLifetimeSpend(definition, instance, state);
+  const lifetimeNet = lifetimeIncome - estimatedSpend;
+  const createdOnDay = Math.max(0, clampNumber(instance?.createdOnDay));
+  const currentDay = Math.max(1, clampNumber(state?.day) || 1);
+  const daysActive = instance.status === 'active' && createdOnDay > 0
+    ? Math.max(1, currentDay - createdOnDay + 1)
+    : 0;
+  const qualityLevel = Math.max(0, clampNumber(instance?.quality?.level));
+  const qualityInfo = getQualityLevel(definition, qualityLevel);
+  const milestone = buildMilestoneProgress(definition, instance);
+  const qualityRange = getInstanceQualityRange(definition, instance);
+  const payoutBreakdown = buildPayoutBreakdown(instance);
+  const actionSnapshots = shared.actions.map(action =>
+    buildActionSnapshot(definition, instance, action, state)
+  );
+  const quickAction = actionSnapshots.find(entry => entry.available) || actionSnapshots[0] || null;
+  const nicheInfo = getInstanceNicheInfo(instance, state);
+  const niche = nicheInfo
+    ? {
+        id: nicheInfo.definition?.id || '',
+        name: nicheInfo.definition?.name || nicheInfo.definition?.id || '',
+        summary: nicheInfo.popularity?.summary || '',
+        label: nicheInfo.popularity?.label || '',
+        multiplier: nicheInfo.popularity?.multiplier || 1,
+        score: clampNumber(nicheInfo.popularity?.score),
+        delta: Number.isFinite(Number(nicheInfo.popularity?.delta))
+          ? Number(nicheInfo.popularity.delta)
+          : null
+      }
+    : null;
+
+  return {
+    id: instance.id,
+    label: instanceLabel(definition, index),
+    status,
+    latestPayout: Math.max(0, clampNumber(instance.lastIncome)),
+    averagePayout,
+    lifetimeIncome,
+    estimatedSpend,
+    lifetimeNet,
+    maintenanceFunded: Boolean(instance.maintenanceFundedToday),
+    pendingIncome: Math.max(0, clampNumber(instance.pendingIncome)),
+    daysActive,
+    qualityLevel,
+    qualityInfo: qualityInfo || null,
+    qualityRange,
+    milestone,
+    payoutBreakdown,
+    actions: actionSnapshots,
+    quickAction,
+    niche,
+    nicheLocked: Boolean(instance.nicheId),
+    nicheOptions: shared.nicheOptions,
+    maintenance: shared.maintenance,
+    definition,
+    instance
+  };
+}
+
+export function formatBlogpressModel({ definition, state = getState() } = {}) {
+  if (!definition) {
+    return {
+      summary: {
+        total: 0,
+        active: 0,
+        setup: 0,
+        needsUpkeep: 0,
+        meta: 'Launch your first blog'
+      },
+      instances: [],
+      nicheOptions: []
+    };
+  }
+
+  const assetState = getAssetState('blog', state) || { instances: [] };
+  const instances = ensureArray(assetState.instances);
+  const actions = ensureArray(getQualityActions(definition));
+  const nicheOptions = mapNicheOptions(definition, state);
+  const maintenance = formatMaintenanceSummary(definition);
+
+  const formattedInstances = instances.map((instance, index) =>
+    formatInstance(definition, instance, index, state, {
+      actions,
+      nicheOptions,
+      maintenance
+    })
+  );
+
+  const summary = buildDefaultSummary(formattedInstances, {
+    fallbackLabel: 'blog',
+    includeNeedsUpkeep: true,
+    setupMeta: 'Launch prep in progress'
+  });
+
+  return {
+    summary,
+    instances: formattedInstances,
+    nicheOptions
+  };
+}
+
+export default {
+  formatBlogpressModel
+};

--- a/src/ui/views/browser/components/blogpress.js
+++ b/src/ui/views/browser/components/blogpress.js
@@ -1,4 +1,5 @@
 import { formatHours, formatMoney } from '../../../../core/helpers.js';
+import { getState } from '../../../../core/state.js';
 import { selectBlogpressNiche } from '../../../cards/model/index.js';
 import { performQualityAction } from '../../../../game/assets/index.js';
 import { formatCurrency as baseFormatCurrency, formatNetCurrency } from '../utils/formatting.js';
@@ -8,6 +9,7 @@ import { createTabbedWorkspacePresenter } from '../utils/createTabbedWorkspacePr
 import { createNavTabs } from './common/navBuilders.js';
 import { createWorkspaceLockRenderer } from './common/renderWorkspaceLock.js';
 import { getWorkspaceLockTheme } from './common/workspaceLockThemes.js';
+import { formatBlogpressModel } from '../../../blogpress/blogModel.js';
 import renderHomeView from './blogpress/views/homeView.js';
 import createBackButton from './blogpress/views/createBackButton.js';
 import { createDetailViewController } from './blogpress/views/createDetailViewController.js';
@@ -297,6 +299,19 @@ const presenter = createTabbedWorkspacePresenter({
   isLocked: model => !model?.definition
 });
 
+function prepareModelForRender(model = {}) {
+  if (!model?.definition || model?.lock) {
+    return model;
+  }
+  const formatted = formatBlogpressModel({ definition: model.definition, state: getState() });
+  return {
+    ...model,
+    summary: formatted.summary,
+    instances: formatted.instances,
+    nicheOptions: formatted.nicheOptions
+  };
+}
+
 function setView(view, options = {}) {
   presenter.updateState(currentState => {
     const next = { ...currentState };
@@ -311,7 +326,8 @@ function setView(view, options = {}) {
 }
 
 export function render(model = {}, context = {}) {
-  return presenter.render(model, context);
+  const preparedModel = prepareModelForRender(model);
+  return presenter.render(preparedModel, context);
 }
 
 export default { render };

--- a/tests/ui/blogpressModel.test.js
+++ b/tests/ui/blogpressModel.test.js
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { formatBlogpressModel } from '../../src/ui/blogpress/blogModel.js';
+import blogDefinition from '../../src/game/assets/definitions/blog.js';
+import { ensureRegistryReady } from '../../src/game/registryBootstrap.js';
+
+function createState() {
+  return {
+    day: 5,
+    timeLeft: 12,
+    money: 180,
+    assets: {
+      blog: {
+        instances: [
+          {
+            id: 'blog-1',
+            status: 'active',
+            createdOnDay: 2,
+            lastIncome: 28,
+            totalIncome: 140,
+            pendingIncome: 12,
+            maintenanceFundedToday: true,
+            quality: { level: 1, progress: { posts: 3, seo: 1 } },
+            nicheId: 'healthWellness',
+            lastIncomeBreakdown: {
+              entries: [
+                { id: 'base', label: 'Base', amount: 20 },
+                { id: 'bonus', label: 'Bonus', amount: 8 }
+              ],
+              total: 28
+            }
+          },
+          {
+            id: 'blog-2',
+            status: 'setup',
+            daysCompleted: 1,
+            daysRemaining: 2,
+            createdOnDay: 4,
+            lastIncome: 0,
+            totalIncome: 0,
+            pendingIncome: 0,
+            maintenanceFundedToday: false,
+            quality: { level: 0, progress: {} }
+          }
+        ]
+      }
+    },
+    niches: {
+      popularity: {
+        healthWellness: { score: 82, previousScore: 74 },
+        personalFinance: { score: 68, previousScore: 60 },
+        travelAdventures: { score: 55, previousScore: 50 }
+      },
+      watchlist: [],
+      analyticsHistory: [],
+      lastRollDay: 5
+    }
+  };
+}
+
+test('formatBlogpressModel returns formatted instances and summary', () => {
+  ensureRegistryReady();
+  const state = createState();
+  const { summary, instances, nicheOptions } = formatBlogpressModel({ definition: blogDefinition, state });
+
+  assert.equal(summary.total, 2);
+  assert.equal(summary.active, 1);
+  assert.equal(summary.needsUpkeep, 0);
+  assert.equal(summary.meta, '1 blog live');
+
+  assert.equal(instances.length, 2);
+  const active = instances.find(entry => entry.id === 'blog-1');
+  assert.ok(active, 'expected active blog instance');
+  assert.equal(active.status?.id, 'active');
+  assert.equal(active.quickAction?.id, 'writePost');
+  assert.equal(active.quickAction?.available, true);
+  assert.equal(active.actions.length, 3);
+  assert.equal(active.niche?.name, 'Health & Wellness');
+  assert.equal(active.niche?.label, 'Surging');
+  assert.equal(active.maintenanceFunded, true);
+  assert.equal(active.payoutBreakdown.total, 28);
+
+  const setup = instances.find(entry => entry.id === 'blog-2');
+  assert.ok(setup, 'expected setup blog instance');
+  assert.equal(setup.status?.id, 'setup');
+  assert.equal(setup.quickAction?.available, false);
+  assert.match(setup.quickAction?.disabledReason || '', /Launch finishes in/);
+
+  assert.ok(Array.isArray(nicheOptions));
+  const nicheIds = nicheOptions.map(option => option.id);
+  assert.ok(nicheIds.includes('healthWellness'));
+  assert.ok(nicheIds.includes('personalFinance'));
+});


### PR DESCRIPTION
## Summary
- add a shared blogpress formatter that standardises instance summaries, niche options, and action metadata
- update the card model and browser workspace to consume the shared formatter while keeping lock handling intact
- cover the shared formatter with a focused unit test to confirm the data contract

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e18d3389fc832cb29026eb8d692634