### PR TITLE
Support claimed hustle offers and acceptance flow

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@
 - Unified instant hustles and study sessions under a shared action registry that tracks accepted instances, daily limits, and
   completion history without erasing legacy hustle progress.
 - Hustle market rolls daily offers from immutable templates, tracks multi-day availability, and persists timestamps for clean day rollovers.
+- Hustle market offers now expose per-variant requirements and payout metadata, support simultaneous variants, and surface claimed-contract selectors via the new `acceptHustleOffer` helper.
 - TODO/action queue now runs through the shared action-provider registry so dashboard widgets and TimoDoro stay aligned, and the landing page no longer swallows the default workspace when tasks populate mid-load.
 - Browser shell keeps the tabbed chrome, notification bell, and modular stylesheets; add new surfaces by pairing a presenter with a stylesheet.
 - Home dashboard stays focused on the three core widgets (ToDo, cash snapshot, app tiles) with drag-to-arrange and End Day gating.

--- a/src/core/state/slices/hustleMarket.js
+++ b/src/core/state/slices/hustleMarket.js
@@ -3,7 +3,8 @@ import { structuredClone, createId } from '../../helpers.js';
 const DEFAULT_STATE = Object.freeze({
   lastRolledAt: 0,
   lastRolledOnDay: 0,
-  offers: []
+  offers: [],
+  accepted: []
 });
 
 function clampDay(value, fallback = 1) {
@@ -30,6 +31,18 @@ function clampNonNegativeInteger(value, fallback = 0) {
   return Math.floor(parsed);
 }
 
+function clampNonNegativeNumber(value, fallback = 0) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    const fallbackParsed = Number(fallback);
+    if (!Number.isFinite(fallbackParsed) || fallbackParsed < 0) {
+      return 0;
+    }
+    return fallbackParsed;
+  }
+  return parsed;
+}
+
 function buildDaysActive(startDay, endDay) {
   const start = clampDay(startDay, 1);
   const end = clampDay(endDay, start);
@@ -44,7 +57,8 @@ export function createDefaultHustleMarketState() {
   return {
     lastRolledAt: 0,
     lastRolledOnDay: 0,
-    offers: []
+    offers: [],
+    accepted: []
   };
 }
 
@@ -99,7 +113,14 @@ export function normalizeHustleMarketOffer(offer, {
     ? offer.id
     : `market-${definitionId}-${rolledOnDay}-${createId()}`;
 
-  return {
+  const claimedOnDay = offer.claimedOnDay != null
+    ? clampDay(offer.claimedOnDay, availableOnDay)
+    : null;
+  const instanceId = typeof offer.instanceId === 'string' && offer.instanceId
+    ? offer.instanceId
+    : null;
+
+  const normalized = {
     id,
     templateId,
     variantId,
@@ -110,7 +131,73 @@ export function normalizeHustleMarketOffer(offer, {
     expiresOnDay,
     daysActive: buildDaysActive(availableOnDay, expiresOnDay),
     metadata,
-    variant
+    variant,
+    claimed: offer.claimed === true || claimedOnDay != null,
+    claimedOnDay,
+    instanceId,
+    status: offer.status === 'claimed' || offer.claimed === true
+      ? 'claimed'
+      : 'available'
+  };
+
+  if (normalized.claimed) {
+    normalized.status = 'claimed';
+  }
+
+  return normalized;
+}
+
+function normalizeAcceptedOffer(entry, { fallbackDay = 1 } = {}) {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+
+  const offerId = typeof entry.offerId === 'string' && entry.offerId
+    ? entry.offerId
+    : null;
+  const templateId = typeof entry.templateId === 'string' && entry.templateId
+    ? entry.templateId
+    : null;
+  if (!offerId || !templateId) {
+    return null;
+  }
+
+  const definitionId = typeof entry.definitionId === 'string' && entry.definitionId
+    ? entry.definitionId
+    : templateId;
+
+  const acceptedOnDay = clampDay(entry.acceptedOnDay, fallbackDay);
+  const deadlineDay = clampDay(entry.deadlineDay, acceptedOnDay);
+  const hoursRequired = clampNonNegativeNumber(entry.hoursRequired, 0);
+  const metadata = typeof entry.metadata === 'object' && entry.metadata !== null
+    ? structuredClone(entry.metadata)
+    : {};
+  const payout = typeof entry.payout === 'object' && entry.payout !== null
+    ? { ...entry.payout }
+    : {};
+  if (payout.amount != null) {
+    payout.amount = clampNonNegativeNumber(payout.amount, 0);
+  }
+  if (!payout.schedule) {
+    payout.schedule = 'onCompletion';
+  }
+
+  const instanceId = typeof entry.instanceId === 'string' && entry.instanceId
+    ? entry.instanceId
+    : null;
+
+  return {
+    id: typeof entry.id === 'string' && entry.id ? entry.id : `accepted-${offerId}-${createId()}`,
+    offerId,
+    templateId,
+    definitionId,
+    acceptedOnDay,
+    deadlineDay,
+    hoursRequired,
+    instanceId,
+    payout,
+    status: entry.status === 'complete' ? 'complete' : 'active',
+    metadata
   };
 }
 
@@ -134,14 +221,49 @@ export function ensureHustleMarketState(state, { fallbackDay = 1 } = {}) {
     : 0;
 
   const offers = Array.isArray(marketState.offers) ? marketState.offers : [];
+  const accepted = Array.isArray(marketState.accepted) ? marketState.accepted : [];
+
+  const normalizedAccepted = accepted
+    .map(entry => normalizeAcceptedOffer(entry, { fallbackDay: normalizedFallbackDay }))
+    .filter(entry => entry && entry.deadlineDay >= normalizedFallbackDay);
+
+  const acceptedByOffer = new Map();
+  normalizedAccepted.forEach(entry => {
+    acceptedByOffer.set(entry.offerId, entry);
+  });
+
   const normalizedOffers = offers
     .map(offer => normalizeHustleMarketOffer(offer, {
       fallbackTimestamp: marketState.lastRolledAt,
       fallbackDay: normalizedFallbackDay
     }))
-    .filter(Boolean);
+    .filter(offer => offer && offer.expiresOnDay >= normalizedFallbackDay);
+
+  const normalizedOffersById = new Map();
+  normalizedOffers.forEach(offer => {
+    normalizedOffersById.set(offer.id, offer);
+    const acceptedEntry = acceptedByOffer.get(offer.id);
+    if (acceptedEntry) {
+      offer.claimed = true;
+      offer.status = 'claimed';
+      offer.claimedOnDay = acceptedEntry.acceptedOnDay;
+      offer.instanceId = acceptedEntry.instanceId;
+      offer.claimMetadata = structuredClone(acceptedEntry.metadata || {});
+      offer.claimDeadlineDay = acceptedEntry.deadlineDay;
+    } else {
+      offer.claimed = false;
+      offer.status = 'available';
+      offer.claimedOnDay = null;
+      offer.instanceId = null;
+      delete offer.claimMetadata;
+      delete offer.claimDeadlineDay;
+    }
+  });
+
+  const filteredAccepted = normalizedAccepted.filter(entry => normalizedOffersById.has(entry.offerId));
 
   marketState.offers = normalizedOffers;
+  marketState.accepted = filteredAccepted;
 
   return marketState;
 }
@@ -158,7 +280,8 @@ export function cloneHustleMarketState(state) {
   return {
     lastRolledAt: ensured.lastRolledAt,
     lastRolledOnDay: ensured.lastRolledOnDay,
-    offers: ensured.offers.map(offer => structuredClone(offer))
+    offers: ensured.offers.map(offer => structuredClone(offer)),
+    accepted: ensured.accepted.map(entry => structuredClone(entry))
   };
 }
 
@@ -168,6 +291,99 @@ export function clearHustleMarketState(state) {
   marketState.lastRolledAt = 0;
   marketState.lastRolledOnDay = 0;
   marketState.offers = [];
+  marketState.accepted = [];
+}
+
+export function claimHustleMarketOffer(state, offerId, details = {}) {
+  if (!state || !offerId) {
+    return null;
+  }
+  const marketState = ensureHustleMarketState(state, { fallbackDay: details.acceptedOnDay || state.day || 1 });
+  const offer = marketState.offers.find(entry => entry.id === offerId);
+  if (!offer) {
+    return null;
+  }
+
+  const acceptedEntry = normalizeAcceptedOffer({
+    offerId: offer.id,
+    templateId: offer.templateId,
+    definitionId: offer.definitionId,
+    acceptedOnDay: details.acceptedOnDay ?? state.day ?? offer.availableOnDay,
+    deadlineDay: details.deadlineDay ?? offer.expiresOnDay,
+    hoursRequired: details.hoursRequired ?? offer.metadata?.hoursRequired ?? offer.metadata?.requirements?.hours ?? 0,
+    instanceId: details.instanceId ?? offer.instanceId ?? null,
+    payout: details.payout ?? offer.metadata?.payout ?? {},
+    status: details.status ?? 'active',
+    metadata: details.metadata ?? offer.metadata ?? {}
+  }, { fallbackDay: state.day || 1 });
+
+  if (!acceptedEntry) {
+    return null;
+  }
+
+  const existingIndex = marketState.accepted.findIndex(entry => entry.offerId === offer.id);
+  if (existingIndex >= 0) {
+    marketState.accepted[existingIndex] = acceptedEntry;
+  } else {
+    marketState.accepted.push(acceptedEntry);
+  }
+
+  offer.claimed = true;
+  offer.status = 'claimed';
+  offer.claimedOnDay = acceptedEntry.acceptedOnDay;
+  offer.instanceId = acceptedEntry.instanceId;
+  offer.claimMetadata = structuredClone(acceptedEntry.metadata || {});
+  offer.claimDeadlineDay = acceptedEntry.deadlineDay;
+
+  ensureHustleMarketState(state, { fallbackDay: state.day || acceptedEntry.acceptedOnDay || 1 });
+  return acceptedEntry;
+}
+
+export function getMarketOfferById(state, offerId, options = {}) {
+  if (!state || !offerId) {
+    return null;
+  }
+  const fallbackDay = clampDay(options.day ?? state.day ?? 1, 1);
+  const marketState = ensureHustleMarketState(state, { fallbackDay });
+  const offer = marketState.offers.find(entry => entry.id === offerId);
+  return offer ? structuredClone(offer) : null;
+}
+
+export function getMarketAvailableOffers(state, {
+  day,
+  includeUpcoming = false,
+  includeClaimed = false
+} = {}) {
+  if (!state) {
+    return [];
+  }
+  const fallbackDay = clampDay(day ?? state.day ?? 1, 1);
+  const marketState = ensureHustleMarketState(state, { fallbackDay });
+  return marketState.offers
+    .filter(offer => {
+      if (!includeClaimed && offer.claimed) {
+        return false;
+      }
+      if (includeUpcoming) {
+        return offer.expiresOnDay >= fallbackDay;
+      }
+      return offer.availableOnDay <= fallbackDay && offer.expiresOnDay >= fallbackDay;
+    })
+    .map(offer => structuredClone(offer));
+}
+
+export function getMarketClaimedOffers(state, {
+  day,
+  includeExpired = false
+} = {}) {
+  if (!state) {
+    return [];
+  }
+  const fallbackDay = clampDay(day ?? state.day ?? 1, 1);
+  const marketState = ensureHustleMarketState(state, { fallbackDay });
+  return marketState.accepted
+    .filter(entry => includeExpired || entry.deadlineDay >= fallbackDay)
+    .map(entry => structuredClone(entry));
 }
 
 export { DEFAULT_STATE as DEFAULT_HUSTLE_MARKET_STATE };


### PR DESCRIPTION
## Summary
- allow hustle market variants to coexist, embed requirement/payout metadata, and expose claimed offer selectors
- add an `acceptHustleOffer` helper that creates action instances, marks offers claimed, and records payout schedules
- normalize the hustle market slice to track accepted entries, prune expirations, and document the updated lifecycle with new tests

## Testing
- node --test tests/hustleMarket.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e28a27a0a8832cbbfe2a7b2487a407