### PR TITLE
Centralize economy configuration data

### DIFF
--- a/src/game/assets/definitions/blog.js
+++ b/src/game/assets/definitions/blog.js
@@ -1,6 +1,20 @@
 import { formatMoney } from '../../../core/helpers.js';
 import { triggerQualityActionEvents } from '../../events/index.js';
 import { createAssetDefinition } from '../../content/schema.js';
+import { assets as assetConfigs } from '../../data/economyConfig.js';
+
+const blogConfig = assetConfigs.blog; // Spec: docs/normalized_economy.json → assets.blog
+const blogSetup = blogConfig.setup; // Spec: docs/normalized_economy.json → assets.blog.schedule
+const blogMaintenance = blogConfig.maintenance; // Spec: docs/normalized_economy.json → assets.blog.maintenance_time
+const blogIncome = blogConfig.income; // Spec: docs/normalized_economy.json → assets.blog.base_income
+const [
+  blogQualityLevel0,
+  blogQualityLevel1,
+  blogQualityLevel2,
+  blogQualityLevel3,
+  blogQualityLevel4,
+  blogQualityLevel5
+] = blogConfig.qualityLevels; // Spec: docs/normalized_economy.json → assets.blog.quality_curve
 
 const blogDefinition = createAssetDefinition({
   id: 'blog',
@@ -9,15 +23,15 @@ const blogDefinition = createAssetDefinition({
   tag: { label: 'Foundation', type: 'passive' },
   tags: ['writing', 'content', 'desktop_work'],
   description: 'Launch cozy blogs that drip ad revenue once the posts are polished.',
-  setup: { days: 3, hoursPerDay: 3, cost: 180 },
-  maintenance: { hours: 0.6, cost: 3 },
+  setup: { ...blogSetup },
+  maintenance: { ...blogMaintenance },
   skills: {
     setup: [
       'writing',
       { id: 'promotion', weight: 0.5 }
     ]
   },
-  income: { base: 30, variance: 0.2, logType: 'passive' },
+  income: { ...blogIncome, logType: 'passive' },
   quality: {
     summary: 'Draft posts, tune SEO, and rally backlinks to climb from skeleton sites to a thriving blog constellation.',
     tracks: {
@@ -27,46 +41,46 @@ const blogDefinition = createAssetDefinition({
     },
     levels: [
       {
-        level: 0,
+        level: blogQualityLevel0.level,
         name: 'Skeleton Drafts',
         description: 'Bare pages with placeholder copy and sleepy earnings.',
-        income: { min: 3, max: 6 },
-        requirements: {}
+        income: { ...blogQualityLevel0.income }, // Spec: docs/normalized_economy.json → assets.blog.quality_curve[0]
+        requirements: { ...blogQualityLevel0.requirements }
       },
       {
-        level: 1,
+        level: blogQualityLevel1.level,
         name: 'Content Sprout',
         description: 'Three polished posts that finally catch organic clicks.',
-        income: { min: 9, max: 15 },
-        requirements: { posts: 3 }
+        income: { ...blogQualityLevel1.income }, // Spec: docs/normalized_economy.json → assets.blog.quality_curve[1]
+        requirements: { ...blogQualityLevel1.requirements }
       },
       {
-        level: 2,
+        level: blogQualityLevel2.level,
         name: 'SEO Groove',
         description: 'Evergreen articles plus SEO sweeps pull in steady readers.',
-        income: { min: 16, max: 24 },
-        requirements: { posts: 9, seo: 2 }
+        income: { ...blogQualityLevel2.income }, // Spec: docs/normalized_economy.json → assets.blog.quality_curve[2]
+        requirements: { ...blogQualityLevel2.requirements }
       },
       {
-        level: 3,
+        level: blogQualityLevel3.level,
         name: 'Authority Hub',
         description: 'Backlinks and authority content turn ad clicks into a gush.',
-        income: { min: 30, max: 42 },
-        requirements: { posts: 18, seo: 5, outreach: 3 }
+        income: { ...blogQualityLevel3.income }, // Spec: docs/normalized_economy.json → assets.blog.quality_curve[3]
+        requirements: { ...blogQualityLevel3.requirements }
       },
       {
-        level: 4,
+        level: blogQualityLevel4.level,
         name: 'Syndication Dynamo',
         description: 'Guest post swaps and sponsor bundles send payouts soaring.',
-        income: { min: 46, max: 62 },
-        requirements: { posts: 28, seo: 9, outreach: 6 }
+        income: { ...blogQualityLevel4.income }, // Spec: docs/normalized_economy.json → assets.blog.quality_curve[4]
+        requirements: { ...blogQualityLevel4.requirements }
       },
       {
-        level: 5,
+        level: blogQualityLevel5.level,
         name: 'Constellation Network',
         description: 'An interlinked brand empire showers you in evergreen commissions.',
-        income: { min: 64, max: 84 },
-        requirements: { posts: 40, seo: 14, outreach: 10 }
+        income: { ...blogQualityLevel5.income }, // Spec: docs/normalized_economy.json → assets.blog.quality_curve[5]
+        requirements: { ...blogQualityLevel5.requirements }
       }
     ],
     actions: [

--- a/src/game/assets/definitions/dropshipping.js
+++ b/src/game/assets/definitions/dropshipping.js
@@ -1,6 +1,20 @@
 import { formatMoney } from '../../../core/helpers.js';
 import { createAssetDefinition } from '../../content/schema.js';
 import { triggerQualityActionEvents } from '../../events/index.js';
+import { assets as assetConfigs } from '../../data/economyConfig.js';
+
+const dropshippingConfig = assetConfigs.dropshipping; // Spec: docs/normalized_economy.json → assets.dropshipping
+const dropshippingSetup = dropshippingConfig.setup; // Spec: docs/normalized_economy.json → assets.dropshipping.schedule
+const dropshippingMaintenance = dropshippingConfig.maintenance; // Spec: docs/normalized_economy.json → assets.dropshipping.maintenance_time
+const dropshippingIncome = dropshippingConfig.income; // Spec: docs/normalized_economy.json → assets.dropshipping.base_income
+const [
+  dropshippingQualityLevel0,
+  dropshippingQualityLevel1,
+  dropshippingQualityLevel2,
+  dropshippingQualityLevel3,
+  dropshippingQualityLevel4,
+  dropshippingQualityLevel5
+] = dropshippingConfig.qualityLevels; // Spec: docs/normalized_economy.json → assets.dropshipping.quality_curve
 
 const dropshippingDefinition = createAssetDefinition({
   id: 'dropshipping',
@@ -9,8 +23,8 @@ const dropshippingDefinition = createAssetDefinition({
   tag: { label: 'Commerce', type: 'passive' },
   tags: ['commerce', 'ecommerce', 'fulfillment'],
   description: 'Prototype products, source suppliers, and automate fulfillment funnels.',
-  setup: { days: 6, hoursPerDay: 4, cost: 720 },
-  maintenance: { hours: 1.1, cost: 12 },
+  setup: { ...dropshippingSetup },
+  maintenance: { ...dropshippingMaintenance },
   skills: {
     setup: [
       'commerce',
@@ -18,11 +32,8 @@ const dropshippingDefinition = createAssetDefinition({
       { id: 'promotion', weight: 0.5 }
     ]
   },
-  income: { base: 84, variance: 0.35, logType: 'passive' },
-  requirements: {
-    knowledge: ['ecomPlaybook'],
-    experience: [{ assetId: 'blog', count: 2 }]
-  },
+  income: { ...dropshippingIncome, logType: 'passive' },
+  requirements: { ...dropshippingConfig.requirements },
   quality: {
     summary: 'Research products, optimize listings, and scale advertising to grow a dependable e-commerce machine.',
     tracks: {
@@ -32,46 +43,46 @@ const dropshippingDefinition = createAssetDefinition({
     },
     levels: [
       {
-        level: 0,
+        level: dropshippingQualityLevel0.level,
         name: 'Prototype Pile',
         description: 'Inconsistent suppliers mean sporadic payouts.',
-        income: { min: 12, max: 20 },
-        requirements: {}
+        income: { ...dropshippingQualityLevel0.income }, // Spec: docs/normalized_economy.json → assets.dropshipping.quality_curve[0]
+        requirements: { ...dropshippingQualityLevel0.requirements }
       },
       {
-        level: 1,
+        level: dropshippingQualityLevel1.level,
         name: 'Optimized Listings',
         description: 'Top products have polished listings and reviews.',
-        income: { min: 24, max: 38 },
-        requirements: { research: 4 }
+        income: { ...dropshippingQualityLevel1.income }, // Spec: docs/normalized_economy.json → assets.dropshipping.quality_curve[1]
+        requirements: { ...dropshippingQualityLevel1.requirements }
       },
       {
-        level: 2,
+        level: dropshippingQualityLevel2.level,
         name: 'Automation Groove',
         description: 'Fulfillment and ad funnels make sales steady.',
-        income: { min: 44, max: 62 },
-        requirements: { research: 11, listing: 5 }
+        income: { ...dropshippingQualityLevel2.income }, // Spec: docs/normalized_economy.json → assets.dropshipping.quality_curve[2]
+        requirements: { ...dropshippingQualityLevel2.requirements }
       },
       {
-        level: 3,
+        level: dropshippingQualityLevel3.level,
         name: 'Scaled Flywheel',
         description: 'Paid campaigns bring consistent high-ticket orders.',
-        income: { min: 68, max: 92 },
-        requirements: { research: 18, listing: 8, ads: 7 }
+        income: { ...dropshippingQualityLevel3.income }, // Spec: docs/normalized_economy.json → assets.dropshipping.quality_curve[3]
+        requirements: { ...dropshippingQualityLevel3.requirements }
       },
       {
-        level: 4,
+        level: dropshippingQualityLevel4.level,
         name: 'Omnichannel Engine',
         description: 'Automation spans every marketplace and upsell funnel you run.',
-        income: { min: 95, max: 128 },
-        requirements: { research: 26, listing: 12, ads: 10 }
+        income: { ...dropshippingQualityLevel4.income }, // Spec: docs/normalized_economy.json → assets.dropshipping.quality_curve[4]
+        requirements: { ...dropshippingQualityLevel4.requirements }
       },
       {
-        level: 5,
+        level: dropshippingQualityLevel5.level,
         name: 'Global Logistics Titan',
         description: 'Worldwide warehouses and brand loyalty make daily profits thunder.',
-        income: { min: 130, max: 176 },
-        requirements: { research: 38, listing: 18, ads: 16 }
+        income: { ...dropshippingQualityLevel5.income }, // Spec: docs/normalized_economy.json → assets.dropshipping.quality_curve[5]
+        requirements: { ...dropshippingQualityLevel5.requirements }
       }
     ],
     actions: [

--- a/src/game/assets/definitions/ebook.js
+++ b/src/game/assets/definitions/ebook.js
@@ -1,6 +1,20 @@
 import { formatMoney } from '../../../core/helpers.js';
 import { createAssetDefinition } from '../../content/schema.js';
 import { triggerQualityActionEvents } from '../../events/index.js';
+import { assets as assetConfigs } from '../../data/economyConfig.js';
+
+const ebookConfig = assetConfigs.ebook; // Spec: docs/normalized_economy.json → assets.ebook
+const ebookSetup = ebookConfig.setup; // Spec: docs/normalized_economy.json → assets.ebook.schedule
+const ebookMaintenance = ebookConfig.maintenance; // Spec: docs/normalized_economy.json → assets.ebook.maintenance_time
+const ebookIncome = ebookConfig.income; // Spec: docs/normalized_economy.json → assets.ebook.base_income
+const [
+  ebookQualityLevel0,
+  ebookQualityLevel1,
+  ebookQualityLevel2,
+  ebookQualityLevel3,
+  ebookQualityLevel4,
+  ebookQualityLevel5
+] = ebookConfig.qualityLevels; // Spec: docs/normalized_economy.json → assets.ebook.quality_curve
 
 const ebookDefinition = createAssetDefinition({
   id: 'ebook',
@@ -9,15 +23,15 @@ const ebookDefinition = createAssetDefinition({
   tag: { label: 'Creative', type: 'passive' },
   tags: ['writing', 'product', 'digital'],
   description: 'Package your expertise into downloadable page-turners that sell while you snooze.',
-  setup: { days: 4, hoursPerDay: 3, cost: 260 },
-  maintenance: { hours: 0.5, cost: 3 },
+  setup: { ...ebookSetup },
+  maintenance: { ...ebookMaintenance },
   skills: {
     setup: [
       'writing',
       { id: 'editing', weight: 0.75 }
     ]
   },
-  income: { base: 30, variance: 0.2, logType: 'passive' },
+  income: { ...ebookIncome, logType: 'passive' },
   requirements: {
     knowledge: ['outlineMastery']
   },
@@ -30,46 +44,46 @@ const ebookDefinition = createAssetDefinition({
     },
     levels: [
       {
-        level: 0,
+        level: ebookQualityLevel0.level,
         name: 'Rough Manuscript',
         description: 'A handful of notes generate only trickle royalties.',
-        income: { min: 3, max: 6 },
-        requirements: {}
+        income: { ...ebookQualityLevel0.income }, // Spec: docs/normalized_economy.json → assets.ebook.quality_curve[0]
+        requirements: { ...ebookQualityLevel0.requirements }
       },
       {
-        level: 1,
+        level: ebookQualityLevel1.level,
         name: 'Polished Draft',
         description: 'Six chapters stitched into a bingeable volume.',
-        income: { min: 12, max: 20 },
-        requirements: { chapters: 6 }
+        income: { ...ebookQualityLevel1.income }, // Spec: docs/normalized_economy.json → assets.ebook.quality_curve[1]
+        requirements: { ...ebookQualityLevel1.requirements }
       },
       {
-        level: 2,
+        level: ebookQualityLevel2.level,
         name: 'Collector Edition',
         description: 'A premium cover and full season keep fans engaged.',
-        income: { min: 20, max: 30 },
-        requirements: { chapters: 12, cover: 1 }
+        income: { ...ebookQualityLevel2.income }, // Spec: docs/normalized_economy.json → assets.ebook.quality_curve[2]
+        requirements: { ...ebookQualityLevel2.requirements }
       },
       {
-        level: 3,
+        level: ebookQualityLevel3.level,
         name: 'Fandom Favorite',
         description: 'Glowing reviews lock in bestseller status.',
-        income: { min: 30, max: 42 },
-        requirements: { chapters: 18, cover: 2, reviews: 6 }
+        income: { ...ebookQualityLevel3.income }, // Spec: docs/normalized_economy.json → assets.ebook.quality_curve[3]
+        requirements: { ...ebookQualityLevel3.requirements }
       },
       {
-        level: 4,
+        level: ebookQualityLevel4.level,
         name: 'Box Set Sensation',
         description: 'Expanded universes and deluxe art bundles keep royalties rolling.',
-        income: { min: 44, max: 58 },
-        requirements: { chapters: 24, cover: 3, reviews: 10 }
+        income: { ...ebookQualityLevel4.income }, // Spec: docs/normalized_economy.json → assets.ebook.quality_curve[4]
+        requirements: { ...ebookQualityLevel4.requirements }
       },
       {
-        level: 5,
+        level: ebookQualityLevel5.level,
         name: 'Fandom Universe',
         description: 'Merch tie-ins and superfans push the series into evergreen bestseller lists.',
-        income: { min: 60, max: 78 },
-        requirements: { chapters: 32, cover: 4, reviews: 16 }
+        income: { ...ebookQualityLevel5.income }, // Spec: docs/normalized_economy.json → assets.ebook.quality_curve[5]
+        requirements: { ...ebookQualityLevel5.requirements }
       }
     ],
     actions: [

--- a/src/game/assets/definitions/saas.js
+++ b/src/game/assets/definitions/saas.js
@@ -1,6 +1,20 @@
 import { formatMoney } from '../../../core/helpers.js';
 import { createAssetDefinition } from '../../content/schema.js';
 import { triggerQualityActionEvents } from '../../events/index.js';
+import { assets as assetConfigs } from '../../data/economyConfig.js';
+
+const saasConfig = assetConfigs.saas; // Spec: docs/normalized_economy.json → assets.saas
+const saasSetup = saasConfig.setup; // Spec: docs/normalized_economy.json → assets.saas.schedule
+const saasMaintenance = saasConfig.maintenance; // Spec: docs/normalized_economy.json → assets.saas.maintenance_time
+const saasIncome = saasConfig.income; // Spec: docs/normalized_economy.json → assets.saas.base_income
+const [
+  saasQualityLevel0,
+  saasQualityLevel1,
+  saasQualityLevel2,
+  saasQualityLevel3,
+  saasQualityLevel4,
+  saasQualityLevel5
+] = saasConfig.qualityLevels; // Spec: docs/normalized_economy.json → assets.saas.quality_curve
 
 const saasDefinition = createAssetDefinition({
   id: 'saas',
@@ -9,8 +23,8 @@ const saasDefinition = createAssetDefinition({
   tag: { label: 'Tech', type: 'passive' },
   tags: ['software', 'tech', 'product'],
   description: 'Design lean software services, onboard early users, and ship updates that keep churn low.',
-  setup: { days: 8, hoursPerDay: 4, cost: 960 },
-  maintenance: { hours: 2.2, cost: 24 },
+  setup: { ...saasSetup },
+  maintenance: { ...saasMaintenance },
   skills: {
     setup: [
       'software',
@@ -18,15 +32,8 @@ const saasDefinition = createAssetDefinition({
       { id: 'promotion', weight: 0.5 }
     ]
   },
-  income: { base: 108, variance: 0.4, logType: 'passive' },
-  requirements: {
-    knowledge: ['automationCourse'],
-    equipment: ['serverCluster'],
-    experience: [
-      { assetId: 'dropshipping', count: 1 },
-      { assetId: 'ebook', count: 1 }
-    ]
-  },
+  income: { ...saasIncome, logType: 'passive' },
+  requirements: { ...saasConfig.requirements },
   quality: {
     summary: 'Build features, squash bugs, and fan out edge nodes to transform prototypes into global revenue engines.',
     tracks: {
@@ -37,46 +44,46 @@ const saasDefinition = createAssetDefinition({
     },
     levels: [
       {
-        level: 0,
+        level: saasQualityLevel0.level,
         name: 'Beta Sandbox',
         description: 'Tiny user base and messy bugs limit revenue.',
-        income: { min: 20, max: 32 },
-        requirements: {}
+        income: { ...saasQualityLevel0.income }, // Spec: docs/normalized_economy.json → assets.saas.quality_curve[0]
+        requirements: { ...saasQualityLevel0.requirements }
       },
       {
-        level: 1,
+        level: saasQualityLevel1.level,
         name: 'Early Traction',
         description: 'Feature roadmap clicks with early adopters.',
-        income: { min: 32, max: 48 },
-        requirements: { features: 4 }
+        income: { ...saasQualityLevel1.income }, // Spec: docs/normalized_economy.json → assets.saas.quality_curve[1]
+        requirements: { ...saasQualityLevel1.requirements }
       },
       {
-        level: 2,
+        level: saasQualityLevel2.level,
         name: 'Reliable Service',
         description: 'Reliability boosts and updates reduce churn.',
-        income: { min: 54, max: 74 },
-        requirements: { features: 12, stability: 5 }
+        income: { ...saasQualityLevel2.income }, // Spec: docs/normalized_economy.json → assets.saas.quality_curve[2]
+        requirements: { ...saasQualityLevel2.requirements }
       },
       {
-        level: 3,
+        level: saasQualityLevel3.level,
         name: 'Scaling Flywheel',
         description: 'Marketing pushes and infrastructure unlock bigger accounts.',
-        income: { min: 84, max: 120 },
-        requirements: { features: 24, stability: 8, marketing: 6 }
+        income: { ...saasQualityLevel3.income }, // Spec: docs/normalized_economy.json → assets.saas.quality_curve[3]
+        requirements: { ...saasQualityLevel3.requirements }
       },
       {
-        level: 4,
+        level: saasQualityLevel4.level,
         name: 'Global Edge Authority',
         description: 'Edge coverage, uptime bragging rights, and enterprise case studies pour gasoline on growth.',
-        income: { min: 120, max: 168 },
-        requirements: { features: 34, stability: 12, marketing: 10, edge: 4 }
+        income: { ...saasQualityLevel4.income }, // Spec: docs/normalized_economy.json → assets.saas.quality_curve[4]
+        requirements: { ...saasQualityLevel4.requirements }
       },
       {
-        level: 5,
+        level: saasQualityLevel5.level,
         name: 'Ecosystem Powerhouse',
         description: 'A thriving partner marketplace and integrations make churn basically mythical.',
-        income: { min: 168, max: 220 },
-        requirements: { features: 48, stability: 18, marketing: 15, edge: 8 }
+        income: { ...saasQualityLevel5.income }, // Spec: docs/normalized_economy.json → assets.saas.quality_curve[5]
+        requirements: { ...saasQualityLevel5.requirements }
       }
     ],
     actions: [

--- a/src/game/assets/definitions/stockPhotos.js
+++ b/src/game/assets/definitions/stockPhotos.js
@@ -1,6 +1,20 @@
 import { formatMoney } from '../../../core/helpers.js';
 import { createAssetDefinition } from '../../content/schema.js';
 import { triggerQualityActionEvents } from '../../events/index.js';
+import { assets as assetConfigs } from '../../data/economyConfig.js';
+
+const stockPhotosConfig = assetConfigs.stockPhotos; // Spec: docs/normalized_economy.json → assets.stockPhotos
+const stockPhotosSetup = stockPhotosConfig.setup; // Spec: docs/normalized_economy.json → assets.stockPhotos.schedule
+const stockPhotosMaintenance = stockPhotosConfig.maintenance; // Spec: docs/normalized_economy.json → assets.stockPhotos.maintenance_time
+const stockPhotosIncome = stockPhotosConfig.income; // Spec: docs/normalized_economy.json → assets.stockPhotos.base_income
+const [
+  stockPhotosQualityLevel0,
+  stockPhotosQualityLevel1,
+  stockPhotosQualityLevel2,
+  stockPhotosQualityLevel3,
+  stockPhotosQualityLevel4,
+  stockPhotosQualityLevel5
+] = stockPhotosConfig.qualityLevels; // Spec: docs/normalized_economy.json → assets.stockPhotos.quality_curve
 
 const stockPhotosDefinition = createAssetDefinition({
   id: 'stockPhotos',
@@ -9,8 +23,8 @@ const stockPhotosDefinition = createAssetDefinition({
   tag: { label: 'Creative', type: 'passive' },
   tags: ['photo', 'visual', 'content'],
   description: 'Stage props, shoot themed collections, and list them across marketplaces.',
-  setup: { days: 5, hoursPerDay: 4, cost: 560 },
-  maintenance: { hours: 0.8, cost: 10 },
+  setup: { ...stockPhotosSetup },
+  maintenance: { ...stockPhotosMaintenance },
   skills: {
     setup: [
       'visual',
@@ -18,7 +32,7 @@ const stockPhotosDefinition = createAssetDefinition({
       { id: 'promotion', weight: 0.4 }
     ]
   },
-  income: { base: 58, variance: 0.35, logType: 'passive' },
+  income: { ...stockPhotosIncome, logType: 'passive' },
   requirements: {
     equipment: ['camera', 'studio'],
     knowledge: ['photoLibrary']
@@ -32,46 +46,46 @@ const stockPhotosDefinition = createAssetDefinition({
     },
     levels: [
       {
-        level: 0,
+        level: stockPhotosQualityLevel0.level,
         name: 'Camera Roll Chaos',
         description: 'Unsorted shoots drip pennies.',
-        income: { min: 8, max: 14 },
-        requirements: {}
+        income: { ...stockPhotosQualityLevel0.income }, // Spec: docs/normalized_economy.json → assets.stockPhotos.quality_curve[0]
+        requirements: { ...stockPhotosQualityLevel0.requirements }
       },
       {
-        level: 1,
+        level: stockPhotosQualityLevel1.level,
         name: 'Curated Collections',
         description: 'Four themed shoots unlock daily bundles.',
-        income: { min: 18, max: 30 },
-        requirements: { shoots: 4 }
+        income: { ...stockPhotosQualityLevel1.income }, // Spec: docs/normalized_economy.json → assets.stockPhotos.quality_curve[1]
+        requirements: { ...stockPhotosQualityLevel1.requirements }
       },
       {
-        level: 2,
+        level: stockPhotosQualityLevel2.level,
         name: 'Marketplace Darling',
         description: 'Batch edits make downloads soar.',
-        income: { min: 34, max: 52 },
-        requirements: { shoots: 10, editing: 4 }
+        income: { ...stockPhotosQualityLevel2.income }, // Spec: docs/normalized_economy.json → assets.stockPhotos.quality_curve[2]
+        requirements: { ...stockPhotosQualityLevel2.requirements }
       },
       {
-        level: 3,
+        level: stockPhotosQualityLevel3.level,
         name: 'Brand Staple',
         description: 'Marketing funnels keep cash flowing.',
-        income: { min: 54, max: 78 },
-        requirements: { shoots: 16, editing: 7, marketing: 5 }
+        income: { ...stockPhotosQualityLevel3.income }, // Spec: docs/normalized_economy.json → assets.stockPhotos.quality_curve[3]
+        requirements: { ...stockPhotosQualityLevel3.requirements }
       },
       {
-        level: 4,
+        level: stockPhotosQualityLevel4.level,
         name: 'Agency Mainstay',
         description: 'Every campaign brief leans on your polished libraries.',
-        income: { min: 80, max: 108 },
-        requirements: { shoots: 24, editing: 11, marketing: 9 }
+        income: { ...stockPhotosQualityLevel4.income }, // Spec: docs/normalized_economy.json → assets.stockPhotos.quality_curve[4]
+        requirements: { ...stockPhotosQualityLevel4.requirements }
       },
       {
-        level: 5,
+        level: stockPhotosQualityLevel5.level,
         name: 'Global Brand Kit',
         description: 'Exclusive partnerships and licensing deals rain down premium royalties.',
-        income: { min: 112, max: 150 },
-        requirements: { shoots: 36, editing: 16, marketing: 14 }
+        income: { ...stockPhotosQualityLevel5.income }, // Spec: docs/normalized_economy.json → assets.stockPhotos.quality_curve[5]
+        requirements: { ...stockPhotosQualityLevel5.requirements }
       }
     ],
     actions: [

--- a/src/game/assets/definitions/vlog.js
+++ b/src/game/assets/definitions/vlog.js
@@ -1,6 +1,20 @@
 import { formatMoney } from '../../../core/helpers.js';
 import { createAssetDefinition } from '../../content/schema.js';
 import { triggerQualityActionEvents } from '../../events/index.js';
+import { assets as assetConfigs } from '../../data/economyConfig.js';
+
+const vlogConfig = assetConfigs.vlog; // Spec: docs/normalized_economy.json → assets.vlog
+const vlogSetup = vlogConfig.setup; // Spec: docs/normalized_economy.json → assets.vlog.schedule
+const vlogMaintenance = vlogConfig.maintenance; // Spec: docs/normalized_economy.json → assets.vlog.maintenance_time
+const vlogIncome = vlogConfig.income; // Spec: docs/normalized_economy.json → assets.vlog.base_income
+const [
+  vlogQualityLevel0,
+  vlogQualityLevel1,
+  vlogQualityLevel2,
+  vlogQualityLevel3,
+  vlogQualityLevel4,
+  vlogQualityLevel5
+] = vlogConfig.qualityLevels; // Spec: docs/normalized_economy.json → assets.vlog.quality_curve
 
 const vlogDefinition = createAssetDefinition({
   id: 'vlog',
@@ -9,8 +23,8 @@ const vlogDefinition = createAssetDefinition({
   tag: { label: 'Creative', type: 'passive' },
   tags: ['video', 'visual', 'content', 'studio'],
   description: 'Film upbeat vlogs, edit late-night montages, and ride the algorithmic rollercoaster.',
-  setup: { days: 4, hoursPerDay: 4, cost: 420 },
-  maintenance: { hours: 1.0, cost: 9 },
+  setup: { ...vlogSetup },
+  maintenance: { ...vlogMaintenance },
   skills: {
     setup: [
       'visual',
@@ -18,8 +32,7 @@ const vlogDefinition = createAssetDefinition({
     ]
   },
   income: {
-    base: 34,
-    variance: 0.2,
+    ...vlogIncome, // Spec: docs/normalized_economy.json → assets.vlog.base_income
     logType: 'passive'
   },
   requirements: {
@@ -34,46 +47,46 @@ const vlogDefinition = createAssetDefinition({
     },
     levels: [
       {
-        level: 0,
+        level: vlogQualityLevel0.level,
         name: 'Camera Shy',
         description: 'Footage trickles in with shaky vlogs and tiny ad pennies.',
-        income: { min: 2, max: 5 },
-        requirements: {}
+        income: { ...vlogQualityLevel0.income }, // Spec: docs/normalized_economy.json → assets.vlog.quality_curve[0]
+        requirements: { ...vlogQualityLevel0.requirements }
       },
       {
-        level: 1,
+        level: vlogQualityLevel1.level,
         name: 'Weekly Rhythm',
         description: 'A trio of uploads keeps subscribers checking in.',
-        income: { min: 12, max: 20 },
-        requirements: { videos: 4 }
+        income: { ...vlogQualityLevel1.income }, // Spec: docs/normalized_economy.json → assets.vlog.quality_curve[1]
+        requirements: { ...vlogQualityLevel1.requirements }
       },
       {
-        level: 2,
+        level: vlogQualityLevel2.level,
         name: 'Studio Shine',
         description: 'Crisp edits and pacing win over binge-watchers.',
-        income: { min: 20, max: 30 },
-        requirements: { videos: 10, edits: 4 }
+        income: { ...vlogQualityLevel2.income }, // Spec: docs/normalized_economy.json → assets.vlog.quality_curve[2]
+        requirements: { ...vlogQualityLevel2.requirements }
       },
       {
-        level: 3,
+        level: vlogQualityLevel3.level,
         name: 'Algorithm Darling',
         description: 'Hyped launches and collaborations unlock viral bursts.',
-        income: { min: 32, max: 40 },
-        requirements: { videos: 18, edits: 7, promotion: 5 }
+        income: { ...vlogQualityLevel3.income }, // Spec: docs/normalized_economy.json → assets.vlog.quality_curve[3]
+        requirements: { ...vlogQualityLevel3.requirements }
       },
       {
-        level: 4,
+        level: vlogQualityLevel4.level,
         name: 'Prime Time Partner',
         description: 'Sponsorship suites, editors, and co-hosts keep audiences glued.',
-        income: { min: 45, max: 58 },
-        requirements: { videos: 26, edits: 11, promotion: 9 }
+        income: { ...vlogQualityLevel4.income }, // Spec: docs/normalized_economy.json → assets.vlog.quality_curve[4]
+        requirements: { ...vlogQualityLevel4.requirements }
       },
       {
-        level: 5,
+        level: vlogQualityLevel5.level,
         name: 'Network Phenomenon',
         description: 'Streaming deals and global tours make every drop an event.',
-        income: { min: 62, max: 82 },
-        requirements: { videos: 38, edits: 16, promotion: 14 }
+        income: { ...vlogQualityLevel5.income }, // Spec: docs/normalized_economy.json → assets.vlog.quality_curve[5]
+        requirements: { ...vlogQualityLevel5.requirements }
       }
     ],
     actions: [

--- a/src/game/data/economyConfig.js
+++ b/src/game/data/economyConfig.js
@@ -1,0 +1,211 @@
+import normalizedEconomy from '../../../docs/normalized_economy.json' with { type: 'json' };
+
+const MINUTES_PER_HOUR = 60;
+
+const toHours = minutes => minutes / MINUTES_PER_HOUR;
+
+const mapQualityCurve = curve =>
+  curve.map(entry => ({
+    level: entry.level,
+    income: {
+      min: entry.income_min,
+      max: entry.income_max
+    },
+    requirements: entry.requirements || {}
+  }));
+
+const createAssetConfig = key => {
+  const asset = normalizedEconomy.assets[key];
+  const schedule = asset.schedule || {};
+
+  return {
+    setup: {
+      days: schedule.setup_days,
+      hoursPerDay: toHours(schedule.setup_minutes_per_day),
+      cost: asset.setup_cost
+    },
+    maintenance: {
+      hours: toHours(asset.maintenance_time),
+      cost: asset.maintenance_cost
+    },
+    income: {
+      base: asset.base_income,
+      variance: asset.variance
+    },
+    requirements: asset.requirements || {},
+    qualityLevels: mapQualityCurve(asset.quality_curve || [])
+  };
+};
+
+const createHustleConfig = key => {
+  const hustle = normalizedEconomy.hustles[key];
+  return {
+    timeHours: toHours(hustle.setup_time),
+    payout: hustle.base_income,
+    cost: hustle.setup_cost,
+    dailyLimit: hustle.daily_limit
+  };
+};
+
+const createUpgradeConfig = key => {
+  const upgrade = normalizedEconomy.upgrades[key];
+  return {
+    cost: upgrade.setup_cost,
+    requires: upgrade.requirements || []
+  };
+};
+
+const createTrackConfig = key => {
+  const track = normalizedEconomy.tracks[key];
+  const schedule = track.schedule || {};
+  return {
+    schedule: {
+      days: schedule.setup_days ?? schedule.days,
+      minutesPerDay: schedule.setup_minutes_per_day ?? schedule.minutes_per_day
+    },
+    rewards: track.rewards || {}
+  };
+};
+
+export const assets = {
+  // Spec: docs/normalized_economy.json → assets.blog
+  blog: createAssetConfig('blog'),
+  // Spec: docs/normalized_economy.json → assets.ebook
+  ebook: createAssetConfig('ebook'),
+  // Spec: docs/normalized_economy.json → assets.vlog
+  vlog: createAssetConfig('vlog'),
+  // Spec: docs/normalized_economy.json → assets.stockPhotos
+  stockPhotos: createAssetConfig('stockPhotos'),
+  // Spec: docs/normalized_economy.json → assets.dropshipping
+  dropshipping: createAssetConfig('dropshipping'),
+  // Spec: docs/normalized_economy.json → assets.saas
+  saas: createAssetConfig('saas')
+};
+
+export const hustles = {
+  // Spec: docs/normalized_economy.json → hustles.freelance
+  freelance: createHustleConfig('freelance'),
+  // Spec: docs/normalized_economy.json → hustles.audienceCall
+  audienceCall: createHustleConfig('audienceCall'),
+  // Spec: docs/normalized_economy.json → hustles.bundlePush
+  bundlePush: createHustleConfig('bundlePush'),
+  // Spec: docs/normalized_economy.json → hustles.surveySprint
+  surveySprint: createHustleConfig('surveySprint'),
+  // Spec: docs/normalized_economy.json → hustles.eventPhotoGig
+  eventPhotoGig: createHustleConfig('eventPhotoGig'),
+  // Spec: docs/normalized_economy.json → hustles.popUpWorkshop
+  popUpWorkshop: createHustleConfig('popUpWorkshop'),
+  // Spec: docs/normalized_economy.json → hustles.vlogEditRush
+  vlogEditRush: createHustleConfig('vlogEditRush'),
+  // Spec: docs/normalized_economy.json → hustles.dropshipPackParty
+  dropshipPackParty: createHustleConfig('dropshipPackParty'),
+  // Spec: docs/normalized_economy.json → hustles.saasBugSquash
+  saasBugSquash: createHustleConfig('saasBugSquash'),
+  // Spec: docs/normalized_economy.json → hustles.audiobookNarration
+  audiobookNarration: createHustleConfig('audiobookNarration'),
+  // Spec: docs/normalized_economy.json → hustles.streetPromoSprint
+  streetPromoSprint: createHustleConfig('streetPromoSprint')
+};
+
+export const upgrades = {
+  // Spec: docs/normalized_economy.json → upgrades.coffee
+  coffee: createUpgradeConfig('coffee'),
+  // Spec: docs/normalized_economy.json → upgrades.studio
+  studio: createUpgradeConfig('studio'),
+  // Spec: docs/normalized_economy.json → upgrades.studioExpansion
+  studioExpansion: createUpgradeConfig('studioExpansion'),
+  // Spec: docs/normalized_economy.json → upgrades.assistant
+  assistant: createUpgradeConfig('assistant'),
+  // Spec: docs/normalized_economy.json → upgrades.serverRack
+  serverRack: createUpgradeConfig('serverRack'),
+  // Spec: docs/normalized_economy.json → upgrades.fulfillmentAutomation
+  fulfillmentAutomation: createUpgradeConfig('fulfillmentAutomation'),
+  // Spec: docs/normalized_economy.json → upgrades.serverCluster
+  serverCluster: createUpgradeConfig('serverCluster'),
+  // Spec: docs/normalized_economy.json → upgrades.globalSupplyMesh
+  globalSupplyMesh: createUpgradeConfig('globalSupplyMesh'),
+  // Spec: docs/normalized_economy.json → upgrades.serverEdge
+  serverEdge: createUpgradeConfig('serverEdge'),
+  // Spec: docs/normalized_economy.json → upgrades.whiteLabelAlliance
+  whiteLabelAlliance: createUpgradeConfig('whiteLabelAlliance'),
+  // Spec: docs/normalized_economy.json → upgrades.creatorPhone
+  creatorPhone: createUpgradeConfig('creatorPhone'),
+  // Spec: docs/normalized_economy.json → upgrades.creatorPhonePro
+  creatorPhonePro: createUpgradeConfig('creatorPhonePro'),
+  // Spec: docs/normalized_economy.json → upgrades.creatorPhoneUltra
+  creatorPhoneUltra: createUpgradeConfig('creatorPhoneUltra'),
+  // Spec: docs/normalized_economy.json → upgrades.studioLaptop
+  studioLaptop: createUpgradeConfig('studioLaptop'),
+  // Spec: docs/normalized_economy.json → upgrades.editingWorkstation
+  editingWorkstation: createUpgradeConfig('editingWorkstation'),
+  // Spec: docs/normalized_economy.json → upgrades.quantumRig
+  quantumRig: createUpgradeConfig('quantumRig'),
+  // Spec: docs/normalized_economy.json → upgrades.monitorHub
+  monitorHub: createUpgradeConfig('monitorHub'),
+  // Spec: docs/normalized_economy.json → upgrades.dualMonitorArray
+  dualMonitorArray: createUpgradeConfig('dualMonitorArray'),
+  // Spec: docs/normalized_economy.json → upgrades.colorGradingDisplay
+  colorGradingDisplay: createUpgradeConfig('colorGradingDisplay'),
+  // Spec: docs/normalized_economy.json → upgrades.camera
+  camera: createUpgradeConfig('camera'),
+  // Spec: docs/normalized_economy.json → upgrades.cameraPro
+  cameraPro: createUpgradeConfig('cameraPro'),
+  // Spec: docs/normalized_economy.json → upgrades.audioSuite
+  audioSuite: createUpgradeConfig('audioSuite'),
+  // Spec: docs/normalized_economy.json → upgrades.ergonomicRefit
+  ergonomicRefit: createUpgradeConfig('ergonomicRefit'),
+  // Spec: docs/normalized_economy.json → upgrades.fiberInternet
+  fiberInternet: createUpgradeConfig('fiberInternet'),
+  // Spec: docs/normalized_economy.json → upgrades.backupPowerArray
+  backupPowerArray: createUpgradeConfig('backupPowerArray'),
+  // Spec: docs/normalized_economy.json → upgrades.scratchDriveArray
+  scratchDriveArray: createUpgradeConfig('scratchDriveArray'),
+  // Spec: docs/normalized_economy.json → upgrades.editorialPipeline
+  editorialPipeline: createUpgradeConfig('editorialPipeline'),
+  // Spec: docs/normalized_economy.json → upgrades.syndicationSuite
+  syndicationSuite: createUpgradeConfig('syndicationSuite'),
+  // Spec: docs/normalized_economy.json → upgrades.immersiveStoryWorlds
+  immersiveStoryWorlds: createUpgradeConfig('immersiveStoryWorlds'),
+  // Spec: docs/normalized_economy.json → upgrades.course
+  course: createUpgradeConfig('course')
+};
+
+export const tracks = {
+  // Spec: docs/normalized_economy.json → tracks.storycraftJumpstart
+  storycraftJumpstart: createTrackConfig('storycraftJumpstart'),
+  // Spec: docs/normalized_economy.json → tracks.vlogStudioJumpstart
+  vlogStudioJumpstart: createTrackConfig('vlogStudioJumpstart'),
+  // Spec: docs/normalized_economy.json → tracks.digitalShelfPrimer
+  digitalShelfPrimer: createTrackConfig('digitalShelfPrimer'),
+  // Spec: docs/normalized_economy.json → tracks.commerceLaunchPrimer
+  commerceLaunchPrimer: createTrackConfig('commerceLaunchPrimer'),
+  // Spec: docs/normalized_economy.json → tracks.microSaasJumpstart
+  microSaasJumpstart: createTrackConfig('microSaasJumpstart'),
+  // Spec: docs/normalized_economy.json → tracks.outlineMastery
+  outlineMastery: createTrackConfig('outlineMastery'),
+  // Spec: docs/normalized_economy.json → tracks.photoLibrary
+  photoLibrary: createTrackConfig('photoLibrary'),
+  // Spec: docs/normalized_economy.json → tracks.ecomPlaybook
+  ecomPlaybook: createTrackConfig('ecomPlaybook'),
+  // Spec: docs/normalized_economy.json → tracks.automationCourse
+  automationCourse: createTrackConfig('automationCourse'),
+  // Spec: docs/normalized_economy.json → tracks.brandVoiceLab
+  brandVoiceLab: createTrackConfig('brandVoiceLab'),
+  // Spec: docs/normalized_economy.json → tracks.guerillaBuzzWorkshop
+  guerillaBuzzWorkshop: createTrackConfig('guerillaBuzzWorkshop'),
+  // Spec: docs/normalized_economy.json → tracks.curriculumDesignStudio
+  curriculumDesignStudio: createTrackConfig('curriculumDesignStudio'),
+  // Spec: docs/normalized_economy.json → tracks.postProductionPipelineLab
+  postProductionPipelineLab: createTrackConfig('postProductionPipelineLab'),
+  // Spec: docs/normalized_economy.json → tracks.fulfillmentOpsMasterclass
+  fulfillmentOpsMasterclass: createTrackConfig('fulfillmentOpsMasterclass'),
+  // Spec: docs/normalized_economy.json → tracks.customerRetentionClinic
+  customerRetentionClinic: createTrackConfig('customerRetentionClinic'),
+  // Spec: docs/normalized_economy.json → tracks.narrationPerformanceWorkshop
+  narrationPerformanceWorkshop: createTrackConfig('narrationPerformanceWorkshop'),
+  // Spec: docs/normalized_economy.json → tracks.galleryLicensingSummit
+  galleryLicensingSummit: createTrackConfig('galleryLicensingSummit'),
+  // Spec: docs/normalized_economy.json → tracks.syndicationResidency
+  syndicationResidency: createTrackConfig('syndicationResidency')
+};
+

--- a/src/game/hustles/definitions/instantHustles.js
+++ b/src/game/hustles/definitions/instantHustles.js
@@ -10,6 +10,19 @@ import {
   NARRATION_REQUIREMENTS,
   STREET_PROMO_REQUIREMENTS
 } from '../helpers.js';
+import { hustles as hustleConfigs } from '../../data/economyConfig.js';
+
+const freelanceConfig = hustleConfigs.freelance; // Spec: docs/normalized_economy.json → hustles.freelance
+const audienceCallConfig = hustleConfigs.audienceCall; // Spec: docs/normalized_economy.json → hustles.audienceCall
+const bundlePushConfig = hustleConfigs.bundlePush; // Spec: docs/normalized_economy.json → hustles.bundlePush
+const surveySprintConfig = hustleConfigs.surveySprint; // Spec: docs/normalized_economy.json → hustles.surveySprint
+const eventPhotoGigConfig = hustleConfigs.eventPhotoGig; // Spec: docs/normalized_economy.json → hustles.eventPhotoGig
+const popUpWorkshopConfig = hustleConfigs.popUpWorkshop; // Spec: docs/normalized_economy.json → hustles.popUpWorkshop
+const vlogEditRushConfig = hustleConfigs.vlogEditRush; // Spec: docs/normalized_economy.json → hustles.vlogEditRush
+const dropshipPackPartyConfig = hustleConfigs.dropshipPackParty; // Spec: docs/normalized_economy.json → hustles.dropshipPackParty
+const saasBugSquashConfig = hustleConfigs.saasBugSquash; // Spec: docs/normalized_economy.json → hustles.saasBugSquash
+const audiobookNarrationConfig = hustleConfigs.audiobookNarration; // Spec: docs/normalized_economy.json → hustles.audiobookNarration
+const streetPromoSprintConfig = hustleConfigs.streetPromoSprint; // Spec: docs/normalized_economy.json → hustles.streetPromoSprint
 
 const instantHustleDefinitions = [
   {
@@ -18,12 +31,12 @@ const instantHustleDefinitions = [
     tag: { label: 'Instant', type: 'instant' },
     description: 'Crank out a quick article for a client. Not Pulitzer material, but it pays.',
     tags: ['writing', 'desktop_work'],
-    time: 2,
+    time: freelanceConfig.timeHours, // Spec: docs/normalized_economy.json → hustles.freelance.setup_time
     payout: {
-      amount: 18,
+      amount: freelanceConfig.payout, // Spec: docs/normalized_economy.json → hustles.freelance.base_income
       logType: 'hustle',
       message: context => {
-        const payout = context?.finalPayout ?? context?.payoutGranted ?? 18;
+        const payout = context?.finalPayout ?? context?.payoutGranted ?? freelanceConfig.payout;
         const bonusNote = context?.appliedEducationBoosts?.length
           ? ' Your storytelling drills juiced the rate!'
           : '';
@@ -43,14 +56,14 @@ const instantHustleDefinitions = [
     tag: { label: 'Instant', type: 'instant' },
     description: 'Host a 60-minute livestream for your blog readers and pitch a premium checklist.',
     tags: ['community', 'live', 'video'],
-    time: 1,
+    time: audienceCallConfig.timeHours, // Spec: docs/normalized_economy.json → hustles.audienceCall.setup_time
     requirements: AUDIENCE_CALL_REQUIREMENTS,
-    dailyLimit: 1,
+    dailyLimit: audienceCallConfig.dailyLimit, // Spec: docs/normalized_economy.json → hustles.audienceCall.daily_limit
     payout: {
-      amount: 12,
+      amount: audienceCallConfig.payout, // Spec: docs/normalized_economy.json → hustles.audienceCall.base_income
       logType: 'hustle',
       message: context => {
-        const payout = context?.finalPayout ?? context?.payoutGranted ?? 12;
+        const payout = context?.finalPayout ?? context?.payoutGranted ?? audienceCallConfig.payout;
         const bonusNote = context?.appliedEducationBoosts?.length
           ? ' Spotlight-ready banter brought in extra tips.'
           : '';
@@ -70,13 +83,13 @@ const instantHustleDefinitions = [
     tag: { label: 'Instant', type: 'instant' },
     description: 'Pair your top blogs with an e-book bonus bundle for a limited-time flash sale.',
     tags: ['commerce', 'marketing'],
-    time: 2.5,
+    time: bundlePushConfig.timeHours, // Spec: docs/normalized_economy.json → hustles.bundlePush.setup_time
     requirements: BUNDLE_PUSH_REQUIREMENTS,
     payout: {
-      amount: 48,
+      amount: bundlePushConfig.payout, // Spec: docs/normalized_economy.json → hustles.bundlePush.base_income
       logType: 'hustle',
       message: context => {
-        const payout = context?.finalPayout ?? context?.payoutGranted ?? 48;
+        const payout = context?.finalPayout ?? context?.payoutGranted ?? bundlePushConfig.payout;
         const bonusNote = context?.appliedEducationBoosts?.length
           ? ' Funnel math mastery made every upsell sparkle.'
           : '';
@@ -96,13 +109,13 @@ const instantHustleDefinitions = [
     tag: { label: 'Instant', type: 'instant' },
     description: 'Knock out a 15-minute feedback survey while your coffee is still warm.',
     tags: ['ops', 'desktop_work'],
-    time: 0.25,
-    dailyLimit: 4,
+    time: surveySprintConfig.timeHours, // Spec: docs/normalized_economy.json → hustles.surveySprint.setup_time
+    dailyLimit: surveySprintConfig.dailyLimit, // Spec: docs/normalized_economy.json → hustles.surveySprint.daily_limit
     payout: {
-      amount: 1,
+      amount: surveySprintConfig.payout, // Spec: docs/normalized_economy.json → hustles.surveySprint.base_income
       logType: 'hustle',
       message: context => {
-        const payout = context?.finalPayout ?? context?.payoutGranted ?? 1;
+        const payout = context?.finalPayout ?? context?.payoutGranted ?? surveySprintConfig.payout;
         const bonusNote = context?.appliedEducationBoosts?.length
           ? ' Guerrilla research savvy bumped the stipend.'
           : '';
@@ -122,13 +135,13 @@ const instantHustleDefinitions = [
     tag: { label: 'Instant', type: 'instant' },
     description: 'Grab your gallery gear and capture candid magic at a pop-up showcase.',
     tags: ['photo', 'shoot', 'studio'],
-    time: 3.5,
+    time: eventPhotoGigConfig.timeHours, // Spec: docs/normalized_economy.json → hustles.eventPhotoGig.setup_time
     requirements: EVENT_PHOTO_REQUIREMENTS,
     payout: {
-      amount: 72,
+      amount: eventPhotoGigConfig.payout, // Spec: docs/normalized_economy.json → hustles.eventPhotoGig.base_income
       logType: 'hustle',
       message: context => {
-        const payout = context?.finalPayout ?? context?.payoutGranted ?? 72;
+        const payout = context?.finalPayout ?? context?.payoutGranted ?? eventPhotoGigConfig.payout;
         const bonusNote = context?.appliedEducationBoosts?.length
           ? ' Curated portfolios impressed every client.'
           : '';
@@ -148,13 +161,13 @@ const instantHustleDefinitions = [
     tag: { label: 'Instant', type: 'instant' },
     description: 'Host a cozy crash course that blends your blog insights with e-book handouts.',
     tags: ['education', 'in_person'],
-    time: 2.5,
+    time: popUpWorkshopConfig.timeHours, // Spec: docs/normalized_economy.json → hustles.popUpWorkshop.setup_time
     requirements: WORKSHOP_REQUIREMENTS,
     payout: {
-      amount: 38,
+      amount: popUpWorkshopConfig.payout, // Spec: docs/normalized_economy.json → hustles.popUpWorkshop.base_income
       logType: 'hustle',
       message: context => {
-        const payout = context?.finalPayout ?? context?.payoutGranted ?? 38;
+        const payout = context?.finalPayout ?? context?.payoutGranted ?? popUpWorkshopConfig.payout;
         const bonusNote = context?.appliedEducationBoosts?.length
           ? ' Teaching polish turned browsers into buyers.'
           : '';
@@ -174,13 +187,13 @@ const instantHustleDefinitions = [
     tag: { label: 'Instant', type: 'instant' },
     description: 'Slice, color, and caption a backlog vlog episode for a partner channel.',
     tags: ['video', 'editing', 'desktop_work'],
-    time: 1.5,
+    time: vlogEditRushConfig.timeHours, // Spec: docs/normalized_economy.json → hustles.vlogEditRush.setup_time
     requirements: EDIT_RUSH_REQUIREMENTS,
     payout: {
-      amount: 24,
+      amount: vlogEditRushConfig.payout, // Spec: docs/normalized_economy.json → hustles.vlogEditRush.base_income
       logType: 'hustle',
       message: context => {
-        const payout = context?.finalPayout ?? context?.payoutGranted ?? 24;
+        const payout = context?.finalPayout ?? context?.payoutGranted ?? vlogEditRushConfig.payout;
         const bonusNote = context?.appliedEducationBoosts?.length
           ? ' Post-production precision shaved hours off the deadline.'
           : '';
@@ -200,14 +213,14 @@ const instantHustleDefinitions = [
     tag: { label: 'Instant', type: 'instant' },
     description: 'Bundle hot orders with branded tissue paper and a confetti of thank-you notes.',
     tags: ['commerce', 'fulfillment'],
-    time: 2,
-    cost: 8,
+    time: dropshipPackPartyConfig.timeHours, // Spec: docs/normalized_economy.json → hustles.dropshipPackParty.setup_time
+    cost: dropshipPackPartyConfig.cost, // Spec: docs/normalized_economy.json → hustles.dropshipPackParty.setup_cost
     requirements: PACK_PARTY_REQUIREMENTS,
     payout: {
-      amount: 28,
+      amount: dropshipPackPartyConfig.payout, // Spec: docs/normalized_economy.json → hustles.dropshipPackParty.base_income
       logType: 'hustle',
       message: context => {
-        const payout = context?.finalPayout ?? context?.payoutGranted ?? 28;
+        const payout = context?.finalPayout ?? context?.payoutGranted ?? dropshipPackPartyConfig.payout;
         const bonusNote = context?.appliedEducationBoosts?.length
           ? ' Logistics drills kept the conveyor humming.'
           : '';
@@ -228,13 +241,13 @@ const instantHustleDefinitions = [
     tag: { label: 'Instant', type: 'instant' },
     description: 'Dig through error logs and deploy a patch before support tickets pile up.',
     tags: ['software', 'ops'],
-    time: 1,
+    time: saasBugSquashConfig.timeHours, // Spec: docs/normalized_economy.json → hustles.saasBugSquash.setup_time
     requirements: BUG_SQUASH_REQUIREMENTS,
     payout: {
-      amount: 30,
+      amount: saasBugSquashConfig.payout, // Spec: docs/normalized_economy.json → hustles.saasBugSquash.base_income
       logType: 'hustle',
       message: context => {
-        const payout = context?.finalPayout ?? context?.payoutGranted ?? 30;
+        const payout = context?.finalPayout ?? context?.payoutGranted ?? saasBugSquashConfig.payout;
         const bonusNote = context?.appliedEducationBoosts?.length
           ? ' Architectural insights made debugging a breeze.'
           : '';
@@ -254,13 +267,13 @@ const instantHustleDefinitions = [
     tag: { label: 'Instant', type: 'instant' },
     description: 'Record a silky-smooth sample chapter to hype your flagship e-book series.',
     tags: ['audio', 'studio'],
-    time: 2.75,
+    time: audiobookNarrationConfig.timeHours, // Spec: docs/normalized_economy.json → hustles.audiobookNarration.setup_time
     requirements: NARRATION_REQUIREMENTS,
     payout: {
-      amount: 44,
+      amount: audiobookNarrationConfig.payout, // Spec: docs/normalized_economy.json → hustles.audiobookNarration.base_income
       logType: 'hustle',
       message: context => {
-        const payout = context?.finalPayout ?? context?.payoutGranted ?? 44;
+        const payout = context?.finalPayout ?? context?.payoutGranted ?? audiobookNarrationConfig.payout;
         const bonusNote = context?.appliedEducationBoosts?.length
           ? ' Narrative confidence kept the script soaring.'
           : '';
@@ -280,14 +293,14 @@ const instantHustleDefinitions = [
     tag: { label: 'Instant', type: 'instant' },
     description: 'Hand out QR stickers at a pop-up market to funnel readers toward your latest drops.',
     tags: ['marketing', 'field'],
-    time: 0.75,
-    cost: 5,
+    time: streetPromoSprintConfig.timeHours, // Spec: docs/normalized_economy.json → hustles.streetPromoSprint.setup_time
+    cost: streetPromoSprintConfig.cost, // Spec: docs/normalized_economy.json → hustles.streetPromoSprint.setup_cost
     requirements: STREET_PROMO_REQUIREMENTS,
     payout: {
-      amount: 18,
+      amount: streetPromoSprintConfig.payout, // Spec: docs/normalized_economy.json → hustles.streetPromoSprint.base_income
       logType: 'hustle',
       message: context => {
-        const payout = context?.finalPayout ?? context?.payoutGranted ?? 18;
+        const payout = context?.finalPayout ?? context?.payoutGranted ?? streetPromoSprintConfig.payout;
         const bonusNote = context?.appliedEducationBoosts?.length
           ? ' Guerrilla tactics drew a bigger crowd.'
           : '';

--- a/src/game/upgrades/definitions/house.js
+++ b/src/game/upgrades/definitions/house.js
@@ -1,3 +1,8 @@
+import { upgrades as upgradeConfigs } from '../../data/economyConfig.js';
+
+const studioConfig = upgradeConfigs.studio; // Spec: docs/normalized_economy.json → upgrades.studio
+const studioExpansionConfig = upgradeConfigs.studioExpansion; // Spec: docs/normalized_economy.json → upgrades.studioExpansion
+
 const house = [
   {
     id: 'studio',
@@ -7,7 +12,7 @@ const house = [
     category: 'house',
     family: 'lighting',
     exclusivityGroup: 'house:lighting',
-    cost: 220,
+    cost: studioConfig.cost, // Spec: docs/normalized_economy.json → upgrades.studio.setup_cost
     unlocks: 'Stock Photo Galleries',
     skills: [ 'visual' ],
     effects: { maint_time_mult: 0.9 },
@@ -30,8 +35,8 @@ const house = [
     category: 'house',
     family: 'studio',
     exclusivityGroup: 'house:studio',
-    cost: 540,
-    requires: [ 'studio' ],
+    cost: studioExpansionConfig.cost, // Spec: docs/normalized_economy.json → upgrades.studioExpansion.setup_cost
+    requires: studioExpansionConfig.requires, // Spec: docs/normalized_economy.json → upgrades.studioExpansion.requirements
     boosts: 'Stock photo payouts + faster shoot progress',
     effects: {
       setup_time_mult: 0.85,

--- a/src/game/upgrades/definitions/infra.js
+++ b/src/game/upgrades/definitions/infra.js
@@ -1,3 +1,12 @@
+import { upgrades as upgradeConfigs } from '../../data/economyConfig.js';
+
+const serverRackConfig = upgradeConfigs.serverRack; // Spec: docs/normalized_economy.json → upgrades.serverRack
+const fulfillmentAutomationConfig = upgradeConfigs.fulfillmentAutomation; // Spec: docs/normalized_economy.json → upgrades.fulfillmentAutomation
+const serverClusterConfig = upgradeConfigs.serverCluster; // Spec: docs/normalized_economy.json → upgrades.serverCluster
+const globalSupplyMeshConfig = upgradeConfigs.globalSupplyMesh; // Spec: docs/normalized_economy.json → upgrades.globalSupplyMesh
+const serverEdgeConfig = upgradeConfigs.serverEdge; // Spec: docs/normalized_economy.json → upgrades.serverEdge
+const whiteLabelAllianceConfig = upgradeConfigs.whiteLabelAlliance; // Spec: docs/normalized_economy.json → upgrades.whiteLabelAlliance
+
 const infra = [
   {
     id: 'assistant',
@@ -18,7 +27,7 @@ const infra = [
     description: 'Spin up a reliable rack with monitoring so prototypes stay online.',
     category: 'infra',
     family: 'cloud_compute',
-    cost: 650,
+    cost: serverRackConfig.cost, // Spec: docs/normalized_economy.json → upgrades.serverRack.setup_cost
     unlocks: 'Stable environments for advanced products',
     effects: { setup_time_mult: 0.95 },
     affects: {
@@ -46,7 +55,7 @@ const infra = [
     description: 'Tie together your winning storefronts with automated pick, pack, and ship magic.',
     category: 'infra',
     family: 'automation',
-    cost: 780,
+    cost: fulfillmentAutomationConfig.cost, // Spec: docs/normalized_economy.json → upgrades.fulfillmentAutomation.setup_cost
     requires: [
       { type: 'asset', id: 'dropshipping', count: 2, active: true },
       {
@@ -82,8 +91,8 @@ const infra = [
     description: 'Deploy auto-scaling containers and CI pipelines so your SaaS survives launch day.',
     category: 'infra',
     family: 'cloud_compute',
-    cost: 1150,
-    requires: [ 'serverRack' ],
+    cost: serverClusterConfig.cost, // Spec: docs/normalized_economy.json → upgrades.serverCluster.setup_cost
+    requires: serverClusterConfig.requires, // Spec: docs/normalized_economy.json → upgrades.serverCluster.requirements
     unlocks: 'SaaS deployments',
     effects: { payout_mult: 1.2, quality_progress_mult: 1.5 },
     affects: {
@@ -110,7 +119,7 @@ const infra = [
     description: 'Forge data-sharing deals with worldwide 3PL partners so inventory never sleeps.',
     category: 'infra',
     family: 'automation',
-    cost: 1150,
+    cost: globalSupplyMeshConfig.cost, // Spec: docs/normalized_economy.json → upgrades.globalSupplyMesh.setup_cost
     requires: [
       'fulfillmentAutomation',
       { type: 'asset', id: 'dropshipping', count: 3, active: true },
@@ -155,8 +164,8 @@ const infra = [
     description: 'Distribute workloads across edge nodes for instant response times and uptime bragging rights.',
     category: 'infra',
     family: 'edge_network',
-    cost: 1450,
-    requires: [ 'serverCluster' ],
+    cost: serverEdgeConfig.cost, // Spec: docs/normalized_economy.json → upgrades.serverEdge.setup_cost
+    requires: serverEdgeConfig.requires, // Spec: docs/normalized_economy.json → upgrades.serverEdge.requirements
     boosts: 'SaaS payouts + stability progress surges',
     effects: {
       payout_mult: 1.35,
@@ -188,7 +197,7 @@ const infra = [
     description: 'Partner with boutique studios to bundle your galleries with each storefront launch.',
     category: 'infra',
     family: 'commerce_network',
-    cost: 1500,
+    cost: whiteLabelAllianceConfig.cost, // Spec: docs/normalized_economy.json → upgrades.whiteLabelAlliance.setup_cost
     requires: [
       'globalSupplyMesh',
       { type: 'asset', id: 'dropshipping', count: 4, active: true },

--- a/src/game/upgrades/definitions/support.js
+++ b/src/game/upgrades/definitions/support.js
@@ -1,3 +1,7 @@
+import { upgrades as upgradeConfigs } from '../../data/economyConfig.js';
+
+const coffeeConfig = upgradeConfigs.coffee; // Spec: docs/normalized_economy.json → upgrades.coffee
+
 const support = [
   {
     id: 'coffee',
@@ -6,7 +10,7 @@ const support = [
     description: 'Instantly gain +1h of focus for today. Side effects include jittery success.',
     category: 'support',
     family: 'consumable',
-    cost: 40,
+    cost: coffeeConfig.cost, // Spec: docs/normalized_economy.json → upgrades.coffee.setup_cost
     repeatable: true,
     defaultState: { usedToday: 0 },
     actionClassName: 'secondary',

--- a/src/game/upgrades/definitions/tech/audio.js
+++ b/src/game/upgrades/definitions/tech/audio.js
@@ -1,3 +1,7 @@
+import { upgrades as upgradeConfigs } from '../../../data/economyConfig.js';
+
+const audioSuiteConfig = upgradeConfigs.audioSuite; // Spec: docs/normalized_economy.json → upgrades.audioSuite
+
 const audio = [
   {
     id: 'audioSuite',
@@ -6,7 +10,7 @@ const audio = [
     description: 'Treat the studio with acoustic foam, preamps, and mastering plug-ins.',
     category: 'tech',
     family: 'audio',
-    cost: 420,
+    cost: audioSuiteConfig.cost, // Spec: docs/normalized_economy.json → upgrades.audioSuite.setup_cost
     effects: { quality_progress_mult: 1.4 },
     affects: {
       assets: { tags: [ 'audio', 'video' ] },

--- a/src/game/upgrades/definitions/tech/cameras.js
+++ b/src/game/upgrades/definitions/tech/cameras.js
@@ -1,3 +1,8 @@
+import { upgrades as upgradeConfigs } from '../../../data/economyConfig.js';
+
+const cameraConfig = upgradeConfigs.camera; // Spec: docs/normalized_economy.json → upgrades.camera
+const cameraProConfig = upgradeConfigs.cameraPro; // Spec: docs/normalized_economy.json → upgrades.cameraPro
+
 const cameras = [
   {
     id: 'camera',
@@ -7,7 +12,7 @@ const cameras = [
     category: 'tech',
     family: 'camera',
     exclusivityGroup: 'tech:camera',
-    cost: 200,
+    cost: cameraConfig.cost, // Spec: docs/normalized_economy.json → upgrades.camera.setup_cost
     unlocks: 'Weekly Vlog Channel & Stock Photo Galleries',
     skills: [ 'visual' ],
     effects: { setup_time_mult: 0.9 },
@@ -31,8 +36,8 @@ const cameras = [
     category: 'tech',
     family: 'camera',
     exclusivityGroup: 'tech:camera',
-    cost: 480,
-    requires: [ 'camera' ],
+    cost: cameraProConfig.cost, // Spec: docs/normalized_economy.json → upgrades.cameraPro.setup_cost
+    requires: cameraProConfig.requires, // Spec: docs/normalized_economy.json → upgrades.cameraPro.requirements
     boosts: 'Boosts vlog payouts and doubles quality progress',
     effects: {
       setup_time_mult: 0.85,

--- a/src/game/upgrades/definitions/tech/ergonomics.js
+++ b/src/game/upgrades/definitions/tech/ergonomics.js
@@ -1,3 +1,7 @@
+import { upgrades as upgradeConfigs } from '../../../data/economyConfig.js';
+
+const ergonomicRefitConfig = upgradeConfigs.ergonomicRefit; // Spec: docs/normalized_economy.json → upgrades.ergonomicRefit
+
 const ergonomics = [
   {
     id: 'ergonomicRefit',
@@ -6,7 +10,7 @@ const ergonomics = [
     description: 'Sit-stand desk, supportive chair, and smart lighting for marathon editing sessions.',
     category: 'tech',
     family: 'ergonomics',
-    cost: 180,
+    cost: ergonomicRefitConfig.cost, // Spec: docs/normalized_economy.json → upgrades.ergonomicRefit.setup_cost
     effects: { maint_time_mult: 0.95 },
     affects: {
       assets: { tags: [ 'desktop_work' ] },

--- a/src/game/upgrades/definitions/tech/monitors.js
+++ b/src/game/upgrades/definitions/tech/monitors.js
@@ -1,3 +1,9 @@
+import { upgrades as upgradeConfigs } from '../../../data/economyConfig.js';
+
+const monitorHubConfig = upgradeConfigs.monitorHub; // Spec: docs/normalized_economy.json → upgrades.monitorHub
+const dualMonitorArrayConfig = upgradeConfigs.dualMonitorArray; // Spec: docs/normalized_economy.json → upgrades.dualMonitorArray
+const colorGradingDisplayConfig = upgradeConfigs.colorGradingDisplay; // Spec: docs/normalized_economy.json → upgrades.colorGradingDisplay
+
 const monitors = [
   {
     id: 'monitorHub',
@@ -6,7 +12,7 @@ const monitors = [
     description: 'Dock station that powers two 4K monitors with one cable and instant switching.',
     category: 'tech',
     family: 'monitor_hub',
-    cost: 180,
+    cost: monitorHubConfig.cost, // Spec: docs/normalized_economy.json → upgrades.monitorHub.setup_cost
     provides: { monitor: 2 },
     effects: { setup_time_mult: 0.95 },
     affects: {
@@ -24,8 +30,8 @@ const monitors = [
     description: 'Mount two ultra-thin displays for editing, dashboards, and reference boards.',
     category: 'tech',
     family: 'monitor',
-    cost: 240,
-    requires: [ 'monitorHub' ],
+    cost: dualMonitorArrayConfig.cost, // Spec: docs/normalized_economy.json → upgrades.dualMonitorArray.setup_cost
+    requires: dualMonitorArrayConfig.requires, // Spec: docs/normalized_economy.json → upgrades.dualMonitorArray.requirements
     consumes: { monitor: 1 },
     effects: { quality_progress_mult: 1.2 },
     affects: {
@@ -43,8 +49,8 @@ const monitors = [
     description: 'Reference-grade display for colorists and photo editors who need true-to-life hues.',
     category: 'tech',
     family: 'monitor',
-    cost: 380,
-    requires: [ 'dualMonitorArray' ],
+    cost: colorGradingDisplayConfig.cost, // Spec: docs/normalized_economy.json → upgrades.colorGradingDisplay.setup_cost
+    requires: colorGradingDisplayConfig.requires, // Spec: docs/normalized_economy.json → upgrades.colorGradingDisplay.requirements
     consumes: { monitor: 1 },
     effects: { quality_progress_mult: 1.3 },
     affects: {

--- a/src/game/upgrades/definitions/tech/network.js
+++ b/src/game/upgrades/definitions/tech/network.js
@@ -1,3 +1,7 @@
+import { upgrades as upgradeConfigs } from '../../../data/economyConfig.js';
+
+const fiberInternetConfig = upgradeConfigs.fiberInternet; // Spec: docs/normalized_economy.json → upgrades.fiberInternet
+
 const network = [
   {
     id: 'fiberInternet',
@@ -6,7 +10,7 @@ const network = [
     description: 'Symmetrical gigabit connection with service-level guarantees for uploads.',
     category: 'tech',
     family: 'internet',
-    cost: 260,
+    cost: fiberInternetConfig.cost, // Spec: docs/normalized_economy.json → upgrades.fiberInternet.setup_cost
     effects: { maint_time_mult: 0.9 },
     affects: {
       assets: { tags: [ 'video', 'software' ] },

--- a/src/game/upgrades/definitions/tech/pcs.js
+++ b/src/game/upgrades/definitions/tech/pcs.js
@@ -1,3 +1,9 @@
+import { upgrades as upgradeConfigs } from '../../../data/economyConfig.js';
+
+const studioLaptopConfig = upgradeConfigs.studioLaptop; // Spec: docs/normalized_economy.json → upgrades.studioLaptop
+const editingWorkstationConfig = upgradeConfigs.editingWorkstation; // Spec: docs/normalized_economy.json → upgrades.editingWorkstation
+const quantumRigConfig = upgradeConfigs.quantumRig; // Spec: docs/normalized_economy.json → upgrades.quantumRig
+
 const pcs = [
   {
     id: 'studioLaptop',
@@ -7,7 +13,7 @@ const pcs = [
     category: 'tech',
     family: 'pc',
     exclusivityGroup: 'tech:pc',
-    cost: 280,
+    cost: studioLaptopConfig.cost, // Spec: docs/normalized_economy.json → upgrades.studioLaptop.setup_cost
     effects: { setup_time_mult: 0.92 },
     affects: {
       assets: { tags: [ 'desktop_work' ] },
@@ -26,8 +32,8 @@ const pcs = [
     category: 'tech',
     family: 'pc',
     exclusivityGroup: 'tech:pc',
-    cost: 640,
-    requires: [ 'studioLaptop' ],
+    cost: editingWorkstationConfig.cost, // Spec: docs/normalized_economy.json → upgrades.editingWorkstation.setup_cost
+    requires: editingWorkstationConfig.requires, // Spec: docs/normalized_economy.json → upgrades.editingWorkstation.requirements
     effects: { setup_time_mult: 0.85, maint_time_mult: 0.9 },
     affects: {
       assets: { tags: [ 'desktop_work', 'video' ] },
@@ -47,8 +53,8 @@ const pcs = [
     category: 'tech',
     family: 'pc',
     exclusivityGroup: 'tech:pc',
-    cost: 1280,
-    requires: [ 'editingWorkstation' ],
+    cost: quantumRigConfig.cost, // Spec: docs/normalized_economy.json → upgrades.quantumRig.setup_cost
+    requires: quantumRigConfig.requires, // Spec: docs/normalized_economy.json → upgrades.quantumRig.requirements
     effects: { payout_mult: 1.12, maint_time_mult: 0.85 },
     affects: {
       assets: { tags: [ 'desktop_work', 'software', 'video' ] },

--- a/src/game/upgrades/definitions/tech/phones.js
+++ b/src/game/upgrades/definitions/tech/phones.js
@@ -1,3 +1,9 @@
+import { upgrades as upgradeConfigs } from '../../../data/economyConfig.js';
+
+const creatorPhoneConfig = upgradeConfigs.creatorPhone; // Spec: docs/normalized_economy.json → upgrades.creatorPhone
+const creatorPhoneProConfig = upgradeConfigs.creatorPhonePro; // Spec: docs/normalized_economy.json → upgrades.creatorPhonePro
+const creatorPhoneUltraConfig = upgradeConfigs.creatorPhoneUltra; // Spec: docs/normalized_economy.json → upgrades.creatorPhoneUltra
+
 const phones = [
   {
     id: 'creatorPhone',
@@ -7,7 +13,7 @@ const phones = [
     category: 'tech',
     family: 'phone',
     exclusivityGroup: 'tech:phone',
-    cost: 140,
+    cost: creatorPhoneConfig.cost, // Spec: docs/normalized_economy.json → upgrades.creatorPhone.setup_cost
     effects: { setup_time_mult: 0.95 },
     affects: {
       hustles: { tags: [ 'live', 'field' ] },
@@ -26,8 +32,8 @@ const phones = [
     category: 'tech',
     family: 'phone',
     exclusivityGroup: 'tech:phone',
-    cost: 360,
-    requires: [ 'creatorPhone' ],
+    cost: creatorPhoneProConfig.cost, // Spec: docs/normalized_economy.json → upgrades.creatorPhonePro.setup_cost
+    requires: creatorPhoneProConfig.requires, // Spec: docs/normalized_economy.json → upgrades.creatorPhonePro.requirements
     effects: { setup_time_mult: 0.85, payout_mult: 1.05 },
     affects: {
       hustles: { tags: [ 'live', 'field' ] },
@@ -48,8 +54,8 @@ const phones = [
     category: 'tech',
     family: 'phone',
     exclusivityGroup: 'tech:phone',
-    cost: 720,
-    requires: [ 'creatorPhonePro' ],
+    cost: creatorPhoneUltraConfig.cost, // Spec: docs/normalized_economy.json → upgrades.creatorPhoneUltra.setup_cost
+    requires: creatorPhoneUltraConfig.requires, // Spec: docs/normalized_economy.json → upgrades.creatorPhoneUltra.requirements
     effects: { setup_time_mult: 0.8, payout_mult: 1.08 },
     affects: {
       hustles: { tags: [ 'live', 'field' ] },

--- a/src/game/upgrades/definitions/tech/power.js
+++ b/src/game/upgrades/definitions/tech/power.js
@@ -1,3 +1,7 @@
+import { upgrades as upgradeConfigs } from '../../../data/economyConfig.js';
+
+const backupPowerArrayConfig = upgradeConfigs.backupPowerArray; // Spec: docs/normalized_economy.json → upgrades.backupPowerArray
+
 const power = [
   {
     id: 'backupPowerArray',
@@ -6,7 +10,7 @@ const power = [
     description: 'Battery backups and surge protection that keep the studio live during outages.',
     category: 'tech',
     family: 'power_backup',
-    cost: 260,
+    cost: backupPowerArrayConfig.cost, // Spec: docs/normalized_economy.json → upgrades.backupPowerArray.setup_cost
     effects: { maint_time_mult: 0.95 },
     affects: {
       assets: { tags: [ 'desktop_work', 'video' ] },

--- a/src/game/upgrades/definitions/tech/storage.js
+++ b/src/game/upgrades/definitions/tech/storage.js
@@ -1,3 +1,7 @@
+import { upgrades as upgradeConfigs } from '../../../data/economyConfig.js';
+
+const scratchDriveArrayConfig = upgradeConfigs.scratchDriveArray; // Spec: docs/normalized_economy.json → upgrades.scratchDriveArray
+
 const storage = [
   {
     id: 'scratchDriveArray',
@@ -6,7 +10,7 @@ const storage = [
     description: 'High-speed NVMe array that turns renders and transfers into blink-and-done tasks.',
     category: 'tech',
     family: 'storage',
-    cost: 320,
+    cost: scratchDriveArrayConfig.cost, // Spec: docs/normalized_economy.json → upgrades.scratchDriveArray.setup_cost
     effects: { maint_time_mult: 0.9 },
     affects: {
       assets: { tags: [ 'video', 'photo', 'software' ] },

--- a/src/game/upgrades/definitions/tech/workflow.js
+++ b/src/game/upgrades/definitions/tech/workflow.js
@@ -1,3 +1,10 @@
+import { upgrades as upgradeConfigs } from '../../../data/economyConfig.js';
+
+const editorialPipelineConfig = upgradeConfigs.editorialPipeline; // Spec: docs/normalized_economy.json → upgrades.editorialPipeline
+const syndicationSuiteConfig = upgradeConfigs.syndicationSuite; // Spec: docs/normalized_economy.json → upgrades.syndicationSuite
+const immersiveStoryWorldsConfig = upgradeConfigs.immersiveStoryWorlds; // Spec: docs/normalized_economy.json → upgrades.immersiveStoryWorlds
+const courseConfig = upgradeConfigs.course; // Spec: docs/normalized_economy.json → upgrades.course
+
 const workflow = [
   {
     id: 'editorialPipeline',
@@ -6,7 +13,7 @@ const workflow = [
     description: 'Stand up pro-grade editorial calendars so every blog post ships polished and on schedule.',
     category: 'tech',
     family: 'workflow',
-    cost: 360,
+    cost: editorialPipelineConfig.cost, // Spec: docs/normalized_economy.json → upgrades.editorialPipeline.setup_cost
     requires: [
       'course',
       { type: 'asset', id: 'blog', active: true, count: 1 },
@@ -60,7 +67,7 @@ const workflow = [
     description: 'Spin up partner feeds, guest slots, and cross-promotions to syndicate your best work everywhere.',
     category: 'tech',
     family: 'workflow',
-    cost: 720,
+    cost: syndicationSuiteConfig.cost, // Spec: docs/normalized_economy.json → upgrades.syndicationSuite.setup_cost
     requires: [
       'editorialPipeline',
       { type: 'asset', id: 'blog', active: true, count: 1 },
@@ -125,7 +132,7 @@ const workflow = [
     description: 'Blend blogs, books, and vlogs into one living universe with AR teasers and fan quests.',
     category: 'tech',
     family: 'workflow',
-    cost: 1080,
+    cost: immersiveStoryWorldsConfig.cost, // Spec: docs/normalized_economy.json → upgrades.immersiveStoryWorlds.setup_cost
     requires: [
       'syndicationSuite',
       { type: 'asset', id: 'blog', active: true, count: 1 },
@@ -195,7 +202,7 @@ const workflow = [
     description: 'Unlocks smarter blogging tools, boosting blog income by +50%.',
     category: 'tech',
     family: 'workflow',
-    cost: 260,
+    cost: courseConfig.cost, // Spec: docs/normalized_economy.json → upgrades.course.setup_cost
     requires: [
       {
         type: 'asset',

--- a/tests/economyConfig.test.js
+++ b/tests/economyConfig.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import normalizedEconomy from '../docs/normalized_economy.json' with { type: 'json' };
+import { assets, hustles, upgrades } from '../src/game/data/economyConfig.js';
+
+const minutesToHours = minutes => minutes / 60;
+
+test('blog economy config matches normalized spec', () => {
+  const spec = normalizedEconomy.assets.blog;
+  const config = assets.blog;
+
+  assert.strictEqual(config.setup.days, spec.schedule.setup_days);
+  assert.strictEqual(config.setup.hoursPerDay, minutesToHours(spec.schedule.setup_minutes_per_day));
+  assert.strictEqual(config.setup.cost, spec.setup_cost);
+  assert.strictEqual(config.maintenance.hours, minutesToHours(spec.maintenance_time));
+  assert.strictEqual(config.maintenance.cost, spec.maintenance_cost);
+  assert.strictEqual(config.income.base, spec.base_income);
+  assert.strictEqual(config.income.variance, spec.variance);
+
+  const [quality0, quality1] = config.qualityLevels;
+  assert.deepEqual(quality0.income, {
+    min: spec.quality_curve[0].income_min,
+    max: spec.quality_curve[0].income_max
+  });
+  assert.deepEqual(quality1.requirements, spec.quality_curve[1].requirements);
+});
+
+test('dropship pack party hustle stays aligned with spec', () => {
+  const spec = normalizedEconomy.hustles.dropshipPackParty;
+  const config = hustles.dropshipPackParty;
+
+  assert.strictEqual(config.timeHours, minutesToHours(spec.setup_time));
+  assert.strictEqual(config.payout, spec.base_income);
+  assert.strictEqual(config.cost, spec.setup_cost);
+});
+
+test('editorial pipeline upgrade pulls its cost from the spec', () => {
+  const spec = normalizedEconomy.upgrades.editorialPipeline;
+  const config = upgrades.editorialPipeline;
+
+  assert.strictEqual(config.cost, spec.setup_cost);
+});


### PR DESCRIPTION
## Summary
- add a shared economy configuration module that normalizes asset, hustle, upgrade, and track data from docs/normalized_economy.json
- refactor asset, hustle, and upgrade definitions to pull setup times, payouts, costs, and quality thresholds from the shared config
- add a node:test suite that guards the config against drift from the source JSON

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e284c58030832c9da7499419cdb6cd