### PR TITLE
Align niche trend copy with event language

### DIFF
--- a/src/ui/cards/model/trends.js
+++ b/src/ui/cards/model/trends.js
@@ -5,7 +5,7 @@ import { registerModelBuilder } from '../modelBuilderRegistry.js';
 const DEFAULT_MODEL = {
   highlights: {
     hot: { title: 'No readings yet', note: 'Assign a niche to start tracking buzz.' },
-    swing: { title: 'Awaiting data', note: 'Fresh deltas will appear after the first reroll.' },
+    swing: { title: 'Awaiting data', note: 'Fresh deltas will appear once the first trend readings roll in.' },
     risk: { title: 'All calm', note: 'We’ll flag niches that are cooling off fast.' }
   },
   board: {

--- a/src/ui/dashboard/nicheModel.js
+++ b/src/ui/dashboard/nicheModel.js
@@ -5,7 +5,7 @@ import { collectNicheAnalytics, summarizeNicheHighlights } from '../../game/anal
 export function createHighlightDefaults() {
   return {
     hot: { title: 'No readings yet', note: 'Assign a niche to start tracking buzz.' },
-    swing: { title: 'Awaiting data', note: 'Fresh deltas will appear after the first reroll.' },
+    swing: { title: 'Awaiting data', note: 'Fresh deltas will appear once the first trend readings roll in.' },
     risk: { title: 'All calm', note: 'We’ll flag niches that are cooling off fast.' }
   };
 }

--- a/src/ui/views/browser/components/serverhub/views/apps/nicheSelector.js
+++ b/src/ui/views/browser/components/serverhub/views/apps/nicheSelector.js
@@ -70,7 +70,7 @@ export function renderNichePanel(instance, helpers) {
   if (instance.nicheLocked) {
     const locked = document.createElement('p');
     locked.className = 'serverhub-panel__hint';
-    locked.textContent = 'Niche locked in — reroll popularity tomorrow for fresh multipliers.';
+    locked.textContent = 'Niche locked in — ride out the current streak and savor the ongoing event boosts.';
     section.appendChild(locked);
     return section;
   }


### PR DESCRIPTION
## Summary
- refresh the locked niche hint to reference ongoing streak events instead of rerolls
- clarify swing highlight defaults to mention first trend readings rather than rerolls
- ensure all niche trend copy aligns with event-driven terminology while keeping the upbeat tone

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2c2aa7b78832cb3c31a641a31a7aa