### PR TITLE
Expand balancing workbench for multi-asset upgrades

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Tooling: Added a Streamlit balancing workbench (`tools/balancingWorkbench/`) with live sliders, ROI charts, and PNG exports to accelerate economy tuning sessions.
+- Tooling: Balancing workbench can now simulate multi-asset lineups and upgrade combos, with a handy summary of setup hours, upkeep, and bonus time.
 - Governance: Gameplay PRs that adjust economy constants must update `docs/EconomySpec.md`, rerun `npm run rebuild-economy-docs`, and attach the refreshed appendix before review.
 - Knowledge study tracks now spawn manual study actions; log hours yourself to advance days and earn completion rewards, with migrated saves seeding pending sessions for existing enrollments.
 - Action progress now records per-day hours, supports deferred completions, and exposes helpers for advancing or resetting in-flight hustles.

--- a/docs/features/balancing-workbench.md
+++ b/docs/features/balancing-workbench.md
@@ -11,8 +11,14 @@ fast while grounding every experiment in the authoritative simulation logic.
 
 ## Key Parameters
 - Starting cash, daily hours, assistant costs, and passive blog upkeep are all adjustable via sliders.
-- Multipliers target the freelance writing hustle, survey sprint hustle, and the first blog's payout/expenses.
+- Asset roster & upgrade picks live in the sidebar: select any mix of assets and layer on upgrades to see their combined upkeep and payouts.
+- Multipliers target the freelance writing hustle, survey sprint hustle, and the first blog's payout/expenses, and now stack with upgrade modifiers.
 - Sensitivity scans run a short sweep of multipliers to spotlight how final-day cash responds across a given range.
+
+## Recent Enhancements
+- The workbench previews the daily setup/maintenance load for every selected asset, including upgrade-provided bonuses.
+- Upgrade choices apply their full modifier set across assets, hustles, and bonus time so designers can model late-game automation plans.
+- Hustle and time bonuses are summarized inline, making it easier to narrate how a build achieves a given cashflow profile.
 
 ## Follow-up Actions
 - When the team approves a new target, update `docs/normalized_economy.json`, rerun `npm run rebuild-economy-docs`, and

--- a/scripts/economy_simulations.py
+++ b/scripts/economy_simulations.py
@@ -321,12 +321,12 @@ def run_simulation(
     assets = data['assets']
     hustles = data['hustles']
 
-    selected_assets: List[str] = list(asset_ids) if asset_ids is not None else list(config.asset_ids)
-    if not selected_assets:
-        if build_blog:
+    if asset_ids is None:
+        selected_assets: List[str] = list(config.asset_ids)
+        if not selected_assets and build_blog:
             selected_assets = ['blog']
-        else:
-            selected_assets = []
+    else:
+        selected_assets = list(asset_ids)
 
     selected_upgrades: List[str] = list(upgrade_ids) if upgrade_ids is not None else list(config.upgrade_ids)
 


### PR DESCRIPTION
## Summary
- allow the balancing workbench to select multiple assets and upgrades from the sidebar
- surface an asset plan overview with upkeep, payout, and bonus summaries based on chosen upgrades
- extend the simulation engine to apply upgrade modifiers across assets, hustles, and bonus time

## Testing
- python -m compileall tools/balancingWorkbench/app.py scripts/economy_simulations.py

------
https://chatgpt.com/codex/tasks/task_e_68e29b90d0e4832cbb29353879b661b5