### PR TITLE
Sync game test harness with niche trend snapshots

### DIFF
--- a/tests/game/events/syncNicheTrendSnapshots.test.js
+++ b/tests/game/events/syncNicheTrendSnapshots.test.js
@@ -8,6 +8,9 @@ const gameEventsModule = await import('../../../src/game/events/index.js');
 const { addEvent } = eventsModule;
 const { advanceEventsAfterDay } = gameEventsModule;
 const { syncNicheTrendSnapshots } = await import('../../../src/game/events/syncNicheTrendSnapshots.js');
+const { createNeutralPopularitySnapshot } = await import(
+  '../../../src/game/niches/popularitySnapshot.js'
+);
 
 const { stateModule } = harness;
 const { getState } = stateModule;
@@ -30,6 +33,7 @@ test('syncNicheTrendSnapshots caches event-driven popularity and preserves histo
     state.day = 1;
 
     state.events.active = state.events.active.filter(event => event?.target?.type !== 'niche');
+    state.niches.popularity[NICHE_ID] = createNeutralPopularitySnapshot();
 
     addEvent(state, {
       templateId: 'test-niche-trend',

--- a/tests/helpers/gameTestHarness.js
+++ b/tests/helpers/gameTestHarness.js
@@ -26,6 +26,9 @@ export async function getGameTestHarness() {
   const registryService = await import('../../src/game/registryService.js');
   const { ensureRegistryReady } = await import('../../src/game/registryBootstrap.js');
   const eventsModule = await import('../../src/game/events/index.js');
+  const { syncNicheTrendSnapshots } = await import(
+    '../../src/game/events/syncNicheTrendSnapshots.js'
+  );
 
   registryService.resetRegistry();
   ensureRegistryReady();
@@ -33,6 +36,7 @@ export async function getGameTestHarness() {
   const resetState = () => {
     const nextState = stateModule.initializeState(stateModule.buildDefaultState());
     eventsModule.maybeSpawnNicheEvents({ state: nextState, day: nextState.day || 1 });
+    syncNicheTrendSnapshots(nextState);
     const logNodes = elementRegistryModule.getElement('browserNotifications');
     if (logNodes?.badge) {
       logNodes.badge.textContent = '';


### PR DESCRIPTION
## Summary
- synchronize the test harness state reset with runtime behavior by syncing niche trend snapshots after spawning events
- seed the syncNicheTrendSnapshots test with a neutral snapshot before injecting custom events to keep expectations deterministic

## Testing
- node --test tests/game
- node --test tests/nicheAnalytics.test.js
- node --test tests/ui/dashboardModel.test.js
- node --test tests/stateManagement.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2c2ab82b4832c8f8604da003e323b