### PR TITLE
Load state before setting initial view

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -38,9 +38,6 @@ function createAppContext() {
 
 ensureRegistryReady();
 const appContext = createAppContext();
-const initialView = resolveInitialView(document);
-setActiveView(initialView, document);
-ensureUpdateSubscriptions();
 const { loadState, saveState } = appContext.storage;
 const { returning, lastSaved } = loadState({
   onFirstLoad: () =>
@@ -49,6 +46,9 @@ const { returning, lastSaved } = loadState({
 if (returning) {
   handleOfflineProgress(lastSaved);
 }
+const initialView = resolveInitialView(document);
+setActiveView(initialView, document);
+ensureUpdateSubscriptions();
 renderLog();
 renderCards();
 updateUI();


### PR DESCRIPTION
## Summary
- load the saved game state before resolving the initial view so the developer dashboard renders populated data immediately

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2a3af6abc832c91b1d53c1247bc79