### PR TITLE
Refine Timodoro todo card navigation

### DIFF
--- a/styles/widgets/widgets.css
+++ b/styles/widgets/widgets.css
@@ -158,6 +158,22 @@
   align-items: baseline;
 }
 
+.browser-card__header--stacked {
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 0.6rem;
+}
+
+.browser-card__header--stacked .timodoro-tabs__nav {
+  width: 100%;
+  margin-top: 0.25rem;
+}
+
+.browser-card__header--stacked .timodoro-tabs__button {
+  align-self: flex-start;
+}
+
 .browser-card__title {
   margin: 0;
   font-size: 1.2rem;

--- a/styles/workspaces/timodoro.css
+++ b/styles/workspaces/timodoro.css
@@ -17,6 +17,11 @@
   gap: 0.75rem;
 }
 
+.timodoro-tabs__nav--inline {
+  margin: 0;
+  padding: 0;
+}
+
 .timodoro-tabs__button {
   border: 1px solid var(--browser-panel-border);
   border-radius: var(--browser-radius-pill, 999px);

--- a/tests/ui/workspaces/timodoroWorkspacePresenter.test.js
+++ b/tests/ui/workspaces/timodoroWorkspacePresenter.test.js
@@ -96,8 +96,9 @@ test('timodoro component renders layout and populates lists', t => {
   assert.equal(summary.meta, viewModel.meta, 'render returns view model meta');
   assert.equal(mount.className, 'timodoro', 'mount receives root class');
 
-  const tabs = [...mount.querySelectorAll('.timodoro-tabs__button')];
-  assert.equal(tabs.length, 2, 'two navigation tabs rendered');
+  const activeTodoPanel = mount.querySelector('[data-tab="todo"]');
+  const tabs = [...(activeTodoPanel?.querySelectorAll('.timodoro-tabs__button') ?? [])];
+  assert.equal(tabs.length, 2, 'two navigation tabs rendered in active panel');
   assert.ok(tabs[0].classList.contains('is-active'), 'TODO tab active by default');
 
   const todoItems = [


### PR DESCRIPTION
## Summary
- embed the Timodoro tab navigation inside the ToDo and Done card headers and remove the old ToDo summary copy
- suppress study task detail text so the Study & training lane only shows task names
- add stacked card header styling, inline nav spacing, and update the Timodoro workspace test for the relocated navigation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e18e76cba0832c8c7ba5148f965b19