### PR TITLE
Ensure study tasks update daily flags immediately

### DIFF
--- a/src/ui/views/browser/widgets/todoWidget.js
+++ b/src/ui/views/browser/widgets/todoWidget.js
@@ -12,6 +12,7 @@ import {
 import { advanceActionInstance, completeActionInstance } from '../../../../game/actions/progress.js';
 import { getActionDefinition } from '../../../../game/registryService.js';
 import { spendTime } from '../../../../game/time.js';
+import { allocateDailyStudy } from '../../../../game/requirements.js';
 import todoDom from './todoDom.js';
 import todoState from './todoState.js';
 
@@ -225,6 +226,38 @@ function createProgressHandler(entry = {}) {
 
     spendTime(hours);
     advanceActionInstance(definition, { id: instanceId }, { hours, metadata });
+
+    const isStudy =
+      definition.studyTrackId ||
+      definition?.progress?.type === 'study' ||
+      progress?.type === 'study';
+    if (isStudy) {
+      const resolvedTrackId = (() => {
+        const directIdCandidates = [
+          definition.studyTrackId,
+          progress?.studyTrackId,
+          progress?.trackId,
+          definition?.progress?.studyTrackId,
+          definition?.progress?.trackId
+        ].filter(id => typeof id === 'string' && id.trim().length > 0);
+        if (directIdCandidates.length > 0) {
+          return directIdCandidates[0];
+        }
+        const stripStudyPrefix = value =>
+          typeof value === 'string' && value.startsWith('study-') ? value.slice('study-'.length) : null;
+        return (
+          stripStudyPrefix(definition?.id) ||
+          stripStudyPrefix(progress?.definitionId) ||
+          null
+        );
+      })();
+
+      if (resolvedTrackId) {
+        allocateDailyStudy({ trackIds: [resolvedTrackId] });
+      } else {
+        allocateDailyStudy();
+      }
+    }
     return { success: true, hours };
   };
 }
@@ -539,4 +572,8 @@ export default {
   hasPendingTasks,
   peekNextTask,
   runNextTask
+};
+
+export const __testables = {
+  createProgressHandler
 };


### PR DESCRIPTION
## Summary
- call `allocateDailyStudy` when logging study progress in the todo widget so daily flags flip immediately
- expose the todo progress handler for tests and cover the new flow with a focused study regression test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2b96e2bd8832cafebf067206c1be4