### PR TITLE
Update deadline messaging for near-due commitments

### DIFF
--- a/src/ui/views/browser/components/commitmentMeters.js
+++ b/src/ui/views/browser/components/commitmentMeters.js
@@ -51,8 +51,13 @@ function createTrack(percent, tone) {
 function describeDeadline(remainingDays) {
   const remaining = safeNumber(remainingDays);
   if (!Number.isFinite(remaining)) return '';
-  if (remaining <= 0) return 'Due today';
-  if (remaining === 1) return 'Due tomorrow';
+  if (remaining < 0) {
+    const overdueDays = Math.ceil(Math.abs(remaining));
+    if (overdueDays <= 1) return 'Running a little late (1 day overdue)';
+    return `Running a little late (${overdueDays} days overdue)`;
+  }
+  if (remaining <= 1) return 'Due today';
+  if (remaining <= 2) return 'Due tomorrow';
   return `${remaining} days remaining`;
 }
 

--- a/tests/ui/views/browser/components/commitmentMeters.test.js
+++ b/tests/ui/views/browser/components/commitmentMeters.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ensureTestDom } from '../../../../helpers/setupDom.js';
+import {
+  createCommitmentTimeline,
+  describeDeadlineLabel
+} from '../../../../../src/ui/views/browser/components/commitmentMeters.js';
+
+test('describeDeadlineLabel treats anything due in a day or less as due today', () => {
+  assert.equal(describeDeadlineLabel({ remainingDays: 1 }), 'Due today');
+  assert.equal(describeDeadlineLabel({ remainingDays: 0 }), 'Due today');
+  assert.equal(describeDeadlineLabel({ remainingDays: 0.25 }), 'Due today');
+});
+
+test('describeDeadlineLabel adds a friendly overdue message for past deadlines', () => {
+  assert.equal(
+    describeDeadlineLabel({ remainingDays: -0.5 }),
+    'Running a little late (1 day overdue)'
+  );
+  assert.equal(
+    describeDeadlineLabel({ remainingDays: -2.1 }),
+    'Running a little late (3 days overdue)'
+  );
+});
+
+test('commitment timeline renders the updated deadline label', () => {
+  ensureTestDom();
+  const timeline = createCommitmentTimeline(
+    { remainingDays: 1 },
+    { showHours: false, showDeadline: true }
+  );
+
+  assert.ok(timeline, 'timeline should render when deadline information is present');
+  const label = timeline.querySelector('.commitment-meter__label');
+  assert.ok(label, 'timeline should include a label element');
+  assert.equal(label.textContent, 'Due today');
+});


### PR DESCRIPTION
## Summary
- update the deadline helper so commitments due within a day show "Due today" and add upbeat overdue copy
- ensure the commitment timeline renders the refreshed deadline label
- add tests covering the updated helper and timeline label

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e29fac1138832cba432eecca5c69d5