### PR TITLE
Tune niche trend events to ramp over 5–10 days

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,7 @@
 - ShopStack workspace trims unused detail builders—`buildDetailView` and the old `detailBuilders.js` helper are gone, with `detail/index.js` re-exporting the focused helpers directly.
 - Quality actions across passive assets can now spark upbeat celebration events that grant short-lived payout boosts.
 - Niche popularity now syncs with active trend events, keeping multipliers, history, and analytics aligned across saves.
+- Niche trend events now stretch across 5–10 days, building from gentle nudges to pronounced peaks (or dips) so players can react to the swelling momentum.
 
 ## Recent Highlights
 - Passive assets gained Quality 4–5 payout milestones with clearer upkeep cues.

--- a/docs/features/niche-popularity-snapshots.md
+++ b/docs/features/niche-popularity-snapshots.md
@@ -12,3 +12,4 @@ Niche popularity now mirrors the current roster of active trend events instead o
 - `syncNicheTrendSnapshots(state)` aggregates `currentPercent` modifiers from `getNicheEvents(state, nicheId)` and caches the derived snapshot for each niche.
 - Popularity initialization paths (`ensureNicheState`, persistence load/save hooks, and the day-end lifecycle) now call the synchronizer so state stays deterministic.
 - Snapshots clamp and round derived values through `src/game/niches/popularitySnapshot.js` to avoid runaway numbers while keeping deltas for comparison charts.
+- Niche trend blueprints roll 5–10 day schedules that ramp: upbeat waves open around +10% before climbing toward +35–55% boosts, while fatigue dips start near -12% and steepen toward -35–-60% hits before easing.

--- a/src/game/events/blueprints/nicheTrends.js
+++ b/src/game/events/blueprints/nicheTrends.js
@@ -1,5 +1,54 @@
 import { randomBetween } from './utils.js';
 
+const PLAN_CACHE_KEY = Symbol('nicheTrendPlans');
+
+const DURATION_RANGE = { min: 5, max: 10 };
+
+const POSITIVE_PLAN_CONFIG = {
+  tone: 'positive',
+  initialRange: { min: 0.08, max: 0.16 },
+  swingRange: { min: 0.22, max: 0.38 },
+  clamp: value => Math.min(0.95, value)
+};
+
+const NEGATIVE_PLAN_CONFIG = {
+  tone: 'negative',
+  initialRange: { min: -0.18, max: -0.12 },
+  swingRange: { min: 0.24, max: 0.42 },
+  clamp: value => Math.max(-0.95, value)
+};
+
+function rollDuration() {
+  const rolled = Math.round(randomBetween(DURATION_RANGE.min, DURATION_RANGE.max));
+  return Math.max(DURATION_RANGE.min, Math.min(DURATION_RANGE.max, rolled));
+}
+
+function rollPlan({ tone, initialRange, swingRange, clamp }) {
+  const duration = rollDuration();
+  const steps = Math.max(1, duration - 1);
+  const initialPercent = randomBetween(initialRange.min, initialRange.max);
+  const swing = randomBetween(swingRange.min, swingRange.max);
+  const targetPercent = clamp(initialPercent + (tone === 'positive' ? swing : -swing));
+  const dailyPercentChange = (targetPercent - initialPercent) / steps;
+  return {
+    duration,
+    initialPercent,
+    dailyPercentChange,
+    targetPercent
+  };
+}
+
+function getPlan(context, blueprintId, config) {
+  if (!context || typeof context !== 'object') {
+    return rollPlan(config);
+  }
+  const plans = (context[PLAN_CACHE_KEY] = context[PLAN_CACHE_KEY] || {});
+  if (!plans[blueprintId]) {
+    plans[blueprintId] = rollPlan(config);
+  }
+  return plans[blueprintId];
+}
+
 export const NICHE_TREND_BLUEPRINTS = [
   {
     id: 'niche:trendWave',
@@ -9,9 +58,9 @@ export const NICHE_TREND_BLUEPRINTS = [
     modifierType: 'percent',
     appliesTo: ({ definition }) => Boolean(definition?.id),
     chance: () => 0.1,
-    duration: () => 3,
-    initialPercent: () => randomBetween(0.18, 0.32),
-    dailyPercentChange: () => -0.06
+    duration: context => getPlan(context, 'niche:trendWave', POSITIVE_PLAN_CONFIG).duration,
+    initialPercent: context => getPlan(context, 'niche:trendWave', POSITIVE_PLAN_CONFIG).initialPercent,
+    dailyPercentChange: context => getPlan(context, 'niche:trendWave', POSITIVE_PLAN_CONFIG).dailyPercentChange
   },
   {
     id: 'niche:trendDip',
@@ -21,8 +70,8 @@ export const NICHE_TREND_BLUEPRINTS = [
     modifierType: 'percent',
     appliesTo: ({ definition }) => Boolean(definition?.id),
     chance: () => 0.06,
-    duration: () => 3,
-    initialPercent: () => randomBetween(-0.28, -0.12),
-    dailyPercentChange: () => 0.07
+    duration: context => getPlan(context, 'niche:trendDip', NEGATIVE_PLAN_CONFIG).duration,
+    initialPercent: context => getPlan(context, 'niche:trendDip', NEGATIVE_PLAN_CONFIG).initialPercent,
+    dailyPercentChange: context => getPlan(context, 'niche:trendDip', NEGATIVE_PLAN_CONFIG).dailyPercentChange
   }
 ];

--- a/tests/game/events/blueprints.test.js
+++ b/tests/game/events/blueprints.test.js
@@ -2,6 +2,21 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { ASSET_EVENT_BLUEPRINTS, NICHE_EVENT_BLUEPRINTS } from '../../../src/game/events/config.js';
 
+function withMockedRandom(sequence, callback) {
+  const original = Math.random;
+  let index = 0;
+  Math.random = () => {
+    const nextIndex = index++;
+    if (nextIndex >= sequence.length) return sequence[sequence.length - 1] ?? 0;
+    return sequence[nextIndex];
+  };
+  try {
+    return callback();
+  } finally {
+    Math.random = original;
+  }
+}
+
 const expectedAssetBlueprintIds = [
   'asset:viralTrend',
   'asset:platformSetback',
@@ -23,4 +38,64 @@ test('asset event blueprints retain expected ordering', () => {
 test('niche event blueprints retain expected ordering', () => {
   const ids = NICHE_EVENT_BLUEPRINTS.map(blueprint => blueprint.id);
   assert.deepEqual(ids, expectedNicheBlueprintIds);
+});
+
+test('niche trend wave ramps toward a stronger boost across its duration', () => {
+  const blueprint = NICHE_EVENT_BLUEPRINTS.find(entry => entry.id === 'niche:trendWave');
+  assert.ok(blueprint, 'trend wave blueprint is registered');
+
+  withMockedRandom([0.4, 0.25, 0.6], () => {
+    const context = {};
+    const duration = blueprint.duration(context);
+    const initial = blueprint.initialPercent(context);
+    const daily = blueprint.dailyPercentChange(context);
+
+    assert.equal(duration, 7);
+    assert.ok(duration >= 5 && duration <= 10);
+    assert.ok(initial >= 0.08 && initial <= 0.16);
+    assert.ok(daily > 0, 'positive trends gain steam each day');
+
+    const final = initial + daily * (duration - 1);
+    assert.ok(final > initial);
+    assert.ok(final >= 0.3 && final <= 0.6);
+  });
+});
+
+test('niche trend dip deepens before recovering', () => {
+  const blueprint = NICHE_EVENT_BLUEPRINTS.find(entry => entry.id === 'niche:trendDip');
+  assert.ok(blueprint, 'trend dip blueprint is registered');
+
+  withMockedRandom([0.8, 0.1, 0.3], () => {
+    const context = {};
+    const duration = blueprint.duration(context);
+    const initial = blueprint.initialPercent(context);
+    const daily = blueprint.dailyPercentChange(context);
+
+    assert.equal(duration, 9);
+    assert.ok(duration >= 5 && duration <= 10);
+    assert.ok(initial <= -0.12 && initial >= -0.18);
+    assert.ok(daily < 0, 'negative trends slide downward each day');
+
+    const final = initial + daily * (duration - 1);
+    assert.ok(final < initial);
+    assert.ok(final <= -0.32 && final >= -0.7);
+  });
+});
+
+test('niche trend durations roll between five and ten days', () => {
+  const wave = NICHE_EVENT_BLUEPRINTS.find(entry => entry.id === 'niche:trendWave');
+  const dip = NICHE_EVENT_BLUEPRINTS.find(entry => entry.id === 'niche:trendDip');
+  assert.ok(wave && dip, 'trend blueprints should exist');
+
+  withMockedRandom([0, 0, 0], () => {
+    const context = {};
+    const minDuration = wave.duration(context);
+    assert.equal(minDuration, 5);
+  });
+
+  withMockedRandom([0.999, 0.999, 0.999], () => {
+    const context = {};
+    const maxDuration = dip.duration(context);
+    assert.equal(maxDuration, 10);
+  });
 });


### PR DESCRIPTION
## Summary
- extend niche trend blueprints to roll 5–10 day schedules with tone-specific ramps toward stronger peaks
- expand blueprint coverage to assert the new duration bounds and progressive percent changes
- document the tuning adjustments in the niche popularity design note and changelog

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e2985c84f8832cb10a137871d3ef47