### PR TITLE
Sync niche popularity snapshots with trend events

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,7 @@
 - Routine hustle payouts and quality work logs now auto-dismiss so the notification bell spotlights urgent alerts.
 - ShopStack workspace trims unused detail builders—`buildDetailView` and the old `detailBuilders.js` helper are gone, with `detail/index.js` re-exporting the focused helpers directly.
 - Quality actions across passive assets can now spark upbeat celebration events that grant short-lived payout boosts.
+- Niche popularity now syncs with active trend events, keeping multipliers, history, and analytics aligned across saves.
 
 ## Recent Highlights
 - Passive assets gained Quality 4–5 payout milestones with clearer upkeep cues.

--- a/docs/features/niche-popularity-snapshots.md
+++ b/docs/features/niche-popularity-snapshots.md
@@ -1,0 +1,14 @@
+# Niche Popularity Snapshots
+
+## Overview
+Niche popularity now mirrors the current roster of active trend events instead of rolling random values at the start of each day. The synchronizer composes every niche's multiplier from ongoing events and stores the results as a snapshot (`score`, `delta`, `multiplier`, `label`, `tone`, `summary`). When no events apply, niches fall back to a neutral, steady baseline so dashboards and analytics remain grounded.
+
+## Goals
+- Keep niche popularity aligned with trend events so payouts and UI copy match the live modifiers.
+- Persist multi-day events across reloads without rerolling random scores that desync the UI and analytics history.
+- Provide sanitized snapshots that can be surfaced in tooltips, watchlists, and archived analytics without ad-hoc formatting per call site.
+
+## Implementation Notes
+- `syncNicheTrendSnapshots(state)` aggregates `currentPercent` modifiers from `getNicheEvents(state, nicheId)` and caches the derived snapshot for each niche.
+- Popularity initialization paths (`ensureNicheState`, persistence load/save hooks, and the day-end lifecycle) now call the synchronizer so state stays deterministic.
+- Snapshots clamp and round derived values through `src/game/niches/popularitySnapshot.js` to avoid runaway numbers while keeping deltas for comparison charts.

--- a/src/core/persistence/index.js
+++ b/src/core/persistence/index.js
@@ -3,6 +3,7 @@ import { createAssetInstance } from '../state/assets.js';
 import { SnapshotRepository } from './snapshotRepository.js';
 import { StateMigrationRunner } from './stateMigrationRunner.js';
 import { success, error, empty, tryCatch } from './result.js';
+import { syncNicheTrendSnapshots } from '../../game/events/syncNicheTrendSnapshots.js';
 
 function migrateLegacySnapshot(snapshot, context) {
   if (!snapshot || typeof snapshot !== 'object') {
@@ -158,6 +159,7 @@ export class StatePersistence {
     state.lastSaved = lastSaved;
     state.version = effectiveVersion;
     this.ensureStateShape(state);
+    syncNicheTrendSnapshots(state);
 
     if (typeof onReturning === 'function') {
       onReturning({ state, lastSaved });
@@ -205,6 +207,7 @@ export class StatePersistence {
     state.version = Math.max(this.version, initialVersion);
     state.lastSaved = lastSavedFallback;
     this.ensureStateShape(state);
+    syncNicheTrendSnapshots(state);
 
     if (typeof onFirstLoad === 'function') {
       onFirstLoad({ state, lastSaved: state.lastSaved });
@@ -217,6 +220,7 @@ export class StatePersistence {
     const state = this.getState();
     if (!state) return null;
     this.ensureStateShape(state);
+    syncNicheTrendSnapshots(state);
     const snapshot = this.clone(state);
     const lastSaved = this.now();
     const stateVersion = Number.isInteger(state.version) ? state.version : 0;

--- a/src/core/state/events.js
+++ b/src/core/state/events.js
@@ -67,11 +67,15 @@ function normalizeEventEntry(entry, { fallbackDay = 1 } = {}) {
     min: MIN_DURATION_DAYS,
     max: MAX_DURATION_DAYS
   });
-  const remainingDaysRaw = sanitizePositiveInteger(entry.remainingDays, {
-    min: 0,
-    max: MAX_DURATION_DAYS
-  });
-  const remainingDays = Math.min(totalDays, remainingDaysRaw || totalDays);
+  const hasExplicitRemaining = entry.remainingDays !== undefined && entry.remainingDays !== null;
+  const remainingDaysRaw = sanitizePositiveInteger(
+    hasExplicitRemaining ? entry.remainingDays : totalDays,
+    {
+      min: 0,
+      max: MAX_DURATION_DAYS
+    }
+  );
+  const remainingDays = Math.min(totalDays, remainingDaysRaw);
 
   const currentPercent = clampPercent(entry.currentPercent || entry.percent || 0);
   const dailyPercentChange = clampPercent(entry.dailyPercentChange || 0);

--- a/src/game/events/getNicheEvents.js
+++ b/src/game/events/getNicheEvents.js
@@ -1,0 +1,8 @@
+import { findEvents } from '../../core/state/events.js';
+
+export function getNicheEvents(state, nicheId) {
+  if (!nicheId) return [];
+  return findEvents(state, event => event.target?.type === 'niche' && event.target.nicheId === nicheId);
+}
+
+export default getNicheEvents;

--- a/src/game/events/nicheEvents.js
+++ b/src/game/events/nicheEvents.js
@@ -1,12 +1,7 @@
-import { findEvents } from '../../core/state/events.js';
 import { getNicheDefinitions } from '../assets/nicheData.js';
 import { NICHE_EVENT_BLUEPRINTS } from './config.js';
 import { logNicheEventStart } from './logging.js';
-
-function getNicheEvents(state, nicheId) {
-  if (!nicheId) return [];
-  return findEvents(state, event => event.target?.type === 'niche' && event.target.nicheId === nicheId);
-}
+import { getNicheEvents } from './getNicheEvents.js';
 
 export function createNicheEvents({ clampChance, buildEventFromBlueprint, hasEventWithTone }) {
   function maybeSpawnNicheEvents({ state, day }) {
@@ -49,3 +44,5 @@ export function createNicheEvents({ clampChance, buildEventFromBlueprint, hasEve
 export function getNicheEventsForState(state, nicheId) {
   return getNicheEvents(state, nicheId);
 }
+
+export { getNicheEvents };

--- a/src/game/events/syncNicheTrendSnapshots.js
+++ b/src/game/events/syncNicheTrendSnapshots.js
@@ -1,0 +1,38 @@
+import { getNicheDefinitions } from '../assets/nicheData.js';
+import { getNicheEvents } from './getNicheEvents.js';
+import { computePopularitySnapshot, createNeutralPopularitySnapshot } from '../niches/popularitySnapshot.js';
+
+function aggregateMultiplier(events = []) {
+  return events.reduce((product, event) => {
+    if (!event) return product;
+    if (event.stat !== 'income' || event.modifierType !== 'percent') return product;
+    if (!Number.isFinite(Number(event.currentPercent))) return product;
+    if (event.remainingDays != null && event.remainingDays <= 0) return product;
+    return Math.max(0, product * (1 + Number(event.currentPercent)));
+  }, 1);
+}
+
+export function syncNicheTrendSnapshots(state) {
+  if (!state || typeof state !== 'object') return null;
+  state.niches = state.niches || {};
+  const nicheState = state.niches;
+  nicheState.popularity = nicheState.popularity || {};
+
+  const definitions = getNicheDefinitions();
+  const knownIds = new Set(definitions.map(definition => definition.id));
+
+  for (const id of Object.keys(nicheState.popularity)) {
+    if (!knownIds.has(id)) {
+      delete nicheState.popularity[id];
+    }
+  }
+
+  definitions.forEach(definition => {
+    const events = getNicheEvents(state, definition.id);
+    const multiplier = aggregateMultiplier(events);
+    const existing = nicheState.popularity[definition.id] || createNeutralPopularitySnapshot();
+    nicheState.popularity[definition.id] = computePopularitySnapshot({ multiplier, existing });
+  });
+
+  return nicheState.popularity;
+}

--- a/src/game/lifecycle.js
+++ b/src/game/lifecycle.js
@@ -7,10 +7,10 @@ import { getTimeCap } from './time.js';
 import { flushDirty, markAllDirty, markDirty } from '../core/events/invalidationBus.js';
 import { advanceKnowledgeTracks, allocateDailyStudy } from './requirements.js';
 import { archiveDailyMetrics, resetDailyMetrics } from './metrics.js';
-import { rerollNichePopularity } from './assets/niches.js';
 import { computeDailySummary } from './summary.js';
 import { advanceEventsAfterDay } from './events/index.js';
 import { archiveNicheAnalytics } from './analytics/niches.js';
+import { syncNicheTrendSnapshots } from './events/syncNicheTrendSnapshots.js';
 
 function flushUiWithFallback(fallbackToFull = false) {
   const flushed = flushDirty();
@@ -30,6 +30,7 @@ export function endDay(auto = false) {
 
   closeOutDay();
   advanceEventsAfterDay(state.day);
+  syncNicheTrendSnapshots(state);
   advanceKnowledgeTracks();
   markAllDirty();
   flushUiWithFallback(true);
@@ -59,7 +60,6 @@ export function endDay(auto = false) {
       hustleState.lastRunDay = state.day;
     }
   }
-  rerollNichePopularity();
   state.dailyBonusTime = 0;
   getUpgradeState('coffee').usedToday = 0;
   state.timeLeft = getTimeCap();

--- a/src/game/niches/popularitySnapshot.js
+++ b/src/game/niches/popularitySnapshot.js
@@ -1,0 +1,117 @@
+const POPULARITY_BANDS = [
+  { min: 85, label: 'Blazing', tone: 'hot', summary: 'Audiences are ravenous — capitalize now.' },
+  { min: 70, label: 'Surging', tone: 'warm', summary: 'Momentum is building fast and payouts love it.' },
+  { min: 55, label: 'Trending', tone: 'warm', summary: 'Steady waves of interest keep income humming.' },
+  { min: 40, label: 'Steady', tone: 'steady', summary: 'Reliable attention with room for creative twists.' },
+  { min: 25, label: 'Cooling', tone: 'cool', summary: 'Interest is dipping — refresh your hooks soon.' },
+  { min: 0, label: 'Dormant', tone: 'cold', summary: 'Only superfans are tuning in today.' }
+];
+
+const NEUTRAL_SCORE = 50;
+
+function roundMultiplier(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return 1;
+  }
+  return Math.max(0, Math.round(numeric * 100) / 100);
+}
+
+export function clampScore(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return null;
+  return Math.max(0, Math.min(100, Math.round(numeric)));
+}
+
+export function describePopularity(score) {
+  const numeric = Number(score);
+  const target = Number.isFinite(numeric) ? numeric : NEUTRAL_SCORE;
+  const band = POPULARITY_BANDS.find(entry => target >= entry.min) || POPULARITY_BANDS.at(-1);
+  return {
+    label: band?.label || 'Unknown',
+    tone: band?.tone || 'steady',
+    summary: band?.summary || ''
+  };
+}
+
+export function createNeutralPopularitySnapshot() {
+  const descriptor = describePopularity(NEUTRAL_SCORE);
+  return {
+    score: NEUTRAL_SCORE,
+    previousScore: null,
+    delta: null,
+    multiplier: 1,
+    label: descriptor.label,
+    tone: descriptor.tone,
+    summary: descriptor.summary
+  };
+}
+
+export function sanitizePopularitySnapshot(entry) {
+  const neutral = createNeutralPopularitySnapshot();
+  if (!entry || typeof entry !== 'object') {
+    return { ...neutral };
+  }
+
+  const score = clampScore(entry.score);
+  const previousScore = clampScore(entry.previousScore);
+  const descriptor = describePopularity(score ?? neutral.score);
+  const multiplier = roundMultiplier(entry.multiplier);
+  const deltaRaw = Number(entry.delta);
+  const label = typeof entry.label === 'string' && entry.label ? entry.label : descriptor.label;
+  const summary = typeof entry.summary === 'string' && entry.summary ? entry.summary : descriptor.summary;
+  const tone = typeof entry.tone === 'string' && entry.tone ? entry.tone : descriptor.tone;
+
+  const resolvedScore = score ?? neutral.score;
+  const resolvedPrevious = previousScore ?? null;
+  const resolvedDelta = Number.isFinite(deltaRaw)
+    ? Math.round(deltaRaw)
+    : resolvedPrevious != null
+    ? resolvedScore - resolvedPrevious
+    : null;
+
+  return {
+    score: resolvedScore,
+    previousScore: resolvedPrevious,
+    delta: resolvedDelta,
+    multiplier,
+    label,
+    summary,
+    tone
+  };
+}
+
+export function computePopularitySnapshot({ multiplier, existing }) {
+  const neutral = createNeutralPopularitySnapshot();
+  const safeMultiplier = roundMultiplier(multiplier);
+  const combinedPercent = Math.max(-0.95, safeMultiplier - 1);
+  const rawScore = NEUTRAL_SCORE + combinedPercent * 100;
+  const score = clampScore(rawScore) ?? neutral.score;
+  const descriptor = describePopularity(score);
+  const existingSnapshot = sanitizePopularitySnapshot(existing);
+
+  if (existingSnapshot.score === score) {
+    return {
+      ...existingSnapshot,
+      multiplier: safeMultiplier,
+      label: descriptor.label,
+      summary: descriptor.summary,
+      tone: descriptor.tone
+    };
+  }
+
+  const previousScore = existingSnapshot.score ?? neutral.score;
+  const delta = previousScore != null ? score - previousScore : null;
+
+  return {
+    score,
+    previousScore,
+    delta,
+    multiplier: safeMultiplier,
+    label: descriptor.label,
+    summary: descriptor.summary,
+    tone: descriptor.tone
+  };
+}
+
+export { POPULARITY_BANDS, NEUTRAL_SCORE };

--- a/tests/game/events/syncNicheTrendSnapshots.test.js
+++ b/tests/game/events/syncNicheTrendSnapshots.test.js
@@ -1,0 +1,91 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getGameTestHarness } from '../../helpers/gameTestHarness.js';
+
+const harness = await getGameTestHarness();
+const eventsModule = await import('../../../src/core/state/events.js');
+const gameEventsModule = await import('../../../src/game/events/index.js');
+const { addEvent } = eventsModule;
+const { advanceEventsAfterDay } = gameEventsModule;
+const { syncNicheTrendSnapshots } = await import('../../../src/game/events/syncNicheTrendSnapshots.js');
+
+const { stateModule } = harness;
+const { getState } = stateModule;
+
+const NICHE_ID = 'techInnovators';
+
+function getSnapshot(state, nicheId = NICHE_ID) {
+  return state?.niches?.popularity?.[nicheId] ?? null;
+}
+
+test.beforeEach(() => {
+  harness.resetState();
+});
+
+test('syncNicheTrendSnapshots caches event-driven popularity and preserves history', () => {
+  const originalRandom = Math.random;
+  Math.random = () => 1;
+  try {
+    const state = getState();
+    state.day = 1;
+
+    addEvent(state, {
+      templateId: 'test-niche-trend',
+      label: 'Test Trend',
+      stat: 'income',
+      modifierType: 'percent',
+      target: { type: 'niche', nicheId: NICHE_ID },
+      currentPercent: 0.25,
+      dailyPercentChange: -0.05,
+      totalDays: 3,
+      remainingDays: 3,
+      createdOnDay: state.day,
+      lastProcessedDay: state.day - 1
+    });
+
+    syncNicheTrendSnapshots(state);
+
+    let snapshot = getSnapshot(state);
+    assert.ok(snapshot, 'trend snapshot should exist after syncing');
+    assert.equal(snapshot.score, 75, 'score should reflect aggregated percent boost');
+    assert.equal(snapshot.previousScore, 50, 'previous score should track neutral baseline');
+    assert.equal(snapshot.delta, 25, 'delta should compare against previous score');
+    assert.equal(snapshot.multiplier, 1.25, 'multiplier should mirror event payout impact');
+    assert.equal(snapshot.label, 'Surging', 'label should match computed score band');
+
+    advanceEventsAfterDay(state.day);
+    syncNicheTrendSnapshots(state);
+
+    snapshot = getSnapshot(state);
+    assert.equal(snapshot.score, 70, 'score should decay with event daily change');
+    assert.equal(snapshot.previousScore, 75, 'previous score should capture prior reading');
+    assert.equal(snapshot.delta, -5, 'delta should update relative to previous score');
+
+    syncNicheTrendSnapshots(state);
+    const repeated = getSnapshot(state);
+    assert.equal(repeated.previousScore, snapshot.previousScore, 're-sync should not reset previous score');
+    assert.equal(repeated.delta, snapshot.delta, 're-sync should keep existing delta when unchanged');
+
+    state.day += 1;
+    advanceEventsAfterDay(state.day);
+    syncNicheTrendSnapshots(state);
+
+    snapshot = getSnapshot(state);
+    assert.ok(snapshot.score <= 65, 'score should continue trending toward neutral');
+    assert.ok(snapshot.previousScore >= 70, 'previous score should retain last active value');
+
+    state.day += 1;
+    advanceEventsAfterDay(state.day);
+    syncNicheTrendSnapshots(state);
+
+    assert.equal(state.events.active.length, 0, 'event should be removed after final advance');
+
+    snapshot = getSnapshot(state);
+    assert.equal(snapshot.multiplier, 1, 'multiplier should reset to neutral when event ends');
+    assert.equal(snapshot.score, 50, 'score should fall back to neutral after event completion');
+    assert.equal(snapshot.previousScore, 65, 'previous score should capture last active reading for delta context');
+    assert.equal(snapshot.delta, -15, 'delta should reflect the drop back to neutral');
+  } finally {
+    Math.random = originalRandom;
+  }
+});

--- a/tests/stateManagement.test.js
+++ b/tests/stateManagement.test.js
@@ -149,10 +149,9 @@ test('ensureNicheStateShape repairs popularity map and fallback day', () => {
   assert.ok(state.niches.popularity.techInnovators, 'known niches should be kept');
   assert.equal(state.niches.popularity.fake, undefined, 'unknown niches should be removed');
   assert.equal(state.niches.popularity.techInnovators.previousScore, 15);
-  assert.ok(
-    state.niches.popularity.techInnovators.score >= 0 &&
-      state.niches.popularity.techInnovators.score <= 100
-  );
+  assert.equal(state.niches.popularity.techInnovators.score, 100);
+  assert.equal(state.niches.popularity.techInnovators.delta, 85);
+  assert.equal(state.niches.popularity.techInnovators.label, 'Blazing');
 });
 
 test('resetState clears runtime progress and log history', () => {


### PR DESCRIPTION
## Summary
- add a syncNicheTrendSnapshots helper that aggregates active niche events into cached popularity snapshots
- persist the event-driven snapshot across state initialization, daily advancement, and save/load flows
- document the deterministic niche popularity flow and cover it with regression tests while fixing event duration rollover

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2902de42c832ca1738ff35c44a24d