### PR TITLE
Hide completed hustle commitments

### DIFF
--- a/src/game/actions/progress.js
+++ b/src/game/actions/progress.js
@@ -1,6 +1,7 @@
 import { createId, toNumber } from '../../core/helpers.js';
 import { getActionState, getState } from '../../core/state.js';
 import { markDirty } from '../../core/events/invalidationBus.js';
+import { completeHustleMarketInstance } from '../../core/state/slices/hustleMarket.js';
 
 const FLOAT_PRECISION = 4;
 
@@ -277,6 +278,14 @@ export function completeActionInstance(definition, instance, context = {}) {
       stored.progress.hoursLogged = roundHours(stored.hoursLogged);
     }
   }
+
+  const completionHours = Number(stored.hoursLogged);
+  const completionPayload = { completionDay };
+  if (Number.isFinite(completionHours) && completionHours >= 0) {
+    completionPayload.hoursLogged = completionHours;
+  }
+  completeHustleMarketInstance(state, stored.id, completionPayload);
+
   markDirty('actions');
   return stored;
 }

--- a/src/game/hustles/market.js
+++ b/src/game/hustles/market.js
@@ -360,13 +360,15 @@ export function getAvailableOffers(state = getState(), {
 
 export function getClaimedOffers(state = getState(), {
   day,
-  includeExpired = false
+  includeExpired = false,
+  includeCompleted = false
 } = {}) {
   const workingState = state || getState();
   const targetDay = resolveDay(day, workingState?.day || 1);
   return getMarketClaimedOffers(workingState, {
     day: targetDay,
-    includeExpired
+    includeExpired,
+    includeCompleted
   });
 }
 

--- a/src/ui/cards/model/finance/opportunities.js
+++ b/src/ui/cards/model/finance/opportunities.js
@@ -220,6 +220,9 @@ export function buildHustleOpportunities(hustleDefinitions = [], state, services
 
     const acceptedForDefinition = acceptedByDefinition.get(definition.id) || [];
     acceptedForDefinition.forEach(entry => {
+      if (entry?.status === 'complete') {
+        return;
+      }
       if (commitmentsByInstance.has(entry?.instanceId)) {
         return;
       }

--- a/src/ui/cards/model/hustles.js
+++ b/src/ui/cards/model/hustles.js
@@ -236,6 +236,9 @@ export default function buildHustleModels(definitions = [], helpers = {}) {
 
     const acceptedForDefinition = acceptedByDefinition.get(definition.id) || [];
     acceptedForDefinition.forEach(entry => {
+      if (entry?.status === 'complete') {
+        return;
+      }
       const instanceId = entry?.instanceId;
       const exists = commitments.some(commitment => commitment?.progress?.instanceId === instanceId);
       if (exists) {


### PR DESCRIPTION
## Summary
- add a helper to mark hustle market entries as complete and preserve completion metadata
- invoke the helper when finishing action instances and filter selectors/UI to drop completed commitments
- add coverage to verify completing a hustle removes it from pending commitments

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2b97a837c832c81840c73a939b0f1