### PR TITLE
Fix Learnly course study duration and completion pacing

### DIFF
--- a/src/game/actions/progress.js
+++ b/src/game/actions/progress.js
@@ -141,25 +141,33 @@ function recomputeProgressSnapshot(progress) {
 function isCompletionSatisfied(definition, stored) {
   if (!stored) return false;
   const progress = stored.progress;
+  let hasAnyRequirement = false;
+
   if (progress) {
     if (Number.isFinite(progress.daysRequired) && progress.daysRequired > 0) {
-      if (Number(progress.daysCompleted) >= progress.daysRequired) {
-        return true;
+      hasAnyRequirement = true;
+      if (Number(progress.daysCompleted) < progress.daysRequired) {
+        return false;
       }
     }
     const progressRequired = resolveProgressField(progress.hoursRequired, null);
     if (progressRequired != null && progressRequired >= 0) {
-      if (Number(stored.hoursLogged) >= progressRequired - 0.0001) {
-        return true;
+      hasAnyRequirement = true;
+      if (Number(stored.hoursLogged) < progressRequired - 0.0001) {
+        return false;
       }
     }
   }
 
   const required = resolveProgressField(stored.hoursRequired, null);
   if (required != null && required >= 0) {
-    return Number(stored.hoursLogged) >= required - 0.0001;
+    hasAnyRequirement = true;
+    if (Number(stored.hoursLogged) < required - 0.0001) {
+      return false;
+    }
   }
-  return false;
+
+  return hasAnyRequirement;
 }
 
 function resolveInstance(entry, instanceOrId) {

--- a/src/game/requirements/data/knowledgeTracks.js
+++ b/src/game/requirements/data/knowledgeTracks.js
@@ -64,9 +64,32 @@ const buildInstantBoost = boost => {
   return entry;
 };
 
+const MINUTES_PER_HOUR = 60;
+
+const resolveStudyHoursPerDay = schedule => {
+  if (!schedule || typeof schedule !== 'object') {
+    return 0;
+  }
+
+  const rawHours = Number(schedule.hoursPerDay ?? schedule.hours_per_day);
+  if (Number.isFinite(rawHours) && rawHours > 0) {
+    return rawHours;
+  }
+
+  const rawMinutes = Number(
+    schedule.minutesPerDay ?? schedule.minutes_per_day ?? schedule.minutes
+  );
+  if (Number.isFinite(rawMinutes) && rawMinutes > 0) {
+    return rawMinutes / MINUTES_PER_HOUR;
+  }
+
+  return 0;
+};
+
 const knowledgeTrackData = Object.fromEntries(
   Object.entries(trackConfig).map(([id, track]) => {
     const schedule = track?.schedule || {};
+    const hoursPerDay = resolveStudyHoursPerDay(schedule);
     const instantBoosts = Array.isArray(track?.instantBoosts)
       ? track.instantBoosts.map(buildInstantBoost).filter(Boolean)
       : [];
@@ -77,7 +100,7 @@ const knowledgeTrackData = Object.fromEntries(
         id,
         name: track?.name || id,
         description: TRACK_DESCRIPTIONS[id] || '',
-        hoursPerDay: Number(schedule.hoursPerDay) || 0,
+        hoursPerDay,
         days: Number(schedule.days) || 0,
         tuition: Number(track?.setupCost ?? 0) || 0,
         instantBoosts

--- a/src/game/requirements/orchestrator.js
+++ b/src/game/requirements/orchestrator.js
@@ -232,8 +232,11 @@ export function createRequirementsOrchestrator({
       const { studiedToday, daysCompleted, completedFlag } = evaluateStudyProgress(track, state);
       const isActive = Boolean(progress.enrolled && !progress.completed);
 
-      if (progress.daysCompleted !== Math.min(track.days, daysCompleted)) {
-        progress.daysCompleted = Math.min(track.days, daysCompleted);
+      const previousDaysCompleted = Number(progress.daysCompleted) || 0;
+      const nextDaysCompleted = Math.min(track.days, daysCompleted);
+
+      if (progress.daysCompleted !== nextDaysCompleted) {
+        progress.daysCompleted = nextDaysCompleted;
         dirty = true;
       }
 
@@ -248,8 +251,11 @@ export function createRequirementsOrchestrator({
       }
 
       const participated = Boolean(studiedToday && isActive);
-      if (progress.studiedToday !== participated) {
-        progress.studiedToday = participated;
+      const advancedToday = nextDaysCompleted > previousDaysCompleted;
+      const nextStudiedToday = advancedToday ? false : participated;
+
+      if (progress.studiedToday !== nextStudiedToday) {
+        progress.studiedToday = nextStudiedToday;
         dirty = true;
       }
 


### PR DESCRIPTION
## Summary
- convert Learnly track schedules from minutes-per-day to hours so course actions reserve the intended study time
- require all configured study-day progress before study actions can auto-complete, preventing one-day finishes

## Testing
- npm test -- --watch=false *(terminated early after hanging waiting for additional suites)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c9ae15e0832c8ff4196d3c98521f