### PR TITLE
Propagate hustle progress metadata through market and UI

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@
   keeping dashboards tidy without hiding fresh wins.
 - Hustle market rolls daily offers from immutable templates, tracks multi-day availability, and persists timestamps for clean day rollovers.
 - Hustle market offers now expose per-variant requirements and payout metadata, support simultaneous variants, and surface claimed-contract selectors via the new `acceptHustleOffer` helper.
+- Hustle market variants can define `hoursPerDay`, `daysRequired`, and manual completion flags; accepted offers flow those hints into action instances so the todo queue mirrors multi-day commitments accurately.
 - TODO/action queue now runs through the shared action-provider registry so dashboard widgets and TimoDoro stay aligned, and the landing page no longer swallows the default workspace when tasks populate mid-load.
 - Browser shell keeps the tabbed chrome, notification bell, and modular stylesheets; add new surfaces by pairing a presenter with a stylesheet.
 - Home dashboard stays focused on the three core widgets (ToDo, cash snapshot, app tiles) with drag-to-arrange and End Day gating.

--- a/docs/features/hustle-market.md
+++ b/docs/features/hustle-market.md
@@ -11,6 +11,10 @@
   - `variants`: optional array of variant configs (id, label, weight, duration, availableAfterDays, metadata, definitionId).
   - `durationDays` and `availableAfterDays`: defaults applied when variants omit explicit values.
   - `metadata`: extra properties merged into each offer.
+- Variant metadata now supports structured progress hints:
+  - `hoursPerDay` and `daysRequired` capture daily effort expectations for multi-day gigs.
+  - `completionMode` toggles whether the resulting action auto-completes (`instant` / `deferred`) or requires manual wrap-up.
+  - `progressLabel` lets variants override the default log title so accepted instances read naturally in the todo list.
 - If no variants are provided the `rollDailyOffers` helper fabricates a default variant that mirrors the template. When variants exist, multiple offers can coexist so long as each variant is represented at most once per active window.
 
 ## Rolling Logic
@@ -29,6 +33,7 @@
 
 ## Acceptance Flow
 - `acceptHustleOffer(offerId, { state })` reads the offer metadata, accepts an action instance through `acceptActionInstance`, marks the offer as claimed, and records an accepted entry with `acceptedOnDay`, `deadlineDay`, required hours, and payout schedule.
+- Progress metadata is piped directly into `acceptActionInstance` so accepted entries inherit `hoursPerDay`, `daysRequired`, and manual completion flags. The todo queue uses these hints to compute step hours and keeps manual tasks visible even when hour goals are satisfied.
 - Claimed offers continue to persist until their deadlines elapse so completion logging and payout scheduling remain traceable.
 
 ## Availability Queries

--- a/src/game/hustles/market.js
+++ b/src/game/hustles/market.js
@@ -224,6 +224,91 @@ function buildOfferMetadata(template, variant) {
     durationDays: variant.durationDays
   };
 
+  const baseProgress = typeof baseMetadata.progress === 'object' && baseMetadata.progress !== null
+    ? structuredClone(baseMetadata.progress)
+    : {};
+  const variantProgress = typeof variantMetadata.progress === 'object' && variantMetadata.progress !== null
+    ? structuredClone(variantMetadata.progress)
+    : {};
+
+  const progress = {
+    ...baseProgress,
+    ...variantProgress
+  };
+
+  const resolvedHoursPerDay = resolveFirstNumber(
+    variantMetadata.hoursPerDay,
+    variantProgress.hoursPerDay,
+    baseMetadata.hoursPerDay,
+    baseProgress.hoursPerDay,
+    template?.progress?.hoursPerDay
+  );
+  if (resolvedHoursPerDay != null && resolvedHoursPerDay > 0) {
+    const normalized = Math.max(0, Number(resolvedHoursPerDay));
+    progress.hoursPerDay = normalized;
+    metadata.hoursPerDay = normalized;
+  } else {
+    delete progress.hoursPerDay;
+    delete metadata.hoursPerDay;
+  }
+
+  const resolvedDaysRequired = resolveFirstNumber(
+    variantMetadata.daysRequired,
+    variantProgress.daysRequired,
+    baseMetadata.daysRequired,
+    baseProgress.daysRequired,
+    template?.progress?.daysRequired
+  );
+  if (resolvedDaysRequired != null && resolvedDaysRequired > 0) {
+    const normalized = Math.max(1, Math.floor(resolvedDaysRequired));
+    progress.daysRequired = normalized;
+    metadata.daysRequired = normalized;
+  } else {
+    delete progress.daysRequired;
+    delete metadata.daysRequired;
+  }
+
+  const resolvedCompletion = resolveFirstString(
+    variantMetadata.completionMode,
+    variantMetadata.completion,
+    variantProgress.completionMode,
+    variantProgress.completion,
+    baseMetadata.completionMode,
+    baseProgress.completionMode,
+    baseProgress.completion,
+    template?.progress?.completionMode,
+    template?.progress?.completion
+  );
+  if (resolvedCompletion) {
+    progress.completion = resolvedCompletion;
+    progress.completionMode = resolvedCompletion;
+    metadata.completionMode = resolvedCompletion;
+  } else {
+    delete progress.completionMode;
+    delete progress.completion;
+    delete metadata.completionMode;
+  }
+
+  const resolvedProgressLabel = resolveFirstString(
+    variantMetadata.progressLabel,
+    variantProgress.label,
+    variantProgress.progressLabel,
+    baseMetadata.progressLabel,
+    baseProgress.label,
+    template?.progress?.label
+  );
+  if (resolvedProgressLabel) {
+    progress.label = resolvedProgressLabel;
+    metadata.progressLabel = resolvedProgressLabel;
+  } else {
+    delete progress.label;
+    delete metadata.progressLabel;
+  }
+
+  if (Object.keys(progress).length) {
+    metadata.progress = progress;
+  }
+
   if (resolvedHours != null) {
     metadata.hoursRequired = resolvedHours;
   }

--- a/tests/hustleMarket.test.js
+++ b/tests/hustleMarket.test.js
@@ -102,6 +102,67 @@ test('acceptHustleOffer claims offers and records accepted state', () => {
   assert.equal(actionState.instances[0].id, accepted.instanceId);
 });
 
+test('acceptHustleOffer seeds progress overrides from metadata', () => {
+  const state = getState();
+  state.day = 10;
+
+  const baseTemplate = HUSTLE_TEMPLATES[0];
+  assert.ok(baseTemplate, 'expected a base hustle template for progress overrides');
+  const template = {
+    ...baseTemplate,
+    market: {
+      metadata: {
+        requirements: { hours: 12 },
+        payout: { amount: 240 }
+      },
+      variants: [
+        {
+          id: 'manual-progress',
+          durationDays: 5,
+          metadata: {
+            requirements: { hours: 12 },
+            hoursPerDay: 3,
+            daysRequired: 4,
+            completionMode: 'manual',
+            progressLabel: 'Publish daily updates',
+            payout: { amount: 240, schedule: 'onCompletion' }
+          }
+        }
+      ]
+    }
+  };
+
+  const [offer] = rollDailyOffers({ templates: [template], day: state.day, now: 5000, state, rng: () => 0 });
+  assert.ok(offer, 'expected an offer for progress override test');
+  const storedOffer = state.hustleMarket.offers.find(entry => entry.id === offer.id);
+  assert.ok(storedOffer, 'rolled offer should persist in hustle market state');
+
+  const accepted = acceptHustleOffer(storedOffer, { state });
+  assert.ok(accepted, 'expected accepted entry for progress override test');
+
+  assert.equal(accepted.metadata.hoursPerDay, 3);
+  assert.equal(accepted.metadata.daysRequired, 4);
+  assert.equal(accepted.metadata.completionMode, 'manual');
+  assert.equal(accepted.metadata.progressLabel, 'Publish daily updates');
+  assert.ok(accepted.metadata.progress, 'progress metadata should exist');
+  assert.equal(accepted.metadata.progress.hoursPerDay, 3);
+  assert.equal(accepted.metadata.progress.daysRequired, 4);
+  assert.equal(accepted.metadata.progress.completionMode, 'manual');
+  assert.equal(accepted.metadata.progress.label, 'Publish daily updates');
+
+  const actionState = getActionState(template.id, state);
+  assert.ok(actionState.instances.length > 0, 'acceptance should create an instance for multi-day offer');
+  const instance = actionState.instances[0];
+  assert.equal(instance.progress.hoursPerDay, 3);
+  assert.equal(instance.progress.daysRequired, 4);
+  assert.equal(instance.progress.completion, 'manual');
+  assert.equal(instance.progress.completionMode ?? instance.progress.completion, 'manual');
+  const progressLabel = instance.progress.label
+    ?? accepted.metadata.progress?.label
+    ?? accepted.metadata.progressLabel;
+  assert.equal(progressLabel, 'Publish daily updates');
+});
+
 test('availability selectors can include claimed offers when requested', () => {
   const state = getState();
   state.day = 6;


### PR DESCRIPTION
## Summary
- allow hustle market variants to specify daily pacing and manual completion metadata that flows into accepted instances
- surface multi-day requirements on hustle cards and todo progress snapshots for manual contracts
- document the new metadata hooks in hustle-market feature notes and changelog entries

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2ccca0944832c9d6f88205758295f