### PR TITLE
Track active day in action queue

### DIFF
--- a/src/ui/actions/registry.js
+++ b/src/ui/actions/registry.js
@@ -271,6 +271,9 @@ export function buildActionQueue({ state = {}, summary = {} } = {}) {
     autoCompletedEntries: createAutoCompletedEntries(summary)
   };
 
+  const activeDay = coerceNumber(state?.day, null);
+  queue.day = Number.isFinite(activeDay) ? activeDay : null;
+
   const snapshots = collectActionProviders({ state, summary });
 
   snapshots.forEach(snapshot => {

--- a/tests/ui/actions/registry.test.js
+++ b/tests/ui/actions/registry.test.js
@@ -96,6 +96,16 @@ test('buildActionQueue merges auto-completed entries from the summary', () => {
   }
 });
 
+test('buildActionQueue includes the active day when provided', () => {
+  const restore = clearActionProviders();
+  try {
+    const queue = buildActionQueue({ state: { day: 7 } });
+    assert.equal(queue.day, 7);
+  } finally {
+    restore();
+  }
+});
+
 test('normalizeActionEntries mirrors todo normalization rules', () => {
   const entries = normalizeActionEntries([
     { id: 'direct', timeCost: 3, payout: 90 }


### PR DESCRIPTION
## Summary
- keep the action queue aware of the current in-game day by reflecting state.day when available
- add a regression test to confirm the queue exposes the active day value

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e258497824832ca09103c710cb3798