### PR TITLE
Refactor action queue into registry

### DIFF
--- a/src/ui/actions/registry.js
+++ b/src/ui/actions/registry.js
@@ -1,0 +1,237 @@
+import { formatHours } from '../../core/helpers.js';
+
+const DEFAULT_EMPTY_MESSAGE = 'Queue a hustle or upgrade to add new tasks.';
+
+let providers = [];
+
+function coerceNumber(value, fallback = 0) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+function clampToZero(value) {
+  return Math.max(0, coerceNumber(value));
+}
+
+function formatDuration(hours) {
+  const numeric = coerceNumber(hours);
+  if (numeric <= 0) {
+    return formatHours(0);
+  }
+  return formatHours(Math.max(0, numeric));
+}
+
+export function normalizeActionEntries(source = []) {
+  const entries = Array.isArray(source?.entries)
+    ? source.entries
+    : Array.isArray(source)
+      ? source
+      : [];
+
+  return entries
+    .map((entry, index) => {
+      const id = entry?.id ?? `todo-${index}`;
+      if (!id) return null;
+
+      const durationHours = coerceNumber(entry?.durationHours ?? entry?.timeCost);
+      const normalizedDuration = durationHours > 0 ? durationHours : 0;
+      const durationText = entry?.durationText || formatDuration(normalizedDuration);
+
+      const payoutText = entry?.payoutText || entry?.payoutLabel || '';
+      const meta = entry?.meta || [payoutText, durationText].filter(Boolean).join(' • ');
+
+      const rawRemaining = coerceNumber(entry?.remainingRuns, null);
+      const hasRemaining = Number.isFinite(rawRemaining);
+      const remainingRuns = hasRemaining ? Math.max(0, rawRemaining) : null;
+      const repeatable = Boolean(entry?.repeatable) || (hasRemaining && remainingRuns > 1);
+
+      const moneyCost = coerceNumber(entry?.moneyCost);
+      const normalizedMoney = moneyCost > 0 ? moneyCost : 0;
+
+      const rawPayout = coerceNumber(entry?.payout);
+      const normalizedPayout = rawPayout > 0 ? rawPayout : 0;
+      const moneyPerHour = normalizedDuration > 0
+        ? normalizedPayout / normalizedDuration
+        : normalizedPayout;
+
+      const focusCategory = entry?.focusCategory || entry?.category || entry?.type || null;
+      const rawUpgradeRemaining = coerceNumber(
+        entry?.upgradeRemaining ?? entry?.remaining ?? entry?.requirementsRemaining,
+        null
+      );
+      const upgradeRemaining = Number.isFinite(rawUpgradeRemaining)
+        ? Math.max(0, rawUpgradeRemaining)
+        : null;
+      const orderIndex = Number.isFinite(entry?.orderIndex) ? entry.orderIndex : index;
+
+      return {
+        id,
+        title: entry?.title || 'Action',
+        meta,
+        onClick: typeof entry?.onClick === 'function' ? entry.onClick : null,
+        durationHours: normalizedDuration,
+        durationText,
+        moneyCost: normalizedMoney,
+        repeatable,
+        remainingRuns,
+        payout: normalizedPayout,
+        moneyPerHour: Number.isFinite(moneyPerHour) ? moneyPerHour : 0,
+        focusCategory,
+        upgradeRemaining,
+        orderIndex
+      };
+    })
+    .filter(Boolean);
+}
+
+function createAutoCompletedEntries(summary = {}) {
+  const entries = Array.isArray(summary?.timeBreakdown) ? summary.timeBreakdown : [];
+  return entries
+    .map((entry, index) => {
+      const hours = clampToZero(entry?.hours);
+      if (hours <= 0) return null;
+      const category = typeof entry?.category === 'string' ? entry.category.toLowerCase() : '';
+      const tracksMaintenance = category.startsWith('maintenance');
+      const tracksStudy = category.startsWith('study') || category.startsWith('education');
+      if (!tracksMaintenance && !tracksStudy) {
+        return null;
+      }
+
+      const title = entry?.label
+        || entry?.definition?.label
+        || entry?.definition?.name
+        || 'Scheduled work';
+      const key = entry?.key || `${category || 'auto'}-${index}`;
+      return {
+        id: `auto:${key}`,
+        title,
+        durationHours: hours,
+        durationText: formatHours(hours),
+        category
+      };
+    })
+    .filter(Boolean);
+}
+
+export function registerActionProvider(provider) {
+  if (typeof provider !== 'function') {
+    return () => {};
+  }
+  providers.push(provider);
+  let active = true;
+  return () => {
+    if (!active) return;
+    active = false;
+    providers = providers.filter(item => item !== provider);
+  };
+}
+
+export function clearActionProviders() {
+  const previous = providers.slice();
+  providers = [];
+  return () => {
+    providers = previous.slice();
+  };
+}
+
+function applyMetrics(target, metrics = {}) {
+  if (!metrics || typeof metrics !== 'object') return;
+
+  const keys = [
+    'emptyMessage',
+    'buttonClass',
+    'defaultLabel',
+    'hoursAvailable',
+    'hoursAvailableLabel',
+    'hoursSpent',
+    'hoursSpentLabel',
+    'moneyAvailable'
+  ];
+
+  keys.forEach(key => {
+    if (target[key] == null && metrics[key] != null) {
+      target[key] = metrics[key];
+    }
+  });
+
+  if (!target.scroller && metrics.scroller) {
+    target.scroller = metrics.scroller;
+  }
+}
+
+function ensureResourceLabels(queue, state = {}) {
+  if (queue.hoursAvailable == null) {
+    queue.hoursAvailable = clampToZero(state.timeLeft);
+  }
+
+  if (queue.hoursSpent == null) {
+    const baseHours = clampToZero(state.baseTime)
+      + clampToZero(state.bonusTime)
+      + clampToZero(state.dailyBonusTime);
+    const available = clampToZero(queue.hoursAvailable);
+    queue.hoursSpent = Math.max(0, baseHours - available);
+  }
+
+  if (!queue.hoursAvailableLabel && queue.hoursAvailable != null) {
+    queue.hoursAvailableLabel = formatHours(clampToZero(queue.hoursAvailable));
+  }
+
+  if (!queue.hoursSpentLabel && queue.hoursSpent != null) {
+    queue.hoursSpentLabel = formatHours(clampToZero(queue.hoursSpent));
+  }
+
+  if (queue.moneyAvailable == null && state.money != null) {
+    queue.moneyAvailable = clampToZero(state.money);
+  }
+}
+
+export function buildActionQueue({ state = {}, summary = {} } = {}) {
+  const queue = {
+    entries: [],
+    autoCompletedEntries: createAutoCompletedEntries(summary)
+  };
+
+  providers.forEach(provider => {
+    if (typeof provider !== 'function') return;
+    let result;
+    try {
+      result = provider({ state, summary });
+    } catch (error) {
+      result = null;
+    }
+    if (!result) return;
+
+    const focusCategory = result.focusCategory || null;
+    const normalized = normalizeActionEntries(result.entries).map((entry, index) => ({
+      ...entry,
+      focusCategory: entry.focusCategory || focusCategory,
+      orderIndex: Number.isFinite(entry.orderIndex) ? entry.orderIndex : index
+    }));
+
+    queue.entries.push(...normalized);
+    applyMetrics(queue, result.metrics);
+  });
+
+  if (!queue.entries.length && !queue.emptyMessage) {
+    queue.emptyMessage = DEFAULT_EMPTY_MESSAGE;
+  }
+
+  ensureResourceLabels(queue, state);
+
+  if (!queue.autoCompletedEntries.length) {
+    delete queue.autoCompletedEntries;
+  }
+
+  if (!queue.scroller) {
+    delete queue.scroller;
+  }
+
+  return queue;
+}
+
+export default {
+  registerActionProvider,
+  clearActionProviders,
+  buildActionQueue,
+  normalizeActionEntries
+};

--- a/src/ui/dashboard/knowledge.js
+++ b/src/ui/dashboard/knowledge.js
@@ -2,6 +2,10 @@ import { formatHours, formatMoney } from '../../core/helpers.js';
 import { clampNumber } from './formatters.js';
 import { getHustles } from '../../game/registryService.js';
 import { KNOWLEDGE_TRACKS, getKnowledgeProgress } from '../../game/requirements.js';
+import {
+  registerActionProvider,
+  normalizeActionEntries
+} from '../actions/registry.js';
 
 export function computeStudyProgress(state = {}) {
   const tracks = Object.values(KNOWLEDGE_TRACKS);
@@ -120,4 +124,30 @@ export function buildStudyEnrollmentActionModel(state = {}) {
     hoursSpentLabel: formatHours(hoursSpent)
   };
 }
+
+registerActionProvider(({ state }) => {
+  const model = buildStudyEnrollmentActionModel(state);
+  const entries = normalizeActionEntries(
+    (Array.isArray(model?.entries) ? model.entries : []).map((entry, index) => ({
+      ...entry,
+      meta: [entry?.subtitle, entry?.meta].filter(Boolean).join(' • ') || entry?.meta || '',
+      focusCategory: entry?.focusCategory || 'study',
+      orderIndex: Number.isFinite(entry?.orderIndex) ? entry.orderIndex : index
+    }))
+  );
+
+  return {
+    id: 'study-enrollment',
+    focusCategory: 'study',
+    entries,
+    metrics: {
+      emptyMessage: model?.emptyMessage,
+      moneyAvailable: model?.moneyAvailable,
+      hoursAvailable: model?.hoursAvailable,
+      hoursAvailableLabel: model?.hoursAvailableLabel,
+      hoursSpent: model?.hoursSpent,
+      hoursSpentLabel: model?.hoursSpentLabel
+    }
+  };
+});
 

--- a/src/ui/dashboard/quickActions.js
+++ b/src/ui/dashboard/quickActions.js
@@ -10,6 +10,10 @@ import {
 } from '../../game/assets/quality/actions.js';
 import { getNextQualityLevel } from '../../game/assets/quality/levels.js';
 import { instanceLabel } from '../../game/assets/details.js';
+import {
+  registerActionProvider,
+  normalizeActionEntries
+} from '../actions/registry.js';
 
 function getQualitySnapshot(instance = {}) {
   const level = Math.max(0, clampNumber(instance?.quality?.level));
@@ -279,4 +283,57 @@ export function buildAssetActionModel(state = {}) {
     moneyAvailable: clampNumber(state.money)
   };
 }
+
+registerActionProvider(({ state }) => {
+  const model = buildQuickActionModel(state);
+  const entries = normalizeActionEntries(
+    (Array.isArray(model?.entries) ? model.entries : []).map((entry, index) => ({
+      ...entry,
+      focusCategory: entry?.focusCategory || 'hustle',
+      orderIndex: Number.isFinite(entry?.orderIndex) ? entry.orderIndex : index
+    }))
+  );
+
+  return {
+    id: 'quick-actions',
+    focusCategory: 'hustle',
+    entries,
+    metrics: {
+      emptyMessage: model?.emptyMessage,
+      buttonClass: model?.buttonClass,
+      defaultLabel: model?.defaultLabel,
+      hoursAvailable: model?.hoursAvailable,
+      hoursAvailableLabel: model?.hoursAvailableLabel,
+      hoursSpent: model?.hoursSpent,
+      hoursSpentLabel: model?.hoursSpentLabel,
+      moneyAvailable: model?.moneyAvailable,
+      scroller: model?.scroller
+    }
+  };
+});
+
+registerActionProvider(({ state }) => {
+  const model = buildAssetActionModel(state);
+  const entries = normalizeActionEntries(
+    (Array.isArray(model?.entries) ? model.entries : []).map((entry, index) => ({
+      ...entry,
+      meta: [entry?.subtitle, entry?.meta].filter(Boolean).join(' • ') || entry?.meta || '',
+      focusCategory: entry?.focusCategory || 'upgrade',
+      orderIndex: Number.isFinite(entry?.orderIndex) ? entry.orderIndex : index
+    }))
+  );
+
+  return {
+    id: 'asset-upgrades',
+    focusCategory: 'upgrade',
+    entries,
+    metrics: {
+      emptyMessage: model?.emptyMessage,
+      buttonClass: model?.buttonClass,
+      defaultLabel: model?.defaultLabel,
+      moneyAvailable: model?.moneyAvailable,
+      scroller: model?.scroller
+    }
+  };
+});
 

--- a/src/ui/views/browser/apps/timodoro.js
+++ b/src/ui/views/browser/apps/timodoro.js
@@ -1,11 +1,6 @@
 import { getState } from '../../../../core/state.js';
 import { computeDailySummary } from '../../../../game/summary.js';
-import {
-  buildQuickActionModel,
-  buildAssetActionModel,
-  buildStudyEnrollmentActionModel
-} from '../../../dashboard/model.js';
-import { composeTodoModel, createAutoCompletedEntries } from '../dashboardPresenter.js';
+import { buildActionQueue } from '../../../actions/registry.js';
 import timodoroApp from './timodoro/ui.js';
 import { createWorkspaceRenderer } from '../utils/workspaceFactories.js';
 import { buildTimodoroViewModel } from './timodoro/model.js';
@@ -29,11 +24,7 @@ function resolveViewModel(model, state) {
   }
 
   const summary = computeDailySummary(state);
-  const quickActions = buildQuickActionModel(state);
-  const assetActions = buildAssetActionModel(state);
-  const studyActions = buildStudyEnrollmentActionModel(state);
-  const autoEntries = createAutoCompletedEntries(summary);
-  const todoModel = composeTodoModel(quickActions, assetActions, studyActions, autoEntries);
+  const todoModel = buildActionQueue({ state, summary });
 
   return buildTimodoroViewModel(state, summary, todoModel);
 }

--- a/src/ui/views/browser/dashboardPresenter.js
+++ b/src/ui/views/browser/dashboardPresenter.js
@@ -1,170 +1,15 @@
 import { getElement } from '../../elements/registry.js';
-import { formatHours } from '../../../core/helpers.js';
 import todoWidget from './widgets/todoWidget.js';
 import appsWidget from './widgets/appsWidget.js';
 import bankWidget from './widgets/bankWidget.js';
 import notificationsPresenter from './notificationsPresenter.js';
+import { buildActionQueue } from '../../actions/registry.js';
 
 const widgetModules = {
   todo: todoWidget,
   apps: appsWidget,
   bank: bankWidget
 };
-
-function toNumber(value, fallback = 0) {
-  const numeric = Number(value);
-  return Number.isFinite(numeric) ? numeric : fallback;
-}
-
-function createUpgradeTodoEntries(entries = []) {
-  const list = Array.isArray(entries) ? entries.filter(Boolean) : [];
-  return list.map((entry, index) => {
-    const hours = Math.max(0, toNumber(entry?.durationHours, toNumber(entry?.timeCost)));
-    const durationText = entry?.durationText || formatHours(hours);
-    const moneyCost = Math.max(0, toNumber(entry?.moneyCost));
-    const metaParts = [entry?.subtitle, entry?.meta].filter(Boolean);
-    const rawRemaining = Number(entry?.remaining);
-    const upgradeRemaining = Number.isFinite(rawRemaining) ? Math.max(0, rawRemaining) : null;
-    return {
-      id: entry?.id || `upgrade-${index}`,
-      title: entry?.title || 'Upgrade',
-      meta: metaParts.join(' • '),
-      onClick: typeof entry?.onClick === 'function' ? entry.onClick : null,
-      durationHours: hours,
-      durationText,
-      moneyCost,
-      repeatable: Boolean(entry?.repeatable),
-      remainingRuns: entry?.remainingRuns ?? null,
-      focusCategory: 'upgrade',
-      upgradeRemaining,
-      orderIndex: index
-    };
-  });
-}
-
-function createEnrollmentTodoEntries(entries = []) {
-  const list = Array.isArray(entries) ? entries.filter(Boolean) : [];
-  return list.map((entry, index) => {
-    const hours = Math.max(0, toNumber(entry?.durationHours, toNumber(entry?.timeCost)));
-    const durationText = entry?.durationText || formatHours(hours);
-    const moneyCost = Math.max(0, toNumber(entry?.moneyCost));
-    const metaParts = [entry?.subtitle, entry?.meta].filter(Boolean);
-    return {
-      id: entry?.id || `study-${index}`,
-      title: entry?.title || 'Study Track',
-      meta: metaParts.join(' • '),
-      onClick: typeof entry?.onClick === 'function' ? entry.onClick : null,
-      durationHours: hours,
-      durationText,
-      moneyCost,
-      repeatable: Boolean(entry?.repeatable),
-      remainingRuns: entry?.remainingRuns ?? null,
-      focusCategory: 'study',
-      orderIndex: index
-    };
-  });
-}
-
-export function composeTodoModel(
-  quickActions = {},
-  assetActions = {},
-  enrollmentActions = {},
-  autoCompletedEntries = []
-) {
-  const quickEntries = Array.isArray(quickActions?.entries)
-    ? quickActions.entries.filter(Boolean).map((entry, index) => ({
-      ...entry,
-      focusCategory: entry?.focusCategory || 'hustle',
-      orderIndex: Number.isFinite(entry?.orderIndex) ? entry.orderIndex : index
-    }))
-    : [];
-  const upgradeEntries = createUpgradeTodoEntries(assetActions?.entries);
-  const enrollmentEntries = createEnrollmentTodoEntries(enrollmentActions?.entries);
-  const entries = [...quickEntries, ...upgradeEntries, ...enrollmentEntries];
-
-  const model = { ...(quickActions || {}) };
-  model.entries = entries;
-  model.emptyMessage = quickActions?.emptyMessage
-    || assetActions?.emptyMessage
-    || enrollmentActions?.emptyMessage
-    || 'Queue a hustle or upgrade to add new tasks.';
-
-  if (Array.isArray(autoCompletedEntries) && autoCompletedEntries.length) {
-    model.autoCompletedEntries = autoCompletedEntries.filter(Boolean);
-  } else if (model.autoCompletedEntries) {
-    delete model.autoCompletedEntries;
-  }
-
-  if (quickActions?.scroller || assetActions?.scroller || enrollmentActions?.scroller) {
-    model.scroller = quickActions?.scroller || assetActions?.scroller || enrollmentActions?.scroller;
-  } else if (model.scroller) {
-    delete model.scroller;
-  }
-
-  if (model.hoursAvailable == null && assetActions?.hoursAvailable != null) {
-    model.hoursAvailable = assetActions.hoursAvailable;
-  }
-  if (model.hoursAvailable == null && enrollmentActions?.hoursAvailable != null) {
-    model.hoursAvailable = enrollmentActions.hoursAvailable;
-  }
-  if (model.hoursSpent == null && assetActions?.hoursSpent != null) {
-    model.hoursSpent = assetActions.hoursSpent;
-  }
-  if (model.hoursSpent == null && enrollmentActions?.hoursSpent != null) {
-    model.hoursSpent = enrollmentActions.hoursSpent;
-  }
-  if (!model.hoursAvailableLabel && model.hoursAvailable != null) {
-    const available = toNumber(model.hoursAvailable);
-    model.hoursAvailableLabel = formatHours(Math.max(0, available));
-  }
-  if (!model.hoursSpentLabel && model.hoursSpent != null) {
-    const spent = toNumber(model.hoursSpent);
-    model.hoursSpentLabel = formatHours(Math.max(0, spent));
-  }
-
-  if (model.moneyAvailable == null) {
-    const moneySources = [
-      quickActions?.moneyAvailable,
-      assetActions?.moneyAvailable,
-      enrollmentActions?.moneyAvailable
-    ];
-    const sourced = moneySources.find(value => value != null);
-    if (sourced != null) {
-      model.moneyAvailable = sourced;
-    }
-  }
-
-  return model;
-}
-
-export function createAutoCompletedEntries(summary = {}) {
-  const entries = Array.isArray(summary?.timeBreakdown) ? summary.timeBreakdown : [];
-  return entries
-    .map((entry, index) => {
-      const hours = Math.max(0, toNumber(entry?.hours));
-      if (hours <= 0) return null;
-      const category = typeof entry?.category === 'string' ? entry.category.toLowerCase() : '';
-      const tracksMaintenance = category.startsWith('maintenance');
-      const tracksStudy = category.startsWith('study') || category.startsWith('education');
-      if (!tracksMaintenance && !tracksStudy) {
-        return null;
-      }
-
-      const title = entry?.label
-        || entry?.definition?.label
-        || entry?.definition?.name
-        || 'Scheduled work';
-      const key = entry?.key || `${category || 'auto'}-${index}`;
-      return {
-        id: `auto:${key}`,
-        title,
-        durationHours: hours,
-        durationText: formatHours(hours),
-        category
-      };
-    })
-    .filter(Boolean);
-}
 
 function getWidgetMounts() {
   return getElement('homepageWidgets') || {};
@@ -182,16 +27,10 @@ function ensureWidget(key) {
   return module;
 }
 
-function renderTodo(quickActions = {}, assetActions = {}, enrollmentActions = {}, summary = {}) {
+function renderTodo(state = {}, summary = {}) {
   const widget = ensureWidget('todo');
   if (!widget) return;
-  const autoCompletedEntries = createAutoCompletedEntries(summary);
-  const model = composeTodoModel(
-    quickActions,
-    assetActions,
-    enrollmentActions,
-    autoCompletedEntries
-  );
+  const model = buildActionQueue({ state, summary });
   widget.render(model);
 }
 
@@ -208,12 +47,7 @@ function renderBank(context = {}) {
 function renderDashboard(viewModel = {}, context = {}) {
   if (!viewModel) return;
   notificationsPresenter.render(viewModel.eventLog || {});
-  renderTodo(
-    viewModel.quickActions || {},
-    viewModel.assetActions || {},
-    viewModel.studyActions || {},
-    context?.summary || {}
-  );
+  renderTodo(context?.state || {}, context?.summary || {});
   renderApps(context);
   renderBank(context);
 }

--- a/tests/ui/actions/registry.test.js
+++ b/tests/ui/actions/registry.test.js
@@ -1,0 +1,107 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { formatHours } from '../../../src/core/helpers.js';
+import {
+  buildActionQueue,
+  registerActionProvider,
+  clearActionProviders,
+  normalizeActionEntries
+} from '../../../src/ui/actions/registry.js';
+
+test('registerActionProvider supplies normalized entries to the queue', () => {
+  const restore = clearActionProviders();
+  try {
+    registerActionProvider(() => ({
+      id: 'test-provider',
+      focusCategory: 'hustle',
+      entries: [
+        {
+          id: 'custom-entry',
+          title: 'Custom Quest',
+          timeCost: 2,
+          payout: 40
+        }
+      ],
+      metrics: {
+        emptyMessage: 'custom empty',
+        hoursAvailable: 2
+      }
+    }));
+
+    const queue = buildActionQueue({ state: {} });
+    assert.equal(queue.entries.length, 1);
+    const entry = queue.entries[0];
+    assert.equal(entry.durationHours, 2);
+    assert.equal(entry.durationText, formatHours(2));
+    assert.equal(entry.focusCategory, 'hustle');
+    assert.equal(queue.emptyMessage, 'custom empty');
+    assert.equal(queue.hoursAvailable, 2);
+    assert.equal(queue.hoursAvailableLabel, formatHours(2));
+  } finally {
+    restore();
+  }
+});
+
+test('clearActionProviders restore removes temporary providers', () => {
+  const restore = clearActionProviders();
+  try {
+    registerActionProvider(() => ({
+      id: 'temporary-provider',
+      entries: [
+        {
+          id: 'temp-entry',
+          title: 'Temporary Action',
+          timeCost: 1
+        }
+      ],
+      metrics: {}
+    }));
+
+    const queue = buildActionQueue({ state: {} });
+    assert.ok(queue.entries.some(entry => entry.id === 'temp-entry'));
+  } finally {
+    restore();
+  }
+
+  const queueAfterRestore = buildActionQueue({ state: {} });
+  assert.ok(!queueAfterRestore.entries.some(entry => entry.id === 'temp-entry'));
+});
+
+test('buildActionQueue merges auto-completed entries from the summary', () => {
+  const restore = clearActionProviders();
+  try {
+    registerActionProvider(() => ({
+      id: 'minimal-provider',
+      entries: [],
+      metrics: {}
+    }));
+
+    const summary = {
+      timeBreakdown: [
+        { category: 'Maintenance', hours: 1, label: 'Shop upkeep' },
+        { category: 'Crafting', hours: 2 }
+      ]
+    };
+
+    const queue = buildActionQueue({ state: { timeLeft: 3 }, summary });
+    assert.equal(queue.entries.length, 0);
+    assert.ok(Array.isArray(queue.autoCompletedEntries));
+    assert.equal(queue.autoCompletedEntries.length, 1);
+    const autoEntry = queue.autoCompletedEntries[0];
+    assert.equal(autoEntry.durationHours, 1);
+    assert.equal(autoEntry.durationText, formatHours(1));
+    assert.equal(autoEntry.title, 'Shop upkeep');
+  } finally {
+    restore();
+  }
+});
+
+test('normalizeActionEntries mirrors todo normalization rules', () => {
+  const entries = normalizeActionEntries([
+    { id: 'direct', timeCost: 3, payout: 90 }
+  ]);
+  assert.equal(entries.length, 1);
+  const [entry] = entries;
+  assert.equal(entry.durationText, formatHours(3));
+  assert.equal(entry.moneyPerHour, 30);
+});


### PR DESCRIPTION
## Summary
- add an action registry that normalizes provider output and builds the dashboard queue
- register quick, upgrade, and study providers while switching presenters to the shared queue
- share normalization logic with the todo widget and cover the registry with targeted tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e18d91f6c0832ca657c1aef029a91e