### PR TITLE
Use action registry when building education catalog

### DIFF
--- a/src/ui/cards/collectionService.js
+++ b/src/ui/cards/collectionService.js
@@ -23,8 +23,18 @@ function ensureRegistrySnapshot() {
 
 function buildRegistries() {
   const registry = ensureRegistrySnapshot();
-  const hustles = registry.hustles.filter(hustle => hustle.tag?.type !== 'study');
-  const education = registry.hustles.filter(hustle => hustle.tag?.type === 'study');
+  const actionDefinitions = Array.isArray(registry.actions) && registry.actions.length
+    ? registry.actions
+    : Array.isArray(registry.hustles)
+      ? registry.hustles
+      : [];
+
+  const hustleTemplates = Array.isArray(registry.hustles) && registry.hustles.length
+    ? registry.hustles
+    : actionDefinitions;
+
+  const hustles = hustleTemplates.filter(hustle => hustle.tag?.type !== 'study');
+  const education = actionDefinitions.filter(definition => definition.tag?.type === 'study');
   const assets = registry.assets;
   const upgrades = registry.upgrades;
 


### PR DESCRIPTION
## Summary
- build the education list for collection cards from action definitions so study entries retain enroll handlers
- keep non-study hustles sourced from hustle templates with a fallback for registries lacking explicit actions

## Testing
- not run (environment only)

------
https://chatgpt.com/codex/tasks/task_e_68e2bda2afdc832ca48028effce44cd8