### PR TITLE
Remove legacy niche roll tracking state

### DIFF
--- a/src/core/persistence/index.js
+++ b/src/core/persistence/index.js
@@ -71,7 +71,30 @@ function migrateLegacySnapshot(snapshot, context) {
   return migrated;
 }
 
-const DEFAULT_MIGRATIONS = [migrateLegacySnapshot];
+function removeLegacyNicheRollDay(snapshot) {
+  if (!snapshot || typeof snapshot !== 'object') {
+    return snapshot;
+  }
+
+  const niches = snapshot.niches;
+  const migrated = { ...snapshot };
+
+  if (!niches || typeof niches !== 'object') {
+    if (niches !== undefined) {
+      migrated.niches = niches;
+    }
+    return migrated;
+  }
+
+  const sanitizedNiches = { ...niches };
+  if ('lastRollDay' in sanitizedNiches) {
+    delete sanitizedNiches.lastRollDay;
+  }
+  migrated.niches = sanitizedNiches;
+  return migrated;
+}
+
+const DEFAULT_MIGRATIONS = [migrateLegacySnapshot, removeLegacyNicheRollDay];
 
 export { SnapshotRepository, StateMigrationRunner };
 

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -137,7 +137,8 @@ class StateManager {
       },
       niches: {
         popularity: {},
-        lastRollDay: 0
+        watchlist: [],
+        analyticsHistory: []
       },
       events: {
         active: []

--- a/src/core/state/niches.js
+++ b/src/core/state/niches.js
@@ -151,8 +151,9 @@ export function ensureNicheStateShape(target, { fallbackDay = 1 } = {}) {
       : createNeutralPopularitySnapshot();
   }
 
-  const storedDay = Number(nicheState.lastRollDay);
-  nicheState.lastRollDay = Number.isFinite(storedDay) ? storedDay : fallbackDay;
+  if ('lastRollDay' in nicheState) {
+    delete nicheState.lastRollDay;
+  }
 
   if (!Array.isArray(nicheState.analyticsHistory)) {
     nicheState.analyticsHistory = [];

--- a/src/game/assets/niches.js
+++ b/src/game/assets/niches.js
@@ -48,8 +48,9 @@ export function ensureNicheState(target = getState()) {
       : createNeutralPopularitySnapshot();
   });
 
-  const storedDay = Number(data.lastRollDay);
-  data.lastRollDay = Number.isFinite(storedDay) ? storedDay : target.day || 1;
+  if ('lastRollDay' in data) {
+    delete data.lastRollDay;
+  }
 
   return data;
 }

--- a/tests/stateManagement.test.js
+++ b/tests/stateManagement.test.js
@@ -131,7 +131,7 @@ test('ensureStateShape populates default action, asset, and upgrade state', () =
   }
 });
 
-test('ensureNicheStateShape repairs popularity map and fallback day', () => {
+test('ensureNicheStateShape repairs popularity map and removes legacy fields', () => {
   const state = {
     day: 4,
     niches: {
@@ -145,7 +145,7 @@ test('ensureNicheStateShape repairs popularity map and fallback day', () => {
 
   ensureNicheStateShape(state, { fallbackDay: state.day });
 
-  assert.equal(state.niches.lastRollDay, 4);
+  assert.equal('lastRollDay' in state.niches, false);
   assert.ok(state.niches.popularity.techInnovators, 'known niches should be kept');
   assert.equal(state.niches.popularity.fake, undefined, 'unknown niches should be removed');
   assert.equal(state.niches.popularity.techInnovators.previousScore, 15);

--- a/tests/ui/blogpressModel.test.js
+++ b/tests/ui/blogpressModel.test.js
@@ -52,8 +52,7 @@ function createState() {
         travelAdventures: { score: 55, previousScore: 50 }
       },
       watchlist: [],
-      analyticsHistory: [],
-      lastRollDay: 5
+      analyticsHistory: []
     }
   };
 }

--- a/tests/ui/dashboardModel.test.js
+++ b/tests/ui/dashboardModel.test.js
@@ -189,8 +189,7 @@ test('buildDashboardViewModel includes niche analytics data', t => {
       techInnovators: { score: 82, previousScore: 70 },
       healthWellness: { score: 38, previousScore: 44 }
     },
-    watchlist: ['healthWellness'],
-    lastRollDay: state.day
+    watchlist: ['healthWellness']
   };
 
   const stubAsset = {

--- a/tests/ui/update.integration.test.js
+++ b/tests/ui/update.integration.test.js
@@ -391,8 +391,7 @@ test('state mutators mark dirty sections and drive partial UI refreshes', { conc
       [initialNicheId]: { score: 64, previousScore: 52 },
       [targetNicheId]: { score: 88, previousScore: 70 }
     },
-    watchlist: [],
-    lastRollDay: state.day || 1
+    watchlist: []
   };
 
   resetCounts();


### PR DESCRIPTION
## Summary
- remove the deprecated `lastRollDay` niche field from state defaults and sanitizers
- add a migration to strip the legacy field from saved games and refresh derived state
- update state and UI tests to reflect the streamlined niche shape

## Testing
- node --test tests/stateManagement.test.js tests/persistence.test.js tests/ui/blogpressModel.test.js tests/ui/dashboardModel.test.js tests/ui/update.integration.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2a56ac018832cbe980dc7627de3a5