### PR TITLE
Support multi-offer hustle market rolls

### DIFF
--- a/docs/features/hustle-market.md
+++ b/docs/features/hustle-market.md
@@ -10,17 +10,22 @@
 - Templates may define a `market` block with:
   - `variants`: optional array of variant configs (id, label, weight, duration, availableAfterDays, metadata, definitionId).
   - `durationDays` and `availableAfterDays`: defaults applied when variants omit explicit values.
+  - `slotsPerRoll`: number of offers to attempt each time the market rerolls (defaults to `1`).
+  - `maxActive`: hard cap for simultaneous offers from the template (defaults to `max(slotsPerRoll, variantCount)`).
   - `metadata`: extra properties merged into each offer.
-- If no variants are provided the `rollDailyOffers` helper fabricates a default variant that mirrors the template. When variants exist, multiple offers can coexist so long as each variant is represented at most once per active window.
+- Variants may specify:
+  - `copies`: how many identical offers to spawn when the variant is selected (defaults to `1`).
+  - `maxActive`: ceiling for concurrent offers using that variant (defaults to `copies`).
+- If no variants are provided the `rollDailyOffers` helper fabricates a default variant that mirrors the template. When variants exist, multiple offers can coexist based on the configured slots and copy counts.
 
 ## Rolling Logic
-- `rollDailyOffers({ templates, day, now, state, rng })` clones any existing offers whose `expiresOnDay` is still in the future, then backfills missing templates by selecting a weighted variant (defaulting to equal weights).
+- `rollDailyOffers({ templates, day, now, state, rng })` clones any existing offers whose `expiresOnDay` is still in the future, then fills the configured number of template slots by selecting weighted variants (defaulting to equal weights). Variant copy counts can consume multiple slots per roll while template and variant `maxActive` values prevent overfilling.
 - Each new offer captures:
   - `rolledOnDay`, `availableOnDay`, and `expiresOnDay` (duration is inclusive of the start day).
   - Variant metadata (id, label, description) plus merged template/variant metadata.
   - Resolved requirements (`metadata.requirements.hours` and `metadata.hoursRequired`) and payout details (`metadata.payout.amount`, `metadata.payout.schedule`).
   - A deterministic `daysActive` array so UI layers can render availability windows.
-- Offers are sorted by availability day then template id for consistent rendering.
+- Offers are sorted by availability day, template id, variant id, and finally offer id for consistent rendering even when multiple copies share the same variant.
 
 ## Persistence Helpers
 - `ensureHustleMarketState` guarantees the `state.hustleMarket` slice exists with `{ lastRolledAt, lastRolledOnDay, offers: [], accepted: [] }`.

--- a/src/game/hustles/market.js
+++ b/src/game/hustles/market.js
@@ -39,6 +39,18 @@ function resolveWeight(value, fallback = 1) {
   return parsed;
 }
 
+function resolvePositiveInteger(value, fallback = 1) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    const fallbackParsed = Number(fallback);
+    if (!Number.isFinite(fallbackParsed) || fallbackParsed <= 0) {
+      return 1;
+    }
+    return Math.floor(fallbackParsed);
+  }
+  return Math.floor(parsed);
+}
+
 function buildVariantTemplate(template) {
   const marketConfig = template?.market || {};
   const baseDuration = resolveNonNegative(marketConfig.durationDays ?? 0, 0);
@@ -54,7 +66,9 @@ function buildVariantTemplate(template) {
     weight: 1,
     durationDays: Math.max(0, baseDuration),
     availableAfterDays: Math.max(0, baseOffset),
-    metadata: {}
+    metadata: {},
+    copies: 1,
+    maxActive: 1
   };
 }
 
@@ -92,6 +106,10 @@ function normalizeVariant(entry, index, template) {
   const metadata = typeof entry.metadata === 'object' && entry.metadata !== null
     ? structuredClone(entry.metadata)
     : {};
+  const copies = resolvePositiveInteger(entry.copies ?? fallback.copies ?? 1, fallback.copies ?? 1);
+  const maxActive = entry.maxActive != null
+    ? resolvePositiveInteger(entry.maxActive, copies)
+    : Math.max(1, copies);
 
   return {
     id: variantId,
@@ -103,7 +121,9 @@ function normalizeVariant(entry, index, template) {
     weight,
     durationDays: Math.max(0, duration),
     availableAfterDays: Math.max(0, offset),
-    metadata
+    metadata,
+    copies,
+    maxActive
   };
 }
 
@@ -289,9 +309,17 @@ export function rollDailyOffers({
   for (const offer of preservedOffers) {
     if (!offer || offer.claimed) continue;
     if (!activeVariantsByTemplate.has(offer.templateId)) {
-      activeVariantsByTemplate.set(offer.templateId, new Set());
+      activeVariantsByTemplate.set(offer.templateId, {
+        total: 0,
+        variants: new Map()
+      });
     }
-    activeVariantsByTemplate.get(offer.templateId).add(offer.variantId);
+    const activity = activeVariantsByTemplate.get(offer.templateId);
+    activity.total += 1;
+    activity.variants.set(
+      offer.variantId,
+      (activity.variants.get(offer.variantId) || 0) + 1
+    );
   }
 
   for (const template of templates) {
@@ -301,32 +329,97 @@ export function rollDailyOffers({
     const variants = buildVariantPool(template);
     if (!variants.length) continue;
 
-    const activeVariantSet = activeVariantsByTemplate.get(templateId) || new Set();
-    const unclaimedVariants = variants.filter(variant => !activeVariantSet.has(variant.id));
-    if (!unclaimedVariants.length) {
+    const marketConfig = template?.market || {};
+    const templateSlotsPerRoll = resolvePositiveInteger(marketConfig.slotsPerRoll ?? 1, 1);
+    const defaultTemplateMaxActive = Math.max(templateSlotsPerRoll, variants.length);
+    const templateMaxActive = resolvePositiveInteger(
+      marketConfig.maxActive != null ? marketConfig.maxActive : defaultTemplateMaxActive,
+      defaultTemplateMaxActive
+    );
+
+    if (!activeVariantsByTemplate.has(templateId)) {
+      activeVariantsByTemplate.set(templateId, {
+        total: 0,
+        variants: new Map()
+      });
+    }
+
+    const activity = activeVariantsByTemplate.get(templateId);
+    const currentActive = activity.total;
+    const templateCapacity = Math.max(0, templateMaxActive - currentActive);
+    let slotsRemaining = Math.min(templateSlotsPerRoll, templateCapacity);
+    if (slotsRemaining <= 0) {
       continue;
     }
 
-    const selectedVariant = selectVariantFromPool(unclaimedVariants, rng);
-    if (!selectedVariant) continue;
+    const pendingAdds = new Map();
 
-    const offer = createOfferFromVariant({
-      template,
-      variant: selectedVariant,
-      day: currentDay,
-      timestamp: resolvedTimestamp
-    });
+    while (slotsRemaining > 0) {
+      const availableVariants = variants.filter(variant => {
+        const activeCount = activity.variants.get(variant.id) || 0;
+        const pendingCount = pendingAdds.get(variant.id) || 0;
+        const variantMaxActive = resolvePositiveInteger(
+          variant.maxActive != null ? variant.maxActive : variant.copies ?? 1,
+          variant.copies ?? 1
+        );
+        const capacity = variantMaxActive - activeCount - pendingCount;
+        return capacity > 0;
+      });
 
-    preservedOffers.push(structuredClone(offer));
-    if (!activeVariantsByTemplate.has(templateId)) {
-      activeVariantsByTemplate.set(templateId, new Set());
+      if (!availableVariants.length) {
+        break;
+      }
+
+      const selectedVariant = selectVariantFromPool(availableVariants, rng);
+      if (!selectedVariant) {
+        break;
+      }
+
+      const activeCount = activity.variants.get(selectedVariant.id) || 0;
+      const pendingCount = pendingAdds.get(selectedVariant.id) || 0;
+      const variantMaxActive = resolvePositiveInteger(
+        selectedVariant.maxActive != null ? selectedVariant.maxActive : selectedVariant.copies ?? 1,
+        selectedVariant.copies ?? 1
+      );
+      const variantCapacity = Math.max(0, variantMaxActive - activeCount - pendingCount);
+      if (variantCapacity <= 0) {
+        pendingAdds.set(selectedVariant.id, pendingCount);
+        continue;
+      }
+
+      const variantCopies = resolvePositiveInteger(selectedVariant.copies ?? 1, 1);
+      const spawnCount = Math.min(variantCopies, variantCapacity, slotsRemaining);
+      if (spawnCount <= 0) {
+        pendingAdds.set(selectedVariant.id, pendingCount);
+        break;
+      }
+
+      for (let index = 0; index < spawnCount; index += 1) {
+        const offer = createOfferFromVariant({
+          template,
+          variant: selectedVariant,
+          day: currentDay,
+          timestamp: resolvedTimestamp
+        });
+        preservedOffers.push(structuredClone(offer));
+      }
+
+      activity.total += spawnCount;
+      activity.variants.set(
+        selectedVariant.id,
+        (activity.variants.get(selectedVariant.id) || 0) + spawnCount
+      );
+      pendingAdds.set(selectedVariant.id, pendingCount + spawnCount);
+      slotsRemaining -= spawnCount;
     }
-    activeVariantsByTemplate.get(templateId).add(selectedVariant.id);
   }
 
   preservedOffers.sort((a, b) => {
     if (a.availableOnDay === b.availableOnDay) {
       if (a.templateId === b.templateId) {
+        if (a.variantId === b.variantId) {
+          return a.id.localeCompare(b.id);
+        }
         return a.variantId.localeCompare(b.variantId);
       }
       return a.templateId.localeCompare(b.templateId);

--- a/tests/hustleMarket.test.js
+++ b/tests/hustleMarket.test.js
@@ -4,6 +4,7 @@ import { getGameTestHarness } from './helpers/gameTestHarness.js';
 
 const harness = await getGameTestHarness();
 const { completeActionInstance } = await import('../src/game/actions/progress.js');
+const { ensureHustleMarketState } = await import('../src/core/state/slices/hustleMarket.js');
 const { hustlesModule, stateModule } = harness;
 const {
   rollDailyOffers,
@@ -73,6 +74,50 @@ test('rollDailyOffers builds variant metadata and allows multiple variants', () 
   assert.equal(weekendOffer.metadata.payout.schedule, 'weekend');
 });
 
+test('rollDailyOffers respects slotsPerRoll, variant copies, and maxActive', () => {
+  const state = getState();
+  state.day = 12;
+
+  const template = {
+    id: 'multi-slot',
+    name: 'Multi Slot Hustle',
+    time: 6,
+    market: {
+      slotsPerRoll: 3,
+      maxActive: 5,
+      variants: [
+        {
+          id: 'batch',
+          durationDays: 2,
+          copies: 3,
+          maxActive: 5,
+          metadata: {
+            requirements: { hours: 6 },
+            payout: { amount: 240, schedule: 'onCompletion' }
+          }
+        }
+      ]
+    }
+  };
+
+  const firstRoll = rollDailyOffers({ templates: [template], day: 12, now: 400, state, rng: () => 0.1 });
+  assert.equal(firstRoll.length, 3, 'first roll should respect slotsPerRoll and variant copies');
+  assert.ok(firstRoll.every(offer => offer.variantId === 'batch'), 'all offers should share the configured variant');
+  const firstIds = new Set(firstRoll.map(offer => offer.id));
+  assert.equal(firstIds.size, 3, 'each rolled offer should receive a unique id');
+
+  state.day = 13;
+  const secondRoll = rollDailyOffers({ templates: [template], day: 13, now: 500, state, rng: () => 0.2 });
+  assert.equal(secondRoll.length, 5, 'second roll should fill remaining capacity up to maxActive');
+  const secondIds = new Set(secondRoll.map(offer => offer.id));
+  assert.equal(secondIds.size, 5, 'no duplicate ids should appear after rerolling');
+  const rolledOnSecondDay = secondRoll.filter(offer => offer.rolledOnDay === 13);
+  assert.equal(rolledOnSecondDay.length, 2, 'remaining capacity should be consumed by new offers');
+
+  const ensured = ensureHustleMarketState(state, { fallbackDay: state.day });
+  assert.equal(ensured.offers.length, 5, 'state normalization should keep all repeated variant offers');
+});
+
 test('acceptHustleOffer claims offers and records accepted state', () => {
   const state = getState();
   state.day = 4;
@@ -137,6 +182,44 @@ test('expired offers and claims are pruned on reroll', () => {
 
   const claimedAfterExpiry = getClaimedOffers(state, { day: state.day });
   assert.equal(claimedAfterExpiry.length, 0, 'expired claims should be pruned from selectors');
+});
+
+test('multi-offer templates prune expired entries and refresh capacity', () => {
+  const state = getState();
+  state.day = 21;
+
+  const template = {
+    id: 'multi-expiring',
+    name: 'Batch Delivery',
+    time: 5,
+    market: {
+      slotsPerRoll: 2,
+      maxActive: 4,
+      variants: [
+        {
+          id: 'daily',
+          durationDays: 1,
+          copies: 2,
+          maxActive: 4,
+          metadata: {
+            requirements: { hours: 5 },
+            payout: { amount: 200, schedule: 'onCompletion' }
+          }
+        }
+      ]
+    }
+  };
+
+  const firstRoll = rollDailyOffers({ templates: [template], day: 21, now: 900, state, rng: () => 0 });
+  assert.equal(firstRoll.length, 2, 'initial roll should populate two offers');
+  const expiryDay = Math.max(...firstRoll.map(offer => offer.expiresOnDay));
+
+  state.day = expiryDay + 1;
+  const reroll = rollDailyOffers({ templates: [template], day: state.day, now: 950, state, rng: () => 0 });
+  assert.equal(reroll.length, 2, 'expired offers should be replaced after their window closes');
+  assert.ok(reroll.every(offer => offer.rolledOnDay === state.day), 'replacement offers should reflect the new roll day');
+  const rerollIds = new Set(reroll.map(offer => offer.id));
+  assert.equal(rerollIds.size, 2, 'replacement offers should maintain unique ids');
 });
 
 test('completing a hustle hides the accepted entry from pending lists', () => {


### PR DESCRIPTION
## Summary
- introduce template slot and variant copy controls so rollDailyOffers can create multiple offers per template while preserving expiry tracking
- normalize hustle market state using template, variant, and offer identifiers to keep repeated variants and maintain ordering
- document the new knobs and extend hustle market tests for multi-offer rolls and pruning behaviour

## Testing
- `npm test -- tests/hustleMarket.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68e2ccd94980832cb123d48cffbbedf8