### PR TITLE
Add script to visualize economy modifier graph

### DIFF
--- a/economy_graph.mmd
+++ b/economy_graph.mmd
@@ -1,0 +1,227 @@
+%% Auto-generated economy modifier graph
+%% Total modifiers: 103
+%% Cycle detection: none
+%% Redundant modifiers: none
+graph LR
+  storycraftJumpstart_0["storycraftJumpstart"]
+  asset_blog_income_1["asset:blog.income"]
+  vlogStudioJumpstart_2["vlogStudioJumpstart"]
+  asset_vlog_income_3["asset:vlog.income"]
+  digitalShelfPrimer_4["digitalShelfPrimer"]
+  asset_ebook_income_5["asset:ebook.income"]
+  asset_stockPhotos_income_6["asset:stockPhotos.income"]
+  commerceLaunchPrimer_7["commerceLaunchPrimer"]
+  asset_dropshipping_income_8["asset:dropshipping.income"]
+  microSaasJumpstart_9["microSaasJumpstart"]
+  asset_saas_income_10["asset:saas.income"]
+  outlineMastery_11["outlineMastery"]
+  hustle_freelance_income_12["hustle:freelance.income"]
+  hustle_audiobookNarration_inco_13["hustle:audiobookNarration.income"]
+  photoLibrary_14["photoLibrary"]
+  hustle_eventPhotoGig_income_15["hustle:eventPhotoGig.income"]
+  ecomPlaybook_16["ecomPlaybook"]
+  hustle_bundlePush_income_17["hustle:bundlePush.income"]
+  automationCourse_18["automationCourse"]
+  hustle_saasBugSquash_income_19["hustle:saasBugSquash.income"]
+  brandVoiceLab_20["brandVoiceLab"]
+  hustle_audienceCall_income_21["hustle:audienceCall.income"]
+  guerillaBuzzWorkshop_22["guerillaBuzzWorkshop"]
+  hustle_streetPromoSprint_incom_23["hustle:streetPromoSprint.income"]
+  hustle_surveySprint_income_24["hustle:surveySprint.income"]
+  curriculumDesignStudio_25["curriculumDesignStudio"]
+  hustle_popUpWorkshop_income_26["hustle:popUpWorkshop.income"]
+  postProductionPipelineLab_27["postProductionPipelineLab"]
+  hustle_vlogEditRush_income_28["hustle:vlogEditRush.income"]
+  fulfillmentOpsMasterclass_29["fulfillmentOpsMasterclass"]
+  hustle_dropshipPackParty_incom_30["hustle:dropshipPackParty.income"]
+  customerRetentionClinic_31["customerRetentionClinic"]
+  narrationPerformanceWorkshop_32["narrationPerformanceWorkshop"]
+  galleryLicensingSummit_33["galleryLicensingSummit"]
+  syndicationResidency_34["syndicationResidency"]
+  coffee_35["coffee"]
+  state_time_bonus_36["state:time.bonus"]
+  studio_37["studio"]
+  assets_tag_photo_video_mainten_38["assets[tag=photo|video].maintenance_time"]
+  studioExpansion_39["studioExpansion"]
+  assets_tag_photo_video_setup_t_40["assets[tag=photo|video].setup_time"]
+  assets_tag_photo_video_income_41["assets[tag=photo|video].income"]
+  assets_tag_photo_video_quality_42["assets[tag=photo|video].quality_progress"]
+  hustles_tag_photo_quality_prog_43["hustles[tag=photo].quality_progress"]
+  serverRack_44["serverRack"]
+  assets_tag_software_tech_setup_45["assets[tag=software|tech].setup_time"]
+  hustles_tag_software_automatio_46["hustles[tag=software|automation].setup_time"]
+  fulfillmentAutomation_47["fulfillmentAutomation"]
+  asset_dropshipping_quality_pro_48["asset:dropshipping.quality_progress"]
+  serverCluster_49["serverCluster"]
+  asset_saas_quality_progress_50["asset:saas.quality_progress"]
+  globalSupplyMesh_51["globalSupplyMesh"]
+  asset_dropshipping_setup_time_52["asset:dropshipping.setup_time"]
+  hustles_tag_commerce_ecommerce_53["hustles[tag=commerce|ecommerce].setup_time"]
+  hustles_tag_commerce_ecommerce_54["hustles[tag=commerce|ecommerce].income"]
+  serverEdge_55["serverEdge"]
+  asset_saas_maintenance_time_56["asset:saas.maintenance_time"]
+  whiteLabelAlliance_57["whiteLabelAlliance"]
+  assets_id_dropshipping_stockPh_58["assets[id=dropshipping|stockPhotos].income"]
+  assets_id_dropshipping_stockPh_59["assets[id=dropshipping|stockPhotos].quality_progress"]
+  hustles_tag_commerce_photo_inc_60["hustles[tag=commerce|photo].income"]
+  hustles_tag_commerce_photo_qua_61["hustles[tag=commerce|photo].quality_progress"]
+  creatorPhone_62["creatorPhone"]
+  hustles_tag_live_field_setup_t_63["hustles[tag=live|field].setup_time"]
+  assets_tag_video_setup_time_64["assets[tag=video].setup_time"]
+  creatorPhonePro_65["creatorPhonePro"]
+  hustles_tag_live_field_income_66["hustles[tag=live|field].income"]
+  assets_tag_video_income_67["assets[tag=video].income"]
+  creatorPhoneUltra_68["creatorPhoneUltra"]
+  studioLaptop_69["studioLaptop"]
+  assets_tag_desktop_work_setup__70["assets[tag=desktop_work].setup_time"]
+  hustles_tag_desktop_work_setup_71["hustles[tag=desktop_work].setup_time"]
+  editingWorkstation_72["editingWorkstation"]
+  assets_tag_desktop_work_video__73["assets[tag=desktop_work|video].setup_time"]
+  assets_tag_desktop_work_video__74["assets[tag=desktop_work|video].maintenance_time"]
+  quantumRig_75["quantumRig"]
+  assets_tag_desktop_work_softwa_76["assets[tag=desktop_work|software|video].maintenance_time"]
+  assets_tag_desktop_work_softwa_77["assets[tag=desktop_work|software|video].income"]
+  monitorHub_78["monitorHub"]
+  dualMonitorArray_79["dualMonitorArray"]
+  assets_tag_desktop_work_video__80["assets[tag=desktop_work|video].quality_progress"]
+  colorGradingDisplay_81["colorGradingDisplay"]
+  assets_tag_video_photo_quality_82["assets[tag=video|photo].quality_progress"]
+  camera_83["camera"]
+  assets_tag_video_photo_setup_t_84["assets[tag=video|photo].setup_time"]
+  hustles_tag_video_photo_setup__85["hustles[tag=video|photo].setup_time"]
+  cameraPro_86["cameraPro"]
+  assets_tag_video_photo_mainten_87["assets[tag=video|photo].maintenance_time"]
+  assets_tag_video_photo_income_88["assets[tag=video|photo].income"]
+  audioSuite_89["audioSuite"]
+  assets_tag_audio_video_quality_90["assets[tag=audio|video].quality_progress"]
+  ergonomicRefit_91["ergonomicRefit"]
+  assets_tag_desktop_work_mainte_92["assets[tag=desktop_work].maintenance_time"]
+  fiberInternet_93["fiberInternet"]
+  assets_tag_video_software_main_94["assets[tag=video|software].maintenance_time"]
+  hustles_tag_live_software_main_95["hustles[tag=live|software].maintenance_time"]
+  backupPowerArray_96["backupPowerArray"]
+  scratchDriveArray_97["scratchDriveArray"]
+  assets_tag_video_photo_softwar_98["assets[tag=video|photo|software].maintenance_time"]
+  editorialPipeline_99["editorialPipeline"]
+  assets_tag_writing_content_set_100["assets[tag=writing|content].setup_time"]
+  assets_tag_writing_content_inc_101["assets[tag=writing|content].income"]
+  assets_tag_writing_content_qua_102["assets[tag=writing|content].quality_progress"]
+  hustles_tag_writing_setup_time_103["hustles[tag=writing].setup_time"]
+  hustles_tag_writing_income_104["hustles[tag=writing].income"]
+  hustles_tag_writing_quality_pr_105["hustles[tag=writing].quality_progress"]
+  syndicationSuite_106["syndicationSuite"]
+  assets_tag_writing_content_vid_107["assets[tag=writing|content|video].maintenance_time"]
+  assets_tag_writing_content_vid_108["assets[tag=writing|content|video].income"]
+  assets_tag_writing_content_vid_109["assets[tag=writing|content|video].quality_progress"]
+  hustles_tag_writing_marketing__110["hustles[tag=writing|marketing].maintenance_time"]
+  hustles_tag_writing_marketing__111["hustles[tag=writing|marketing].income"]
+  hustles_tag_writing_marketing__112["hustles[tag=writing|marketing].quality_progress"]
+  immersiveStoryWorlds_113["immersiveStoryWorlds"]
+  assets_tag_writing_video_photo_114["assets[tag=writing|video|photo].income"]
+  assets_tag_writing_video_photo_115["assets[tag=writing|video|photo].setup_time"]
+  assets_tag_writing_video_photo_116["assets[tag=writing|video|photo].quality_progress"]
+  course_117["course"]
+  asset_blog_quality_progress_118["asset:blog.quality_progress"]
+  storycraftJumpstart_0 -->|Adds 5% to blog income.| asset_blog_income_1
+  vlogStudioJumpstart_2 -->|Adds 5% to vlog income.| asset_vlog_income_3
+  digitalShelfPrimer_4 -->|Adds 5% to e-book income.| asset_ebook_income_5
+  digitalShelfPrimer_4 -->|Adds 5% to stock photo income.| asset_stockPhotos_income_6
+  commerceLaunchPrimer_7 -->|Adds 5% to dropshipping income.| asset_dropshipping_income_8
+  microSaasJumpstart_9 -->|Adds 5% to SaaS income.| asset_saas_income_10
+  outlineMastery_11 -->|Freelance writing earns 25% more.| hustle_freelance_income_12
+  outlineMastery_11 -->|Audiobook narration earns 15% more.| hustle_audiobookNarration_inco_13
+  photoLibrary_14 -->|Event photo gig earns 20% more.| hustle_eventPhotoGig_income_15
+  ecomPlaybook_16 -->|Bundle promo push gains $5 flat.| hustle_bundlePush_income_17
+  ecomPlaybook_16 -->|Dropshipping income +15%.| asset_dropshipping_income_8
+  automationCourse_18 -->|SaaS bug squash gains $6 flat.| hustle_saasBugSquash_income_19
+  automationCourse_18 -->|SaaS income +15%.| asset_saas_income_10
+  brandVoiceLab_20 -->|Audience Q&A blast gains $4.| hustle_audienceCall_income_21
+  guerillaBuzzWorkshop_22 -->|Street promo sprint +25%.| hustle_streetPromoSprint_incom_23
+  guerillaBuzzWorkshop_22 -->|Micro survey dash gains $1.5.| hustle_surveySprint_income_24
+  curriculumDesignStudio_25 -->|Pop-up workshop +30%.| hustle_popUpWorkshop_income_26
+  curriculumDesignStudio_25 -->|Bundle promo push +15%.| hustle_bundlePush_income_17
+  postProductionPipelineLab_27 -->|Vlog edit rush +25%.| hustle_vlogEditRush_income_28
+  postProductionPipelineLab_27 -->|Vlog income +15%.| asset_vlog_income_3
+  fulfillmentOpsMasterclass_29 -->|Dropship pack party +20%.| hustle_dropshipPackParty_incom_30
+  fulfillmentOpsMasterclass_29 -->|Dropshipping income +25%.| asset_dropshipping_income_8
+  customerRetentionClinic_31 -->|SaaS bug squash gains $5.| hustle_saasBugSquash_income_19
+  customerRetentionClinic_31 -->|SaaS income +20%.| asset_saas_income_10
+  narrationPerformanceWorkshop_32 -->|Audiobook narration +25%.| hustle_audiobookNarration_inco_13
+  narrationPerformanceWorkshop_32 -->|E-book income +10%.| asset_ebook_income_5
+  galleryLicensingSummit_33 -->|Event photo gig +20%.| hustle_eventPhotoGig_income_15
+  galleryLicensingSummit_33 -->|Stock photo income +15%.| asset_stockPhotos_income_6
+  syndicationResidency_34 -->|Freelance writing +15%.| hustle_freelance_income_12
+  syndicationResidency_34 -->|Street promo sprint gains $2.| hustle_streetPromoSprint_incom_23
+  syndicationResidency_34 -->|Blog income +12%.| asset_blog_income_1
+  coffee_35 -->|Adds 60 bonus minutes (max 3 per day).| state_time_bonus_36
+  studio_37 -->|Lighting kit reduces photo/video maintenance time.| assets_tag_photo_video_mainten_38
+  studioExpansion_39 -->|Studio expansion speeds photo/video setup.| assets_tag_photo_video_setup_t_40
+  studioExpansion_39 -->|Studio expansion boosts photo/video payouts.| assets_tag_photo_video_income_41
+  studioExpansion_39 -->|Studio expansion doubles photo/video quality progress.| assets_tag_photo_video_quality_42
+  studioExpansion_39 -->|Photo hustles gain double quality progress.| hustles_tag_photo_quality_prog_43
+  serverRack_44 -->|Server rack speeds software/tech setup.| assets_tag_software_tech_setup_45
+  serverRack_44 -->|Server rack speeds software/automation hustles.| hustles_tag_software_automatio_46
+  fulfillmentAutomation_47 -->|Automation suite boosts dropshipping payouts.| asset_dropshipping_income_8
+  fulfillmentAutomation_47 -->|Automation suite doubles dropshipping quality progress.| asset_dropshipping_quality_pro_48
+  serverCluster_49 -->|Cloud cluster boosts SaaS payouts.| asset_saas_income_10
+  serverCluster_49 -->|Cloud cluster boosts SaaS quality progress.| asset_saas_quality_progress_50
+  globalSupplyMesh_51 -->|Global supply mesh boosts dropshipping payouts.| asset_dropshipping_income_8
+  globalSupplyMesh_51 -->|Global supply mesh boosts dropshipping quality progress.| asset_dropshipping_quality_pro_48
+  globalSupplyMesh_51 -->|Global supply mesh speeds dropshipping setup.| asset_dropshipping_setup_time_52
+  globalSupplyMesh_51 -->|Commerce/e-commerce hustles run faster.| hustles_tag_commerce_ecommerce_53
+  globalSupplyMesh_51 -->|Commerce/e-commerce hustles earn 30% more.| hustles_tag_commerce_ecommerce_54
+  serverEdge_55 -->|Edge delivery boosts SaaS payouts 35%.| asset_saas_income_10
+  serverEdge_55 -->|Edge delivery doubles SaaS quality progress.| asset_saas_quality_progress_50
+  serverEdge_55 -->|Edge delivery reduces SaaS maintenance time.| asset_saas_maintenance_time_56
+  whiteLabelAlliance_57 -->|White-label alliance boosts dropshipping & stock photo payouts.| assets_id_dropshipping_stockPh_58
+  whiteLabelAlliance_57 -->|White-label alliance increases quality progress by 4/3.| assets_id_dropshipping_stockPh_59
+  whiteLabelAlliance_57 -->|Commerce/photo hustles earn 35% more.| hustles_tag_commerce_photo_inc_60
+  whiteLabelAlliance_57 -->|Commerce/photo hustles gain 4/3 quality progress.| hustles_tag_commerce_photo_qua_61
+  creatorPhone_62 -->|Creator phone speeds live/field hustles.| hustles_tag_live_field_setup_t_63
+  creatorPhone_62 -->|Creator phone speeds video setup.| assets_tag_video_setup_time_64
+  creatorPhonePro_65 -->|Creator phone pro further speeds live/field hustles.| hustles_tag_live_field_setup_t_63
+  creatorPhonePro_65 -->|Creator phone pro speeds video setup.| assets_tag_video_setup_time_64
+  creatorPhonePro_65 -->|Creator phone pro boosts live/field payouts 5%.| hustles_tag_live_field_income_66
+  creatorPhonePro_65 -->|Creator phone pro boosts video income 5%.| assets_tag_video_income_67
+  creatorPhoneUltra_68 -->|Creator phone ultra speeds live/field setup.| hustles_tag_live_field_setup_t_63
+  creatorPhoneUltra_68 -->|Creator phone ultra speeds video setup.| assets_tag_video_setup_time_64
+  creatorPhoneUltra_68 -->|Creator phone ultra boosts live/field payouts 8%.| hustles_tag_live_field_income_66
+  creatorPhoneUltra_68 -->|Creator phone ultra boosts video income 8%.| assets_tag_video_income_67
+  studioLaptop_69 -->|Studio laptop speeds desktop setup.| assets_tag_desktop_work_setup__70
+  studioLaptop_69 -->|Studio laptop speeds desktop hustles.| hustles_tag_desktop_work_setup_71
+  editingWorkstation_72 -->|Editing workstation speeds desktop/video setup.| assets_tag_desktop_work_video__73
+  editingWorkstation_72 -->|Editing workstation trims desktop/video maintenance.| assets_tag_desktop_work_video__74
+  quantumRig_75 -->|Quantum rig reduces maintenance for desktop/software/video assets.| assets_tag_desktop_work_softwa_76
+  quantumRig_75 -->|Quantum rig boosts payouts for desktop/software/video assets.| assets_tag_desktop_work_softwa_77
+  monitorHub_78 -->|Monitor dock speeds desktop setup.| assets_tag_desktop_work_setup__70
+  dualMonitorArray_79 -->|Dual monitor array boosts desktop/video quality progress.| assets_tag_desktop_work_video__80
+  colorGradingDisplay_81 -->|Color grading display boosts video/photo quality progress.| assets_tag_video_photo_quality_82
+  camera_83 -->|Camera speeds video/photo setup.| assets_tag_video_photo_setup_t_84
+  camera_83 -->|Camera speeds video/photo hustles.| hustles_tag_video_photo_setup__85
+  cameraPro_86 -->|Cinema camera upgrade speeds video/photo setup.| assets_tag_video_photo_setup_t_84
+  cameraPro_86 -->|Cinema camera upgrade reduces video/photo maintenance.| assets_tag_video_photo_mainten_87
+  cameraPro_86 -->|Cinema camera upgrade boosts video/photo payouts.| assets_tag_video_photo_income_88
+  cameraPro_86 -->|Cinema camera upgrade doubles video/photo quality progress.| assets_tag_video_photo_quality_82
+  audioSuite_89 -->|Audio suite boosts audio/video quality progress.| assets_tag_audio_video_quality_90
+  ergonomicRefit_91 -->|Ergonomic refit reduces desktop maintenance time.| assets_tag_desktop_work_mainte_92
+  fiberInternet_93 -->|Fiber internet reduces video/software maintenance.| assets_tag_video_software_main_94
+  fiberInternet_93 -->|Fiber internet reduces maintenance for live/software hustles.| hustles_tag_live_software_main_95
+  backupPowerArray_96 -->|Backup power reduces desktop/video maintenance.| assets_tag_desktop_work_video__74
+  scratchDriveArray_97 -->|Scratch drive array reduces maintenance for video/photo/software assets.| assets_tag_video_photo_softwar_98
+  editorialPipeline_99 -->|Editorial pipeline speeds writing/content setup.| assets_tag_writing_content_set_100
+  editorialPipeline_99 -->|Editorial pipeline boosts writing/content payouts.| assets_tag_writing_content_inc_101
+  editorialPipeline_99 -->|Editorial pipeline boosts writing/content quality progress.| assets_tag_writing_content_qua_102
+  editorialPipeline_99 -->|Editorial pipeline speeds writing hustles.| hustles_tag_writing_setup_time_103
+  editorialPipeline_99 -->|Editorial pipeline boosts writing hustle payouts.| hustles_tag_writing_income_104
+  editorialPipeline_99 -->|Editorial pipeline boosts writing hustle quality gains.| hustles_tag_writing_quality_pr_105
+  syndicationSuite_106 -->|Syndication suite trims maintenance for writing/content/video assets.| assets_tag_writing_content_vid_107
+  syndicationSuite_106 -->|Syndication suite boosts payouts for writing/content/video assets.| assets_tag_writing_content_vid_108
+  syndicationSuite_106 -->|Syndication suite increases quality progress by 4/3.| assets_tag_writing_content_vid_109
+  syndicationSuite_106 -->|Syndication suite reduces upkeep for writing/marketing hustles.| hustles_tag_writing_marketing__110
+  syndicationSuite_106 -->|Syndication suite boosts writing/marketing hustle payouts.| hustles_tag_writing_marketing__111
+  syndicationSuite_106 -->|Syndication suite increases hustle quality progress.| hustles_tag_writing_marketing__112
+  immersiveStoryWorlds_113 -->|Immersive story worlds boosts writing/video/photo payouts.| assets_tag_writing_video_photo_114
+  immersiveStoryWorlds_113 -->|Immersive story worlds speeds setup for writing/video/photo assets.| assets_tag_writing_video_photo_115
+  immersiveStoryWorlds_113 -->|Immersive story worlds doubles quality progress for writing/video/photo assets.| assets_tag_writing_video_photo_116
+  course_117 -->|Automation course boosts blog payouts 50%.| asset_blog_income_1
+  course_117 -->|Automation course doubles blog quality progress.| asset_blog_quality_progress_118

--- a/scripts/generateEconomyGraph.mjs
+++ b/scripts/generateEconomyGraph.mjs
@@ -1,0 +1,156 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const DATA_PATH = path.resolve('docs/normalized_economy.json');
+const OUTPUT_PATH = path.resolve('economy_graph.mmd');
+
+function sanitizeId(label, index) {
+  const base = label
+    .replace(/[^a-zA-Z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 30);
+  const candidate = base || `node_${index}`;
+  return `${candidate}_${index}`;
+}
+
+function escapeLabel(label) {
+  return label.replace(/"/g, '\\"');
+}
+
+function formatEdgeLabel(mod) {
+  const raw = mod.notes || mod.formula || mod.type;
+  return raw.replace(/\|/g, '/').replace(/\n/g, ' ');
+}
+
+async function main() {
+  const json = JSON.parse(await fs.readFile(DATA_PATH, 'utf8'));
+  const modifiers = json.modifiers ?? [];
+
+  const entityIds = new Map();
+  const nodes = [];
+
+  function ensureEntity(label) {
+    if (!entityIds.has(label)) {
+      const id = sanitizeId(label, entityIds.size);
+      entityIds.set(label, { id, label });
+      nodes.push({ id, label });
+    }
+    return entityIds.get(label).id;
+  }
+
+  const edges = modifiers.map((mod, index) => {
+    const sourceId = ensureEntity(mod.source);
+    const targetId = ensureEntity(mod.target);
+    return { ...mod, index, sourceId, targetId };
+  });
+
+  // Build adjacency for cycle detection
+  const adjacency = new Map();
+  function addEdge(from, to) {
+    if (!adjacency.has(from)) {
+      adjacency.set(from, new Set());
+    }
+    adjacency.get(from).add(to);
+  }
+  edges.forEach(({ sourceId, targetId }) => addEdge(sourceId, targetId));
+
+  const cycles = [];
+  const visited = new Set();
+  const stack = new Set();
+  const path = [];
+
+  function dfs(node) {
+    visited.add(node);
+    stack.add(node);
+    path.push(node);
+
+    const neighbors = adjacency.get(node);
+    if (neighbors) {
+      for (const next of neighbors) {
+        if (!visited.has(next)) {
+          dfs(next);
+        } else if (stack.has(next)) {
+          const cycleStart = path.indexOf(next);
+          if (cycleStart !== -1) {
+            const cycle = path.slice(cycleStart);
+            cycle.push(next);
+            const cycleKey = cycle.join('>');
+            if (!cycles.find((c) => c.join('>') === cycleKey)) {
+              cycles.push(cycle);
+            }
+          }
+        }
+      }
+    }
+
+    stack.delete(node);
+    path.pop();
+  }
+
+  for (const { id } of nodes) {
+    if (!visited.has(id)) {
+      dfs(id);
+    }
+  }
+
+  const redundancyMap = new Map();
+  const redundantKeys = new Set();
+  edges.forEach((edge) => {
+    const key = [edge.source, edge.target, edge.type, edge.formula, edge.notes]
+      .map((value) => value ?? '')
+      .join('|');
+    if (redundancyMap.has(key)) {
+      redundantKeys.add(key);
+      redundancyMap.get(key).push(edge.index);
+    } else {
+      redundancyMap.set(key, [edge.index]);
+    }
+  });
+
+  const redundantDetails = Array.from(redundantKeys).map((key) => {
+    const indices = redundancyMap.get(key);
+    return {
+      key,
+      count: indices.length,
+    };
+  });
+
+  const lines = [];
+  lines.push('%% Auto-generated economy modifier graph');
+  lines.push(`%% Total modifiers: ${edges.length}`);
+  if (cycles.length === 0) {
+    lines.push('%% Cycle detection: none');
+  } else {
+    cycles.forEach((cycle, idx) => {
+      const labels = cycle.map((id) => {
+        const match = nodes.find((n) => n.id === id);
+        return match ? match.label : id;
+      });
+      lines.push(`%% Cycle ${idx + 1}: ${labels.join(' -> ')}`);
+    });
+  }
+  if (redundantDetails.length === 0) {
+    lines.push('%% Redundant modifiers: none');
+  } else {
+    redundantDetails.forEach(({ key, count }, idx) => {
+      lines.push(`%% Redundant ${idx + 1} (count ${count}): ${key}`);
+    });
+  }
+  lines.push('graph LR');
+
+  nodes.forEach(({ id, label }) => {
+    lines.push(`  ${id}["${escapeLabel(label)}"]`);
+  });
+
+  edges.forEach((edge) => {
+    const label = escapeLabel(formatEdgeLabel(edge));
+    lines.push(`  ${edge.sourceId} -->|${label}| ${edge.targetId}`);
+  });
+
+  await fs.writeFile(OUTPUT_PATH, `${lines.join('\n')}\n`, 'utf8');
+}
+
+main().catch((error) => {
+  console.error('Failed to generate economy graph:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a Node.js script that converts docs/normalized_economy.json modifiers into a Mermaid graph
- generate economy_graph.mmd with node listings and annotations for cycles and redundant edges

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e2772eb22c832c8a1e2fc67d0c3b65