### PR TITLE
Refactor quality action helpers and add coverage

### DIFF
--- a/src/game/assets/quality/actions.js
+++ b/src/game/assets/quality/actions.js
@@ -1,287 +1,36 @@
-import { formatHours, formatMoney } from '../../../core/helpers.js';
-import { addLog } from '../../../core/log.js';
-import { getAssetState, getState, getUpgradeState } from '../../../core/state.js';
+import { getState } from '../../../core/state.js';
 import { getAssetDefinition } from '../../../core/state/registry.js';
-import { getAssetEffectMultiplier } from '../../upgrades/effects.js';
 import { executeAction } from '../../actions.js';
-import { spendMoney } from '../../currency.js';
 import { checkDayEnd } from '../../lifecycle.js';
-import { recordCostContribution, recordTimeContribution } from '../../metrics.js';
-import { spendTime } from '../../time.js';
-import { awardSkillProgress } from '../../skills/index.js';
 import { markDirty } from '../../../core/events/invalidationBus.js';
-import { instanceLabel } from '../details.js';
-import { triggerQualityActionEvents } from '../../events/index.js';
+import { getQualityConfig } from './levels.js';
+import { getUsageStatus } from './usage.js';
 import {
-  calculateEligibleQualityLevel,
-  ensureInstanceQuality,
-  getHighestQualityLevel,
-  getQualityConfig,
-  getQualityLevel
-} from './levels.js';
-import { getUsageStatus, trackUsage } from './usage.js';
-
-function createActionContext(definition, instance, state = getState()) {
-  const quality = ensureInstanceQuality(definition, instance);
-  return {
-    state,
-    definition,
-    instance,
-    quality,
-    upgrade: id => getUpgradeState(id)
-  };
-}
-
-export function evaluateActionAvailability(action, context) {
-  if (!action) {
-    return { unlocked: false, reason: '' };
-  }
-
-  if (typeof action.available === 'function') {
-    const available = action.available(context);
-    if (!available) {
-      const reason = typeof action.unavailableMessage === 'function'
-        ? action.unavailableMessage(context)
-        : action.unavailableMessage || action.lockedMessage || 'Requirements not yet met.';
-      return { unlocked: false, reason };
-    }
-  }
-
-  const upgradeRequirement = action.requiresUpgrades ?? action.requiresUpgrade;
-  if (upgradeRequirement) {
-    const ids = Array.isArray(upgradeRequirement) ? upgradeRequirement : [upgradeRequirement];
-    for (const upgradeId of ids) {
-      const purchased = context.upgrade(upgradeId)?.purchased;
-      if (!purchased) {
-        const reasonContext = { ...context, missingUpgrade: upgradeId };
-        const reason = typeof action.unavailableMessage === 'function'
-          ? action.unavailableMessage(reasonContext)
-          : typeof action.lockedMessage === 'function'
-            ? action.lockedMessage(reasonContext)
-            : action.lockedMessage || action.unavailableMessage || 'Upgrade required first.';
-        return { unlocked: false, reason };
-      }
-    }
-  }
-
-  return { unlocked: true, reason: '' };
-}
-
-function getQualityActionAvailabilityInternal(definition, instance, action, state = getState()) {
-  const context = createActionContext(definition, instance, state);
-  const availability = evaluateActionAvailability(action, context);
-  return { ...availability };
-}
-
-function getActionLabel(definition, assetState, instance) {
-  const index = assetState.instances.indexOf(instance);
-  return instanceLabel(definition, index, { instance });
-}
-
-function resolveProgressAmount(action, context) {
-  if (typeof action.progressAmount === 'function') {
-    return Number(action.progressAmount(context)) || 0;
-  }
-  if (Number.isFinite(Number(action.progressAmount))) {
-    return Number(action.progressAmount);
-  }
-  return action.progressKey ? 1 : 0;
-}
-
-function updateQualityLevel(definition, assetState, instance, quality) {
-  const previous = quality.level || 0;
-  const progress = quality.progress || {};
-  const eligible = calculateEligibleQualityLevel(definition, progress);
-  if (eligible === previous) return;
-
-  const highest = getHighestQualityLevel(definition);
-  quality.level = Math.min(eligible, highest?.level ?? eligible);
-  const label = getActionLabel(definition, assetState, instance);
-  const levelDef = getQualityLevel(definition, quality.level);
-  const config = getQualityConfig(definition);
-  if (typeof config?.messages?.levelUp === 'function') {
-    const message = config.messages.levelUp({
-      level: quality.level,
-      levelDef,
-      label,
-      definition,
-      instance,
-      progress
-    });
-    if (message) {
-      addLog(message, 'passive');
-    }
-  } else {
-    const title = levelDef?.name ? ` (${levelDef.name})` : '';
-    addLog(`${label} advanced to Quality ${quality.level}${title}.`, 'passive');
-  }
-}
+  createActionContext,
+  evaluateActionAvailability,
+  getQualityActionAvailability as getAvailabilityResult
+} from './availability.js';
+import {
+  applyCosts,
+  logCompletion,
+  updateProgressAndLevel,
+  validateReadiness
+} from './execution.js';
 
 export function runQualityAction(definition, instanceId, actionId) {
-  const state = getState();
-  if (!state) return { qualityUpdated: false };
-  const assetState = getAssetState(definition.id);
-  if (!assetState) {
-    return { qualityUpdated: false };
-  }
-  const instance = assetState.instances.find(item => item.id === instanceId);
-  if (!instance) return { qualityUpdated: false };
-  const instanceIndex = assetState.instances.indexOf(instance);
-  if (instance.status !== 'active') {
-    const label = getActionLabel(definition, assetState, instance);
-    addLog(`${label} needs to finish setup before quality work will stick.`, 'warning');
-    return { qualityUpdated: false };
-  }
-  const config = getQualityConfig(definition);
-  const action = config?.actions?.find(entry => entry.id === actionId);
-  if (!action) return { qualityUpdated: false };
-
-  const context = createActionContext(definition, instance, state);
-  const availability = evaluateActionAvailability(action, context);
-  if (!availability.unlocked) {
-    const label = getActionLabel(definition, assetState, instance);
-    const message = availability.reason
-      ? `${label} can’t run that move yet: ${availability.reason}`
-      : `${label} can’t run that move yet.`;
-    addLog(message, 'info');
+  const readiness = validateReadiness({ definition, instanceId, actionId });
+  if (!readiness.ok) {
     return { qualityUpdated: false };
   }
 
-  const usage = getUsageStatus(instance, action);
-  if (usage.exhausted) {
-    const label = getActionLabel(definition, assetState, instance);
-    addLog(`${label} already used that move today. Fresh inspiration returns tomorrow.`, 'info');
-    return { qualityUpdated: false };
-  }
-
-  const timeCost = Math.max(0, Number(action.time) || 0);
-  const moneyCost = Math.max(0, Number(action.cost) || 0);
-  if (timeCost > 0 && state.timeLeft < timeCost) {
-    addLog(`You need ${formatHours(timeCost)} free before diving into that quality push.`, 'warning');
-    return { qualityUpdated: false };
-  }
-  if (moneyCost > 0 && state.money < moneyCost) {
-    addLog(`You need $${formatMoney(moneyCost)} ready for that quality push.`, 'warning');
-    return { qualityUpdated: false };
-  }
-
-  if (moneyCost > 0) {
-    spendMoney(moneyCost);
-    recordCostContribution({
-      key: `asset:${definition.id}:quality:${action.id}:cost`,
-      label: `✨ ${definition.singular || definition.name} quality`,
-      amount: moneyCost,
-      category: 'quality'
-    });
-  }
-  if (timeCost > 0) {
-    spendTime(timeCost);
-    recordTimeContribution({
-      key: `asset:${definition.id}:quality:${action.id}:time`,
-      label: `✨ ${definition.singular || definition.name} quality`,
-      hours: timeCost,
-      category: 'quality'
-    });
-  }
-
-  const quality = context.quality;
-  const progressKey = action.progressKey;
-  if (progressKey) {
-    const amount = resolveProgressAmount(action, context);
-    if (amount !== 0) {
-      const effect = getAssetEffectMultiplier(definition, 'quality_progress_mult', {
-        actionType: 'quality'
-      });
-      const multiplier = Number.isFinite(effect.multiplier) ? effect.multiplier : 1;
-      const adjusted = amount * multiplier;
-      const current = Number(quality.progress[progressKey]) || 0;
-      quality.progress[progressKey] = Math.max(0, current + adjusted);
-    }
-  }
-
-  awardSkillProgress({
-    skills: action.skills,
-    timeSpentHours: timeCost,
-    moneySpent: moneyCost,
-    label: `${definition.singular || definition.name} quality work`
-  });
-
-  trackUsage(instance, action);
-
-  triggerQualityActionEvents({
-    definition,
-    assetState,
-    instance,
-    instanceIndex,
-    action,
-    context: { quality }
-  });
-
-  if (typeof action.onComplete === 'function') {
-    action.onComplete({
-      state,
-      definition,
-      assetState,
-      instance,
-      instanceIndex,
-      quality,
-      action
-    });
-  }
-
-  const label = getActionLabel(definition, assetState, instance);
-  if (typeof action.log === 'function') {
-    const message = action.log({
-      label,
-      definition,
-      instance,
-      quality,
-      timeCost,
-      moneyCost
-    });
-    if (message) {
-      addLog(message, 'quality');
-    }
-  } else {
-    const parts = [];
-    if (timeCost > 0) parts.push(`${formatHours(timeCost)} invested`);
-    if (moneyCost > 0) parts.push(`$${formatMoney(moneyCost)} spent`);
-    const summary = parts.length ? ` (${parts.join(', ')})` : '';
-    addLog(`${label} received focused quality work${summary}.`, 'quality');
-  }
-
-  updateQualityLevel(definition, assetState, instance, quality);
-  if (!instance.quality) {
-    instance.quality = { level: quality.level, progress: { ...quality.progress } };
-  } else {
-    instance.quality.level = quality.level;
-    instance.quality.progress = { ...quality.progress };
-  }
-  if (Array.isArray(assetState.instances) && instanceIndex >= 0 && assetState.instances[instanceIndex]) {
-    assetState.instances[instanceIndex] = {
-      ...assetState.instances[instanceIndex],
-      quality: { level: quality.level, progress: { ...quality.progress } }
-    };
-  }
-  const rootState = getState();
-  const storedAssetState = rootState?.assets?.[definition.id];
-  if (
-    storedAssetState &&
-    Array.isArray(storedAssetState.instances) &&
-    instanceIndex >= 0 &&
-    storedAssetState.instances[instanceIndex]
-  ) {
-    storedAssetState.instances[instanceIndex] = {
-      ...storedAssetState.instances[instanceIndex],
-      quality: { level: quality.level, progress: { ...quality.progress } }
-    };
-  }
-  return { qualityUpdated: true };
+  applyCosts(readiness);
+  return updateProgressAndLevel({ ...readiness, log: logCompletion });
 }
 
 export function performQualityAction(assetId, instanceId, actionId) {
   const definition = getAssetDefinition(assetId);
   if (!definition) return;
+
   executeAction(() => {
     const result = runQualityAction(definition, instanceId, actionId);
     if (result?.qualityUpdated) {
@@ -295,14 +44,19 @@ export function canPerformQualityAction(definition, instance, action, state = ge
   if (!definition || !instance || !action) return false;
   if (!state) return false;
   if (instance.status !== 'active') return false;
-  const availability = getQualityActionAvailabilityInternal(definition, instance, action, state);
+
+  const context = createActionContext(definition, instance, state);
+  const availability = evaluateActionAvailability(action, context);
   if (!availability.unlocked) return false;
+
   const usage = getUsageStatus(instance, action);
   if (usage.exhausted) return false;
+
   const timeCost = Math.max(0, Number(action.time) || 0);
   const moneyCost = Math.max(0, Number(action.cost) || 0);
   if (timeCost > 0 && state.timeLeft < timeCost) return false;
   if (moneyCost > 0 && state.money < moneyCost) return false;
+
   return true;
 }
 
@@ -312,7 +66,10 @@ export function getQualityActions(definition) {
 }
 
 export function getQualityActionAvailability(definition, instance, action, state = getState()) {
-  return getQualityActionAvailabilityInternal(definition, instance, action, state);
+  if (!definition || !instance || !action) {
+    return { unlocked: false, reason: '' };
+  }
+  return getAvailabilityResult(definition, instance, action, state);
 }
 
 export function getQualityTracks(definition) {

--- a/src/game/assets/quality/availability.js
+++ b/src/game/assets/quality/availability.js
@@ -1,0 +1,59 @@
+import { getState, getUpgradeState } from '../../../core/state.js';
+import { ensureInstanceQuality } from './levels.js';
+
+export function createActionContext(definition, instance, state = getState()) {
+  const quality = ensureInstanceQuality(definition, instance);
+  return {
+    state,
+    definition,
+    instance,
+    quality,
+    upgrade: id => getUpgradeState(id)
+  };
+}
+
+export function evaluateActionAvailability(action, context) {
+  if (!action) {
+    return { unlocked: false, reason: '' };
+  }
+
+  if (typeof action.available === 'function') {
+    const available = action.available(context);
+    if (!available) {
+      const reason = typeof action.unavailableMessage === 'function'
+        ? action.unavailableMessage(context)
+        : action.unavailableMessage || action.lockedMessage || 'Requirements not yet met.';
+      return { unlocked: false, reason };
+    }
+  }
+
+  const upgradeRequirement = action.requiresUpgrades ?? action.requiresUpgrade;
+  if (upgradeRequirement) {
+    const ids = Array.isArray(upgradeRequirement) ? upgradeRequirement : [upgradeRequirement];
+    for (const upgradeId of ids) {
+      const purchased = context.upgrade(upgradeId)?.purchased;
+      if (!purchased) {
+        const reasonContext = { ...context, missingUpgrade: upgradeId };
+        const reason = typeof action.unavailableMessage === 'function'
+          ? action.unavailableMessage(reasonContext)
+          : typeof action.lockedMessage === 'function'
+            ? action.lockedMessage(reasonContext)
+            : action.lockedMessage || action.unavailableMessage || 'Upgrade required first.';
+        return { unlocked: false, reason };
+      }
+    }
+  }
+
+  return { unlocked: true, reason: '' };
+}
+
+export function getQualityActionAvailability(definition, instance, action, state = getState()) {
+  const context = createActionContext(definition, instance, state);
+  return evaluateActionAvailability(action, context);
+}
+
+export default {
+  createActionContext,
+  evaluateActionAvailability,
+  getQualityActionAvailability
+};

--- a/src/game/assets/quality/execution.js
+++ b/src/game/assets/quality/execution.js
@@ -1,0 +1,285 @@
+import { formatHours, formatMoney } from '../../../core/helpers.js';
+import { addLog } from '../../../core/log.js';
+import { getAssetState, getState } from '../../../core/state.js';
+import { getAssetEffectMultiplier } from '../../upgrades/effects.js';
+import { spendMoney } from '../../currency.js';
+import { spendTime } from '../../time.js';
+import { recordCostContribution, recordTimeContribution } from '../../metrics.js';
+import { awardSkillProgress } from '../../skills/index.js';
+import { triggerQualityActionEvents } from '../../events/index.js';
+import {
+  calculateEligibleQualityLevel,
+  getHighestQualityLevel,
+  getQualityConfig,
+  getQualityLevel
+} from './levels.js';
+import { getUsageStatus, trackUsage } from './usage.js';
+import { createActionContext, evaluateActionAvailability } from './availability.js';
+import { instanceLabel } from '../details.js';
+
+function getActionLabel(definition, assetState, instance) {
+  const index = assetState.instances.indexOf(instance);
+  return instanceLabel(definition, index, { instance });
+}
+
+export function logCompletion({ action, label, definition, instance, quality, timeCost, moneyCost }) {
+  if (typeof action.log === 'function') {
+    const message = action.log({
+      label,
+      definition,
+      instance,
+      quality,
+      timeCost,
+      moneyCost
+    });
+    if (message) {
+      addLog(message, 'quality');
+    }
+    return;
+  }
+
+  const parts = [];
+  if (timeCost > 0) parts.push(`${formatHours(timeCost)} invested`);
+  if (moneyCost > 0) parts.push(`$${formatMoney(moneyCost)} spent`);
+  const summary = parts.length ? ` (${parts.join(', ')})` : '';
+  addLog(`${label} received focused quality work${summary}.`, 'quality');
+}
+
+function resolveProgressAmount(action, context) {
+  if (typeof action.progressAmount === 'function') {
+    return Number(action.progressAmount(context)) || 0;
+  }
+  if (Number.isFinite(Number(action.progressAmount))) {
+    return Number(action.progressAmount);
+  }
+  return action.progressKey ? 1 : 0;
+}
+
+function updateQualityLevel(definition, assetState, instance, quality, label) {
+  const previous = quality.level || 0;
+  const progress = quality.progress || {};
+  const eligible = calculateEligibleQualityLevel(definition, progress);
+  if (eligible === previous) return;
+
+  const highest = getHighestQualityLevel(definition);
+  quality.level = Math.min(eligible, highest?.level ?? eligible);
+  const levelDef = getQualityLevel(definition, quality.level);
+  const config = getQualityConfig(definition);
+  if (typeof config?.messages?.levelUp === 'function') {
+    const message = config.messages.levelUp({
+      level: quality.level,
+      levelDef,
+      label,
+      definition,
+      instance,
+      progress
+    });
+    if (message) {
+      addLog(message, 'passive');
+    }
+  } else {
+    const title = levelDef?.name ? ` (${levelDef.name})` : '';
+    addLog(`${label} advanced to Quality ${quality.level}${title}.`, 'passive');
+  }
+}
+
+function syncQualityState(definition, assetState, instance, instanceIndex, quality) {
+  if (!instance.quality) {
+    instance.quality = { level: quality.level, progress: { ...quality.progress } };
+  } else {
+    instance.quality.level = quality.level;
+    instance.quality.progress = { ...quality.progress };
+  }
+
+  if (Array.isArray(assetState.instances) && instanceIndex >= 0 && assetState.instances[instanceIndex]) {
+    assetState.instances[instanceIndex] = {
+      ...assetState.instances[instanceIndex],
+      quality: { level: quality.level, progress: { ...quality.progress } }
+    };
+  }
+
+  const rootState = getState();
+  const storedAssetState = rootState?.assets?.[definition.id];
+  if (
+    storedAssetState &&
+    Array.isArray(storedAssetState.instances) &&
+    instanceIndex >= 0 &&
+    storedAssetState.instances[instanceIndex]
+  ) {
+    storedAssetState.instances[instanceIndex] = {
+      ...storedAssetState.instances[instanceIndex],
+      quality: { level: quality.level, progress: { ...quality.progress } }
+    };
+  }
+}
+
+export function validateReadiness({ definition, instanceId, actionId, state = getState() }) {
+  if (!state) {
+    return { ok: false };
+  }
+
+  const assetState = getAssetState(definition.id);
+  if (!assetState) {
+    return { ok: false };
+  }
+
+  const instance = assetState.instances.find(item => item.id === instanceId);
+  if (!instance) {
+    return { ok: false };
+  }
+
+  const instanceIndex = assetState.instances.indexOf(instance);
+  if (instance.status !== 'active') {
+    const label = getActionLabel(definition, assetState, instance);
+    addLog(`${label} needs to finish setup before quality work will stick.`, 'warning');
+    return { ok: false };
+  }
+
+  const config = getQualityConfig(definition);
+  const action = config?.actions?.find(entry => entry.id === actionId);
+  if (!action) {
+    return { ok: false };
+  }
+
+  const context = createActionContext(definition, instance, state);
+  const availability = evaluateActionAvailability(action, context);
+  if (!availability.unlocked) {
+    const label = getActionLabel(definition, assetState, instance);
+    const message = availability.reason
+      ? `${label} can’t run that move yet: ${availability.reason}`
+      : `${label} can’t run that move yet.`;
+    addLog(message, 'info');
+    return { ok: false };
+  }
+
+  const usage = getUsageStatus(instance, action);
+  if (usage.exhausted) {
+    const label = getActionLabel(definition, assetState, instance);
+    addLog(`${label} already used that move today. Fresh inspiration returns tomorrow.`, 'info');
+    return { ok: false };
+  }
+
+  const timeCost = Math.max(0, Number(action.time) || 0);
+  const moneyCost = Math.max(0, Number(action.cost) || 0);
+  if (timeCost > 0 && state.timeLeft < timeCost) {
+    addLog(`You need ${formatHours(timeCost)} free before diving into that quality push.`, 'warning');
+    return { ok: false };
+  }
+  if (moneyCost > 0 && state.money < moneyCost) {
+    addLog(`You need $${formatMoney(moneyCost)} ready for that quality push.`, 'warning');
+    return { ok: false };
+  }
+
+  const label = getActionLabel(definition, assetState, instance);
+
+  return {
+    ok: true,
+    definition,
+    state,
+    assetState,
+    instance,
+    instanceIndex,
+    action,
+    context,
+    label,
+    timeCost,
+    moneyCost
+  };
+}
+
+export function applyCosts({ definition, action, timeCost, moneyCost }) {
+  if (moneyCost > 0) {
+    spendMoney(moneyCost);
+    recordCostContribution({
+      key: `asset:${definition.id}:quality:${action.id}:cost`,
+      label: `✨ ${definition.singular || definition.name} quality`,
+      amount: moneyCost,
+      category: 'quality'
+    });
+  }
+
+  if (timeCost > 0) {
+    spendTime(timeCost);
+    recordTimeContribution({
+      key: `asset:${definition.id}:quality:${action.id}:time`,
+      label: `✨ ${definition.singular || definition.name} quality`,
+      hours: timeCost,
+      category: 'quality'
+    });
+  }
+}
+
+export function updateProgressAndLevel({
+  definition,
+  assetState,
+  instance,
+  instanceIndex,
+  action,
+  context,
+  label,
+  timeCost,
+  moneyCost,
+  log = logCompletion
+}) {
+  const quality = context.quality;
+  quality.progress = quality.progress || {};
+
+  if (action.progressKey) {
+    const amount = resolveProgressAmount(action, context);
+    if (amount !== 0) {
+      const effect = getAssetEffectMultiplier(definition, 'quality_progress_mult', {
+        actionType: 'quality'
+      });
+      const multiplier = Number.isFinite(effect.multiplier) ? effect.multiplier : 1;
+      const adjusted = amount * multiplier;
+      const current = Number(quality.progress[action.progressKey]) || 0;
+      quality.progress[action.progressKey] = Math.max(0, current + adjusted);
+    }
+  }
+
+  awardSkillProgress({
+    skills: action.skills,
+    timeSpentHours: timeCost,
+    moneySpent: moneyCost,
+    label: `${definition.singular || definition.name} quality work`
+  });
+
+  trackUsage(instance, action);
+
+  triggerQualityActionEvents({
+    definition,
+    assetState,
+    instance,
+    instanceIndex,
+    action,
+    context: { quality }
+  });
+
+  if (typeof action.onComplete === 'function') {
+    action.onComplete({
+      state: context.state,
+      definition,
+      assetState,
+      instance,
+      instanceIndex,
+      quality,
+      action
+    });
+  }
+
+  if (typeof log === 'function') {
+    log({ action, label, definition, instance, quality, timeCost, moneyCost });
+  }
+
+  updateQualityLevel(definition, assetState, instance, quality, label);
+  syncQualityState(definition, assetState, instance, instanceIndex, quality);
+
+  return { qualityUpdated: true, quality };
+}
+
+export default {
+  applyCosts,
+  logCompletion,
+  updateProgressAndLevel,
+  validateReadiness
+};

--- a/tests/game/qualityActions.test.js
+++ b/tests/game/qualityActions.test.js
@@ -1,0 +1,96 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ensureTestDom } from '../helpers/setupDom.js';
+import { getGameTestHarness } from '../helpers/gameTestHarness.js';
+
+ensureTestDom();
+
+const harness = await getGameTestHarness();
+const qualityActions = await import('../../src/game/assets/quality/actions.js');
+
+const { getAssetDefinition } = harness.registryModule;
+const { createAssetInstance } = harness.assetStateModule;
+const { getAssetState, getState } = harness.stateModule;
+
+const resetAndPrepareState = () => {
+  const state = harness.resetState();
+  state.log.length = 0;
+  return state;
+};
+
+test('quality action surfaces upgrade availability messaging', { concurrency: false }, () => {
+  const state = resetAndPrepareState();
+  const saasDefinition = getAssetDefinition('saas');
+  const saasState = getAssetState('saas');
+  saasState.instances = [createAssetInstance(saasDefinition, { status: 'active', dailyUsage: {} })];
+  const instance = saasState.instances[0];
+
+  state.timeLeft = 12;
+  state.money = 500;
+
+  const result = qualityActions.runQualityAction(saasDefinition, instance.id, 'deployEdgeNodes');
+  assert.deepEqual(result, { qualityUpdated: false }, 'action should not run without required upgrade');
+
+  const latest = state.log.at(-1)?.message || '';
+  assert.match(latest, /Activate the Edge Delivery Network upgrade/, 'expected availability message to mention missing upgrade');
+});
+
+test('quality action deducts costs and time while recording metrics', { concurrency: false }, () => {
+  const state = resetAndPrepareState();
+  const blogDefinition = getAssetDefinition('blog');
+  const blogState = getAssetState('blog');
+  blogState.instances = [createAssetInstance(blogDefinition, { status: 'active', dailyUsage: {} })];
+  const instance = blogState.instances[0];
+
+  state.timeLeft = 10;
+  state.money = 200;
+
+  const beforeMoney = state.money;
+  const beforeTime = state.timeLeft;
+
+  const result = qualityActions.runQualityAction(blogDefinition, instance.id, 'seoSprint');
+  assert.equal(result.qualityUpdated, true, 'quality action should complete');
+
+  assert.equal(state.money, beforeMoney - 16, 'money should be deducted for quality cost');
+  assert.equal(state.timeLeft, beforeTime - 2, 'time should be deducted for quality action');
+
+  const costKey = `asset:${blogDefinition.id}:quality:seoSprint:cost`;
+  const timeKey = `asset:${blogDefinition.id}:quality:seoSprint:time`;
+  const dailyMetrics = state.metrics?.daily;
+  assert.ok(dailyMetrics?.costs?.[costKey], 'cost contribution should be recorded');
+  assert.equal(dailyMetrics.costs[costKey].amount, 16, 'cost metric should match spend');
+  assert.ok(dailyMetrics?.time?.[timeKey], 'time contribution should be recorded');
+  assert.equal(dailyMetrics.time[timeKey].hours, 2, 'time metric should match hours spent');
+});
+
+test('quality action grants skill progress and raises asset quality levels', { concurrency: false }, () => {
+  const state = resetAndPrepareState();
+  const blogDefinition = getAssetDefinition('blog');
+  const blogState = getAssetState('blog');
+  blogState.instances = [
+    createAssetInstance(blogDefinition, {
+      status: 'active',
+      dailyUsage: {},
+      quality: { level: 0, progress: { posts: 2 } }
+    })
+  ];
+  const instance = blogState.instances[0];
+
+  state.timeLeft = 10;
+  state.money = 0;
+
+  const beforeXp = state.skills?.writing?.xp || 0;
+
+  const result = qualityActions.runQualityAction(blogDefinition, instance.id, 'writePost');
+  assert.equal(result.qualityUpdated, true, 'quality action should advance progress');
+
+  const writingSkill = getState().skills.writing;
+  assert.ok(writingSkill.xp > beforeXp, 'writing skill XP should increase after action');
+
+  const updatedInstance = getAssetState('blog').instances[0];
+  assert.equal(updatedInstance.quality.progress.posts, 3, 'progress should increment by one');
+  assert.equal(updatedInstance.quality.level, 1, 'quality level should advance when requirements met');
+
+  const levelLog = state.log.find(entry => entry.message.includes('reached Quality 1'));
+  assert.ok(levelLog, 'level-up log message should be recorded');
+});


### PR DESCRIPTION
## Summary
- extract quality action context and availability helpers for reuse across modules
- move execution logic into dedicated helpers so actions.js orchestrates validation, costs, and progress updates
- add focused unit tests that confirm availability messaging, resource deductions, and quality progression after refactors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e25bbde354832ca81c79dc59a08d57