### PR TITLE
Prioritize action providers in registry

### DIFF
--- a/src/ui/dashboard/knowledge.js
+++ b/src/ui/dashboard/knowledge.js
@@ -149,5 +149,5 @@ registerActionProvider(({ state }) => {
       hoursSpentLabel: model?.hoursSpentLabel
     }
   };
-});
+}, 10);
 

--- a/src/ui/dashboard/quickActions.js
+++ b/src/ui/dashboard/quickActions.js
@@ -310,7 +310,7 @@ registerActionProvider(({ state }) => {
       scroller: model?.scroller
     }
   };
-});
+}, 30);
 
 registerActionProvider(({ state }) => {
   const model = buildAssetActionModel(state);
@@ -335,5 +335,5 @@ registerActionProvider(({ state }) => {
       scroller: model?.scroller
     }
   };
-});
+}, 20);
 

--- a/tests/ui/actions/registry.test.js
+++ b/tests/ui/actions/registry.test.js
@@ -67,6 +67,43 @@ test('clearActionProviders restore removes temporary providers', () => {
   assert.ok(!queueAfterRestore.entries.some(entry => entry.id === 'temp-entry'));
 });
 
+test('providers with higher priority contribute entries first', () => {
+  const restore = clearActionProviders();
+  try {
+    registerActionProvider(() => ({
+      id: 'low-priority',
+      entries: [
+        { id: 'low', title: 'Low priority' }
+      ],
+      metrics: {}
+    }), 0);
+
+    registerActionProvider(() => ({
+      id: 'high-priority-a',
+      entries: [
+        { id: 'high-a', title: 'High priority A' }
+      ],
+      metrics: {}
+    }), 10);
+
+    registerActionProvider(() => ({
+      id: 'high-priority-b',
+      entries: [
+        { id: 'high-b', title: 'High priority B' }
+      ],
+      metrics: {}
+    }), 10);
+
+    const queue = buildActionQueue({ state: {} });
+    assert.deepEqual(
+      queue.entries.map(entry => entry.id),
+      ['high-a', 'high-b', 'low']
+    );
+  } finally {
+    restore();
+  }
+});
+
 test('buildActionQueue merges auto-completed entries from the summary', () => {
   const restore = clearActionProviders();
   try {


### PR DESCRIPTION
## Summary
- extend the action provider registry to track priorities and invoke providers in priority order
- assign explicit priorities to quick action, asset upgrade, and study enrollment providers
- add a regression test ensuring higher-priority providers contribute entries first

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e260fe1540832caa407dff9bf5ad0e