### PR TITLE
Refactor assistant config to use economy spec

### DIFF
--- a/docs/EconomySpec.appendix.md
+++ b/docs/EconomySpec.appendix.md
@@ -1,6 +1,6 @@
 # Economy Specification Appendix (Auto-generated)
 
-Last generated: 2025-10-05T15:45:29.537Z
+Last generated: 2025-10-05T17:07:42.069Z
 
 ## Asset Summary
 | Asset | Setup Schedule | Setup Cost | Maintenance Time | Maintenance Cost | Base Income | Variance |

--- a/docs/normalized_economy.json
+++ b/docs/normalized_economy.json
@@ -1299,6 +1299,11 @@
       "maintenance_cost": 0,
       "quality_curve": [],
       "category": "infra",
+      "hiring_cost": 180,
+      "bonus_minutes_per_day": 180,
+      "daily_wage": 24,
+      "hourly_wage": 8,
+      "max_count": 4,
       "notes": "Hire cost $180, adds 180 bonus minutes/day, $24 daily wage."
     },
     "serverRack": {

--- a/src/game/assistant.js
+++ b/src/game/assistant.js
@@ -6,15 +6,32 @@ import { gainTime } from './time.js';
 import { recordCostContribution } from './metrics.js';
 import { awardSkillProgress } from './skills/index.js';
 import { markDirty } from '../core/events/invalidationBus.js';
+import { assistantUpgrade } from './data/economyConfig.js';
 
 const CORE_UI_SECTIONS = ['dashboard', 'player', 'skillsWidget', 'headerAction'];
 
-export const ASSISTANT_CONFIG = {
-  hiringCost: 180,
-  hourlyRate: 8,
-  hoursPerAssistant: 3,
-  maxAssistants: 4
+const DEFAULT_ASSISTANT_VALUES = {
+  hiringCost: 0,
+  hourlyRate: 0,
+  hoursPerAssistant: 0,
+  bonusMinutesPerAssistant: 0,
+  dailyWage: 0,
+  maxAssistants: 0
 };
+
+export const ASSISTANT_CONFIG = Object.freeze({
+  ...DEFAULT_ASSISTANT_VALUES,
+  ...assistantUpgrade,
+  hoursPerAssistant:
+    assistantUpgrade.hoursPerAssistant ??
+    (assistantUpgrade.bonusMinutesPerAssistant
+      ? assistantUpgrade.bonusMinutesPerAssistant / 60
+      : DEFAULT_ASSISTANT_VALUES.hoursPerAssistant),
+  dailyWage:
+    assistantUpgrade.dailyWage ??
+    (assistantUpgrade.hourlyRate ?? DEFAULT_ASSISTANT_VALUES.hourlyRate) *
+      (assistantUpgrade.hoursPerAssistant ?? DEFAULT_ASSISTANT_VALUES.hoursPerAssistant)
+});
 
 function getAssistantState(target = getState()) {
   return getUpgradeState('assistant', target);

--- a/src/game/upgrades/assistantBehavior.js
+++ b/src/game/upgrades/assistantBehavior.js
@@ -2,8 +2,8 @@ import { formatMoney } from '../../core/helpers.js';
 import { getState } from '../../core/state.js';
 import { executeAction } from '../actions.js';
 import { checkDayEnd } from '../lifecycle.js';
+import { assistantUpgrade as assistantConfig } from '../data/economyConfig.js';
 import {
-  ASSISTANT_CONFIG,
   canFireAssistant,
   canHireAssistant,
   fireAssistant,
@@ -14,12 +14,12 @@ import {
 
 function buildAssistantDetails() {
   return [
-    () => `💵 Hiring Cost: <strong>$${formatMoney(ASSISTANT_CONFIG.hiringCost)}</strong>`,
-    () => `👥 Team Size: <strong>${getAssistantCount()} / ${ASSISTANT_CONFIG.maxAssistants}</strong>`,
-    () => `⏳ Support: <strong>+${ASSISTANT_CONFIG.hoursPerAssistant}h per assistant</strong>`,
+    () => `💵 Hiring Cost: <strong>$${formatMoney(assistantConfig.hiringCost)}</strong>`,
+    () => `👥 Team Size: <strong>${getAssistantCount()} / ${assistantConfig.maxAssistants}</strong>`,
+    () => `⏳ Support: <strong>+${assistantConfig.hoursPerAssistant}h per assistant</strong>`,
     () =>
       `💰 Payroll: <strong>$${formatMoney(
-        ASSISTANT_CONFIG.hourlyRate * ASSISTANT_CONFIG.hoursPerAssistant
+        assistantConfig.hourlyRate * assistantConfig.hoursPerAssistant
       )}</strong> each day per assistant`,
     () => `📅 Current Payroll: <strong>$${formatMoney(getAssistantDailyCost())} / day</strong>`
   ];
@@ -49,7 +49,7 @@ function createFireButton(card) {
 export const assistantHooks = {
   details: buildAssistantDetails(),
   actionLabel: () =>
-    getAssistantCount() >= ASSISTANT_CONFIG.maxAssistants ? 'Assistant Team Full' : 'Hire Assistant',
+    getAssistantCount() >= assistantConfig.maxAssistants ? 'Assistant Team Full' : 'Hire Assistant',
   disabled: () => !canHireAssistant(),
   onPurchase: () => {
     hireAssistant();


### PR DESCRIPTION
## Summary
- parse assistant upgrade metadata from the normalized economy spec and expose a shared assistant config
- refactor assistant logic and upgrade UI to consume the shared assistant config values
- capture assistant-specific fields in the normalized economy dataset and regenerate the appendix doc

## Testing
- npm test
- npm run rebuild-economy-docs

------
https://chatgpt.com/codex/tasks/task_e_68e2a4aeaffc832cb7ce96993c269c2d