### PR TITLE
Ensure todo widget triggers automatic day end

### DIFF
--- a/src/ui/views/browser/widgets/todoWidget.js
+++ b/src/ui/views/browser/widgets/todoWidget.js
@@ -1,7 +1,7 @@
 import { formatHours } from '../../../../core/helpers.js';
 import { addLog } from '../../../../core/log.js';
 import { getState } from '../../../../core/state.js';
-import { endDay } from '../../../../game/lifecycle.js';
+import { endDay, checkDayEnd } from '../../../../game/lifecycle.js';
 import { normalizeActionEntries } from '../../../actions/registry.js';
 import {
   DEFAULT_FOCUS_BUCKET,
@@ -225,6 +225,7 @@ function createProgressHandler(entry = {}) {
 
     spendTime(hours);
     advanceActionInstance(definition, { id: instanceId }, { hours, metadata });
+    checkDayEnd();
     return { success: true, hours };
   };
 }


### PR DESCRIPTION
## Summary
- call `checkDayEnd` after todo widget progress entries advance so the UI auto-ends the day when time is exhausted
- add a UI-focused time and lifecycle test that logs hours through the todo widget and verifies the automatic `endDay(true)` flow

## Testing
- node --test tests/timeAndLifecycle.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2b982922c832c92c879cec245af0c