### PR TITLE
Add developer action memory panel

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,7 @@
 - Niche popularity now syncs with active trend events, keeping multipliers, history, and analytics aligned across saves.
 - Niche trend events now stretch across 5–10 days, building from gentle nudges to pronounced peaks (or dips) so players can react to the swelling momentum.
 - Tooling: Added a `?view=developer` state explorer that surfaces the live memory snapshot, active random events, and long-term buff sources for faster balancing passes.
+- Tooling: Developer state explorer now includes an Action Memory panel that lists every action definition with run counters, availability metadata, and per-instance progress logs pulled from live state.
 - Niche trend rerolls now guarantee every niche is always riding exactly one weighted event, including immediately after loads and daily advances.
 
 ## Recent Highlights

--- a/docs/features/developer-state-explorer.md
+++ b/docs/features/developer-state-explorer.md
@@ -17,12 +17,14 @@ Append `?view=developer` (or `?ui=developer`) to the game URL to boot directly i
 - **Overview card** – current day, cash, time remaining, active asset count, and total active events plus a timestamp for the snapshot.
 - **Random event buffs** – sortable table (by modifier magnitude) showing label, percent impact, target resolution, remaining days, and tone for each active event.
 - **Long-term buffs** – grouped by education completions, purchased upgrades with boost text, and current time bonuses (base, bonus, and daily additions).
+- **Action memory** – rich cards for every action definition showing availability, base costs, run counters, and per-instance progress logs pulled from live state.
 - **Raw state snapshot** – pretty-printed JSON dump of the full state object for quick copying into tests.
 
 ## Implementation Notes
 - Registered as a UI view with guard `#developer-root`; does not interfere with normal shell boot.
 - Uses `subscribeToInvalidation` to stay in sync with the simulation tick.
 - Relies on registry definitions to label assets/upgrades and on `educationEffects` helpers to translate track bonuses into readable strings.
+- Action explorer cards merge registry metadata with `state.actions` so devs can audit instance progress (daily logs, hours remaining, payouts) without digging through JSON.
 - Styling lives in `styles/developer.css` and reuses existing font tokens while embracing a darker, data-dashboard motif.
 
 ## Follow-ups / Ideas

--- a/index.html
+++ b/index.html
@@ -370,6 +370,17 @@
         </div>
       </section>
 
+      <section class="developer-card developer-card--wide" aria-labelledby="developer-actions-heading">
+        <header class="developer-card__header">
+          <h2 id="developer-actions-heading" class="developer-card__title">Action memory</h2>
+          <p class="developer-card__subtitle">Every action definition currently tracked in save data.</p>
+        </header>
+        <div class="developer-card__body developer-actions">
+          <p id="developer-actions-empty" class="developer-empty" hidden>No action runs logged yet.</p>
+          <ul id="developer-actions-list" class="developer-actions__list" aria-live="polite"></ul>
+        </div>
+      </section>
+
       <section class="developer-card" aria-labelledby="developer-state-heading">
         <header class="developer-card__header">
           <h2 id="developer-state-heading" class="developer-card__title">Raw state snapshot</h2>

--- a/src/ui/views/developer/render.js
+++ b/src/ui/views/developer/render.js
@@ -1,6 +1,6 @@
 import { formatMoney, formatHours } from '../../../core/helpers.js';
 import { getState, getUpgradeState } from '../../../core/state.js';
-import { getAssetDefinition } from '../../../core/state/registry.js';
+import { getAssetDefinition, getActionDefinition } from '../../../core/state/registry.js';
 import { getNicheDefinition } from '../../../game/assets/nicheData.js';
 import { KNOWLEDGE_TRACKS, getKnowledgeProgress } from '../../../game/requirements.js';
 import { describeTrackEducationBonuses } from '../../../game/educationEffects.js';
@@ -247,6 +247,618 @@ function renderUpgradeBuffs(container, state) {
   });
 }
 
+function toFiniteNumber(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function capitalize(value) {
+  if (typeof value !== 'string' || value.length === 0) {
+    return '';
+  }
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function formatDay(value) {
+  const numeric = toFiniteNumber(value);
+  if (numeric == null || numeric <= 0) {
+    return '—';
+  }
+  return `Day ${Math.max(1, Math.floor(numeric))}`;
+}
+
+function formatHoursValue(value) {
+  const numeric = toFiniteNumber(value);
+  if (numeric == null) {
+    return null;
+  }
+  return formatHours(numeric);
+}
+
+function formatMoneyValue(value) {
+  const numeric = toFiniteNumber(value);
+  if (numeric == null) {
+    return null;
+  }
+  return `$${formatMoney(numeric)}`;
+}
+
+function describeAvailability(availability) {
+  if (!availability || typeof availability !== 'object') {
+    return 'Always available';
+  }
+
+  const type = availability.type;
+  if (!type || type === 'always') {
+    return 'Always available';
+  }
+
+  if (type === 'dailyLimit') {
+    const limit = toFiniteNumber(availability.limit);
+    return limit != null ? `Daily cap ${limit}` : 'Daily limited';
+  }
+
+  if (type === 'enrollable') {
+    return 'Requires enrollment';
+  }
+
+  const extras = Object.entries(availability)
+    .filter(([key]) => key !== 'type')
+    .map(([key, value]) => `${capitalize(key)}: ${value}`)
+    .join(' • ');
+  const base = `${capitalize(type)} availability`;
+  return extras ? `${base} (${extras})` : base;
+}
+
+function describeExpiry(expiry) {
+  if (!expiry || typeof expiry !== 'object') {
+    return 'Permanent';
+  }
+
+  const type = expiry.type;
+  if (!type || type === 'permanent') {
+    return 'Permanent';
+  }
+
+  const extras = Object.entries(expiry)
+    .filter(([key]) => key !== 'type')
+    .map(([key, value]) => `${capitalize(key)}: ${value}`)
+    .join(' • ');
+  const base = `${capitalize(type)} expiry`;
+  return extras ? `${base} (${extras})` : base;
+}
+
+function describeProgressTemplate(progress) {
+  if (!progress || typeof progress !== 'object') {
+    return 'Instant (no tracking)';
+  }
+
+  const parts = [];
+  if (progress.type) {
+    parts.push(`${capitalize(progress.type)} progress`);
+  }
+  if (progress.completion) {
+    parts.push(`Completion: ${progress.completion}`);
+  }
+  const required = formatHoursValue(progress.hoursRequired);
+  if (required) {
+    parts.push(`${required} required`);
+  }
+  const cadence = formatHoursValue(progress.hoursPerDay);
+  if (cadence) {
+    parts.push(`${cadence}/day`);
+  }
+  const daysRequired = toFiniteNumber(progress.daysRequired);
+  if (daysRequired != null) {
+    parts.push(`${Math.max(0, Math.floor(daysRequired))} day goal`);
+  }
+  return parts.length ? parts.join(' • ') : 'Instant (no tracking)';
+}
+
+function normalizeDailyLog(log) {
+  if (!log || typeof log !== 'object') {
+    return [];
+  }
+
+  return Object.entries(log)
+    .map(([dayKey, hoursValue]) => {
+      const day = toFiniteNumber(dayKey);
+      const hours = toFiniteNumber(hoursValue);
+      if (day == null || hours == null) {
+        return null;
+      }
+      return {
+        day: Math.max(1, Math.floor(day)),
+        hours
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.day - b.day);
+}
+
+function buildInstanceSnapshot(instance = {}, { definition, index }) {
+  const identifier = typeof instance.id === 'string' && instance.id ? instance.id : `instance-${index + 1}`;
+  const displayName = instance.nickname || instance.label || `Instance ${index + 1}`;
+  const statusSource = typeof instance.status === 'string' ? instance.status.toLowerCase() : null;
+  const accepted = instance.accepted === true || statusSource === 'active' || statusSource === 'completed';
+  const completed = instance.completed === true || statusSource === 'completed';
+  const status = statusSource || (completed ? 'completed' : accepted ? 'active' : 'pending');
+
+  const acceptedOnDay = toFiniteNumber(instance.acceptedOnDay);
+  const deadlineDay = toFiniteNumber(instance.deadlineDay);
+  const completedOn = completed ? toFiniteNumber(instance.completedOnDay) : null;
+  const resolvedCompletedOn = completedOn != null ? completedOn : completed && acceptedOnDay != null ? acceptedOnDay : null;
+  const payoutAwarded = toFiniteNumber(instance.payoutAwarded);
+
+  const progressSource = typeof instance.progress === 'object' && instance.progress !== null ? instance.progress : {};
+  const hoursLogged = toFiniteNumber(progressSource.hoursLogged ?? instance.hoursLogged);
+  const definitionHoursRequired = definition?.progress?.hoursRequired;
+  const hoursRequired = toFiniteNumber(progressSource.hoursRequired ?? instance.hoursRequired ?? definitionHoursRequired);
+  let hoursRemaining = null;
+  if (hoursRequired != null && hoursLogged != null) {
+    hoursRemaining = Math.max(0, hoursRequired - hoursLogged);
+  }
+  const hoursPerDay = toFiniteNumber(progressSource.hoursPerDay ?? definition?.progress?.hoursPerDay);
+  const daysCompleted = toFiniteNumber(progressSource.daysCompleted);
+  const definitionDaysRequired = definition?.progress?.daysRequired;
+  const daysRequired = toFiniteNumber(progressSource.daysRequired ?? definitionDaysRequired);
+  let daysRemaining = null;
+  if (daysRequired != null) {
+    const completedDays = Math.max(0, Math.floor(daysCompleted ?? 0));
+    daysRemaining = Math.max(0, Math.floor(daysRequired) - completedDays);
+  }
+  const lastWorkedDay = toFiniteNumber(progressSource.lastWorkedDay);
+  const completionMode = progressSource.completion || definition?.progress?.completion || null;
+  const logEntries = normalizeDailyLog(progressSource.dailyLog);
+
+  const notes = Array.isArray(instance.notes)
+    ? instance.notes.map(entry => String(entry)).join(' ')
+    : instance.notes != null
+      ? String(instance.notes)
+      : '';
+
+  return {
+    id: identifier,
+    shortId: identifier.slice(0, 8),
+    displayName,
+    status,
+    acceptedOnDay,
+    deadlineDay,
+    completedOnDay: resolvedCompletedOn,
+    payoutAwarded,
+    notes,
+    progress: {
+      type: progressSource.type || definition?.progress?.type || null,
+      completion: completionMode,
+      hoursLogged,
+      hoursRequired,
+      hoursRemaining,
+      hoursPerDay,
+      daysCompleted,
+      daysRequired,
+      daysRemaining,
+      lastWorkedDay,
+      completed,
+      logEntries
+    }
+  };
+}
+
+function countInstanceStatuses(instances) {
+  const counts = { total: instances.length, statuses: {} };
+  instances.forEach(instance => {
+    const status = typeof instance.status === 'string' && instance.status ? instance.status : 'unknown';
+    counts.statuses[status] = (counts.statuses[status] || 0) + 1;
+  });
+  return counts;
+}
+
+function buildActionBadges(definition, stateEntry) {
+  const badges = [];
+  if (definition?.tag?.label) {
+    const tone = definition?.tag?.type === 'instant' ? 'accent' : 'neutral';
+    badges.push({ label: definition.tag.label, tone });
+  }
+  const progressType = definition?.progress?.type;
+  if (progressType) {
+    badges.push({ label: `${capitalize(progressType)} track`, tone: 'muted' });
+  }
+  const availabilityType = definition?.availability?.type || stateEntry?.availability?.type;
+  if (availabilityType === 'dailyLimit') {
+    const limit = toFiniteNumber(definition?.availability?.limit ?? stateEntry?.availability?.limit);
+    badges.push({ label: limit != null ? `Cap ${limit}/day` : 'Daily limited', tone: 'neutral' });
+  } else if (availabilityType === 'enrollable') {
+    badges.push({ label: 'Enrollment required', tone: 'neutral' });
+  } else if (availabilityType && availabilityType !== 'always') {
+    badges.push({ label: capitalize(availabilityType), tone: 'neutral' });
+  }
+  return badges;
+}
+
+function collectActionSnapshots(state) {
+  const slice = state?.actions;
+  if (!slice || typeof slice !== 'object') {
+    return [];
+  }
+
+  return Object.entries(slice)
+    .map(([id, entry]) => {
+      if (!entry) {
+        return null;
+      }
+      const definition = getActionDefinition(id);
+      const name = definition?.name || entry?.name || id;
+      const description = definition?.description || '';
+      const runsToday = toFiniteNumber(entry.runsToday);
+      const lastRunDay = toFiniteNumber(entry.lastRunDay);
+      const instances = Array.isArray(entry.instances)
+        ? entry.instances.map((instance, index) => buildInstanceSnapshot(instance, { definition, index }))
+        : [];
+      const counts = countInstanceStatuses(instances);
+      const availability = describeAvailability(definition?.availability || entry?.availability);
+      const expiry = describeExpiry(definition?.expiry || entry?.expiry);
+      const progressTemplate = describeProgressTemplate(definition?.progress);
+      const baseTimeCost = toFiniteNumber(definition?.time ?? definition?.action?.timeCost);
+      const basePayout = toFiniteNumber(
+        definition?.payout?.amount ?? definition?.action?.payout?.amount ?? entry?.payout?.amount
+      );
+      const badges = buildActionBadges(definition, entry);
+      return {
+        id,
+        name,
+        description,
+        runsToday,
+        lastRunDay,
+        instances,
+        counts,
+        availability,
+        expiry,
+        progressTemplate,
+        baseTime: baseTimeCost,
+        basePayout,
+        badges
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function createBadge(doc, label, tone = 'neutral') {
+  const badge = doc.createElement('span');
+  badge.className = `developer-badge developer-badge--${tone}`;
+  badge.textContent = label;
+  return badge;
+}
+
+function appendStatRow(doc, list, label, value) {
+  if (value == null) {
+    return;
+  }
+  const row = doc.createElement('div');
+  row.className = 'developer-actions__stat';
+  const dt = doc.createElement('dt');
+  dt.textContent = label;
+  const dd = doc.createElement('dd');
+  dd.textContent = typeof value === 'string' ? value : String(value);
+  row.append(dt, dd);
+  list.appendChild(row);
+}
+
+function formatStatusLabel(status) {
+  if (typeof status !== 'string' || status.length === 0) {
+    return 'Unknown';
+  }
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+function mapStatusTone(status) {
+  if (!status) {
+    return 'status-unknown';
+  }
+  const normalized = status.toLowerCase();
+  if (normalized === 'active') {
+    return 'status-active';
+  }
+  if (normalized === 'completed') {
+    return 'status-completed';
+  }
+  if (normalized === 'pending') {
+    return 'status-pending';
+  }
+  return 'status-unknown';
+}
+
+function buildCountsSummary(counts) {
+  if (!counts) {
+    return null;
+  }
+  const parts = [`${counts.total} total`];
+  Object.entries(counts.statuses || {}).forEach(([status, count]) => {
+    parts.push(`${formatStatusLabel(status)} ${count}`);
+  });
+  return parts.join(' • ');
+}
+
+function buildProgressHoursSummary(progress) {
+  if (!progress) {
+    return null;
+  }
+  const logged = formatHoursValue(progress.hoursLogged);
+  const required = formatHoursValue(progress.hoursRequired);
+  const remaining = formatHoursValue(progress.hoursRemaining);
+  const segments = [];
+  if (logged) {
+    segments.push(required ? `${logged} logged of ${required}` : `${logged} logged`);
+  } else if (required) {
+    segments.push(`${required} required`);
+  }
+  if (remaining && progress.hoursRemaining > 0.05) {
+    segments.push(`${remaining} remaining`);
+  }
+  return segments.length ? segments.join(' • ') : null;
+}
+
+function buildProgressDaysSummary(progress) {
+  if (!progress) {
+    return null;
+  }
+  const completed = toFiniteNumber(progress.daysCompleted);
+  const required = toFiniteNumber(progress.daysRequired);
+  const remaining = toFiniteNumber(progress.daysRemaining);
+  const segments = [];
+  if (completed != null) {
+    const completedLabel = Math.max(0, Math.floor(completed));
+    if (required != null) {
+      segments.push(`${completedLabel}/${Math.max(0, Math.floor(required))} days`);
+    } else {
+      segments.push(`${completedLabel} days logged`);
+    }
+  } else if (required != null) {
+    segments.push(`${Math.max(0, Math.floor(required))} day goal`);
+  }
+  if (remaining != null && required != null) {
+    segments.push(`${Math.max(0, Math.floor(remaining))} days remaining`);
+  }
+  return segments.length ? segments.join(' • ') : null;
+}
+
+function renderActionInstance(doc, instance, index) {
+  const item = doc.createElement('li');
+  item.className = 'developer-actions__instance';
+
+  const header = doc.createElement('div');
+  header.className = 'developer-actions__instance-header';
+
+  const titleGroup = doc.createElement('div');
+  titleGroup.className = 'developer-actions__instance-title-group';
+
+  const title = doc.createElement('p');
+  title.className = 'developer-actions__instance-title';
+  title.textContent = instance.displayName || `Instance ${index + 1}`;
+
+  const id = doc.createElement('p');
+  id.className = 'developer-actions__instance-id';
+  id.textContent = instance.shortId;
+
+  titleGroup.append(title, id);
+
+  const badgeGroup = doc.createElement('div');
+  badgeGroup.className = 'developer-actions__instance-badges';
+  badgeGroup.appendChild(createBadge(doc, formatStatusLabel(instance.status), mapStatusTone(instance.status)));
+  if (instance.progress?.completed) {
+    badgeGroup.appendChild(createBadge(doc, 'Completed', 'status-completed'));
+  } else if (instance.progress?.completion) {
+    badgeGroup.appendChild(createBadge(doc, `Completion: ${instance.progress.completion}`, 'muted'));
+  }
+
+  header.append(titleGroup, badgeGroup);
+  item.appendChild(header);
+
+  const stats = doc.createElement('dl');
+  stats.className = 'developer-actions__instance-stats';
+
+  appendStatRow(doc, stats, 'Accepted', formatDay(instance.acceptedOnDay));
+  appendStatRow(doc, stats, 'Deadline', formatDay(instance.deadlineDay));
+  if (instance.progress?.completed || instance.completedOnDay != null) {
+    appendStatRow(doc, stats, 'Completed on', formatDay(instance.completedOnDay));
+  }
+  if (instance.progress?.type) {
+    appendStatRow(doc, stats, 'Progress type', `${capitalize(instance.progress.type)} track`);
+  }
+  if (instance.progress?.hoursPerDay != null) {
+    const cadence = formatHoursValue(instance.progress.hoursPerDay);
+    if (cadence) {
+      appendStatRow(doc, stats, 'Daily cadence', `${cadence}/day`);
+    }
+  }
+  const hoursSummary = buildProgressHoursSummary(instance.progress);
+  if (hoursSummary) {
+    appendStatRow(doc, stats, 'Hours', hoursSummary);
+  }
+  const daysSummary = buildProgressDaysSummary(instance.progress);
+  if (daysSummary) {
+    appendStatRow(doc, stats, 'Days', daysSummary);
+  }
+  if (instance.progress?.lastWorkedDay != null) {
+    appendStatRow(doc, stats, 'Last worked', formatDay(instance.progress.lastWorkedDay));
+  }
+  if (instance.payoutAwarded != null) {
+    const payout = formatMoneyValue(instance.payoutAwarded);
+    if (payout) {
+      appendStatRow(doc, stats, 'Payout awarded', payout);
+    }
+  }
+
+  if (stats.children.length > 0) {
+    item.appendChild(stats);
+  }
+
+  if (instance.notes) {
+    const notes = doc.createElement('p');
+    notes.className = 'developer-actions__instance-notes';
+    notes.textContent = instance.notes;
+    item.appendChild(notes);
+  }
+
+  if (Array.isArray(instance.progress?.logEntries) && instance.progress.logEntries.length) {
+    const log = doc.createElement('div');
+    log.className = 'developer-actions__instance-log';
+
+    const logTitle = doc.createElement('p');
+    logTitle.className = 'developer-actions__instance-log-title';
+    logTitle.textContent = `Daily log (${instance.progress.logEntries.length})`;
+
+    const logList = doc.createElement('ul');
+    logList.className = 'developer-actions__instance-log-list';
+
+    instance.progress.logEntries.forEach(entry => {
+      const row = doc.createElement('li');
+      row.className = 'developer-actions__instance-log-row';
+
+      const day = doc.createElement('span');
+      day.className = 'developer-actions__instance-log-day';
+      day.textContent = `Day ${entry.day}`;
+
+      const hours = doc.createElement('span');
+      hours.className = 'developer-actions__instance-log-hours';
+      hours.textContent = formatHoursValue(entry.hours) || '—';
+
+      row.append(day, hours);
+      logList.appendChild(row);
+    });
+
+    log.append(logTitle, logList);
+    item.appendChild(log);
+  }
+
+  return item;
+}
+
+function renderActionEntry(doc, entry, index) {
+  const item = doc.createElement('li');
+  item.className = 'developer-actions__item';
+
+  const header = doc.createElement('div');
+  header.className = 'developer-actions__item-header';
+
+  const titleGroup = doc.createElement('div');
+  titleGroup.className = 'developer-actions__item-title-group';
+
+  const title = doc.createElement('h3');
+  title.className = 'developer-actions__item-title';
+  title.textContent = entry.name || `Action ${index + 1}`;
+
+  const id = doc.createElement('p');
+  id.className = 'developer-actions__item-id';
+  id.textContent = entry.id;
+
+  titleGroup.append(title, id);
+  header.appendChild(titleGroup);
+
+  if (Array.isArray(entry.badges) && entry.badges.length) {
+    const badgeGroup = doc.createElement('div');
+    badgeGroup.className = 'developer-actions__badges';
+    entry.badges.forEach(badge => {
+      if (!badge || !badge.label) return;
+      badgeGroup.appendChild(createBadge(doc, badge.label, badge.tone || 'neutral'));
+    });
+    header.appendChild(badgeGroup);
+  }
+
+  item.appendChild(header);
+
+  if (entry.description) {
+    const description = doc.createElement('p');
+    description.className = 'developer-actions__description';
+    description.textContent = entry.description;
+    item.appendChild(description);
+  }
+
+  const stats = doc.createElement('dl');
+  stats.className = 'developer-actions__stats';
+
+  appendStatRow(doc, stats, 'Availability', entry.availability || '—');
+  appendStatRow(doc, stats, 'Expiry', entry.expiry || '—');
+  if (entry.progressTemplate) {
+    appendStatRow(doc, stats, 'Progress template', entry.progressTemplate);
+  }
+  if (entry.baseTime != null) {
+    const baseTime = formatHoursValue(entry.baseTime);
+    if (baseTime) {
+      appendStatRow(doc, stats, 'Base time cost', baseTime);
+    }
+  }
+  if (entry.basePayout != null) {
+    const basePayout = formatMoneyValue(entry.basePayout);
+    if (basePayout) {
+      appendStatRow(doc, stats, 'Base payout', basePayout);
+    }
+  }
+  if (entry.runsToday != null) {
+    appendStatRow(doc, stats, 'Runs today', Math.max(0, Math.floor(entry.runsToday)));
+  }
+  appendStatRow(doc, stats, 'Last run', formatDay(entry.lastRunDay));
+  const countsSummary = buildCountsSummary(entry.counts);
+  if (countsSummary) {
+    appendStatRow(doc, stats, 'Instances', countsSummary);
+  }
+
+  if (stats.children.length > 0) {
+    item.appendChild(stats);
+  }
+
+  const instancesContainer = doc.createElement('div');
+  instancesContainer.className = 'developer-actions__instances';
+
+  const instancesTitle = doc.createElement('h4');
+  instancesTitle.className = 'developer-actions__instances-title';
+  instancesTitle.textContent = 'Instances';
+  instancesContainer.appendChild(instancesTitle);
+
+  if (entry.instances.length) {
+    const list = doc.createElement('ol');
+    list.className = 'developer-actions__instance-list';
+    entry.instances.forEach((instance, instanceIndex) => {
+      list.appendChild(renderActionInstance(doc, instance, instanceIndex));
+    });
+    instancesContainer.appendChild(list);
+  } else {
+    const empty = doc.createElement('p');
+    empty.className = 'developer-empty developer-actions__empty';
+    empty.textContent = 'No action runs logged yet.';
+    instancesContainer.appendChild(empty);
+  }
+
+  item.appendChild(instancesContainer);
+  return item;
+}
+
+function renderActionMemory(container, state) {
+  const list = container.querySelector('#developer-actions-list');
+  const empty = container.querySelector('#developer-actions-empty');
+  if (!list) return;
+
+  const doc = list.ownerDocument || container.ownerDocument || document;
+  const entries = collectActionSnapshots(state);
+
+  list.innerHTML = '';
+
+  if (!entries.length) {
+    if (empty) {
+      empty.hidden = false;
+    }
+    return;
+  }
+
+  if (empty) {
+    empty.hidden = true;
+  }
+
+  entries.forEach((entry, index) => {
+    list.appendChild(renderActionEntry(doc, entry, index));
+  });
+}
+
 function renderTimeBuffs(container, state) {
   const base = formatHours(Number(state?.baseTime) || 0);
   const bonus = formatHours(Number(state?.bonusTime) || 0);
@@ -278,6 +890,7 @@ export function renderDeveloperView(rootDocument = document) {
   renderEvents(container, state);
   renderEducationBuffs(container, state);
   renderUpgradeBuffs(container, state);
+  renderActionMemory(container, state);
   renderTimeBuffs(container, state);
   renderStateDump(container, state);
 }

--- a/styles/developer.css
+++ b/styles/developer.css
@@ -284,6 +284,285 @@ body:not(.developer-view-active) #developer-root {
   font-weight: 700;
 }
 
+.developer-card--wide {
+  grid-column: 1 / -1;
+}
+
+.developer-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.developer-actions__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.developer-actions__item {
+  background: rgba(8, 12, 22, 0.65);
+  border-radius: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.developer-actions__item-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.developer-actions__item-title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.developer-actions__item-title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+}
+
+.developer-actions__item-id {
+  margin: 0;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary-on-dark, rgba(245, 247, 251, 0.55));
+}
+
+.developer-actions__badges,
+.developer-actions__instance-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.developer-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-secondary-on-dark, rgba(245, 247, 251, 0.8));
+}
+
+.developer-badge--accent {
+  background: linear-gradient(135deg, rgba(91, 141, 239, 0.9), rgba(142, 101, 255, 0.9));
+  color: #ffffff;
+  box-shadow: 0 0.4rem 1rem rgba(94, 118, 255, 0.25);
+}
+
+.developer-badge--neutral {
+  background: rgba(255, 255, 255, 0.14);
+  color: #ffffff;
+}
+
+.developer-badge--muted {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-secondary-on-dark, rgba(245, 247, 251, 0.7));
+}
+
+.developer-badge--status-active {
+  background: rgba(81, 176, 255, 0.32);
+  color: #e9f6ff;
+}
+
+.developer-badge--status-completed {
+  background: rgba(123, 235, 190, 0.32);
+  color: #ecfff6;
+}
+
+.developer-badge--status-pending {
+  background: rgba(255, 219, 141, 0.32);
+  color: #fff8e4;
+}
+
+.developer-badge--status-unknown {
+  background: rgba(255, 255, 255, 0.18);
+  color: #f5f7fb;
+}
+
+.developer-actions__description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-secondary-on-dark, rgba(245, 247, 251, 0.75));
+}
+
+.developer-actions__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem 1.1rem;
+  margin: 0;
+}
+
+.developer-actions__stat {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 0.9rem;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.developer-actions__stat dt {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary-on-dark, rgba(245, 247, 251, 0.6));
+}
+
+.developer-actions__stat dd {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.developer-actions__instances {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.developer-actions__instances-title {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary-on-dark, rgba(245, 247, 251, 0.62));
+}
+
+.developer-actions__instance-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.developer-actions__instance {
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 1rem;
+  padding: 1.1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.developer-actions__instance-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.developer-actions__instance-title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.developer-actions__instance-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.developer-actions__instance-id {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary-on-dark, rgba(245, 247, 251, 0.55));
+}
+
+.developer-actions__instance-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.65rem 1rem;
+  margin: 0;
+}
+
+.developer-actions__instance-stats .developer-actions__stat {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.developer-actions__instance-notes {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-secondary-on-dark, rgba(245, 247, 251, 0.75));
+  font-style: italic;
+}
+
+.developer-actions__instance-log {
+  background: rgba(8, 12, 22, 0.55);
+  border-radius: 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  padding: 0.9rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.developer-actions__instance-log-title {
+  margin: 0;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary-on-dark, rgba(245, 247, 251, 0.6));
+}
+
+.developer-actions__instance-log-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.5rem 1rem;
+}
+
+.developer-actions__instance-log-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 0.6rem;
+  padding: 0.4rem 0.6rem;
+}
+
+.developer-actions__instance-log-day {
+  font-weight: 600;
+}
+
+.developer-actions__instance-log-hours {
+  color: var(--text-secondary-on-dark, rgba(245, 247, 251, 0.75));
+}
+
+.developer-actions__empty {
+  margin: 0;
+}
+
 .developer-json {
   background: rgba(0, 0, 0, 0.45);
   border-radius: 1rem;


### PR DESCRIPTION
## Summary
- add an Action Memory card to the developer state explorer that renders every action definition with availability, run counts, and instance detail pulled from live state
- style the new developer action components with badges, grids, and daily log listings so the panel matches the existing dashboard aesthetic
- document the new panel in the developer state explorer notes and changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2bdfa52bc832c9416194ceef0c8f9