### PR TITLE
Prefer model-defined hustle actions

### DIFF
--- a/src/ui/views/browser/apps/hustles.js
+++ b/src/ui/views/browser/apps/hustles.js
@@ -227,10 +227,16 @@ function createHustleCard(definition, model) {
     queueButton.className = 'browser-card__button browser-card__button--primary';
     queueButton.textContent = model.action.label;
     queueButton.disabled = Boolean(model.action.disabled);
-    queueButton.addEventListener('click', () => {
-      if (queueButton.disabled) return;
-      definition.action.onClick?.();
-    });
+    const handleClick =
+      typeof model.action?.onClick === 'function'
+        ? model.action.onClick
+        : definition.action.onClick;
+    if (typeof handleClick === 'function') {
+      queueButton.addEventListener('click', () => {
+        if (queueButton.disabled) return;
+        handleClick();
+      });
+    }
     actions.appendChild(queueButton);
   }
   card.appendChild(actions);


### PR DESCRIPTION
## Summary
- invoke a hustle card's onClick from the model when provided and fall back to the definition handler otherwise
- keep the queue button's disabled guard to avoid accidental clicks

## Testing
- node --test tests/hustles.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2a1b2a9e0832c8bfb36e40e8bcc37