### PR TITLE
Add developer state explorer view

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ Each asset supports multiple instances, tracks setup progress, and rolls a daily
 - Adjust sliders to test new multipliers; export refreshed plots into `docs/economy_sim_report_assets` using the built-in
   snapshot button before updating `docs/normalized_economy.json`.
 
+## Developer State Explorer
+- Append `?view=developer` (or `?ui=developer`) to the game URL to load a dedicated developer dashboard.
+- The explorer hides the standard browser shell and surfaces:
+  - a quick overview (day, money, remaining time, active assets, event count),
+  - a live table of all active random events with their payout impact and remaining days,
+  - grouped long-term buffs (education completions, upgrade boosts, time bonuses), and
+  - a formatted JSON dump of the full in-memory state for copying into tests or fixtures.
+- Use the **Refresh snapshot** button or let it auto-refresh via the invalidation bus when the simulation updates.
+
 ## Styling Workflow
 - The browser shell now links each modular stylesheet directly. Edit the files under `styles/base/`, `styles/components/`, `styles/widgets/`, `styles/workspaces/`, and `styles/overlays/` and the changes will load without a build step.
 - Maintain the documented load order (base → components → widgets → workspaces → overlays) when adding new modules. Update the `<head>` of `index.html` with any additional `<link rel="stylesheet">` entries so the cascade remains intact.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,7 @@
 - Quality actions across passive assets can now spark upbeat celebration events that grant short-lived payout boosts.
 - Niche popularity now syncs with active trend events, keeping multipliers, history, and analytics aligned across saves.
 - Niche trend events now stretch across 5–10 days, building from gentle nudges to pronounced peaks (or dips) so players can react to the swelling momentum.
+- Tooling: Added a `?view=developer` state explorer that surfaces the live memory snapshot, active random events, and long-term buff sources for faster balancing passes.
 
 ## Recent Highlights
 - Passive assets gained Quality 4–5 payout milestones with clearer upkeep cues.

--- a/docs/features/developer-state-explorer.md
+++ b/docs/features/developer-state-explorer.md
@@ -1,0 +1,31 @@
+# Developer State Explorer
+
+## Goal
+Provide a fast, in-browser way for engineers and designers to inspect the full game state while iterating on new systems. The explorer exposes critical progression modifiers like random event buffs, education boosts, and time bonuses without requiring manual logging or digging through storage dumps.
+
+## Player Impact
+This is a developer-only quality-of-life feature. It does not change gameplay for players, but it shortens iteration time for the team by:
+
+- surfacing live memory values that previously required console spelunking,
+- highlighting income modifiers from random events to validate blueprint tuning, and
+- listing long-term buffs (education completions, upgrade perks, and time multipliers) so balancing changes are easier to verify.
+
+## Access
+Append `?view=developer` (or `?ui=developer`) to the game URL to boot directly into the explorer. The module hides the normal browser shell and displays the developer dashboard instead.
+
+## Layout Overview
+- **Overview card** – current day, cash, time remaining, active asset count, and total active events plus a timestamp for the snapshot.
+- **Random event buffs** – sortable table (by modifier magnitude) showing label, percent impact, target resolution, remaining days, and tone for each active event.
+- **Long-term buffs** – grouped by education completions, purchased upgrades with boost text, and current time bonuses (base, bonus, and daily additions).
+- **Raw state snapshot** – pretty-printed JSON dump of the full state object for quick copying into tests.
+
+## Implementation Notes
+- Registered as a UI view with guard `#developer-root`; does not interfere with normal shell boot.
+- Uses `subscribeToInvalidation` to stay in sync with the simulation tick.
+- Relies on registry definitions to label assets/upgrades and on `educationEffects` helpers to translate track bonuses into readable strings.
+- Styling lives in `styles/developer.css` and reuses existing font tokens while embracing a darker, data-dashboard motif.
+
+## Follow-ups / Ideas
+- Add filters to the event table for niche vs asset buffs.
+- Expose hustle- or asset-level computed payout breakdowns for the most recent tick.
+- Provide copy-to-clipboard buttons for JSON and per-section exports.

--- a/index.html
+++ b/index.html
@@ -28,6 +28,8 @@
   <!-- Overlays -->
   <link rel="stylesheet" href="styles/overlays/launch-dialog.css" />
   <link rel="stylesheet" href="styles/overlays/loading-screen.css" />
+  <!-- Developer tools -->
+  <link rel="stylesheet" href="styles/developer.css" />
   <link rel="icon" href="assets/icons/favicon.svg" type="image/svg+xml" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -257,6 +259,126 @@
       </section>
 
       <div id="browser-workspaces" class="browser-stage__pane browser-stage__pane--workspace" aria-live="polite"></div>
+    </div>
+  </div>
+
+  <div id="developer-root" class="developer-view" hidden aria-hidden="true">
+    <header class="developer-view__header">
+      <div class="developer-view__title-group">
+        <p class="developer-view__eyebrow">Developer utilities</p>
+        <h1 class="developer-view__title">State Explorer</h1>
+        <p class="developer-view__subtitle">
+          Review the live memory snapshot, active events, and every buff shaping the economy.
+        </p>
+      </div>
+      <div class="developer-view__actions">
+        <a class="developer-view__action" href="?view=browser">Return to browser shell</a>
+        <button id="developer-refresh-button" class="developer-view__action developer-view__action--button" type="button">
+          Refresh snapshot
+        </button>
+      </div>
+    </header>
+
+    <div class="developer-view__content">
+      <section class="developer-card" aria-labelledby="developer-overview-heading">
+        <header class="developer-card__header">
+          <h2 id="developer-overview-heading" class="developer-card__title">Overview</h2>
+          <p class="developer-card__subtitle">Quick pulse on the current save data.</p>
+        </header>
+        <dl class="developer-overview__grid">
+          <div class="developer-overview__item">
+            <dt>Day</dt>
+            <dd data-dev-field="day">—</dd>
+          </div>
+          <div class="developer-overview__item">
+            <dt>Cash on hand</dt>
+            <dd data-dev-field="money">—</dd>
+          </div>
+          <div class="developer-overview__item">
+            <dt>Time remaining</dt>
+            <dd data-dev-field="time">—</dd>
+          </div>
+          <div class="developer-overview__item">
+            <dt>Active assets</dt>
+            <dd data-dev-field="assets">—</dd>
+          </div>
+          <div class="developer-overview__item">
+            <dt>Active events</dt>
+            <dd data-dev-field="events">—</dd>
+          </div>
+        </dl>
+        <p class="developer-card__footer-note">Last updated <span data-dev-field="updated">—</span></p>
+      </section>
+
+      <section class="developer-card" aria-labelledby="developer-events-heading">
+        <header class="developer-card__header">
+          <h2 id="developer-events-heading" class="developer-card__title">Random event buffs</h2>
+          <p class="developer-card__subtitle">Percent swings currently modifying payouts or niches.</p>
+        </header>
+        <div class="developer-card__body">
+          <p id="developer-events-empty" class="developer-empty" hidden>No random events are active.</p>
+          <div class="developer-table" role="region" aria-live="polite">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Event</th>
+                  <th scope="col">Impact</th>
+                  <th scope="col">Target</th>
+                  <th scope="col">Days left</th>
+                  <th scope="col">Tone</th>
+                </tr>
+              </thead>
+              <tbody id="developer-events-body"></tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      <section class="developer-card" aria-labelledby="developer-buffs-heading">
+        <header class="developer-card__header">
+          <h2 id="developer-buffs-heading" class="developer-card__title">Long-term buffs</h2>
+          <p class="developer-card__subtitle">Education, upgrades, and time effects currently boosting progress.</p>
+        </header>
+        <div class="developer-card__body developer-buffs">
+          <div class="developer-buffs__group">
+            <h3 class="developer-buffs__title">Education</h3>
+            <p id="developer-education-empty" class="developer-empty" hidden>No education boosts unlocked yet.</p>
+            <ul id="developer-education-list" class="developer-buffs__list"></ul>
+          </div>
+          <div class="developer-buffs__group">
+            <h3 class="developer-buffs__title">Upgrades</h3>
+            <p id="developer-upgrades-empty" class="developer-empty" hidden>No upgrade boosts purchased.</p>
+            <ul id="developer-upgrade-list" class="developer-buffs__list"></ul>
+          </div>
+          <div class="developer-buffs__group">
+            <h3 class="developer-buffs__title">Time bonuses</h3>
+            <dl class="developer-buffs__stats">
+              <div>
+                <dt>Base time</dt>
+                <dd data-dev-field="baseTime">—</dd>
+              </div>
+              <div>
+                <dt>Bonus time</dt>
+                <dd data-dev-field="bonusTime">—</dd>
+              </div>
+              <div>
+                <dt>Daily bonus</dt>
+                <dd data-dev-field="dailyBonus">—</dd>
+              </div>
+            </dl>
+          </div>
+        </div>
+      </section>
+
+      <section class="developer-card" aria-labelledby="developer-state-heading">
+        <header class="developer-card__header">
+          <h2 id="developer-state-heading" class="developer-card__title">Raw state snapshot</h2>
+          <p class="developer-card__subtitle">Direct dump of the in-memory save data.</p>
+        </header>
+        <div class="developer-card__body">
+          <pre id="developer-state-json" class="developer-json" aria-live="polite"></pre>
+        </div>
+      </section>
     </div>
   </div>
 

--- a/src/ui/views/developer/index.js
+++ b/src/ui/views/developer/index.js
@@ -1,0 +1,57 @@
+import { subscribeToInvalidation } from '../../../core/events/invalidationBus.js';
+import { renderDeveloperView } from './render.js';
+
+let unsubscribe = null;
+
+function toggleBrowserShell(rootDocument, hidden) {
+  const doc = rootDocument || document;
+  const shell = doc.querySelector('.browser-shell');
+  if (shell) {
+    if (hidden) {
+      shell.setAttribute('hidden', 'true');
+      shell.setAttribute('aria-hidden', 'true');
+    } else {
+      shell.removeAttribute('hidden');
+      shell.removeAttribute('aria-hidden');
+    }
+  }
+}
+
+function bindRefresh(rootDocument) {
+  const doc = rootDocument || document;
+  const button = doc.getElementById('developer-refresh-button');
+  if (!button || button.dataset.bound === 'true') return;
+  button.addEventListener('click', () => {
+    renderDeveloperView(doc);
+  });
+  button.dataset.bound = 'true';
+}
+
+const developerView = {
+  id: 'developer',
+  name: 'Developer Tools',
+  onActivate({ root } = {}) {
+    const doc = root || document;
+    const container = doc.getElementById('developer-root');
+    if (!container) {
+      return;
+    }
+
+    container.hidden = false;
+    container.removeAttribute('aria-hidden');
+    if (!container.hasAttribute('tabindex')) {
+      container.setAttribute('tabindex', '-1');
+    }
+    doc.body?.classList.add('developer-view-active');
+    toggleBrowserShell(doc, true);
+    bindRefresh(doc);
+    renderDeveloperView(doc);
+
+    if (unsubscribe) {
+      unsubscribe();
+    }
+    unsubscribe = subscribeToInvalidation(() => renderDeveloperView(doc));
+  }
+};
+
+export default developerView;

--- a/src/ui/views/developer/render.js
+++ b/src/ui/views/developer/render.js
@@ -1,0 +1,255 @@
+import { formatMoney, formatHours } from '../../../core/helpers.js';
+import { getState, getUpgradeState } from '../../../core/state.js';
+import { getAssetDefinition } from '../../../core/state/registry.js';
+import { getNicheDefinition } from '../../../game/assets/nicheData.js';
+import { KNOWLEDGE_TRACKS, getKnowledgeProgress } from '../../../game/requirements.js';
+import { describeTrackEducationBonuses } from '../../../game/educationEffects.js';
+import { getUpgrades } from '../../../game/registryService.js';
+
+function countActiveAssets(state) {
+  if (!state?.assets) return 0;
+  return Object.values(state.assets).reduce((total, assetState) => {
+    const instances = Array.isArray(assetState?.instances) ? assetState.instances : [];
+    const active = instances.filter(instance => instance?.status === 'active').length;
+    return total + active;
+  }, 0);
+}
+
+function formatPercent(value) {
+  const numeric = Number(value) * 100;
+  if (!Number.isFinite(numeric) || Math.abs(numeric) < 0.0001) {
+    return '0%';
+  }
+  const precision = Math.abs(numeric) >= 10 ? 0 : 1;
+  const rounded = numeric.toFixed(precision);
+  const sign = numeric > 0 ? '+' : '';
+  return `${sign}${rounded}%`;
+}
+
+function describeEventTarget(event, state) {
+  if (!event?.target) return '—';
+  if (event.target.type === 'assetInstance') {
+    const definition = getAssetDefinition(event.target.assetId);
+    const assetState = state?.assets?.[event.target.assetId];
+    const instance = assetState?.instances?.find(entry => entry?.id === event.target.instanceId) || null;
+    const assetName = definition?.name || event.target.assetId;
+    const nickname = instance?.nickname || instance?.label || null;
+    const suffix = nickname ? ` (${nickname})` : instance ? ` (#${instance.id.slice(0, 6)})` : '';
+    return `${assetName}${suffix}`;
+  }
+  if (event.target.type === 'niche') {
+    const definition = getNicheDefinition(event.target.nicheId);
+    return definition?.name || event.target.nicheId || 'Niche';
+  }
+  return '—';
+}
+
+function setText(root, selector, value) {
+  const node = root.querySelector(selector);
+  if (node) {
+    node.textContent = value;
+  }
+}
+
+function renderOverview(container, state) {
+  const events = Array.isArray(state?.events?.active) ? state.events.active.length : 0;
+  const summary = {
+    day: `Day ${Math.max(1, Number(state?.day) || 1)}`,
+    money: `$${formatMoney(Number(state?.money) || 0)}`,
+    time: formatHours(Math.max(0, Number(state?.timeLeft) || 0)),
+    assets: countActiveAssets(state),
+    events,
+    updated: new Date().toLocaleString()
+  };
+
+  setText(container, '[data-dev-field="day"]', summary.day);
+  setText(container, '[data-dev-field="money"]', summary.money);
+  setText(container, '[data-dev-field="time"]', summary.time);
+  setText(container, '[data-dev-field="assets"]', String(summary.assets));
+  setText(container, '[data-dev-field="events"]', String(summary.events));
+  setText(container, '[data-dev-field="updated"]', summary.updated);
+}
+
+function renderEvents(container, state) {
+  const tableBody = container.querySelector('#developer-events-body');
+  const emptyNote = container.querySelector('#developer-events-empty');
+  if (!tableBody) return;
+
+  const events = Array.isArray(state?.events?.active) ? state.events.active : [];
+  tableBody.innerHTML = '';
+
+  if (!events.length) {
+    if (emptyNote) emptyNote.hidden = false;
+    return;
+  }
+
+  if (emptyNote) emptyNote.hidden = true;
+
+  events
+    .slice()
+    .sort((a, b) => Math.abs(b?.currentPercent || 0) - Math.abs(a?.currentPercent || 0))
+    .forEach(event => {
+      if (!event) return;
+      const row = container.ownerDocument.createElement('tr');
+      const impact = formatPercent(event.currentPercent || 0);
+      const target = describeEventTarget(event, state);
+      const remaining = `${Math.max(0, Number(event.remainingDays) || 0)} / ${Math.max(
+        0,
+        Number(event.totalDays) || 0
+      )}`;
+      const cells = [
+        event.label || event.templateId || 'Event',
+        impact,
+        target,
+        remaining,
+        event.tone || 'neutral'
+      ];
+      cells.forEach(value => {
+        const cell = container.ownerDocument.createElement('td');
+        cell.textContent = value;
+        row.appendChild(cell);
+      });
+      tableBody.appendChild(row);
+    });
+}
+
+function buildEducationBuffs(state) {
+  return Object.values(KNOWLEDGE_TRACKS)
+    .map(track => {
+      const progress = getKnowledgeProgress(track.id, state) || {};
+      const status = progress.completed ? 'Completed' : progress.enrolled ? 'In progress' : 'Not enrolled';
+      const details = describeTrackEducationBonuses(track.id).map(descriptor => {
+        try {
+          return descriptor();
+        } catch (error) {
+          return null;
+        }
+      });
+      return {
+        id: track.id,
+        name: track.name,
+        progress,
+        status,
+        details: details.filter(Boolean)
+      };
+    })
+    .filter(entry => entry.details.length > 0 || entry.progress?.enrolled || entry.progress?.completed);
+}
+
+function renderEducationBuffs(container, state) {
+  const list = container.querySelector('#developer-education-list');
+  const empty = container.querySelector('#developer-education-empty');
+  if (!list) return;
+
+  const entries = buildEducationBuffs(state);
+  list.innerHTML = '';
+
+  if (!entries.length) {
+    if (empty) empty.hidden = false;
+    return;
+  }
+
+  if (empty) empty.hidden = true;
+
+  entries.forEach(entry => {
+    const item = container.ownerDocument.createElement('li');
+    item.className = 'developer-buff-card';
+
+    const title = container.ownerDocument.createElement('p');
+    title.className = 'developer-buff-card__title';
+    title.textContent = entry.name;
+
+    const meta = container.ownerDocument.createElement('p');
+    meta.className = 'developer-buff-card__meta';
+    meta.textContent = `${entry.status} • ${entry.progress.daysCompleted || 0}/${
+      entry.progress.totalDays ?? entry.progress.daysTotal ?? 0
+    } days`;
+
+    const notes = container.ownerDocument.createElement('p');
+    notes.className = 'developer-buff-card__notes';
+    notes.textContent = entry.details.join(' ');
+
+    item.append(title, meta, notes);
+    list.appendChild(item);
+  });
+}
+
+function renderUpgradeBuffs(container, state) {
+  const list = container.querySelector('#developer-upgrade-list');
+  const empty = container.querySelector('#developer-upgrades-empty');
+  if (!list) return;
+
+  const owned = getUpgrades()
+    .filter(definition => getUpgradeState(definition.id, state)?.purchased)
+    .map(definition => ({
+      id: definition.id,
+      name: definition.name,
+      boosts: definition.boosts || definition.description || '',
+      tag: definition.tag?.label || null
+    }))
+    .filter(entry => Boolean(entry.boosts));
+
+  list.innerHTML = '';
+
+  if (!owned.length) {
+    if (empty) empty.hidden = false;
+    return;
+  }
+
+  if (empty) empty.hidden = true;
+
+  owned.forEach(entry => {
+    const item = container.ownerDocument.createElement('li');
+    item.className = 'developer-buff-card';
+
+    const title = container.ownerDocument.createElement('p');
+    title.className = 'developer-buff-card__title';
+    title.textContent = entry.name;
+
+    const meta = container.ownerDocument.createElement('p');
+    meta.className = 'developer-buff-card__meta';
+    meta.textContent = entry.tag ? entry.tag : 'Upgrade boost';
+
+    const notes = container.ownerDocument.createElement('p');
+    notes.className = 'developer-buff-card__notes';
+    notes.textContent = entry.boosts;
+
+    item.append(title, meta, notes);
+    list.appendChild(item);
+  });
+}
+
+function renderTimeBuffs(container, state) {
+  const base = formatHours(Number(state?.baseTime) || 0);
+  const bonus = formatHours(Number(state?.bonusTime) || 0);
+  const daily = formatHours(Number(state?.dailyBonusTime) || 0);
+
+  setText(container, '[data-dev-field="baseTime"]', base);
+  setText(container, '[data-dev-field="bonusTime"]', bonus);
+  setText(container, '[data-dev-field="dailyBonus"]', daily);
+}
+
+function renderStateDump(container, state) {
+  const output = container.querySelector('#developer-state-json');
+  if (!output) return;
+  output.textContent = JSON.stringify(state, null, 2);
+}
+
+export function renderDeveloperView(rootDocument = document) {
+  const doc = rootDocument || document;
+  const container = doc.getElementById('developer-root');
+  if (!container) return;
+
+  const state = getState();
+  if (!state) {
+    setText(container, '#developer-state-json', 'State manager not initialized.');
+    return;
+  }
+
+  renderOverview(container, state);
+  renderEvents(container, state);
+  renderEducationBuffs(container, state);
+  renderUpgradeBuffs(container, state);
+  renderTimeBuffs(container, state);
+  renderStateDump(container, state);
+}

--- a/src/ui/views/registry.js
+++ b/src/ui/views/registry.js
@@ -1,4 +1,5 @@
 import browserView from './browser/index.js';
+import developerView from './developer/index.js';
 
 const registeredViews = [];
 
@@ -121,6 +122,10 @@ export function resolveInitialView(
 
 registerView(browserView, {
   guard: root => Boolean(root?.getElementById('browser-home'))
+});
+
+registerView(developerView, {
+  guard: root => Boolean(root?.getElementById('developer-root'))
 });
 
 export default {

--- a/styles/developer.css
+++ b/styles/developer.css
@@ -1,0 +1,303 @@
+body.developer-view-active {
+  background-color: var(--surface-background, #0c0f16);
+  color: var(--text-primary-on-dark, #f5f7fb);
+}
+
+.developer-view {
+  font-family: 'Manrope', system-ui, sans-serif;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 2.5rem clamp(1.5rem, 5vw, 4rem) 3.5rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  color: inherit;
+}
+
+.developer-view__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.developer-view__title-group {
+  max-width: 48ch;
+}
+
+.developer-view__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+  font-size: 0.75rem;
+  margin: 0 0 0.5rem;
+  color: var(--text-secondary-on-dark, rgba(245, 247, 251, 0.72));
+}
+
+.developer-view__title {
+  font-size: clamp(2rem, 5vw, 2.75rem);
+  line-height: 1.1;
+  margin: 0;
+}
+
+.developer-view__subtitle {
+  margin: 0.5rem 0 0;
+  font-size: 1rem;
+  color: var(--text-secondary-on-dark, rgba(245, 247, 251, 0.72));
+}
+
+.developer-view__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.developer-view__action {
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  text-decoration: none;
+  border: 1px solid rgba(245, 247, 251, 0.2);
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: transform 120ms ease, background 120ms ease;
+  cursor: pointer;
+}
+
+.developer-view__action:hover,
+.developer-view__action:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  transform: translateY(-1px);
+}
+
+.developer-view__action--button {
+  border: none;
+  background: linear-gradient(135deg, #5b8def, #8e65ff);
+  color: #fff;
+  box-shadow: 0 0.75rem 1.5rem rgba(94, 118, 255, 0.2);
+}
+
+.developer-view__action--button:hover,
+.developer-view__action--button:focus-visible {
+  background: linear-gradient(135deg, #6b9cff, #9f74ff);
+}
+
+.developer-view__content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.75rem;
+}
+
+.developer-card {
+  background: rgba(17, 23, 38, 0.85);
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 1.5rem 3rem rgba(12, 15, 22, 0.45);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.developer-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.developer-card__title {
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.developer-card__subtitle {
+  margin: 0;
+  color: var(--text-secondary-on-dark, rgba(245, 247, 251, 0.68));
+  font-size: 0.95rem;
+}
+
+.developer-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.developer-card__footer-note {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-secondary-on-dark, rgba(245, 247, 251, 0.6));
+}
+
+.developer-overview__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+  margin: 0;
+}
+
+.developer-overview__item {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 1rem;
+  padding: 1rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.developer-overview__item dt {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary-on-dark, rgba(245, 247, 251, 0.6));
+}
+
+.developer-overview__item dd {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.developer-table table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.developer-table th,
+.developer-table td {
+  text-align: left;
+  padding: 0.6rem 0.75rem;
+}
+
+.developer-table thead {
+  background: rgba(255, 255, 255, 0.05);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
+  color: var(--text-secondary-on-dark, rgba(245, 247, 251, 0.65));
+}
+
+.developer-table tbody tr:nth-child(odd) {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.developer-table tbody tr:hover {
+  background: rgba(94, 118, 255, 0.12);
+}
+
+.developer-empty {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-secondary-on-dark, rgba(245, 247, 251, 0.62));
+}
+
+.developer-buffs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.developer-buffs__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.developer-buffs__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.developer-buffs__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.developer-buff-card {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 1rem;
+  padding: 0.9rem 1rem;
+  display: grid;
+  gap: 0.35rem;
+  border-left: 3px solid rgba(94, 118, 255, 0.55);
+}
+
+.developer-buff-card__title {
+  margin: 0;
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.developer-buff-card__meta {
+  margin: 0;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary-on-dark, rgba(245, 247, 251, 0.56));
+}
+
+.developer-buff-card__notes {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-secondary-on-dark, rgba(245, 247, 251, 0.75));
+}
+
+.developer-buffs__stats {
+  display: grid;
+  gap: 0.65rem;
+  margin: 0;
+}
+
+.developer-buffs__stats div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 0.9rem;
+  padding: 0.75rem 1rem;
+}
+
+.developer-buffs__stats dt {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary-on-dark, rgba(245, 247, 251, 0.58));
+}
+
+.developer-buffs__stats dd {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+.developer-json {
+  background: rgba(0, 0, 0, 0.45);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.85rem;
+  max-height: 480px;
+  overflow: auto;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  color: #e4e9f7;
+}
+
+@media (max-width: 768px) {
+  .developer-view {
+    padding: 2rem 1.25rem 3rem;
+  }
+
+  .developer-view__content {
+    grid-template-columns: 1fr;
+  }
+}

--- a/tests/ui/views/registry.test.js
+++ b/tests/ui/views/registry.test.js
@@ -40,7 +40,7 @@ test('registry exposes built-in views with guards and presenters', () => {
   const entries = getRegisteredViews();
   const ids = entries.map(entry => entry.id);
 
-  assert.deepEqual(ids, ['browser']);
+  assert.deepEqual(ids, ['browser', 'developer']);
 
   for (const entry of entries) {
     assert.equal(typeof entry.guard, 'function');
@@ -82,4 +82,16 @@ test('newly registered views can be resolved without entry point changes', t => 
 
   const resolved = resolveInitialView(dom.window.document);
   assert.equal(resolved, futureView);
+});
+
+test('developer view resolves when requested via query flag', t => {
+  const { dom, restore } = withDom(
+    '<!DOCTYPE html><html><body><div id="browser-home"></div><div id="developer-root"></div></body></html>',
+    { url: 'https://example.com/?view=developer' }
+  );
+
+  t.after(restore);
+
+  const resolved = resolveInitialView(dom.window.document);
+  assert.equal(resolved?.id, 'developer');
 });


### PR DESCRIPTION
## Summary
- add a developer-only "State Explorer" view that hides the browser shell and surfaces the live save snapshot, random events, and buffs
- style the explorer with a dedicated stylesheet and document access in the README plus a feature note and changelog entry
- cover the new view registration with a regression test for query-flag resolution

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e29f289ea0832caf7e4c5b498f7a85