### PR TITLE
Hide developer tools behind opt-in view

### DIFF
--- a/src/ui/views/browser/index.js
+++ b/src/ui/views/browser/index.js
@@ -17,6 +17,25 @@ const browserView = {
     headerAction: headerActionPresenter,
     log: logPresenter
   },
+  onActivate({ root } = {}) {
+    const doc =
+      root || (typeof document !== 'undefined' ? document : null);
+    const developerRoot = doc?.getElementById('developer-root');
+    if (developerRoot) {
+      developerRoot.setAttribute('hidden', 'true');
+      developerRoot.setAttribute('aria-hidden', 'true');
+    }
+
+    if (doc?.body) {
+      doc.body.classList.remove('developer-view-active');
+    }
+
+    const shell = doc?.querySelector('.browser-shell');
+    if (shell) {
+      shell.removeAttribute('hidden');
+      shell.removeAttribute('aria-hidden');
+    }
+  },
   renderDashboard(state, summary) {
     baseRenderDashboard(state, summary, dashboardPresenter);
   }

--- a/styles/developer.css
+++ b/styles/developer.css
@@ -3,6 +3,10 @@ body.developer-view-active {
   color: var(--text-primary-on-dark, #f5f7fb);
 }
 
+body:not(.developer-view-active) #developer-root {
+  display: none;
+}
+
 .developer-view {
   font-family: 'Manrope', system-ui, sans-serif;
   display: flex;

--- a/tests/ui/views/browser/index.test.js
+++ b/tests/ui/views/browser/index.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+import browserView from '../../../../src/ui/views/browser/index.js';
+
+test('browser view activation hides developer utilities', () => {
+  const dom = new JSDOM(`<!DOCTYPE html><html><body>
+    <div class="browser-shell" hidden aria-hidden="true"></div>
+    <div id="developer-root"></div>
+  </body></html>`);
+
+  const { document } = dom.window;
+  document.body.classList.add('developer-view-active');
+
+  browserView.onActivate({ root: document });
+
+  const developerRoot = document.getElementById('developer-root');
+  assert.equal(developerRoot?.hasAttribute('hidden'), true);
+  assert.equal(developerRoot?.getAttribute('aria-hidden'), 'true');
+  assert.equal(document.body.classList.contains('developer-view-active'), false);
+
+  const shell = document.querySelector('.browser-shell');
+  assert.equal(shell?.hasAttribute('hidden'), false);
+  assert.equal(shell?.hasAttribute('aria-hidden'), false);
+});


### PR DESCRIPTION
## Summary
- hide the developer dashboard whenever the browser view becomes active
- add a CSS guard so the developer tools stay hidden without the developer view opt-in
- cover the regression with a browser view activation test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2b6a25430832cbe2dbb3f1c4feb92