### PR TITLE
Refactor knowledge tracks to use shared economy config

### DIFF
--- a/src/game/data/economyConfig.js
+++ b/src/game/data/economyConfig.js
@@ -14,6 +14,80 @@ const mapQualityCurve = curve =>
     requirements: entry.requirements || {}
   }));
 
+const parseModifierTarget = target => {
+  if (!target || typeof target !== 'string') {
+    return { category: null, id: null, stat: null };
+  }
+
+  const [category = null, descriptor = ''] = target.split(':');
+  const [id = null, stat = null] = descriptor.split('.');
+
+  return { category, id, stat };
+};
+
+const parseModifierAmount = modifier => {
+  if (!modifier) return 0;
+  if (typeof modifier.amount === 'number') {
+    return modifier.amount;
+  }
+
+  const formula = modifier.formula || '';
+  if (modifier.type === 'multiplier') {
+    const multiplierMatch = formula.match(/\(1\s*\+\s*([0-9.]+)\)/);
+    if (multiplierMatch) {
+      const value = Number(multiplierMatch[1]);
+      return Number.isFinite(value) ? value : 0;
+    }
+    const directMatch = formula.match(/\*\s*([0-9.]+)/);
+    if (directMatch) {
+      const value = Number(directMatch[1]);
+      return Number.isFinite(value) ? value - 1 : 0;
+    }
+  }
+
+  if (modifier.type === 'flat') {
+    const flatMatch = formula.match(/\+\s*([0-9.]+)/);
+    if (flatMatch) {
+      const value = Number(flatMatch[1]);
+      return Number.isFinite(value) ? value : 0;
+    }
+  }
+
+  return 0;
+};
+
+const mapInstantBoost = modifier => {
+  const target = parseModifierTarget(modifier.target);
+  const amount = parseModifierAmount(modifier);
+  const base = {
+    type: modifier.type,
+    amount,
+    notes: modifier.notes || null,
+    target: modifier.target || null,
+    formula: modifier.formula || null
+  };
+
+  if (target.category === 'asset') {
+    const asset = normalizedEconomy.assets?.[target.id] || {};
+    return {
+      ...base,
+      assetId: target.id,
+      assetName: asset.name || target.id
+    };
+  }
+
+  if (target.category === 'hustle') {
+    const hustle = normalizedEconomy.hustles?.[target.id] || {};
+    return {
+      ...base,
+      hustleId: target.id,
+      hustleName: hustle.name || target.id
+    };
+  }
+
+  return base;
+};
+
 const createAssetConfig = key => {
   const asset = normalizedEconomy.assets[key];
   const schedule = asset.schedule || {};
@@ -58,12 +132,23 @@ const createUpgradeConfig = key => {
 const createTrackConfig = key => {
   const track = normalizedEconomy.tracks[key];
   const schedule = track.schedule || {};
+  const days = schedule.setup_days ?? schedule.days ?? 0;
+  const minutesPerDay = schedule.setup_minutes_per_day ?? schedule.minutes_per_day ?? 0;
+  const instantBoosts = (normalizedEconomy.modifiers || [])
+    .filter(modifier => modifier.source === key)
+    .map(mapInstantBoost);
+
   return {
+    id: key,
+    name: track.name || key,
     schedule: {
-      days: schedule.setup_days ?? schedule.days,
-      minutesPerDay: schedule.setup_minutes_per_day ?? schedule.minutes_per_day
+      days,
+      minutesPerDay,
+      hoursPerDay: toHours(minutesPerDay)
     },
-    rewards: track.rewards || {}
+    setupCost: track.setup_cost ?? 0,
+    rewards: track.rewards || {},
+    instantBoosts
   };
 };
 

--- a/src/game/requirements/data/knowledgeTracks.js
+++ b/src/game/requirements/data/knowledgeTracks.js
@@ -1,370 +1,89 @@
-const knowledgeTrackData = {
-  "storycraftJumpstart": {
-    "id": "storycraftJumpstart",
-    "name": "Storycraft Jumpstart",
-    "description": "Outline pillar posts for 3 days (4h/day) and polish headlines without paying tuition.",
-    "hoursPerDay": 4,
-    "days": 3,
-    "tuition": 0,
-    "instantBoosts": [
-      {
-        "assetId": "blog",
-        "assetName": "Personal Blog Network",
-        "type": "multiplier",
-        "amount": 0.05
-      }
-    ]
-  },
-  "vlogStudioJumpstart": {
-    "id": "vlogStudioJumpstart",
-    "name": "Creator Studio Jumpstart",
-    "description": "Shadow a creator coach for 3 days (4h/day) to frame shots, light sets, and warm up edits. Tuition free.",
-    "hoursPerDay": 4,
-    "days": 3,
-    "tuition": 0,
-    "instantBoosts": [
-      {
-        "assetId": "vlog",
-        "assetName": "Weekly Vlog Channel",
-        "type": "multiplier",
-        "amount": 0.05
-      }
-    ]
-  },
-  "digitalShelfPrimer": {
-    "id": "digitalShelfPrimer",
-    "name": "Digital Shelf Primer",
-    "description": "Curate e-books and galleries for 3 days (4h/day) to master metadata, covers, and storefront polish \u2014 no tuition required.",
-    "hoursPerDay": 4,
-    "days": 3,
-    "tuition": 0,
-    "instantBoosts": [
-      {
-        "assetId": "ebook",
-        "assetName": "Digital E-Book Series",
-        "type": "multiplier",
-        "amount": 0.05
-      },
-      {
-        "assetId": "stockPhotos",
-        "assetName": "Stock Photo Gallery",
-        "type": "multiplier",
-        "amount": 0.05
-      }
-    ]
-  },
-  "commerceLaunchPrimer": {
-    "id": "commerceLaunchPrimer",
-    "name": "Commerce Launch Primer",
-    "description": "Shadow a fulfillment lead for 3 days (4h/day) to set up shipping flows and customer support scripts for free.",
-    "hoursPerDay": 4,
-    "days": 3,
-    "tuition": 0,
-    "instantBoosts": [
-      {
-        "assetId": "dropshipping",
-        "assetName": "Dropshipping Product Lab",
-        "type": "multiplier",
-        "amount": 0.05
-      }
-    ]
-  },
-  "microSaasJumpstart": {
-    "id": "microSaasJumpstart",
-    "name": "Micro SaaS Jumpstart",
-    "description": "Pair with senior engineers for 3 days (4h/day) to ship deploy scripts and uptime monitors with zero tuition.",
-    "hoursPerDay": 4,
-    "days": 3,
-    "tuition": 0,
-    "instantBoosts": [
-      {
-        "assetId": "saas",
-        "assetName": "SaaS Micro-App",
-        "type": "multiplier",
-        "amount": 0.05
-      }
-    ]
-  },
-  "outlineMastery": {
-    "id": "outlineMastery",
-    "name": "Outline Mastery Workshop",
-    "description": "Deep-dive into narrative scaffolding for 5 days (2h/day). Tuition due upfront.",
-    "hoursPerDay": 2,
-    "days": 5,
-    "tuition": 140,
-    "instantBoosts": [
-      {
-        "hustleId": "freelance",
-        "hustleName": "Freelance Writing",
-        "type": "multiplier",
-        "amount": 0.25
-      },
-      {
-        "hustleId": "audiobookNarration",
-        "hustleName": "Audiobook Narration Gig",
-        "type": "multiplier",
-        "amount": 0.15
-      }
-    ]
-  },
-  "photoLibrary": {
-    "id": "photoLibrary",
-    "name": "Photo Catalog Curation",
-    "description": "Archive, tag, and light-edit your best work for 4 days (1.5h/day). Tuition due upfront.",
-    "hoursPerDay": 1.5,
-    "days": 4,
-    "tuition": 95,
-    "instantBoosts": [
-      {
-        "hustleId": "eventPhotoGig",
-        "hustleName": "Event Photo Gig",
-        "type": "multiplier",
-        "amount": 0.2
-      }
-    ]
-  },
-  "ecomPlaybook": {
-    "id": "ecomPlaybook",
-    "name": "E-Commerce Playbook",
-    "description": "Shadow a pro operator for 9 days (3h/day) to master funnels and fulfillment math.",
-    "hoursPerDay": 3,
-    "days": 9,
-    "tuition": 900,
-    "instantBoosts": [
-      {
-        "hustleId": "bundlePush",
-        "hustleName": "Bundle Promo Push",
-        "type": "flat",
-        "amount": 5
-      },
-      {
-        "assetId": "dropshipping",
-        "assetName": "Dropshipping Product Lab",
-        "type": "multiplier",
-        "amount": 0.15
-      }
-    ]
-  },
-  "automationCourse": {
-    "id": "automationCourse",
-    "name": "Automation Architecture Course",
-    "description": "Pair-program with mentors for 15 days (6h/day) to architect a reliable micro-app.",
-    "hoursPerDay": 6,
-    "days": 15,
-    "tuition": 3000,
-    "instantBoosts": [
-      {
-        "hustleId": "saasBugSquash",
-        "hustleName": "SaaS Bug Squash",
-        "type": "flat",
-        "amount": 6
-      },
-      {
-        "assetId": "saas",
-        "assetName": "SaaS Micro-App",
-        "type": "multiplier",
-        "amount": 0.15
-      }
-    ]
-  },
-  "brandVoiceLab": {
-    "id": "brandVoiceLab",
-    "name": "Brand Voice Lab",
-    "description": "Work with pitch coaches for 4 days (1h/day) to sharpen live Q&A charisma.",
-    "hoursPerDay": 1,
-    "days": 4,
-    "tuition": 120,
-    "instantBoosts": [
-      {
-        "hustleId": "audienceCall",
-        "hustleName": "Audience Q&A Blast",
-        "type": "flat",
-        "amount": 4
-      }
-    ]
-  },
-  "guerillaBuzzWorkshop": {
-    "id": "guerillaBuzzWorkshop",
-    "name": "Guerrilla Buzz Workshop",
-    "description": "Field-test hype hooks for 6 days (1.5h/day) with a crew of street marketers.",
-    "hoursPerDay": 1.5,
-    "days": 6,
-    "tuition": 180,
-    "instantBoosts": [
-      {
-        "hustleId": "streetPromoSprint",
-        "hustleName": "Street Promo Sprint",
-        "type": "multiplier",
-        "amount": 0.25
-      },
-      {
-        "hustleId": "surveySprint",
-        "hustleName": "Micro Survey Dash",
-        "type": "flat",
-        "amount": 1.5
-      }
-    ]
-  },
-  "curriculumDesignStudio": {
-    "id": "curriculumDesignStudio",
-    "name": "Curriculum Design Studio",
-    "description": "Prototype interactive lesson plans for 6 days (2.5h/day) with veteran educators.",
-    "hoursPerDay": 2.5,
-    "days": 6,
-    "tuition": 280,
-    "instantBoosts": [
-      {
-        "hustleId": "popUpWorkshop",
-        "hustleName": "Pop-Up Workshop",
-        "type": "multiplier",
-        "amount": 0.3
-      },
-      {
-        "hustleId": "bundlePush",
-        "hustleName": "Bundle Promo Push",
-        "type": "multiplier",
-        "amount": 0.15
-      }
-    ]
-  },
-  "postProductionPipelineLab": {
-    "id": "postProductionPipelineLab",
-    "name": "Post-Production Pipeline Lab",
-    "description": "Run edit bays for 10 days (4h/day) to master color, captions, and delivery workflows.",
-    "hoursPerDay": 4,
-    "days": 10,
-    "tuition": 900,
-    "instantBoosts": [
-      {
-        "hustleId": "vlogEditRush",
-        "hustleName": "Vlog Edit Rush",
-        "type": "multiplier",
-        "amount": 0.25
-      },
-      {
-        "assetId": "vlog",
-        "assetName": "Weekly Vlog Channel",
-        "type": "multiplier",
-        "amount": 0.15
-      }
-    ]
-  },
-  "fulfillmentOpsMasterclass": {
-    "id": "fulfillmentOpsMasterclass",
-    "name": "Fulfillment Ops Masterclass",
-    "description": "Shadow a logistics crew for 10 days (4h/day) to automate pick, pack, and ship perfection.",
-    "hoursPerDay": 4,
-    "days": 10,
-    "tuition": 1200,
-    "instantBoosts": [
-      {
-        "hustleId": "dropshipPackParty",
-        "hustleName": "Dropship Pack Party",
-        "type": "multiplier",
-        "amount": 0.2
-      },
-      {
-        "assetId": "dropshipping",
-        "assetName": "Dropshipping Product Lab",
-        "type": "multiplier",
-        "amount": 0.25
-      }
-    ]
-  },
-  "customerRetentionClinic": {
-    "id": "customerRetentionClinic",
-    "name": "Customer Retention Clinic",
-    "description": "Coach subscription success teams for 7 days (3h/day) to keep churn near zero.",
-    "hoursPerDay": 3,
-    "days": 7,
-    "tuition": 1000,
-    "instantBoosts": [
-      {
-        "hustleId": "saasBugSquash",
-        "hustleName": "SaaS Bug Squash",
-        "type": "flat",
-        "amount": 5
-      },
-      {
-        "assetId": "saas",
-        "assetName": "SaaS Micro-App",
-        "type": "multiplier",
-        "amount": 0.2
-      }
-    ]
-  },
-  "narrationPerformanceWorkshop": {
-    "id": "narrationPerformanceWorkshop",
-    "name": "Narration Performance Workshop",
-    "description": "Spend 7 days (3h/day) with vocal coaches to perfect audiobook cadence.",
-    "hoursPerDay": 3,
-    "days": 7,
-    "tuition": 900,
-    "instantBoosts": [
-      {
-        "hustleId": "audiobookNarration",
-        "hustleName": "Audiobook Narration",
-        "type": "multiplier",
-        "amount": 0.25
-      },
-      {
-        "assetId": "ebook",
-        "assetName": "Digital E-Book Series",
-        "type": "multiplier",
-        "amount": 0.1
-      }
-    ]
-  },
-  "galleryLicensingSummit": {
-    "id": "galleryLicensingSummit",
-    "name": "Gallery Licensing Summit",
-    "description": "Pitch curators for 8 days (4h/day) to secure premium gallery licensing deals.",
-    "hoursPerDay": 4,
-    "days": 8,
-    "tuition": 1100,
-    "instantBoosts": [
-      {
-        "hustleId": "eventPhotoGig",
-        "hustleName": "Event Photo Gig",
-        "type": "multiplier",
-        "amount": 0.2
-      },
-      {
-        "assetId": "stockPhotos",
-        "assetName": "Stock Photo Gallery",
-        "type": "multiplier",
-        "amount": 0.15
-      }
-    ]
-  },
-  "syndicationResidency": {
-    "id": "syndicationResidency",
-    "name": "Syndication Residency",
-    "description": "Curate partnerships for 9 days (4h/day) to syndicate your flagship content network.",
-    "hoursPerDay": 4,
-    "days": 9,
-    "tuition": 1000,
-    "instantBoosts": [
-      {
-        "hustleId": "freelance",
-        "hustleName": "Freelance Writing",
-        "type": "multiplier",
-        "amount": 0.15
-      },
-      {
-        "hustleId": "streetPromoSprint",
-        "hustleName": "Street Promo Sprint",
-        "type": "flat",
-        "amount": 2
-      },
-      {
-        "assetId": "blog",
-        "assetName": "Personal Blog Network",
-        "type": "multiplier",
-        "amount": 0.12
-      }
-    ]
-  }
+import { tracks as trackConfig } from '../../data/economyConfig.js';
+
+const TRACK_DESCRIPTIONS = {
+  storycraftJumpstart:
+    'Outline pillar posts for 3 days (4h/day) and polish headlines without paying tuition.',
+  vlogStudioJumpstart:
+    'Shadow a creator coach for 3 days (4h/day) to frame shots, light sets, and warm up edits. Tuition free.',
+  digitalShelfPrimer:
+    'Curate e-books and galleries for 3 days (4h/day) to master metadata, covers, and storefront polish — no tuition required.',
+  commerceLaunchPrimer:
+    'Shadow a fulfillment lead for 3 days (4h/day) to set up shipping flows and customer support scripts for free.',
+  microSaasJumpstart:
+    'Pair with senior engineers for 3 days (4h/day) to ship deploy scripts and uptime monitors with zero tuition.',
+  outlineMastery:
+    'Deep-dive into narrative scaffolding for 5 days (2h/day). Tuition due upfront.',
+  photoLibrary:
+    'Archive, tag, and light-edit your best work for 4 days (1.5h/day). Tuition due upfront.',
+  ecomPlaybook:
+    'Shadow a pro operator for 9 days (3h/day) to master funnels and fulfillment math.',
+  automationCourse:
+    'Pair-program with mentors for 15 days (6h/day) to architect a reliable micro-app.',
+  brandVoiceLab:
+    'Work with pitch coaches for 4 days (1h/day) to sharpen live Q&A charisma.',
+  guerillaBuzzWorkshop:
+    'Field-test hype hooks for 6 days (1.5h/day) with a crew of street marketers.',
+  curriculumDesignStudio:
+    'Prototype interactive lesson plans for 6 days (2.5h/day) with veteran educators.',
+  postProductionPipelineLab:
+    'Run edit bays for 10 days (4h/day) to master color, captions, and delivery workflows.',
+  fulfillmentOpsMasterclass:
+    'Shadow a logistics crew for 10 days (4h/day) to automate pick, pack, and ship perfection.',
+  customerRetentionClinic:
+    'Coach subscription success teams for 7 days (3h/day) to keep churn near zero.',
+  narrationPerformanceWorkshop:
+    'Spend 7 days (3h/day) with vocal coaches to perfect audiobook cadence.',
+  galleryLicensingSummit:
+    'Pitch curators for 8 days (4h/day) to secure premium gallery licensing deals.',
+  syndicationResidency:
+    'Curate partnerships for 9 days (4h/day) to syndicate your flagship content network.'
 };
+
+const buildInstantBoost = boost => {
+  if (!boost) return null;
+  const amount = Number(boost.amount) || 0;
+  if (!Number.isFinite(amount) || amount === 0) {
+    return null;
+  }
+
+  const entry = {
+    type: boost.type === 'flat' ? 'flat' : 'multiplier',
+    amount
+  };
+
+  if (boost.assetId) {
+    entry.assetId = boost.assetId;
+    entry.assetName = boost.assetName || boost.assetId;
+  }
+
+  if (boost.hustleId) {
+    entry.hustleId = boost.hustleId;
+    entry.hustleName = boost.hustleName || boost.hustleId;
+  }
+
+  return entry;
+};
+
+const knowledgeTrackData = Object.fromEntries(
+  Object.entries(trackConfig).map(([id, track]) => {
+    const schedule = track?.schedule || {};
+    const instantBoosts = Array.isArray(track?.instantBoosts)
+      ? track.instantBoosts.map(buildInstantBoost).filter(Boolean)
+      : [];
+
+    return [
+      id,
+      {
+        id,
+        name: track?.name || id,
+        description: TRACK_DESCRIPTIONS[id] || '',
+        hoursPerDay: Number(schedule.hoursPerDay) || 0,
+        days: Number(schedule.days) || 0,
+        tuition: Number(track?.setupCost ?? 0) || 0,
+        instantBoosts
+      }
+    ];
+  })
+);
 
 export default knowledgeTrackData;


### PR DESCRIPTION
## Summary
- extend the shared track configuration to expose setup costs, derived hours-per-day, and modifiers as instant boosts
- rebuild the knowledge track dataset from the shared config so study requirements and boosts stay in sync with the economy spec
- keep downstream consumers aligned with the config-driven fields and remove duplicated literals

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2a4f63470832ca8bda52ec97e3716