### PR TITLE
Refine action registry integration for dashboard and header

### DIFF
--- a/src/ui/dashboard/model.js
+++ b/src/ui/dashboard/model.js
@@ -11,6 +11,7 @@ import { buildStudyEnrollmentActionModel } from './knowledge.js';
 import { getAssetState } from '../../core/state.js';
 import { getAssets, getUpgrades } from '../../game/registryService.js';
 import { collectNicheAnalytics, summarizeNicheHighlights } from '../../game/analytics/niches.js';
+import { collectActionProviders } from '../actions/registry.js';
 
 function createHighlightDefaults() {
   return {
@@ -266,15 +267,204 @@ export function buildDashboardViewModel(state, summary = {}) {
   };
 
   const daily = buildDailySummaries(state, summary);
+  const providerSnapshots = collectActionProviders({ state, summary }) || [];
+
+  function selectProvider(id, focusCategory) {
+    return providerSnapshots.find(snapshot => snapshot.id === id)
+      || providerSnapshots.find(snapshot => snapshot.focusCategory === focusCategory)
+      || null;
+  }
+
+  function buildQuickActionsFromProvider(provider) {
+    if (!provider) {
+      return buildQuickActionModel(state);
+    }
+
+    const metrics = provider.metrics || {};
+    const entries = (provider.entries || []).map(entry => {
+      const source = entry.raw || {};
+      const title = source.title || entry.title;
+      const subtitle = source.subtitle || source.description || '';
+      const buttonLabel = source.buttonLabel || source.primaryLabel || metrics.defaultLabel || 'Queue';
+      const durationHours = Number.isFinite(entry.timeCost)
+        ? entry.timeCost
+        : Number.isFinite(source.timeCost)
+          ? source.timeCost
+          : entry.durationHours;
+      const payout = Number.isFinite(source.payout)
+        ? source.payout
+        : entry.payout;
+      const payoutText = source.payoutText || entry.payoutText || entry.meta || '';
+      const meta = source.meta || entry.meta || payoutText;
+      return {
+        id: entry.id,
+        title,
+        subtitle,
+        buttonLabel,
+        onClick: entry.onClick,
+        payout,
+        payoutText,
+        durationHours,
+        durationText: source.durationText || entry.durationText,
+        meta,
+        repeatable: source.repeatable ?? entry.repeatable,
+        remainingRuns: source.remainingRuns ?? entry.remainingRuns
+      };
+    });
+
+    const baseHours = clampNumber(state.baseTime)
+      + clampNumber(state.bonusTime)
+      + clampNumber(state.dailyBonusTime);
+    const hoursAvailable = metrics.hoursAvailable != null
+      ? Math.max(0, clampNumber(metrics.hoursAvailable))
+      : Math.max(0, clampNumber(state.timeLeft));
+    const hoursSpent = metrics.hoursSpent != null
+      ? Math.max(0, clampNumber(metrics.hoursSpent))
+      : Math.max(0, baseHours - hoursAvailable);
+
+    const scroller = metrics.scroller;
+    const model = {
+      entries,
+      emptyMessage: metrics.emptyMessage || 'No ready actions. Check upgrades or ventures.',
+      buttonClass: metrics.buttonClass || 'primary',
+      defaultLabel: metrics.defaultLabel || 'Queue',
+      hoursAvailable,
+      hoursAvailableLabel: metrics.hoursAvailableLabel || formatHours(hoursAvailable),
+      hoursSpent,
+      hoursSpentLabel: metrics.hoursSpentLabel || formatHours(hoursSpent),
+      day: clampNumber(state.day),
+      moneyAvailable: metrics.moneyAvailable != null
+        ? clampNumber(metrics.moneyAvailable)
+        : clampNumber(state.money)
+    };
+
+    if (scroller) {
+      model.scroller = scroller;
+    }
+
+    return model;
+  }
+
+  function buildAssetActionsFromProvider(provider) {
+    if (!provider) {
+      return buildAssetActionModel(state);
+    }
+
+    const metrics = provider.metrics || {};
+    const entries = (provider.entries || []).map(entry => {
+      const source = entry.raw || {};
+      const title = source.title || entry.title;
+      const subtitle = source.subtitle || source.description || '';
+      const meta = source.meta || entry.meta || '';
+      const metaClass = source.metaClass || '';
+      const timeCost = Number.isFinite(source.timeCost)
+        ? source.timeCost
+        : Number.isFinite(entry.timeCost)
+          ? entry.timeCost
+          : entry.durationHours;
+      const moneyCost = Number.isFinite(source.moneyCost)
+        ? source.moneyCost
+        : entry.moneyCost;
+      return {
+        id: entry.id,
+        title,
+        subtitle,
+        meta,
+        metaClass,
+        buttonLabel: source.buttonLabel || metrics.defaultLabel || 'Boost',
+        onClick: entry.onClick,
+        timeCost: Number.isFinite(timeCost) ? timeCost : 0,
+        durationHours: Number.isFinite(timeCost) ? timeCost : 0,
+        durationText: source.durationText || entry.durationText,
+        moneyCost,
+        repeatable: source.repeatable ?? entry.repeatable,
+        remainingRuns: source.remainingRuns ?? entry.remainingRuns
+      };
+    });
+
+    return {
+      entries,
+      emptyMessage: metrics.emptyMessage
+        || 'Every venture is humming along. Check back after today’s upkeep.',
+      buttonClass: metrics.buttonClass || 'secondary',
+      defaultLabel: metrics.defaultLabel || 'Boost',
+      scroller: metrics.scroller || { limit: 6 },
+      moneyAvailable: metrics.moneyAvailable != null
+        ? clampNumber(metrics.moneyAvailable)
+        : clampNumber(state.money)
+    };
+  }
+
+  function buildStudyActionsFromProvider(provider) {
+    if (!provider) {
+      return buildStudyEnrollmentActionModel(state);
+    }
+
+    const metrics = provider.metrics || {};
+    const entries = (provider.entries || []).map(entry => {
+      const source = entry.raw || {};
+      const title = source.title || entry.title;
+      const subtitle = source.subtitle || source.description || '';
+      const meta = source.meta || entry.meta || '';
+      const timeCost = Number.isFinite(source.timeCost)
+        ? source.timeCost
+        : Number.isFinite(entry.timeCost)
+          ? entry.timeCost
+          : entry.durationHours;
+      const moneyCost = Number.isFinite(source.moneyCost)
+        ? source.moneyCost
+        : entry.moneyCost;
+      return {
+        id: entry.id,
+        title,
+        subtitle,
+        meta,
+        buttonLabel: source.buttonLabel || metrics.defaultLabel || 'Enroll',
+        onClick: entry.onClick,
+        timeCost: Number.isFinite(timeCost) ? timeCost : 0,
+        durationHours: Number.isFinite(timeCost) ? timeCost : 0,
+        durationText: source.durationText || entry.durationText,
+        moneyCost,
+        repeatable: source.repeatable ?? entry.repeatable,
+        remainingRuns: source.remainingRuns ?? entry.remainingRuns
+      };
+    });
+
+    const baseHours = clampNumber(state.baseTime)
+      + clampNumber(state.bonusTime)
+      + clampNumber(state.dailyBonusTime);
+    const hoursAvailable = metrics.hoursAvailable != null
+      ? Math.max(0, clampNumber(metrics.hoursAvailable))
+      : Math.max(0, clampNumber(state.timeLeft));
+    const hoursSpent = metrics.hoursSpent != null
+      ? Math.max(0, clampNumber(metrics.hoursSpent))
+      : Math.max(0, baseHours - hoursAvailable);
+
+    return {
+      entries,
+      emptyMessage: metrics.emptyMessage || 'No study tracks are ready to enroll right now.',
+      moneyAvailable: metrics.moneyAvailable != null
+        ? clampNumber(metrics.moneyAvailable)
+        : clampNumber(state.money),
+      hoursAvailable,
+      hoursAvailableLabel: metrics.hoursAvailableLabel || formatHours(hoursAvailable),
+      hoursSpent,
+      hoursSpentLabel: metrics.hoursSpentLabel || formatHours(hoursSpent)
+    };
+  }
+
+  const quickProvider = selectProvider('quick-actions', 'hustle');
+  const assetProvider = selectProvider('asset-upgrades', 'upgrade');
+  const studyProvider = selectProvider('study-enrollment', 'study');
 
   return {
     session,
     headerMetrics: daily.headerMetrics,
     kpis: daily.kpis,
     queue: daily.queue,
-    quickActions: buildQuickActionModel(state),
-    assetActions: buildAssetActionModel(state),
-    studyActions: buildStudyEnrollmentActionModel(state),
+    quickActions: buildQuickActionsFromProvider(quickProvider),
+    assetActions: buildAssetActionsFromProvider(assetProvider),
+    studyActions: buildStudyActionsFromProvider(studyProvider),
     notifications: buildNotificationModel(state),
     eventLog: buildEventLogModel(state),
     dailyStats: daily.dailyStats,

--- a/tests/ui/headerAction/model.test.js
+++ b/tests/ui/headerAction/model.test.js
@@ -1,0 +1,104 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildHeaderActionModel } from '../../../src/ui/headerAction/model.js';
+import {
+  registerActionProvider,
+  clearActionProviders
+} from '../../../src/ui/actions/registry.js';
+
+function createNoop() {
+  return () => {};
+}
+
+test('buildHeaderActionModel prefers the top upgrade recommendation from the registry', () => {
+  const restore = clearActionProviders();
+  try {
+    registerActionProvider(() => ({
+      id: 'asset-upgrades',
+      focusCategory: 'upgrade',
+      entries: [
+        {
+          id: 'asset-upgrade:ebook:ebook-1:writeChapter:pages',
+          title: 'Episode 1 · Write Volume',
+          buttonLabel: 'Write Volume',
+          subtitle: 'Log a fresh chapter.',
+          timeCost: 4,
+          onClick: createNoop()
+        },
+        {
+          id: 'asset-upgrade:ebook:ebook-1:batchEdit:shots',
+          title: 'Episode 1 · Batch Edit',
+          buttonLabel: 'Batch Edit',
+          subtitle: 'Polish recent shoots.',
+          timeCost: 2,
+          onClick: createNoop()
+        }
+      ],
+      metrics: {}
+    }));
+
+    registerActionProvider(() => ({
+      id: 'quick-actions',
+      focusCategory: 'hustle',
+      entries: [
+        {
+          id: 'hustle:create-post',
+          title: 'Create Post',
+          primaryLabel: 'Queue',
+          description: 'Draft a daily update.',
+          timeCost: 1,
+          onClick: createNoop()
+        }
+      ],
+      metrics: {}
+    }));
+
+    const model = buildHeaderActionModel({ timeLeft: 6 });
+    assert.equal(model.recommendation.mode, 'asset');
+    assert.match(model.button.text, /Write Volume/);
+  } finally {
+    restore();
+  }
+});
+
+test('buildHeaderActionModel falls back to quick actions when no upgrades exist', () => {
+  const restore = clearActionProviders();
+  try {
+    registerActionProvider(() => ({
+      id: 'asset-upgrades',
+      focusCategory: 'upgrade',
+      entries: [],
+      metrics: {}
+    }));
+
+    registerActionProvider(() => ({
+      id: 'quick-actions',
+      focusCategory: 'hustle',
+      entries: [
+        {
+          id: 'hustle:stream',
+          title: 'Stream Session',
+          primaryLabel: 'Queue',
+          description: 'Go live for fans.',
+          timeCost: 3,
+          onClick: createNoop()
+        },
+        {
+          id: 'hustle:post',
+          title: 'Post Update',
+          primaryLabel: 'Queue',
+          description: 'Share a quick update.',
+          timeCost: 1,
+          onClick: createNoop()
+        }
+      ],
+      metrics: {}
+    }));
+
+    const model = buildHeaderActionModel({ timeLeft: 4 });
+    assert.equal(model.recommendation.mode, 'hustle');
+    assert.match(model.button.text, /Stream Session/);
+  } finally {
+    restore();
+  }
+});

--- a/tests/ui/views/browser/components/digishelf/inventoryTable.test.js
+++ b/tests/ui/views/browser/components/digishelf/inventoryTable.test.js
@@ -1,0 +1,112 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+import renderInventoryTable from '../../../../../../src/ui/views/browser/components/digishelf/inventoryTable.js';
+import {
+  registerActionProvider,
+  clearActionProviders
+} from '../../../../../../src/ui/actions/registry.js';
+
+function setupDom() {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>');
+  const previousWindow = global.window;
+  const previousDocument = global.document;
+  const previousHTMLElement = global.HTMLElement;
+  const previousNode = global.Node;
+
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.HTMLElement = dom.window.HTMLElement;
+  global.Node = dom.window.Node;
+
+  return () => {
+    dom.window.close();
+    if (previousWindow) {
+      global.window = previousWindow;
+    } else {
+      delete global.window;
+    }
+    if (previousDocument) {
+      global.document = previousDocument;
+    } else {
+      delete global.document;
+    }
+    if (previousHTMLElement) {
+      global.HTMLElement = previousHTMLElement;
+    } else {
+      delete global.HTMLElement;
+    }
+    if (previousNode) {
+      global.Node = previousNode;
+    } else {
+      delete global.Node;
+    }
+  };
+}
+
+test('inventory table highlights registry quick actions for stock galleries', () => {
+  const restoreProviders = clearActionProviders();
+  const restoreDom = setupDom();
+  try {
+    registerActionProvider(() => ({
+      id: 'asset-upgrades',
+      focusCategory: 'upgrade',
+      entries: [
+        {
+          id: 'asset-upgrade:stockPhotos:stock-1:batchEdit:progress',
+          title: 'Gallery A · Upload Batch',
+          buttonLabel: 'Upload Batch',
+          timeCost: 2,
+          onClick: () => {}
+        },
+        {
+          id: 'asset-upgrade:stockPhotos:stock-1:planShoot:shots',
+          title: 'Gallery A · Plan Shoot',
+          buttonLabel: 'Launch Gallery',
+          timeCost: 1,
+          onClick: () => {}
+        }
+      ],
+      metrics: {}
+    }));
+
+    const table = renderInventoryTable({
+      instances: [
+        {
+          id: 'stock-1',
+          label: 'Gallery A',
+          status: { id: 'active', label: 'Active' },
+          progress: { shoots: 5, editing: 3 },
+          latestPayout: 120,
+          averagePayout: 110,
+          qualityRange: { min: 90, max: 150 },
+          maintenance: { parts: [] },
+          maintenanceFunded: true,
+          actions: [
+            { id: 'planShoot', label: 'Plan Shoot', available: true, disabledReason: '' },
+            { id: 'batchEdit', label: 'Batch Edit', available: true, disabledReason: '' }
+          ]
+        }
+      ],
+      type: 'stockPhotos',
+      state: {},
+      formatters: {
+        formatCurrency: value => `$${value}`,
+        formatHours: value => `${value}h`
+      },
+      quickActions: { stockPhotos: ['planShoot', 'batchEdit'] },
+      handlers: {
+        onSelectInstance: () => {},
+        onRunQuickAction: () => {}
+      }
+    });
+
+    const buttons = table.querySelectorAll('.digishelf-actions .digishelf-button');
+    assert.ok(buttons.length >= 2);
+    assert.equal(buttons[0].textContent, 'Upload Batch');
+    assert.equal(buttons[1].textContent, 'Launch Gallery');
+  } finally {
+    restoreProviders();
+    restoreDom();
+  }
+});


### PR DESCRIPTION
## Summary
- extend the action registry to retain rich entry metadata and expose a helper for collecting provider snapshots
- build dashboard quick, asset, and study sections from registry data while keeping downstream model shapes intact
- resolve header recommendations and Digishelf quick buttons via registry providers and add focused regression coverage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e24554fc7c832ca7bfc18af197cedc