### PR TITLE
Preserve provider focus buckets in todo ordering

### DIFF
--- a/src/ui/actions/registry.js
+++ b/src/ui/actions/registry.js
@@ -82,6 +82,14 @@ export function normalizeActionEntries(source = []) {
         orderIndex
       };
 
+      if (entry && typeof entry === 'object') {
+        Object.keys(entry).forEach(key => {
+          if (typeof key === 'string' && key.toLowerCase().includes('bucket')) {
+            normalizedEntry[key] = entry[key];
+          }
+        });
+      }
+
       if (entry?.subtitle) {
         normalizedEntry.subtitle = entry.subtitle;
       }

--- a/tests/ui/actions/registry.test.js
+++ b/tests/ui/actions/registry.test.js
@@ -152,3 +152,28 @@ test('normalizeActionEntries mirrors todo normalization rules', () => {
   assert.equal(entry.durationText, formatHours(3));
   assert.equal(entry.moneyPerHour, 30);
 });
+
+test('normalizeActionEntries preserves explicit focus buckets', () => {
+  const entries = normalizeActionEntries([
+    { id: 'bucketed', focusBucket: 'study', focusCategory: 'hustle' }
+  ]);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].focusBucket, 'study');
+
+  const restore = clearActionProviders();
+  try {
+    registerActionProvider(() => ({
+      id: 'bucket-provider',
+      entries: [
+        { id: 'queue-bucketed', focusBucket: 'study', focusCategory: 'hustle' }
+      ],
+      metrics: {}
+    }));
+
+    const queue = buildActionQueue({ state: {} });
+    assert.equal(queue.entries.length, 1);
+    assert.equal(queue.entries[0].focusBucket, 'study');
+  } finally {
+    restore();
+  }
+});

--- a/tests/ui/views/browser/widgets/todoWidget.test.js
+++ b/tests/ui/views/browser/widgets/todoWidget.test.js
@@ -86,6 +86,26 @@ describe('todoWidget focus ordering', () => {
         ['upgrade-fast', 'hustle-high', 'study-a', 'hustle-low', 'upgrade-slow', 'study-b', 'misc-task']
       );
     });
+
+    it('honours explicit focus buckets supplied by providers', () => {
+      const entries = [
+        { id: 'general-task' },
+        {
+          id: 'bucketed-hustle',
+          focusBucket: 'hustle',
+          moneyPerHour: 80,
+          payout: 80,
+          durationHours: 1
+        },
+        { id: 'upgrade-item', focusCategory: 'upgrade', upgradeRemaining: 1, durationHours: 1 }
+      ];
+
+      const ordered = applyFocusOrdering(entries, 'balanced');
+      assert.deepEqual(
+        ordered.map(entry => entry.id),
+        ['upgrade-item', 'bucketed-hustle', 'general-task']
+      );
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- ensure action normalization copies bucket-related hints so explicit focus buckets survive
- cover normalizeActionEntries and buildActionQueue with focusBucket-preservation tests
- verify the todo widget respects provider-supplied buckets when ordering entries

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e26813199c832caf230a569a4df787