### PR TITLE
Refactor Timodoro UI lists into reusable helpers

### DIFF
--- a/src/ui/views/browser/apps/timodoro/components/card.js
+++ b/src/ui/views/browser/apps/timodoro/components/card.js
@@ -1,0 +1,34 @@
+import { appendContent } from '../../../components/common/domHelpers.js';
+
+function createCard({ title, summary, headerClass, headerContent } = {}) {
+  const card = document.createElement('article');
+  card.className = 'browser-card timodoro-card';
+
+  const header = document.createElement('header');
+  header.className = 'browser-card__header';
+  if (headerClass) {
+    header.classList.add(headerClass);
+  }
+
+  const heading = document.createElement('h2');
+  heading.className = 'browser-card__title';
+  appendContent(heading, title);
+  header.appendChild(heading);
+
+  if (summary) {
+    const description = document.createElement('p');
+    description.className = 'browser-card__summary';
+    appendContent(description, summary);
+    header.appendChild(description);
+  }
+
+  if (headerContent) {
+    appendContent(header, headerContent);
+  }
+
+  card.appendChild(header);
+  return card;
+}
+
+export { createCard };
+export default createCard;

--- a/src/ui/views/browser/apps/timodoro/components/lists.js
+++ b/src/ui/views/browser/apps/timodoro/components/lists.js
@@ -1,0 +1,134 @@
+import { appendContent } from '../../../components/common/domHelpers.js';
+
+function createEmptyItem(className, message) {
+  const empty = document.createElement('li');
+  empty.className = className;
+  appendContent(empty, message);
+  return empty;
+}
+
+function createList({
+  className,
+  datasetRole,
+  entries = [],
+  emptyMessage,
+  emptyClassName,
+  buildItem
+}) {
+  const list = document.createElement('ul');
+  list.className = className;
+  if (datasetRole) {
+    list.dataset.role = datasetRole;
+  }
+
+  const items = Array.isArray(entries) ? entries : [];
+  if (items.length === 0) {
+    if (emptyMessage) {
+      list.appendChild(createEmptyItem(emptyClassName, emptyMessage));
+    }
+    return list;
+  }
+
+  if (typeof buildItem === 'function') {
+    items.forEach(entry => {
+      if (!entry) {
+        return;
+      }
+      const item = buildItem(entry);
+      if (item) {
+        list.appendChild(item);
+      }
+    });
+  }
+
+  return list;
+}
+
+function createTaskList(entries = [], emptyText, datasetRole) {
+  return createList({
+    className: 'timodoro-list timodoro-list--tasks',
+    datasetRole,
+    entries,
+    emptyMessage: emptyText,
+    emptyClassName: 'timodoro-list__empty',
+    buildItem: entry => {
+      const item = document.createElement('li');
+      item.className = 'timodoro-list__item';
+
+      const name = document.createElement('span');
+      name.className = 'timodoro-list__name';
+      appendContent(name, entry.name ?? '');
+
+      const meta = document.createElement('span');
+      meta.className = 'timodoro-list__meta';
+      appendContent(meta, entry.detail ?? '');
+
+      item.append(name, meta);
+      return item;
+    }
+  });
+}
+
+function createBreakdownList(entries = []) {
+  return createList({
+    className: 'timodoro-list timodoro-list--breakdown',
+    datasetRole: 'timodoro-breakdown',
+    entries,
+    emptyMessage: 'No hours tracked yet.',
+    emptyClassName: 'timodoro-breakdown__empty',
+    buildItem: entry => {
+      const item = document.createElement('li');
+      item.className = 'timodoro-breakdown__item';
+
+      const label = document.createElement('span');
+      label.className = 'timodoro-breakdown__label';
+      appendContent(label, entry.label ?? '');
+
+      const value = document.createElement('span');
+      value.className = 'timodoro-breakdown__value';
+      appendContent(value, entry.value ?? '');
+
+      item.append(label, value);
+      return item;
+    }
+  });
+}
+
+function createSummaryList(entries = []) {
+  return createList({
+    className: 'timodoro-list timodoro-list--stats',
+    datasetRole: 'timodoro-stats',
+    entries,
+    buildItem: entry => {
+      const item = document.createElement('li');
+      item.className = 'timodoro-stats__item';
+
+      const label = document.createElement('span');
+      label.className = 'timodoro-stats__label';
+      appendContent(label, entry.label ?? '');
+
+      const value = document.createElement('span');
+      value.className = 'timodoro-stats__value';
+      appendContent(value, entry.value ?? '');
+
+      item.append(label, value);
+
+      if (entry.note) {
+        const note = document.createElement('span');
+        note.className = 'timodoro-stats__note';
+        appendContent(note, entry.note);
+        item.appendChild(note);
+      }
+
+      return item;
+    }
+  });
+}
+
+export {
+  createBreakdownList,
+  createEmptyItem,
+  createList,
+  createSummaryList,
+  createTaskList
+};

--- a/src/ui/views/browser/apps/timodoro/sections/completedSection.js
+++ b/src/ui/views/browser/apps/timodoro/sections/completedSection.js
@@ -1,0 +1,44 @@
+import { appendContent } from '../../../components/common/domHelpers.js';
+import { createTaskList } from '../components/lists.js';
+
+const COMPLETED_GROUPS = [
+  { key: 'hustles', label: 'Hustles', empty: 'No hustles wrapped yet.' },
+  { key: 'education', label: 'Education', empty: 'No study blocks logged yet.' },
+  { key: 'upkeep', label: 'Upkeep', empty: 'No upkeep tackled yet.' },
+  { key: 'upgrades', label: 'Upgrades', empty: 'No upgrade pushes finished yet.' }
+];
+
+function createCompletedSection(completedGroups = {}) {
+  const section = document.createElement('section');
+  section.className = 'timodoro-section';
+
+  const heading = document.createElement('h3');
+  heading.className = 'timodoro-section__title';
+  appendContent(heading, 'Completed today');
+
+  const groupsWrapper = document.createElement('div');
+  groupsWrapper.className = 'timodoro-section__groups';
+
+  COMPLETED_GROUPS.forEach(groupConfig => {
+    const group = document.createElement('section');
+    group.className = 'timodoro-subsection';
+
+    const title = document.createElement('h4');
+    title.className = 'timodoro-subsection__title';
+    appendContent(title, groupConfig.label);
+
+    const entries = Array.isArray(completedGroups[groupConfig.key])
+      ? completedGroups[groupConfig.key]
+      : [];
+    const list = createTaskList(entries, groupConfig.empty, `timodoro-completed-${groupConfig.key}`);
+
+    group.append(title, list);
+    groupsWrapper.appendChild(group);
+  });
+
+  section.append(heading, groupsWrapper);
+  return section;
+}
+
+export { COMPLETED_GROUPS, createCompletedSection };
+export default createCompletedSection;


### PR DESCRIPTION
## Summary
- extract shared card and list builders into dedicated Timodoro helper modules
- move the completed section renderer into a focused section module
- update the Timodoro UI to consume the helpers while preserving existing data flow

## Testing
- node --test tests/ui/workspaces/timodoroWorkspacePresenter.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2ca0b45d4832c94a7a3f6e20341d9