### PR TITLE
Add action instance stats summary to developer explorer

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,7 @@
 - Niche trend events now stretch across 5–10 days, building from gentle nudges to pronounced peaks (or dips) so players can react to the swelling momentum.
 - Tooling: Added a `?view=developer` state explorer that surfaces the live memory snapshot, active random events, and long-term buff sources for faster balancing passes.
 - Tooling: Developer state explorer now includes an Action Memory panel that lists every action definition with run counters, availability metadata, and per-instance progress logs pulled from live state.
+- Tooling: Developer state explorer now highlights an instance stats summary atop Action Memory, tallying total runs and per-status counts for quick debugging.
 - Niche trend rerolls now guarantee every niche is always riding exactly one weighted event, including immediately after loads and daily advances.
 
 ## Recent Highlights

--- a/docs/features/developer-state-explorer.md
+++ b/docs/features/developer-state-explorer.md
@@ -17,7 +17,7 @@ Append `?view=developer` (or `?ui=developer`) to the game URL to boot directly i
 - **Overview card** – current day, cash, time remaining, active asset count, and total active events plus a timestamp for the snapshot.
 - **Random event buffs** – sortable table (by modifier magnitude) showing label, percent impact, target resolution, remaining days, and tone for each active event.
 - **Long-term buffs** – grouped by education completions, purchased upgrades with boost text, and current time bonuses (base, bonus, and daily additions).
-- **Action memory** – rich cards for every action definition showing availability, base costs, run counters, and per-instance progress logs pulled from live state.
+- **Action memory** – rich cards for every action definition showing availability, base costs, run counters, per-instance progress logs pulled from live state, and a top-line instance tally grouped by status for fast auditing.
 - **Raw state snapshot** – pretty-printed JSON dump of the full state object for quick copying into tests.
 
 ## Implementation Notes

--- a/index.html
+++ b/index.html
@@ -376,6 +376,10 @@
           <p class="developer-card__subtitle">Every action definition currently tracked in save data.</p>
         </header>
         <div class="developer-card__body developer-actions">
+          <section id="developer-actions-stats" class="developer-actions__summary" hidden aria-live="polite">
+            <h3 class="developer-actions__summary-title">Instance stats</h3>
+            <dl class="developer-actions__stats" data-dev-actions-stats></dl>
+          </section>
           <p id="developer-actions-empty" class="developer-empty" hidden>No action runs logged yet.</p>
           <ul id="developer-actions-list" class="developer-actions__list" aria-live="polite"></ul>
         </div>

--- a/styles/developer.css
+++ b/styles/developer.css
@@ -412,6 +412,21 @@ body:not(.developer-view-active) #developer-root {
   margin: 0;
 }
 
+.developer-actions__summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  margin-bottom: 1.5rem;
+}
+
+.developer-actions__summary-title {
+  margin: 0;
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary-on-dark, rgba(245, 247, 251, 0.65));
+}
+
 .developer-actions__stat {
   background: rgba(255, 255, 255, 0.04);
   border-radius: 0.9rem;


### PR DESCRIPTION
## Summary
- add an instance stats section to the developer action memory card and wire it into the renderer
- aggregate action instance counts by status to power the new summary display
- update developer explorer docs and changelog to cover the new instance stats overview

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2c9d68760832c9535266d8ab92bcf