### PR TITLE
Add economy spec and rebuild automation

### DIFF
--- a/docs/EconomySpec.appendix.md
+++ b/docs/EconomySpec.appendix.md
@@ -1,0 +1,226 @@
+# Economy Specification Appendix (Auto-generated)
+
+Last generated: 2025-10-05T15:45:29.537Z
+
+## Asset Summary
+| Asset | Setup Schedule | Setup Cost | Maintenance Time | Maintenance Cost | Base Income | Variance |
+| --- | --- | --- | --- | --- | --- | --- |
+| Digital E-Book Series | 4 d × 180 min | $260 | 30 min | $3 | $30 | 20% |
+| Dropshipping Product Lab | 6 d × 240 min | $720 | 66 min | $12 | $84 | 35% |
+| Micro SaaS Platform | 8 d × 240 min | $960 | 132 min | $24 | $108 | 40% |
+| Personal Blog Network | 3 d × 180 min | $180 | 36 min | $3 | $30 | 20% |
+| Stock Photo Galleries | 5 d × 240 min | $560 | 48 min | $10 | $58 | 35% |
+| Weekly Vlog Channel | 4 d × 240 min | $420 | 60 min | $9 | $34 | 20% |
+
+## Hustle Summary
+| Hustle | Action Time | Cash Cost | Base Payout | Daily Limit | Requirements | Skills |
+| --- | --- | --- | --- | --- | --- | --- |
+| Audience Q&A Blast | 60 min | $0 | $12 | 1 | blog×1 | audience |
+| Audiobook Narration | 165 min | $0 | $44 | ∞ | ebook×1 | audio |
+| Bundle Promo Push | 150 min | $0 | $48 | ∞ | blog×2, ebook×1 | promotion |
+| Dropship Pack Party | 120 min | $8 | $28 | ∞ | dropshipping×1 | commerce |
+| Event Photo Gig | 210 min | $0 | $72 | ∞ | stockPhotos×1 | visual |
+| Freelance Writing | 120 min | $0 | $18 | ∞ | — | writing |
+| Micro Survey Dash | 15 min | $0 | $1 | 4 | — | research |
+| Pop-Up Workshop | 150 min | $0 | $38 | ∞ | blog×1, ebook×1 | audience, writing 50% |
+| SaaS Bug Squash | 60 min | $0 | $30 | ∞ | saas×1 | software, infrastructure 50% |
+| Street Team Promo | 45 min | $5 | $18 | ∞ | blog×2 | promotion |
+| Vlog Edit Rush | 90 min | $0 | $24 | ∞ | vlog×1 | editing |
+
+## Knowledge Track Summary
+| Track | Study Schedule | Tuition | Base XP | Skill Split |
+| --- | --- | --- | --- | --- |
+| Automation Architecture Course | 15 d × 360 min | $3000 | 120 | software 60%, infrastructure 40% |
+| Brand Voice Lab | 4 d × 60 min | $120 | 100 | audience 60%, promotion 40% |
+| Commerce Launch Primer | 3 d × 240 min | $0 | 120 | commerce 100% |
+| Creator Studio Jumpstart | 3 d × 240 min | $0 | 120 | visual 100% |
+| Curriculum Design Studio | 6 d × 150 min | $280 | 150 | audience 60%, writing 40% |
+| Customer Retention Clinic | 7 d × 180 min | $1000 | 140 | audience 40%, promotion 30%, software 30% |
+| Digital Shelf Primer | 3 d × 240 min | $0 | 120 | editing 100% |
+| E-Commerce Playbook | 9 d × 180 min | $900 | 120 | research 50%, commerce 50% |
+| Fulfillment Ops Masterclass | 10 d × 240 min | $1200 | 140 | commerce 70%, promotion 30% |
+| Gallery Licensing Summit | 8 d × 240 min | $1100 | 140 | visual 60%, commerce 40% |
+| Guerrilla Buzz Workshop | 6 d × 90 min | $180 | 110 | promotion 60%, audience 40% |
+| Micro SaaS Jumpstart | 3 d × 240 min | $0 | 120 | software 100% |
+| Narration Performance Workshop | 7 d × 180 min | $900 | 130 | audio 60%, writing 40% |
+| Outline Mastery Workshop | 5 d × 120 min | $140 | 120 | writing 100% |
+| Photo Catalog Curation | 4 d × 90 min | $95 | 120 | visual 50%, editing 50% |
+| Post-Production Pipeline Lab | 10 d × 240 min | $900 | 150 | editing 70%, visual 30% |
+| Storycraft Jumpstart | 3 d × 240 min | $0 | 120 | writing 100% |
+| Syndication Residency | 9 d × 240 min | $1000 | 150 | promotion 50%, audience 30%, writing 20% |
+
+## Upgrade Summary
+| Upgrade | Category | Cost | Repeatable | Notes |
+| --- | --- | --- | --- | --- |
+| Audio Suite | tech | $420 | No | — |
+| Automation Course | tech | $260 | No | — |
+| Backup Power Array | tech | $260 | No | — |
+| Camera | tech | $200 | No | — |
+| Cinema Camera Upgrade | tech | $480 | No | — |
+| Cloud Cluster | infra | $1150 | No | — |
+| Color Grading Display | tech | $380 | No | — |
+| Creator Phone - Pro | tech | $360 | No | — |
+| Creator Phone - Starter | tech | $140 | No | — |
+| Creator Phone - Ultra | tech | $720 | No | — |
+| Dual Monitor Array | tech | $240 | No | — |
+| Edge Delivery Network | infra | $1450 | No | — |
+| Editing Workstation | tech | $640 | No | — |
+| Editorial Pipeline Suite | tech | $360 | No | — |
+| Ergonomic Refit | tech | $180 | No | — |
+| Fiber Internet Plan | tech | $260 | No | — |
+| Fulfillment Automation Suite | infra | $780 | No | — |
+| Global Supply Mesh | infra | $1150 | No | — |
+| Hire Virtual Assistant | infra | $0 | No | Hire cost $180, adds 180 bonus minutes/day, $24 daily wage. |
+| Immersive Story Worlds | tech | $1080 | No | — |
+| Lighting Kit | house | $220 | No | — |
+| Monitor Dock | tech | $180 | No | — |
+| Quantum Creator Rig | tech | $1280 | No | — |
+| Scratch Drive Array | tech | $320 | No | — |
+| Server Rack - Starter | infra | $650 | No | — |
+| Studio Expansion | house | $540 | No | — |
+| Studio Laptop | tech | $280 | No | — |
+| Syndication Suite | tech | $720 | No | — |
+| Turbo Coffee | support | $40 | Yes | +60 minutes bonus time for the current day, max 3 uses/day. |
+| White-Label Alliance | infra | $1500 | No | — |
+
+## Modifier Taxonomy
+| Type | Domain | Count | Example |
+| --- | --- | --- | --- |
+| add | state | 1 | coffee → state:time.bonus |
+| flat | hustle | 6 | ecomPlaybook → hustle:bundlePush.income |
+| multiplier | asset | 26 | storycraftJumpstart → asset:blog.income |
+| multiplier | assets[id=dropshipping\|stockPhotos] | 2 | whiteLabelAlliance → assets[id=dropshipping\|stockPhotos].income |
+| multiplier | assets[tag=audio\|video] | 1 | audioSuite → assets[tag=audio\|video].quality_progress |
+| multiplier | assets[tag=desktop_work] | 3 | studioLaptop → assets[tag=desktop_work].setup_time |
+| multiplier | assets[tag=desktop_work\|software\|video] | 2 | quantumRig → assets[tag=desktop_work\|software\|video].maintenance_time |
+| multiplier | assets[tag=desktop_work\|video] | 4 | editingWorkstation → assets[tag=desktop_work\|video].setup_time |
+| multiplier | assets[tag=photo\|video] | 4 | studio → assets[tag=photo\|video].maintenance_time |
+| multiplier | assets[tag=software\|tech] | 1 | serverRack → assets[tag=software\|tech].setup_time |
+| multiplier | assets[tag=video] | 5 | creatorPhone → assets[tag=video].setup_time |
+| multiplier | assets[tag=video\|photo] | 6 | colorGradingDisplay → assets[tag=video\|photo].quality_progress |
+| multiplier | assets[tag=video\|photo\|software] | 1 | scratchDriveArray → assets[tag=video\|photo\|software].maintenance_time |
+| multiplier | assets[tag=video\|software] | 1 | fiberInternet → assets[tag=video\|software].maintenance_time |
+| multiplier | assets[tag=writing\|content] | 3 | editorialPipeline → assets[tag=writing\|content].setup_time |
+| multiplier | assets[tag=writing\|content\|video] | 3 | syndicationSuite → assets[tag=writing\|content\|video].maintenance_time |
+| multiplier | assets[tag=writing\|video\|photo] | 3 | immersiveStoryWorlds → assets[tag=writing\|video\|photo].income |
+| multiplier | hustle | 11 | outlineMastery → hustle:freelance.income |
+| multiplier | hustles[tag=commerce\|ecommerce] | 2 | globalSupplyMesh → hustles[tag=commerce\|ecommerce].setup_time |
+| multiplier | hustles[tag=commerce\|photo] | 2 | whiteLabelAlliance → hustles[tag=commerce\|photo].income |
+| multiplier | hustles[tag=desktop_work] | 1 | studioLaptop → hustles[tag=desktop_work].setup_time |
+| multiplier | hustles[tag=live\|field] | 5 | creatorPhone → hustles[tag=live\|field].setup_time |
+| multiplier | hustles[tag=live\|software] | 1 | fiberInternet → hustles[tag=live\|software].maintenance_time |
+| multiplier | hustles[tag=photo] | 1 | studioExpansion → hustles[tag=photo].quality_progress |
+| multiplier | hustles[tag=software\|automation] | 1 | serverRack → hustles[tag=software\|automation].setup_time |
+| multiplier | hustles[tag=video\|photo] | 1 | camera → hustles[tag=video\|photo].setup_time |
+| multiplier | hustles[tag=writing] | 3 | editorialPipeline → hustles[tag=writing].setup_time |
+| multiplier | hustles[tag=writing\|marketing] | 3 | syndicationSuite → hustles[tag=writing\|marketing].maintenance_time |
+
+## Modifier Catalog
+| Source | Target | Type | Formula | Notes |
+| --- | --- | --- | --- | --- |
+| storycraftJumpstart | asset:blog.income | multiplier | income * (1 + 0.05) | Adds 5% to blog income. |
+| vlogStudioJumpstart | asset:vlog.income | multiplier | income * (1 + 0.05) | Adds 5% to vlog income. |
+| digitalShelfPrimer | asset:ebook.income | multiplier | income * (1 + 0.05) | Adds 5% to e-book income. |
+| digitalShelfPrimer | asset:stockPhotos.income | multiplier | income * (1 + 0.05) | Adds 5% to stock photo income. |
+| commerceLaunchPrimer | asset:dropshipping.income | multiplier | income * (1 + 0.05) | Adds 5% to dropshipping income. |
+| microSaasJumpstart | asset:saas.income | multiplier | income * (1 + 0.05) | Adds 5% to SaaS income. |
+| outlineMastery | hustle:freelance.income | multiplier | income * (1 + 0.25) | Freelance writing earns 25% more. |
+| outlineMastery | hustle:audiobookNarration.income | multiplier | income * (1 + 0.15) | Audiobook narration earns 15% more. |
+| photoLibrary | hustle:eventPhotoGig.income | multiplier | income * (1 + 0.2) | Event photo gig earns 20% more. |
+| ecomPlaybook | hustle:bundlePush.income | flat | income + 5 | Bundle promo push gains $5 flat. |
+| ecomPlaybook | asset:dropshipping.income | multiplier | income * (1 + 0.15) | Dropshipping income +15%. |
+| automationCourse | hustle:saasBugSquash.income | flat | income + 6 | SaaS bug squash gains $6 flat. |
+| automationCourse | asset:saas.income | multiplier | income * (1 + 0.15) | SaaS income +15%. |
+| brandVoiceLab | hustle:audienceCall.income | flat | income + 4 | Audience Q&A blast gains $4. |
+| guerillaBuzzWorkshop | hustle:streetPromoSprint.income | multiplier | income * (1 + 0.25) | Street promo sprint +25%. |
+| guerillaBuzzWorkshop | hustle:surveySprint.income | flat | income + 1.5 | Micro survey dash gains $1.5. |
+| curriculumDesignStudio | hustle:popUpWorkshop.income | multiplier | income * (1 + 0.3) | Pop-up workshop +30%. |
+| curriculumDesignStudio | hustle:bundlePush.income | multiplier | income * (1 + 0.15) | Bundle promo push +15%. |
+| postProductionPipelineLab | hustle:vlogEditRush.income | multiplier | income * (1 + 0.25) | Vlog edit rush +25%. |
+| postProductionPipelineLab | asset:vlog.income | multiplier | income * (1 + 0.15) | Vlog income +15%. |
+| fulfillmentOpsMasterclass | hustle:dropshipPackParty.income | multiplier | income * (1 + 0.2) | Dropship pack party +20%. |
+| fulfillmentOpsMasterclass | asset:dropshipping.income | multiplier | income * (1 + 0.25) | Dropshipping income +25%. |
+| customerRetentionClinic | hustle:saasBugSquash.income | flat | income + 5 | SaaS bug squash gains $5. |
+| customerRetentionClinic | asset:saas.income | multiplier | income * (1 + 0.2) | SaaS income +20%. |
+| narrationPerformanceWorkshop | hustle:audiobookNarration.income | multiplier | income * (1 + 0.25) | Audiobook narration +25%. |
+| narrationPerformanceWorkshop | asset:ebook.income | multiplier | income * (1 + 0.1) | E-book income +10%. |
+| galleryLicensingSummit | hustle:eventPhotoGig.income | multiplier | income * (1 + 0.2) | Event photo gig +20%. |
+| galleryLicensingSummit | asset:stockPhotos.income | multiplier | income * (1 + 0.15) | Stock photo income +15%. |
+| syndicationResidency | hustle:freelance.income | multiplier | income * (1 + 0.15) | Freelance writing +15%. |
+| syndicationResidency | hustle:streetPromoSprint.income | flat | income + 2 | Street promo sprint gains $2. |
+| syndicationResidency | asset:blog.income | multiplier | income * (1 + 0.12) | Blog income +12%. |
+| coffee | state:time.bonus | add | minutes + 60 | Adds 60 bonus minutes (max 3 per day). |
+| studio | assets[tag=photo\|video].maintenance_time | multiplier | minutes * 0.9 | Lighting kit reduces photo/video maintenance time. |
+| studioExpansion | assets[tag=photo\|video].setup_time | multiplier | minutes * 0.85 | Studio expansion speeds photo/video setup. |
+| studioExpansion | assets[tag=photo\|video].income | multiplier | income * 1.15 | Studio expansion boosts photo/video payouts. |
+| studioExpansion | assets[tag=photo\|video].quality_progress | multiplier | progress * 2 | Studio expansion doubles photo/video quality progress. |
+| studioExpansion | hustles[tag=photo].quality_progress | multiplier | progress * 2 | Photo hustles gain double quality progress. |
+| serverRack | assets[tag=software\|tech].setup_time | multiplier | minutes * 0.95 | Server rack speeds software/tech setup. |
+| serverRack | hustles[tag=software\|automation].setup_time | multiplier | minutes * 0.95 | Server rack speeds software/automation hustles. |
+| fulfillmentAutomation | asset:dropshipping.income | multiplier | income * 1.25 | Automation suite boosts dropshipping payouts. |
+| fulfillmentAutomation | asset:dropshipping.quality_progress | multiplier | progress * 2 | Automation suite doubles dropshipping quality progress. |
+| serverCluster | asset:saas.income | multiplier | income * 1.2 | Cloud cluster boosts SaaS payouts. |
+| serverCluster | asset:saas.quality_progress | multiplier | progress * 1.5 | Cloud cluster boosts SaaS quality progress. |
+| globalSupplyMesh | asset:dropshipping.income | multiplier | income * 1.3 | Global supply mesh boosts dropshipping payouts. |
+| globalSupplyMesh | asset:dropshipping.quality_progress | multiplier | progress * 1.5 | Global supply mesh boosts dropshipping quality progress. |
+| globalSupplyMesh | asset:dropshipping.setup_time | multiplier | minutes * 0.92 | Global supply mesh speeds dropshipping setup. |
+| globalSupplyMesh | hustles[tag=commerce\|ecommerce].setup_time | multiplier | minutes * 0.92 | Commerce/e-commerce hustles run faster. |
+| globalSupplyMesh | hustles[tag=commerce\|ecommerce].income | multiplier | income * 1.3 | Commerce/e-commerce hustles earn 30% more. |
+| serverEdge | asset:saas.income | multiplier | income * 1.35 | Edge delivery boosts SaaS payouts 35%. |
+| serverEdge | asset:saas.quality_progress | multiplier | progress * 2 | Edge delivery doubles SaaS quality progress. |
+| serverEdge | asset:saas.maintenance_time | multiplier | minutes * 0.85 | Edge delivery reduces SaaS maintenance time. |
+| whiteLabelAlliance | assets[id=dropshipping\|stockPhotos].income | multiplier | income * 1.35 | White-label alliance boosts dropshipping & stock photo payouts. |
+| whiteLabelAlliance | assets[id=dropshipping\|stockPhotos].quality_progress | multiplier | progress * 1.3333333333 | White-label alliance increases quality progress by 4/3. |
+| whiteLabelAlliance | hustles[tag=commerce\|photo].income | multiplier | income * 1.35 | Commerce/photo hustles earn 35% more. |
+| whiteLabelAlliance | hustles[tag=commerce\|photo].quality_progress | multiplier | progress * 1.3333333333 | Commerce/photo hustles gain 4/3 quality progress. |
+| creatorPhone | hustles[tag=live\|field].setup_time | multiplier | minutes * 0.95 | Creator phone speeds live/field hustles. |
+| creatorPhone | assets[tag=video].setup_time | multiplier | minutes * 0.95 | Creator phone speeds video setup. |
+| creatorPhonePro | hustles[tag=live\|field].setup_time | multiplier | minutes * 0.85 | Creator phone pro further speeds live/field hustles. |
+| creatorPhonePro | assets[tag=video].setup_time | multiplier | minutes * 0.85 | Creator phone pro speeds video setup. |
+| creatorPhonePro | hustles[tag=live\|field].income | multiplier | income * 1.05 | Creator phone pro boosts live/field payouts 5%. |
+| creatorPhonePro | assets[tag=video].income | multiplier | income * 1.05 | Creator phone pro boosts video income 5%. |
+| creatorPhoneUltra | hustles[tag=live\|field].setup_time | multiplier | minutes * 0.8 | Creator phone ultra speeds live/field setup. |
+| creatorPhoneUltra | assets[tag=video].setup_time | multiplier | minutes * 0.8 | Creator phone ultra speeds video setup. |
+| creatorPhoneUltra | hustles[tag=live\|field].income | multiplier | income * 1.08 | Creator phone ultra boosts live/field payouts 8%. |
+| creatorPhoneUltra | assets[tag=video].income | multiplier | income * 1.08 | Creator phone ultra boosts video income 8%. |
+| studioLaptop | assets[tag=desktop_work].setup_time | multiplier | minutes * 0.92 | Studio laptop speeds desktop setup. |
+| studioLaptop | hustles[tag=desktop_work].setup_time | multiplier | minutes * 0.92 | Studio laptop speeds desktop hustles. |
+| editingWorkstation | assets[tag=desktop_work\|video].setup_time | multiplier | minutes * 0.85 | Editing workstation speeds desktop/video setup. |
+| editingWorkstation | assets[tag=desktop_work\|video].maintenance_time | multiplier | minutes * 0.9 | Editing workstation trims desktop/video maintenance. |
+| quantumRig | assets[tag=desktop_work\|software\|video].maintenance_time | multiplier | minutes * 0.85 | Quantum rig reduces maintenance for desktop/software/video assets. |
+| quantumRig | assets[tag=desktop_work\|software\|video].income | multiplier | income * 1.12 | Quantum rig boosts payouts for desktop/software/video assets. |
+| monitorHub | assets[tag=desktop_work].setup_time | multiplier | minutes * 0.95 | Monitor dock speeds desktop setup. |
+| dualMonitorArray | assets[tag=desktop_work\|video].quality_progress | multiplier | progress * 1.2 | Dual monitor array boosts desktop/video quality progress. |
+| colorGradingDisplay | assets[tag=video\|photo].quality_progress | multiplier | progress * 1.3 | Color grading display boosts video/photo quality progress. |
+| camera | assets[tag=video\|photo].setup_time | multiplier | minutes * 0.9 | Camera speeds video/photo setup. |
+| camera | hustles[tag=video\|photo].setup_time | multiplier | minutes * 0.9 | Camera speeds video/photo hustles. |
+| cameraPro | assets[tag=video\|photo].setup_time | multiplier | minutes * 0.85 | Cinema camera upgrade speeds video/photo setup. |
+| cameraPro | assets[tag=video\|photo].maintenance_time | multiplier | minutes * 0.85 | Cinema camera upgrade reduces video/photo maintenance. |
+| cameraPro | assets[tag=video\|photo].income | multiplier | income * 1.25 | Cinema camera upgrade boosts video/photo payouts. |
+| cameraPro | assets[tag=video\|photo].quality_progress | multiplier | progress * 2 | Cinema camera upgrade doubles video/photo quality progress. |
+| audioSuite | assets[tag=audio\|video].quality_progress | multiplier | progress * 1.4 | Audio suite boosts audio/video quality progress. |
+| ergonomicRefit | assets[tag=desktop_work].maintenance_time | multiplier | minutes * 0.95 | Ergonomic refit reduces desktop maintenance time. |
+| fiberInternet | assets[tag=video\|software].maintenance_time | multiplier | minutes * 0.9 | Fiber internet reduces video/software maintenance. |
+| fiberInternet | hustles[tag=live\|software].maintenance_time | multiplier | minutes * 0.9 | Fiber internet reduces maintenance for live/software hustles. |
+| backupPowerArray | assets[tag=desktop_work\|video].maintenance_time | multiplier | minutes * 0.95 | Backup power reduces desktop/video maintenance. |
+| scratchDriveArray | assets[tag=video\|photo\|software].maintenance_time | multiplier | minutes * 0.9 | Scratch drive array reduces maintenance for video/photo/software assets. |
+| editorialPipeline | assets[tag=writing\|content].setup_time | multiplier | minutes * 0.88 | Editorial pipeline speeds writing/content setup. |
+| editorialPipeline | assets[tag=writing\|content].income | multiplier | income * 1.2 | Editorial pipeline boosts writing/content payouts. |
+| editorialPipeline | assets[tag=writing\|content].quality_progress | multiplier | progress * 1.5 | Editorial pipeline boosts writing/content quality progress. |
+| editorialPipeline | hustles[tag=writing].setup_time | multiplier | minutes * 0.88 | Editorial pipeline speeds writing hustles. |
+| editorialPipeline | hustles[tag=writing].income | multiplier | income * 1.2 | Editorial pipeline boosts writing hustle payouts. |
+| editorialPipeline | hustles[tag=writing].quality_progress | multiplier | progress * 1.5 | Editorial pipeline boosts writing hustle quality gains. |
+| syndicationSuite | assets[tag=writing\|content\|video].maintenance_time | multiplier | minutes * 0.9 | Syndication suite trims maintenance for writing/content/video assets. |
+| syndicationSuite | assets[tag=writing\|content\|video].income | multiplier | income * 1.25 | Syndication suite boosts payouts for writing/content/video assets. |
+| syndicationSuite | assets[tag=writing\|content\|video].quality_progress | multiplier | progress * 1.3333333333 | Syndication suite increases quality progress by 4/3. |
+| syndicationSuite | hustles[tag=writing\|marketing].maintenance_time | multiplier | minutes * 0.9 | Syndication suite reduces upkeep for writing/marketing hustles. |
+| syndicationSuite | hustles[tag=writing\|marketing].income | multiplier | income * 1.25 | Syndication suite boosts writing/marketing hustle payouts. |
+| syndicationSuite | hustles[tag=writing\|marketing].quality_progress | multiplier | progress * 1.3333333333 | Syndication suite increases hustle quality progress. |
+| immersiveStoryWorlds | assets[tag=writing\|video\|photo].income | multiplier | income * 1.12 | Immersive story worlds boosts writing/video/photo payouts. |
+| immersiveStoryWorlds | assets[tag=writing\|video\|photo].setup_time | multiplier | minutes * 0.85 | Immersive story worlds speeds setup for writing/video/photo assets. |
+| immersiveStoryWorlds | assets[tag=writing\|video\|photo].quality_progress | multiplier | progress * 2 | Immersive story worlds doubles quality progress for writing/video/photo assets. |
+| course | asset:blog.income | multiplier | income * 1.5 | Automation course boosts blog payouts 50%. |
+| course | asset:blog.quality_progress | multiplier | progress * 2 | Automation course doubles blog quality progress. |
+
+_Generated from docs/normalized_economy.json._
+

--- a/docs/EconomySpec.md
+++ b/docs/EconomySpec.md
@@ -1,0 +1,31 @@
+# Economy Specification
+
+## Dataset Overview
+The authoritative economy dataset is `docs/normalized_economy.json`, tagged as Phase 1 and documenting canonical values derived from the earlier economy reference. All timing values are stored in minutes and all currency values in USD to keep downstream tooling consistent.【F:docs/normalized_economy.json†L2-L8】
+
+## Structural Overview
+### Passive Assets
+Six passive ventures — blogs, e-books, vlogs, stock photo galleries, dropshipping labs, and micro SaaS platforms — enumerate base income, variance, setup cadence, upkeep, quality ladders, gating requirements, and thematic tags for each asset type.【F:docs/normalized_economy.json†L10-L499】
+
+### Instant Hustles
+The hustle catalog lists each instant action with its execution time, cash cost, payout, optional daily limit, prerequisite assets, and skill focus tags so balance passes can trace every short-term money source.【F:docs/normalized_economy.json†L502-L775】
+
+### Knowledge Tracks
+Education tracks describe their study schedules (days × minutes per day), tuition, and XP rewards including multi-skill splits, providing the definitive progression requirements used by scheduling and reward systems.【F:docs/normalized_economy.json†L777-L1210】
+
+### Upgrades
+Upgrade entries capture purchase costs, repeatability, categories, requirement chains, and any descriptive notes that modify assets, hustles, or global pacing levers.【F:docs/normalized_economy.json†L1249-L1715】
+
+## Key Formulas & Timing Data
+- Every asset defines `base_income` and a fractional `variance`, while quality tiers supply per-level min/max payouts and milestone requirements that scale earnings over time.【F:docs/normalized_economy.json†L12-L406】
+- Asset and hustle actions rely on minute-level `setup_time` values alongside structured schedules (`setup_days` × `setup_minutes_per_day`) to express multi-day buildouts or single-run action lengths.【F:docs/normalized_economy.json†L15-L83】【F:docs/normalized_economy.json†L237-L406】【F:docs/normalized_economy.json†L503-L775】
+- Daily upkeep draws on explicit `maintenance_time`/`maintenance_cost` pairs so passive streams can be budgeted alongside hustle opportunities.【F:docs/normalized_economy.json†L17-L331】
+- Hustles expose optional `daily_limit` caps and requirement arrays that drive scheduling logic for scarcity-bound gigs.【F:docs/normalized_economy.json†L512-L775】
+- Knowledge tracks contribute study pacing (`minutes_per_day`) and XP splits (`skill_split`) to feed player progression curves.【F:docs/normalized_economy.json†L787-L1120】
+- Upgrade purchases are priced through `setup_cost` and often annotated with notes explaining derived effects such as bonus minutes or repeatability limits.【F:docs/normalized_economy.json†L1250-L1323】
+
+## Modifier Taxonomy
+The modifier list normalizes how bonuses apply across the economy: multipliers scale incomes, progress, or timings; flat adjustments add deterministic payouts; and additive effects extend state values such as time bonuses.【F:docs/normalized_economy.json†L1727-L2154】 Targets span assets, hustles, state resources, and tag-based groups, ensuring every economy lever is discoverable from a single catalog.【F:docs/normalized_economy.json†L1727-L2154】
+
+## Appendix & Regeneration
+`docs/EconomySpec.appendix.md` stores auto-generated tables and charts derived from the normalized dataset and the modifier graph generator. Run `npm run rebuild-economy-docs` whenever constants change to refresh the appendix and update supporting diagrams.【F:scripts/rebuildEconomyDocs.mjs†L1-L286】

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Governance: Gameplay PRs that adjust economy constants must update `docs/EconomySpec.md`, rerun `npm run rebuild-economy-docs`, and attach the refreshed appendix before review.
 - Action progress now records per-day hours, supports deferred completions, and exposes helpers for advancing or resetting in-flight hustles.
 - Unified instant hustles and study sessions under a shared action registry that tracks accepted instances, daily limits, and
   completion history without erasing legacy hustle progress.

--- a/docs/maintenance-plan.md
+++ b/docs/maintenance-plan.md
@@ -3,3 +3,4 @@
 - **Loop basics:** Players budget hours across hustles, upkeep, automation, and study. Morning automation reserves upkeep first so the day never starts broken.
 - **Top chores:** Keep `npm install && npm test` green, document onboarding steps, and keep gameplay definitions separate from engine logic.
 - **Player promises:** New content should respect upkeep prioritization, surface ledger updates, and leave designers free to tweak numbers without touching runtime code.
+- **Economy updates:** After changing any economy constants or modifiers, run `npm run rebuild-economy-docs` to refresh the spec appendix and graphs.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "description": "Charming incremental game with modular browser CSS loaded directly",
   "scripts": {
-    "test": "node --test"
+    "test": "node --test",
+    "rebuild-economy-docs": "node scripts/rebuildEconomyDocs.mjs"
   },
   "devDependencies": {
     "jsdom": "^23.0.0"

--- a/scripts/rebuildEconomyDocs.mjs
+++ b/scripts/rebuildEconomyDocs.mjs
@@ -1,0 +1,286 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { spawn } from 'child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.resolve(__dirname, '..');
+const DATA_PATH = path.resolve(ROOT_DIR, 'docs', 'normalized_economy.json');
+const APPENDIX_PATH = path.resolve(ROOT_DIR, 'docs', 'EconomySpec.appendix.md');
+const GRAPH_SCRIPT = path.resolve(ROOT_DIR, 'scripts', 'generateEconomyGraph.mjs');
+
+function formatNumber(value) {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+  const numeric = Number(value);
+  if (Number.isNaN(numeric)) {
+    return String(value);
+  }
+  if (Number.isInteger(numeric)) {
+    return numeric.toString();
+  }
+  return numeric.toFixed(2).replace(/\.0+$/, '').replace(/(\.\d*[1-9])0+$/, '$1');
+}
+
+function formatCurrency(value) {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+  return `$${formatNumber(value)}`;
+}
+
+function formatMinutes(value) {
+  if (!value) {
+    return value === 0 ? '0' : '—';
+  }
+  return `${formatNumber(value)} min`;
+}
+
+function formatVariance(value) {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+  return `${formatNumber(value * 100)}%`;
+}
+
+function formatDailyLimit(value) {
+  if (value === null || value === undefined) {
+    return '∞';
+  }
+  return formatNumber(value);
+}
+
+function formatSkillSplit(split) {
+  if (!split || split.length === 0) {
+    return '—';
+  }
+  return split
+    .map((entry) => {
+      if (typeof entry === 'string') {
+        return entry;
+      }
+      const percent = entry.weight !== undefined ? `${formatNumber(entry.weight * 100)}%` : '—';
+      return `${entry.id} ${percent}`;
+    })
+    .join(', ');
+}
+
+function formatRequirements(requirements) {
+  if (!requirements || requirements.length === 0) {
+    return '—';
+  }
+  return requirements
+    .map((req) => {
+      if (typeof req === 'string') {
+        return req;
+      }
+      if (req.assetId) {
+        return `${req.assetId}×${formatNumber(req.count ?? 1)}`;
+      }
+      if (req.id) {
+        return `${req.id}${req.type ? ` (${req.type})` : ''}`;
+      }
+      return JSON.stringify(req);
+    })
+    .join(', ');
+}
+
+function escapeCell(value) {
+  return String(value).replace(/\|/g, '\\|');
+}
+
+function renderTable(headers, rows) {
+  if (rows.length === 0) {
+    return '_No data found._';
+  }
+  const headerLine = `| ${headers.join(' | ')} |`;
+  const separatorLine = `| ${headers.map(() => '---').join(' | ')} |`;
+  const rowLines = rows.map((row) => `| ${row.map((cell) => escapeCell(cell)).join(' | ')} |`);
+  return [headerLine, separatorLine, ...rowLines].join('\n');
+}
+
+async function runGraphGenerator() {
+  await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [GRAPH_SCRIPT], {
+      cwd: ROOT_DIR,
+      stdio: 'inherit',
+    });
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`generateEconomyGraph.mjs exited with code ${code}`));
+      }
+    });
+    child.on('error', reject);
+  });
+}
+
+function buildAppendix(json) {
+  const timestamp = new Date().toISOString();
+
+  const assetRows = Object.values(json.assets ?? {})
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((asset) => [
+      asset.name,
+      asset.schedule
+        ? `${formatNumber(asset.schedule.setup_days)} d × ${formatNumber(asset.schedule.setup_minutes_per_day)} min`
+        : formatMinutes(asset.setup_time),
+      formatCurrency(asset.setup_cost),
+      formatMinutes(asset.maintenance_time ?? 0),
+      formatCurrency(asset.maintenance_cost ?? 0),
+      formatCurrency(asset.base_income),
+      formatVariance(asset.variance ?? 0),
+    ]);
+
+  const hustleRows = Object.values(json.hustles ?? {})
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((hustle) => [
+      hustle.name,
+      formatMinutes(hustle.setup_time),
+      formatCurrency(hustle.setup_cost),
+      formatCurrency(hustle.base_income),
+      formatDailyLimit(hustle.daily_limit),
+      formatRequirements(hustle.requirements),
+      Array.isArray(hustle.skills)
+        ? hustle.skills
+            .map((skill) =>
+              typeof skill === 'string'
+                ? skill
+                : `${skill.id} ${formatNumber((skill.weight ?? 0) * 100)}%`,
+            )
+            .join(', ')
+        : '—',
+    ]);
+
+  const trackRows = Object.values(json.tracks ?? {})
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((track) => [
+      track.name,
+      track.schedule
+        ? `${formatNumber(track.schedule.days)} d × ${formatNumber(track.schedule.minutes_per_day)} min`
+        : formatMinutes(track.setup_time),
+      formatCurrency(track.setup_cost),
+      formatNumber(track.rewards?.base_xp ?? 0),
+      formatSkillSplit(track.rewards?.skill_split),
+    ]);
+
+  const upgradeRows = Object.values(json.upgrades ?? {})
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((upgrade) => [
+      upgrade.name,
+      upgrade.category ?? '—',
+      formatCurrency(upgrade.setup_cost),
+      upgrade.repeatable ? 'Yes' : 'No',
+      upgrade.notes ?? '—',
+    ]);
+
+  const modifierTaxonomy = new Map();
+  for (const modifier of json.modifiers ?? []) {
+    const domain = modifier.target?.includes(':')
+      ? modifier.target.split(':')[0]
+      : modifier.target?.split('.')[0] ?? 'misc';
+    const key = `${modifier.type}|${domain}`;
+    if (!modifierTaxonomy.has(key)) {
+      modifierTaxonomy.set(key, {
+        type: modifier.type,
+        domain,
+        count: 0,
+        sample: modifier,
+      });
+    }
+    const bucket = modifierTaxonomy.get(key);
+    bucket.count += 1;
+  }
+
+  const taxonomyRows = Array.from(modifierTaxonomy.values())
+    .sort((a, b) => {
+      if (a.type === b.type) {
+        return a.domain.localeCompare(b.domain);
+      }
+      return a.type.localeCompare(b.type);
+    })
+    .map((bucket) => [
+      bucket.type ?? '—',
+      bucket.domain,
+      formatNumber(bucket.count),
+      bucket.sample
+        ? `${bucket.sample.source ?? '—'} → ${bucket.sample.target ?? '—'}`
+        : '—',
+    ]);
+
+  const modifierRows = (json.modifiers ?? [])
+    .map((modifier) => [
+      modifier.source ?? '—',
+      modifier.target ?? '—',
+      modifier.type ?? '—',
+      modifier.formula ?? '—',
+      modifier.notes ?? '—',
+    ]);
+
+  return [
+    '# Economy Specification Appendix (Auto-generated)',
+    '',
+    `Last generated: ${timestamp}`,
+    '',
+    '## Asset Summary',
+    renderTable(
+      [
+        'Asset',
+        'Setup Schedule',
+        'Setup Cost',
+        'Maintenance Time',
+        'Maintenance Cost',
+        'Base Income',
+        'Variance',
+      ],
+      assetRows,
+    ),
+    '',
+    '## Hustle Summary',
+    renderTable(
+      ['Hustle', 'Action Time', 'Cash Cost', 'Base Payout', 'Daily Limit', 'Requirements', 'Skills'],
+      hustleRows,
+    ),
+    '',
+    '## Knowledge Track Summary',
+    renderTable(
+      ['Track', 'Study Schedule', 'Tuition', 'Base XP', 'Skill Split'],
+      trackRows,
+    ),
+    '',
+    '## Upgrade Summary',
+    renderTable(
+      ['Upgrade', 'Category', 'Cost', 'Repeatable', 'Notes'],
+      upgradeRows,
+    ),
+    '',
+    '## Modifier Taxonomy',
+    renderTable(['Type', 'Domain', 'Count', 'Example'], taxonomyRows),
+    '',
+    '## Modifier Catalog',
+    renderTable(['Source', 'Target', 'Type', 'Formula', 'Notes'], modifierRows),
+    '',
+    '_Generated from docs/normalized_economy.json._',
+    '',
+  ].join('\n');
+}
+
+async function main() {
+  const raw = await fs.readFile(DATA_PATH, 'utf8');
+  const json = JSON.parse(raw);
+
+  await runGraphGenerator();
+
+  const appendix = buildAppendix(json);
+  await fs.writeFile(APPENDIX_PATH, `${appendix}\n`, 'utf8');
+
+  console.log('Economy documentation rebuilt.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add `docs/EconomySpec.md` that summarizes the normalized economy dataset and references the generated appendix
- build `scripts/rebuildEconomyDocs.mjs` to regenerate the spec appendix and graph, and expose it via `npm run rebuild-economy-docs`
- document the maintenance workflow and governance requirement for economy changes

## Testing
- npm run rebuild-economy-docs

------
https://chatgpt.com/codex/tasks/task_e_68e2917d7e84832cacc24949a4c608da