### PR TITLE
Consolidate maintenance summary formatting

### DIFF
--- a/src/game/assets/maintenance.js
+++ b/src/game/assets/maintenance.js
@@ -2,8 +2,8 @@ import { formatHours, formatMoney } from '../../core/helpers.js';
 
 export function formatMaintenanceSummary(definition) {
   const maintenance = definition?.maintenance || {};
-  const hours = Number(maintenance.hours) || 0;
-  const cost = Number(maintenance.cost) || 0;
+  const hours = Math.max(0, Number(maintenance.hours) || 0);
+  const cost = Math.max(0, Number(maintenance.cost) || 0);
   const parts = [];
   if (hours > 0) {
     parts.push(`${formatHours(hours)}/day`);
@@ -11,8 +11,14 @@ export function formatMaintenanceSummary(definition) {
   if (cost > 0) {
     parts.push(`$${formatMoney(cost)}/day`);
   }
+  const text = parts.join(' • ');
+  const detailText = parts.join(' + ');
   return {
+    hours,
+    cost,
     parts,
+    text,
+    detailText,
     hasUpkeep: parts.length > 0
   };
 }
@@ -22,6 +28,6 @@ export function maintenanceDetail(definition) {
   if (!summary.hasUpkeep) {
     return '🛠 Maintenance: <strong>None</strong>';
   }
-  return `🛠 Maintenance: <strong>${summary.parts.join(' + ')}</strong>`;
+  return `🛠 Maintenance: <strong>${summary.detailText}</strong>`;
 }
 

--- a/src/ui/cards/model/assets.js
+++ b/src/ui/cards/model/assets.js
@@ -6,7 +6,8 @@ import {
   listAssetRequirementDescriptors
 } from '../../../game/requirements.js';
 import { getAssetEffectMultiplier } from '../../../game/upgrades/effects.js';
-import { describeAssetCardSummary, formatInstanceUpkeep } from '../utils.js';
+import { formatMaintenanceSummary } from '../../../game/assets/maintenance.js';
+import { describeAssetCardSummary } from '../utils.js';
 
 const ASSET_GROUP_NOTES = {
   Foundation: 'Steady launchpads that bankroll the rest of your ventureverse.',
@@ -129,6 +130,7 @@ function buildAssetModels(definitions = [], helpers = {}) {
     });
 
     if (definition.action) {
+      const maintenance = formatMaintenanceSummary(definition);
       const availability = describeAssetLaunchAvailability(definition, state);
       const labelText = typeof definition.action.label === 'function'
         ? definition.action.label(state)
@@ -142,7 +144,8 @@ function buildAssetModels(definitions = [], helpers = {}) {
           hoursPerDay: Number(definition.setup?.hoursPerDay) || 0,
           cost: Number(definition.setup?.cost) || 0
         },
-        upkeep: formatInstanceUpkeep(definition),
+        upkeep: maintenance.hasUpkeep ? maintenance.text : '',
+        maintenance,
         action: {
           label: labelText,
           disabled: availability.disabled,

--- a/src/ui/cards/model/blogpress.js
+++ b/src/ui/cards/model/blogpress.js
@@ -5,6 +5,7 @@ import { describeAssetLaunchAvailability } from './assets.js';
 import { registerModelBuilder } from '../modelBuilderRegistry.js';
 import { buildSkillLock } from './skillLocks.js';
 import { clampNumber } from './sharedQuality.js';
+import { formatMaintenanceSummary } from '../../../game/assets/maintenance.js';
 import { formatBlogpressModel } from '../../blogpress/blogModel.js';
 
 function extractRelevantUpgrades(upgrades = []) {
@@ -28,7 +29,7 @@ function extractRelevantUpgrades(upgrades = []) {
 
 function buildPricing(definition, upgrades = [], { nicheOptions = [] } = {}) {
   const setup = definition?.setup || {};
-  const maintenance = definition?.maintenance || {};
+  const maintenance = formatMaintenanceSummary(definition);
   const quality = definition?.quality || {};
   const levels = ensureArray(quality.levels).map(level => ({
     level: level.level,

--- a/src/ui/cards/model/videotube.js
+++ b/src/ui/cards/model/videotube.js
@@ -249,6 +249,7 @@ function buildVideoTubeModel(assetDefinitions = [], state = getState()) {
   const launchAction = definition.action || null;
   const defaultName = `Video #${instances.length + 1}`;
   const nicheOptions = mapNicheOptions(definition, state, { includeDelta: true });
+  const maintenance = formatMaintenanceSummary(definition);
 
   const launch = launchAction
     ? {
@@ -258,7 +259,7 @@ function buildVideoTubeModel(assetDefinitions = [], state = getState()) {
           : Boolean(launchAction.disabled),
         availability,
         setup: definition.setup || {},
-        maintenance: definition.maintenance || {},
+        maintenance,
         defaultName,
         nicheOptions,
         create: options => startVideoInstance(definition, options, state)
@@ -268,7 +269,7 @@ function buildVideoTubeModel(assetDefinitions = [], state = getState()) {
         disabled: availability.disabled,
         availability,
         setup: definition.setup || {},
-        maintenance: definition.maintenance || {},
+        maintenance,
         defaultName,
         nicheOptions,
         create: () => null

--- a/src/ui/cards/utils.js
+++ b/src/ui/cards/utils.js
@@ -1,5 +1,3 @@
-import { formatHours, formatMoney } from '../../core/helpers.js';
-
 export function formatLabelFromKey(id, fallback = 'Special') {
   if (!id) return fallback;
   return (
@@ -18,20 +16,5 @@ export function describeAssetCardSummary(definition) {
   const trimmed = copy.trim();
   if (trimmed.length <= 140) return trimmed;
   return `${trimmed.slice(0, 137)}...`;
-}
-
-export function formatInstanceUpkeep(definition) {
-  if (!definition) return '';
-  const maintenance = definition.maintenance || {};
-  const hours = Number(maintenance.hours) || 0;
-  const cost = Number(maintenance.cost) || 0;
-  const parts = [];
-  if (hours > 0) {
-    parts.push(`${formatHours(hours)}/day`);
-  }
-  if (cost > 0) {
-    parts.push(`$${formatMoney(cost)}/day`);
-  }
-  return parts.join(' • ');
 }
 

--- a/src/ui/views/browser/components/blogpress/views/homeView.js
+++ b/src/ui/views/browser/components/blogpress/views/homeView.js
@@ -120,12 +120,8 @@ export default function renderHomeView(options = {}) {
     row.appendChild(createTableCell(payoutCell));
 
     const upkeep = document.createElement('span');
-    const parts = [];
-    const maintenanceHours = instance.maintenance?.parts?.find(part => part.includes('h'));
-    if (maintenanceHours) parts.push(maintenanceHours);
-    const maintenanceCost = instance.maintenance?.parts?.find(part => part.includes('$'));
-    if (maintenanceCost) parts.push(maintenanceCost);
-    upkeep.textContent = parts.length ? parts.join(' • ') : 'None';
+    const maintenance = instance.maintenance || {};
+    upkeep.textContent = maintenance.hasUpkeep ? maintenance.text : 'None';
     row.appendChild(createTableCell(upkeep));
 
     const qualityCell = document.createElement('div');

--- a/src/ui/views/browser/components/blogpress/views/pricingView.js
+++ b/src/ui/views/browser/components/blogpress/views/pricingView.js
@@ -21,7 +21,8 @@ export default function renderPricingView(options = {}) {
   const lead = document.createElement('p');
   const setup = pricing.setup || {};
   const maintenance = pricing.maintenance || {};
-  lead.textContent = `Blueprint: ${setup.days || 0} day${setup.days === 1 ? '' : 's'} × ${formatHours(setup.hoursPerDay || 0)} ($${formatMoney(setup.cost || 0)}) • Daily upkeep ${formatHours(maintenance.hours || 0)} • $${formatMoney(maintenance.cost || 0)}`;
+  const upkeepText = maintenance.hasUpkeep ? maintenance.text : 'No upkeep';
+  lead.textContent = `Blueprint: ${setup.days || 0} day${setup.days === 1 ? '' : 's'} × ${formatHours(setup.hoursPerDay || 0)} ($${formatMoney(setup.cost || 0)}) • Daily upkeep ${upkeepText}`;
   intro.append(title, lead);
   container.appendChild(intro);
 

--- a/src/ui/views/browser/components/blogpress/views/renderIncomePanel.js
+++ b/src/ui/views/browser/components/blogpress/views/renderIncomePanel.js
@@ -57,8 +57,8 @@ export default function renderIncomePanel({ instance, formatCurrency, formatNetC
   panel.appendChild(stats);
 
   const upkeepMessage = document.createElement('p');
-  const upkeepParts = instance.maintenance?.parts || [];
-  const upkeepSummary = upkeepParts.length ? upkeepParts.join(' • ') : 'No upkeep';
+  const maintenance = instance.maintenance || {};
+  const upkeepSummary = maintenance.hasUpkeep ? maintenance.text : 'No upkeep';
   if (instance.status?.id === 'active') {
     if (instance.maintenanceFunded) {
       upkeepMessage.className = 'blogpress-panel__hint';

--- a/src/ui/views/browser/components/blogpress/views/renderUpkeepPanel.js
+++ b/src/ui/views/browser/components/blogpress/views/renderUpkeepPanel.js
@@ -5,10 +5,10 @@ export default function renderUpkeepPanel({ instance }) {
   title.textContent = 'Daily upkeep';
   panel.appendChild(title);
 
-  const upkeepParts = instance.maintenance?.parts || [];
+  const maintenance = instance.maintenance || {};
   const note = document.createElement('p');
   note.className = 'blogpress-panel__lead';
-  note.textContent = upkeepParts.length ? upkeepParts.join(' • ') : 'No upkeep required';
+  note.textContent = maintenance.hasUpkeep ? maintenance.text : 'No upkeep required';
   panel.appendChild(note);
 
   if (instance.status?.id === 'active' && !instance.maintenanceFunded) {

--- a/src/ui/views/browser/components/digishelf/inventoryTable.js
+++ b/src/ui/views/browser/components/digishelf/inventoryTable.js
@@ -68,10 +68,13 @@ function mergeQuickActionIds(primary = [], fallback = []) {
 function renderUpkeepCell(instance) {
   const wrapper = document.createElement('div');
   wrapper.className = 'digishelf-upkeep';
-  const maintenance = instance.maintenance;
-  if (maintenance?.parts?.length) {
+  const maintenance = instance.maintenance || {};
+  const label = maintenance.detailText || maintenance.text || (
+    Array.isArray(maintenance.parts) ? maintenance.parts.join(' + ') : ''
+  );
+  if (label) {
     const value = document.createElement('strong');
-    value.textContent = maintenance.parts.join(' + ');
+    value.textContent = label;
     wrapper.appendChild(value);
   } else {
     const none = document.createElement('span');

--- a/src/ui/views/browser/components/shopily/views/dashboard/statsPanel.js
+++ b/src/ui/views/browser/components/shopily/views/dashboard/statsPanel.js
@@ -1,5 +1,3 @@
-import { ensureArray } from '../../../../../../../core/helpers.js';
-
 export default function createStatsSection(instance, helpers = {}) {
   const {
     formatCurrency = value => String(value ?? ''),
@@ -35,10 +33,11 @@ export default function createStatsSection(instance, helpers = {}) {
     warning.textContent = 'Maintenance unfunded — cover daily upkeep to avoid shutdowns.';
     fragment.appendChild(warning);
   }
-  if (ensureArray(instance.maintenance?.parts).length) {
+  const maintenance = instance.maintenance || {};
+  if (maintenance.hasUpkeep && maintenance.text) {
     const upkeep = document.createElement('p');
     upkeep.className = 'shopily-panel__note';
-    upkeep.textContent = `Daily upkeep: ${instance.maintenance.parts.join(' • ')}`;
+    upkeep.textContent = `Daily upkeep: ${maintenance.text}`;
     fragment.appendChild(upkeep);
   }
   return fragment;

--- a/src/ui/views/browser/components/videotube/views/createView.js
+++ b/src/ui/views/browser/components/videotube/views/createView.js
@@ -23,7 +23,8 @@ export function createCreateView(options = {}) {
 
     const upkeep = document.createElement('p');
     upkeep.className = 'videotube-panel__note';
-    upkeep.textContent = `Upkeep: ${formatHours(maintenance.hours || 0)} • ${formatCurrency(maintenance.cost || 0)} daily`;
+    const upkeepSummary = maintenance.hasUpkeep ? maintenance.text : 'No upkeep required';
+    upkeep.textContent = `Upkeep: ${upkeepSummary}`;
     card.appendChild(upkeep);
 
     const form = document.createElement('form');

--- a/tests/assets.modules.test.js
+++ b/tests/assets.modules.test.js
@@ -44,10 +44,12 @@ test('maintenance helpers summarize daily upkeep nicely', () => {
   };
 
   const summary = formatMaintenanceSummary(definition);
-  assert.deepEqual(summary, {
-    parts: ['1.5h/day', '$42/day'],
-    hasUpkeep: true
-  });
+  assert.equal(summary.hours, 1.5);
+  assert.equal(summary.cost, 42);
+  assert.deepEqual(summary.parts, ['1.5h/day', '$42/day']);
+  assert.equal(summary.text, '1.5h/day • $42/day');
+  assert.equal(summary.detailText, '1.5h/day + $42/day');
+  assert.equal(summary.hasUpkeep, true);
   assert.match(maintenanceDetail(definition), /1.5h\/day \+ \$42\/day/);
 });
 

--- a/tests/ui/maintenanceFormatting.test.js
+++ b/tests/ui/maintenanceFormatting.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { formatMaintenanceSummary } from '../../src/game/assets/maintenance.js';
+
+test('formatMaintenanceSummary returns readable text for upkeep values', () => {
+  const definition = { maintenance: { hours: 1.5, cost: 12 } };
+  const summary = formatMaintenanceSummary(definition);
+
+  assert.equal(summary.hours, 1.5);
+  assert.equal(summary.cost, 12);
+  assert.deepEqual(summary.parts, ['1.5h/day', '$12/day']);
+  assert.equal(summary.text, '1.5h/day • $12/day');
+  assert.equal(summary.detailText, '1.5h/day + $12/day');
+  assert.equal(summary.hasUpkeep, true);
+});
+
+test('formatMaintenanceSummary indicates when upkeep is not required', () => {
+  const definition = { maintenance: { hours: 0, cost: null } };
+  const summary = formatMaintenanceSummary(definition);
+
+  assert.equal(summary.hours, 0);
+  assert.equal(summary.cost, 0);
+  assert.deepEqual(summary.parts, []);
+  assert.equal(summary.text, '');
+  assert.equal(summary.detailText, '');
+  assert.equal(summary.hasUpkeep, false);
+});


### PR DESCRIPTION
## Summary
- extend the maintenance summary helper to expose text/detail strings alongside sanitized values
- update asset models and browser views to rely on the shared maintenance summary instead of duplicating upkeep formatting
- add focused tests covering the consolidated helper and refresh existing expectations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e25bbbebf0832c8dcb34dcdfd85306