### PR TITLE
Refactor action templates and add tests

### DIFF
--- a/docs/features/action-templates.md
+++ b/docs/features/action-templates.md
@@ -1,0 +1,90 @@
+# Action Template Builders
+
+The action registry now exposes helper builders that wrap `acceptActionInstance` so that new
+systems can register reusable contract-style actions with consistent defaults. These templates
+live in `src/game/actions/templates/contract.js` and are designed to keep availability, progress,
+limits, and logging metadata aligned with the shared action instance store.
+
+## Goals
+
+- Provide a single place to normalize availability and expiry metadata for any action that queues
+  instances.
+- Guarantee that every template seeds a `defaultState.instances` array so registry bootstrap does
+  not need to guard for missing state.
+- Wrap `acceptActionInstance` with template-specific defaults so callers only supply the deltas
+  that matter for the current run.
+- Make it obvious how to set daily limits, enrollable states, or manual completion workflows.
+
+## Builders
+
+### `createContractTemplate(definition, options)`
+
+Creates a contract-style template that ensures:
+
+- `availability` falls back to `{ type: 'dailyLimit' }` when a `dailyLimit` is present, otherwise
+  `{ type: 'always' }`.
+- `expiry` defaults to `{ type: 'permanent' }` unless overridden.
+- `progress` merges template defaults with any values supplied at definition time.
+- `acceptInstance({...})` wraps `acceptActionInstance`, merging progress overrides so callers can
+  tweak hours, deadlines, or custom labels without rebuilding the base metadata.
+
+Use this builder for instant hustles, asset upkeep actions, and exploratory contracts that share a
+single-instance queue.
+
+### `createStudyTemplate(definition, options)`
+
+Extends the contract template with study-friendly defaults:
+
+- `availability` defaults to `{ type: 'enrollable' }`.
+- `progress` always reports `{ type: 'study', completion: 'manual' }` unless explicitly overridden.
+
+Study tracks should call this helper after composing their card presenters so they inherit the
+same acceptance flow as hustles. The template still exposes `acceptInstance`, allowing the track to
+log manual study time while respecting shared progress metadata.
+
+## Integration Points
+
+- **Hustles:** `createInstantHustle` now pipes its definition through `createContractTemplate` to
+  inherit availability, progress, and limit logic before wiring logging hooks. When the action runs
+  it calls `definition.acceptInstance` so overrides (deadline, hours required, manual completion)
+  flow through a single wrapper.
+- **Study Tracks:** `src/game/actions/definitions.js` routes knowledge track entries through
+  `createStudyTemplate` so accepted study sessions use the same progress metadata as any other
+  contract.
+- **Asset Upkeep & Exploratory Actions:** Future upkeep timers or exploration contracts should
+  create their definitions with `createContractTemplate`, then customize `acceptInstance` overrides
+  (e.g., to add upkeep-specific log messages) instead of calling `acceptActionInstance` directly.
+  This keeps daily limit bookkeeping aligned with the base implementation.
+
+## Usage Pattern
+
+```js
+import { createContractTemplate } from '../actions/templates/contract.js';
+
+const definition = createContractTemplate({
+  id: 'explore-new-market',
+  name: 'Explore a New Market',
+  defaultState: {},
+  dailyLimit: 1,
+  progress: { completion: 'manual' }
+}, {
+  progress: { type: 'project', hoursPerDay: 2 }
+});
+
+definition.action = {
+  label: 'Scout Leads',
+  onClick: () => {
+    const state = getState();
+    const instance = definition.acceptInstance({
+      state,
+      overrides: {
+        progress: { label: 'Market Research' }
+      }
+    });
+    // perform custom logging, payout hooks, etc.
+  }
+};
+```
+
+With this pattern the registry gains reusable contracts that share consistent defaults, while each
+system can still bolt on bespoke logging, payouts, or manual completion steps.

--- a/src/game/actions/definitions.js
+++ b/src/game/actions/definitions.js
@@ -1,99 +1,32 @@
 import { createInstantHustle } from '../content/schema.js';
 import { getInstantHustleDefinitions } from '../hustles/definitions/instantHustles.js';
 import { createKnowledgeHustles } from '../hustles/knowledgeHustles.js';
-
-function applyAvailabilityMetadata(definition) {
-  if (!definition) return definition;
-  if (!definition.availability) {
-    if (definition.dailyLimit) {
-      definition.availability = {
-        type: 'dailyLimit',
-        limit: definition.dailyLimit
-      };
-    } else {
-      definition.availability = { type: 'always' };
-    }
-  }
-  return definition;
-}
-
-function applyExpiryMetadata(definition) {
-  if (!definition) return definition;
-  if (!definition.expiry) {
-    definition.expiry = { type: 'permanent' };
-  }
-  return definition;
-}
-
-function applyProgressMetadata(definition, overrides = {}) {
-  if (!definition) return definition;
-  const base = typeof definition.progress === 'object' && definition.progress !== null
-    ? { ...definition.progress }
-    : {};
-  const merged = { ...overrides, ...base };
-  if (!merged.type) {
-    merged.type = overrides.type || 'instant';
-  }
-  if (!merged.completion) {
-    merged.completion = overrides.completion || (merged.type === 'instant' ? 'instant' : 'deferred');
-  }
-  if (overrides.hoursRequired != null && merged.hoursRequired == null) {
-    merged.hoursRequired = overrides.hoursRequired;
-  }
-  if (overrides.hoursPerDay != null && merged.hoursPerDay == null) {
-    merged.hoursPerDay = overrides.hoursPerDay;
-  }
-  if (overrides.daysRequired != null && merged.daysRequired == null) {
-    merged.daysRequired = overrides.daysRequired;
-  }
-  definition.progress = merged;
-  return definition;
-}
-
-function ensureDefaultActionState(definition) {
-  if (!definition) return definition;
-  const baseState = typeof definition.defaultState === 'object' && definition.defaultState !== null
-    ? definition.defaultState
-    : {};
-  if (!Array.isArray(baseState.instances)) {
-    baseState.instances = [];
-  }
-  definition.defaultState = baseState;
-  return definition;
-}
+import { createContractTemplate, createStudyTemplate } from './templates/contract.js';
 
 function prepareInstantActions() {
   return getInstantHustleDefinitions().map(config => {
-    const definition = createInstantHustle(config);
-    definition.kind = 'action';
-    ensureDefaultActionState(definition);
-    applyAvailabilityMetadata(definition);
-    applyExpiryMetadata(definition);
-    applyProgressMetadata(definition, {
-      type: 'instant',
-      completion: 'instant',
-      hoursRequired: Number(definition.time || definition.action?.timeCost || 0)
+    const definition = createContractTemplate(createInstantHustle(config), {
+      progress: {
+        type: 'instant',
+        completion: 'instant',
+        hoursRequired: Number(config.time || config.action?.timeCost || 0)
+      }
     });
+    definition.kind = 'action';
     return definition;
   });
 }
 
 function prepareStudyActions() {
   return createKnowledgeHustles().map(definition => {
-    const prepared = { ...definition };
-    prepared.kind = 'action';
-    ensureDefaultActionState(prepared);
-    if (!prepared.availability) {
-      prepared.availability = { type: 'enrollable' };
-    }
-    applyExpiryMetadata(prepared);
-    applyProgressMetadata(prepared, {
-      type: 'study',
-      completion: 'deferred',
-      hoursPerDay: prepared.studyHoursPerDay || prepared.hoursPerDay || null,
-      daysRequired: prepared.studyDays || prepared.days || null
+    const template = createStudyTemplate(definition, {
+      progress: {
+        hoursPerDay: definition.studyHoursPerDay || definition.hoursPerDay || null,
+        daysRequired: definition.studyDays || definition.days || null
+      }
     });
-    return prepared;
+    template.kind = 'action';
+    return template;
   });
 }
 

--- a/src/game/actions/templates/contract.js
+++ b/src/game/actions/templates/contract.js
@@ -1,0 +1,162 @@
+import { acceptActionInstance } from '../progress.js';
+
+function cloneDefaultState(defaultState = {}) {
+  const base = typeof defaultState === 'object' && defaultState !== null
+    ? { ...defaultState }
+    : {};
+  if (!Array.isArray(base.instances)) {
+    base.instances = [];
+  } else {
+    base.instances = base.instances.map(instance => ({ ...instance }));
+  }
+  return base;
+}
+
+function normalizeDailyLimit(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return null;
+  }
+  return Math.max(1, Math.floor(parsed));
+}
+
+function resolveAvailability(definition, options = {}) {
+  if (definition.availability) {
+    return { ...definition.availability };
+  }
+  if (options.availability) {
+    return { ...options.availability };
+  }
+  const limit = normalizeDailyLimit(options.dailyLimit ?? definition.dailyLimit);
+  if (limit) {
+    return { type: 'dailyLimit', limit };
+  }
+  return { type: 'always' };
+}
+
+function resolveExpiry(definition, options = {}) {
+  if (definition.expiry) {
+    return { ...definition.expiry };
+  }
+  if (options.expiry) {
+    return { ...options.expiry };
+  }
+  return { type: 'permanent' };
+}
+
+function cloneProgress(progress = {}) {
+  if (typeof progress !== 'object' || progress === null) {
+    return {};
+  }
+  return { ...progress };
+}
+
+function mergeProgress(baseProgress, defaults = {}) {
+  const base = cloneProgress(baseProgress);
+  const fallback = cloneProgress(defaults);
+  const merged = { ...fallback, ...base };
+  const keys = Object.keys(merged);
+  if (keys.length === 0) {
+    return null;
+  }
+
+  if (!merged.type) {
+    merged.type = fallback.type || 'instant';
+  }
+  if (!merged.completion) {
+    if (fallback.completion) {
+      merged.completion = fallback.completion;
+    } else {
+      merged.completion = merged.type === 'instant' ? 'instant' : 'deferred';
+    }
+  }
+
+  const numericFields = ['hoursRequired', 'hoursPerDay', 'daysRequired', 'deadlineDay'];
+  for (const field of numericFields) {
+    if (merged[field] == null && fallback[field] != null) {
+      merged[field] = fallback[field];
+    }
+  }
+
+  if (merged.label == null && fallback.label != null) {
+    merged.label = fallback.label;
+  }
+
+  return merged;
+}
+
+function mergeOverrides(baseOverrides = {}, incomingOverrides = {}) {
+  const merged = { ...baseOverrides, ...incomingOverrides };
+  if (baseOverrides.progress || incomingOverrides.progress) {
+    merged.progress = {
+      ...(typeof baseOverrides.progress === 'object' && baseOverrides.progress !== null
+        ? baseOverrides.progress
+        : {}),
+      ...(typeof incomingOverrides.progress === 'object' && incomingOverrides.progress !== null
+        ? incomingOverrides.progress
+        : {})
+    };
+  }
+  return merged;
+}
+
+export function createContractTemplate(definition, options = {}) {
+  const template = {
+    ...definition,
+    defaultState: cloneDefaultState(definition?.defaultState)
+  };
+
+  const normalizedLimit = normalizeDailyLimit(options.dailyLimit ?? template.dailyLimit);
+  template.dailyLimit = normalizedLimit;
+
+  template.availability = resolveAvailability(template, {
+    ...options,
+    dailyLimit: normalizedLimit
+  });
+  template.expiry = resolveExpiry(template, options);
+
+  const progressDefaults = options.progress || {};
+  const mergedProgress = mergeProgress(template.progress, progressDefaults);
+  if (mergedProgress) {
+    template.progress = mergedProgress;
+  } else {
+    delete template.progress;
+  }
+
+  const baseAcceptOverrides = mergeOverrides(options.accept?.overrides, {});
+  const acceptProgressDefaults = mergeProgress(options.accept?.progress, progressDefaults) || mergedProgress;
+
+  template.acceptInstance = ({ overrides = {}, ...rest } = {}) => {
+    const combinedOverrides = mergeOverrides(baseAcceptOverrides, overrides);
+    const progressOverride = mergeProgress(combinedOverrides.progress, acceptProgressDefaults);
+    if (progressOverride) {
+      combinedOverrides.progress = progressOverride;
+    } else {
+      delete combinedOverrides.progress;
+    }
+    return acceptActionInstance(template, {
+      ...rest,
+      overrides: combinedOverrides
+    });
+  };
+
+  return template;
+}
+
+export function createStudyTemplate(definition, options = {}) {
+  const progressDefaults = {
+    type: 'study',
+    completion: 'manual',
+    ...options.progress
+  };
+  const availability = options.availability || { type: 'enrollable' };
+  return createContractTemplate(definition, {
+    ...options,
+    progress: progressDefaults,
+    availability
+  });
+}
+
+export function mergeContractProgress(progress, defaults) {
+  return mergeProgress(progress, defaults);
+}

--- a/src/game/content/schema/assetActions.js
+++ b/src/game/content/schema/assetActions.js
@@ -17,7 +17,8 @@ import { applyModifiers } from '../../data/economyMath.js';
 import { applyMetric, normalizeHustleMetrics } from './metrics.js';
 import { logEducationPayoffSummary, logHustleBlocked } from './logMessaging.js';
 import { markDirty } from '../../../core/events/invalidationBus.js';
-import { acceptActionInstance, advanceActionInstance, completeActionInstance } from '../../actions/progress.js';
+import { advanceActionInstance, completeActionInstance } from '../../actions/progress.js';
+import { createContractTemplate } from '../../actions/templates/contract.js';
 
 function formatHourDetail(hours, effective) {
   if (!hours) return '⏳ Time: <strong>Instant</strong>';
@@ -115,7 +116,7 @@ export function createInstantHustle(config) {
     };
   }
 
-  const definition = {
+  const baseDefinition = {
     ...config,
     type: 'hustle',
     tag: config.tag || { label: 'Instant', type: 'instant' },
@@ -130,8 +131,17 @@ export function createInstantHustle(config) {
       }
       return base;
     })(),
-    skills: metadata.skills
+    dailyLimit: metadata.dailyLimit,
+    skills: metadata.skills,
+    progress: config.progress
   };
+
+  const definition = createContractTemplate(baseDefinition, {
+    progress: {
+      type: 'instant',
+      completion: 'instant'
+    }
+  });
 
   definition.tags = Array.isArray(config.tags) ? config.tags.slice() : [];
 
@@ -351,7 +361,7 @@ export function createInstantHustle(config) {
         if (deadlineDay != null) {
           progressOverrides.deadlineDay = deadlineDay;
         }
-        const instance = acceptActionInstance(definition, {
+        const instance = definition.acceptInstance({
           state,
           metadata,
           overrides: {

--- a/src/game/hustles.js
+++ b/src/game/hustles.js
@@ -1,7 +1,6 @@
 import { ACTIONS, INSTANT_ACTIONS, STUDY_ACTIONS } from './actions/definitions.js';
 import { rollDailyOffers, getAvailableOffers, getClaimedOffers } from './hustles/market.js';
 import { getState } from '../core/state.js';
-import { acceptActionInstance } from './actions/progress.js';
 import {
   ensureHustleMarketState,
   claimHustleMarketOffer,
@@ -178,7 +177,11 @@ export function acceptHustleOffer(offerOrId, { state = getState() } = {}) {
     };
   }
 
-  const instance = acceptActionInstance(template, {
+  if (typeof template.acceptInstance !== 'function') {
+    return null;
+  }
+
+  const instance = template.acceptInstance({
     state: workingState,
     metadata,
     overrides

--- a/tests/game/actionTemplates.test.js
+++ b/tests/game/actionTemplates.test.js
@@ -1,0 +1,98 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getGameTestHarness } from '../helpers/gameTestHarness.js';
+
+const harness = await getGameTestHarness();
+const { stateModule } = harness;
+
+const {
+  createContractTemplate,
+  createStudyTemplate
+} = await import('../../src/game/actions/templates/contract.js');
+
+test.beforeEach(() => {
+  harness.resetState();
+});
+
+test('contract template applies availability and progress defaults', () => {
+  const template = createContractTemplate({
+    id: 'test-contract-template',
+    name: 'Test Contract',
+    defaultState: {},
+    dailyLimit: 3
+  }, {
+    progress: {
+      type: 'instant',
+      completion: 'instant',
+      hoursRequired: 2
+    }
+  });
+
+  assert.deepEqual(template.availability, { type: 'dailyLimit', limit: 3 });
+  assert.deepEqual(template.expiry, { type: 'permanent' });
+  assert.ok(Array.isArray(template.defaultState.instances));
+
+  const state = stateModule.getState();
+  const instance = template.acceptInstance({ state });
+  assert.equal(instance.progress.type, 'instant');
+  assert.equal(instance.progress.completion, 'instant');
+  assert.equal(instance.progress.hoursRequired, 2);
+  assert.equal(stateModule.getActionState('test-contract-template', state).instances.length > 0, true);
+});
+
+test('contract template merges accept overrides with defaults', () => {
+  const template = createContractTemplate({
+    id: 'project-contract-template',
+    name: 'Project Contract',
+    defaultState: {}
+  }, {
+    progress: {
+      type: 'project',
+      completion: 'deferred',
+      hoursPerDay: 2
+    }
+  });
+
+  const state = stateModule.getState();
+  const instance = template.acceptInstance({
+    state,
+    overrides: {
+      hoursRequired: 12,
+      progress: {
+        completion: 'manual',
+        hoursPerDay: 3,
+        label: 'Client Work'
+      }
+    }
+  });
+
+  assert.equal(instance.hoursRequired, 12);
+  assert.equal(instance.progress.type, 'project');
+  assert.equal(instance.progress.completion, 'manual');
+  assert.equal(instance.progress.hoursPerDay, 3);
+  assert.equal(instance.progress.label, 'Client Work');
+});
+
+test('study template enforces enrollable availability and manual completion', () => {
+  const template = createStudyTemplate({
+    id: 'study-contract-template',
+    name: 'Study Template',
+    defaultState: {}
+  }, {
+    progress: {
+      hoursPerDay: 4,
+      daysRequired: 5
+    }
+  });
+
+  assert.deepEqual(template.availability, { type: 'enrollable' });
+  assert.equal(template.progress.type, 'study');
+  assert.equal(template.progress.completion, 'manual');
+
+  const state = stateModule.getState();
+  const instance = template.acceptInstance({ state });
+  assert.equal(instance.progress.type, 'study');
+  assert.equal(instance.progress.hoursPerDay, 4);
+  assert.equal(instance.progress.daysRequired, 5);
+});


### PR DESCRIPTION
## Summary
- add shared contract and study template helpers that normalize availability, expiry, and acceptance overrides
- refactor instant hustle creation and action registry wiring to use the new templates and expose `acceptInstance`
- document the template approach and add unit tests covering template behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2d3056910832ca658c50252bf2a28