### PR TITLE
Stop pre-normalizing dashboard provider entries

### DIFF
--- a/src/ui/dashboard/knowledge.js
+++ b/src/ui/dashboard/knowledge.js
@@ -2,10 +2,7 @@ import { formatHours, formatMoney } from '../../core/helpers.js';
 import { clampNumber } from './formatters.js';
 import { getHustles } from '../../game/registryService.js';
 import { KNOWLEDGE_TRACKS, getKnowledgeProgress } from '../../game/requirements.js';
-import {
-  registerActionProvider,
-  normalizeActionEntries
-} from '../actions/registry.js';
+import { registerActionProvider } from '../actions/registry.js';
 
 export function computeStudyProgress(state = {}) {
   const tracks = Object.values(KNOWLEDGE_TRACKS);
@@ -127,14 +124,12 @@ export function buildStudyEnrollmentActionModel(state = {}) {
 
 registerActionProvider(({ state }) => {
   const model = buildStudyEnrollmentActionModel(state);
-  const entries = normalizeActionEntries(
-    (Array.isArray(model?.entries) ? model.entries : []).map((entry, index) => ({
-      ...entry,
-      meta: [entry?.subtitle, entry?.meta].filter(Boolean).join(' • ') || entry?.meta || '',
-      focusCategory: entry?.focusCategory || 'study',
-      orderIndex: Number.isFinite(entry?.orderIndex) ? entry.orderIndex : index
-    }))
-  );
+  const entries = (Array.isArray(model?.entries) ? model.entries : []).map((entry, index) => ({
+    ...entry,
+    meta: [entry?.subtitle, entry?.meta].filter(Boolean).join(' • ') || entry?.meta || '',
+    focusCategory: entry?.focusCategory || 'study',
+    orderIndex: Number.isFinite(entry?.orderIndex) ? entry.orderIndex : index
+  }));
 
   return {
     id: 'study-enrollment',

--- a/src/ui/dashboard/quickActions.js
+++ b/src/ui/dashboard/quickActions.js
@@ -10,10 +10,7 @@ import {
 } from '../../game/assets/quality/actions.js';
 import { getNextQualityLevel } from '../../game/assets/quality/levels.js';
 import { instanceLabel } from '../../game/assets/details.js';
-import {
-  registerActionProvider,
-  normalizeActionEntries
-} from '../actions/registry.js';
+import { registerActionProvider } from '../actions/registry.js';
 
 function getQualitySnapshot(instance = {}) {
   const level = Math.max(0, clampNumber(instance?.quality?.level));
@@ -286,13 +283,11 @@ export function buildAssetActionModel(state = {}) {
 
 registerActionProvider(({ state }) => {
   const model = buildQuickActionModel(state);
-  const entries = normalizeActionEntries(
-    (Array.isArray(model?.entries) ? model.entries : []).map((entry, index) => ({
-      ...entry,
-      focusCategory: entry?.focusCategory || 'hustle',
-      orderIndex: Number.isFinite(entry?.orderIndex) ? entry.orderIndex : index
-    }))
-  );
+  const entries = (Array.isArray(model?.entries) ? model.entries : []).map((entry, index) => ({
+    ...entry,
+    focusCategory: entry?.focusCategory || 'hustle',
+    orderIndex: Number.isFinite(entry?.orderIndex) ? entry.orderIndex : index
+  }));
 
   return {
     id: 'quick-actions',
@@ -314,14 +309,12 @@ registerActionProvider(({ state }) => {
 
 registerActionProvider(({ state }) => {
   const model = buildAssetActionModel(state);
-  const entries = normalizeActionEntries(
-    (Array.isArray(model?.entries) ? model.entries : []).map((entry, index) => ({
-      ...entry,
-      meta: [entry?.subtitle, entry?.meta].filter(Boolean).join(' • ') || entry?.meta || '',
-      focusCategory: entry?.focusCategory || 'upgrade',
-      orderIndex: Number.isFinite(entry?.orderIndex) ? entry.orderIndex : index
-    }))
-  );
+  const entries = (Array.isArray(model?.entries) ? model.entries : []).map((entry, index) => ({
+    ...entry,
+    meta: [entry?.subtitle, entry?.meta].filter(Boolean).join(' • ') || entry?.meta || '',
+    focusCategory: entry?.focusCategory || 'upgrade',
+    orderIndex: Number.isFinite(entry?.orderIndex) ? entry.orderIndex : index
+  }));
 
   return {
     id: 'asset-upgrades',

--- a/tests/ui/actions/registry.test.js
+++ b/tests/ui/actions/registry.test.js
@@ -42,6 +42,34 @@ test('registerActionProvider supplies normalized entries to the queue', () => {
   }
 });
 
+test('registerActionProvider retains the original entry as raw payload', () => {
+  const restore = clearActionProviders();
+  try {
+    const originalEntry = {
+      id: 'raw-entry',
+      title: 'Raw Reference',
+      timeCost: 1,
+      payout: 5,
+      metadata: 'custom-meta'
+    };
+
+    registerActionProvider(() => ({
+      id: 'raw-provider',
+      focusCategory: 'hustle',
+      entries: [originalEntry],
+      metrics: {}
+    }));
+
+    const queue = buildActionQueue({ state: {} });
+    assert.equal(queue.entries.length, 1);
+    assert.equal(queue.entries[0].id, 'raw-entry');
+    assert.strictEqual(queue.entries[0].raw, originalEntry);
+    assert.equal(queue.entries[0].raw.metadata, 'custom-meta');
+  } finally {
+    restore();
+  }
+});
+
 test('clearActionProviders restore removes temporary providers', () => {
   const restore = clearActionProviders();
   try {


### PR DESCRIPTION
## Summary
- update dashboard quick actions and study enrollment providers to return raw entries and rely on the registry normalizer
- keep focus category and order index tagging while composing display meta locally
- add a registry test to confirm provider payloads are retained on the normalized entry `.raw` field

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e26a32b974832cacdf9f45fce42097