### PR TITLE
Gate hustle market fallbacks and surface guidance

### DIFF
--- a/docs/features/hustle-market.md
+++ b/docs/features/hustle-market.md
@@ -52,5 +52,6 @@
 - Market offers render in the same cards as variant rows: available offers get bright accept buttons while upcoming variants show unlock timers and remain disabled until their window opens.
 - The finance dashboard separates hustle commitments from fresh offers, highlighting urgent deadlines with warning tones and mirroring the same progress meters for consistency.
 - Hustle browser cards now offer a manual "Roll a fresh offer" button when a template has no active variants so players can nudge the market without relying on legacy instant runs.
+- When manual rerolls are disabled, hustle cards swap the queue button for a cheerful "Check back tomorrow" hint instead of falling back to hidden instant actions.
 - Dashboard quick actions surface active offers only. When the market is empty they present a "Check back tomorrow" guidance tile instead of invoking hidden instant-action fallbacks.
-- `createInstantHustle` still exposes an `action.onClick` for tests and tooling, but it is flagged with `isLegacyInstant`/`hiddenFromMarket` so production UI layers depend exclusively on offer acceptance.
+- `createInstantHustle` still exposes an `action.onClick` for tests and tooling, but it is flagged with `isLegacyInstant`/`hiddenFromMarket` and UI layers ignore it when building hustle cards or quick actions so production surfaces depend exclusively on offer acceptance.

--- a/src/ui/cards/model/hustles.js
+++ b/src/ui/cards/model/hustles.js
@@ -356,16 +356,25 @@ export default function buildHustleModels(definitions = [], helpers = {}) {
         className: 'primary',
         onClick: ready ? primaryOffer.onAccept : null
       };
-    } else {
+    } else if (typeof rollOffers === 'function') {
       const rerollLabel = definition.market?.manualRerollLabel || 'Roll a fresh offer';
-      const canReroll = typeof rollOffers === 'function';
+      const rerollGuidance = definition.market?.manualRerollHelp || 'Spin up a new lead if you can\'t wait for tomorrow.';
       actionConfig = {
         label: rerollLabel,
-        disabled: !canReroll,
+        disabled: false,
         className: 'secondary',
-        onClick: canReroll
-          ? () => rollOffers({ templates: [definition], day: currentDay, state })
-          : null
+        onClick: () => rollOffers({ templates: [definition], day: currentDay, state }),
+        guidance: rerollGuidance
+      };
+    } else {
+      const emptyLabel = definition.market?.emptyActionLabel || 'Check back tomorrow';
+      const emptyGuidance = definition.market?.emptyGuidance || 'Fresh leads roll in with tomorrow\'s market refresh.';
+      actionConfig = {
+        label: emptyLabel,
+        disabled: true,
+        className: 'secondary',
+        onClick: null,
+        guidance: emptyGuidance
       };
     }
 

--- a/src/ui/views/browser/apps/hustles.js
+++ b/src/ui/views/browser/apps/hustles.js
@@ -221,25 +221,33 @@ function createHustleCard(definition, model) {
 
   const actions = document.createElement('div');
   actions.className = 'browser-card__actions';
-  if (definition.action && model.action?.label) {
+  const hasButton = definition.action && model.action?.label;
+  if (hasButton) {
     const queueButton = document.createElement('button');
     queueButton.type = 'button';
-    queueButton.className = 'browser-card__button browser-card__button--primary';
+    const variant = model.action.className === 'secondary' ? 'secondary' : 'primary';
+    queueButton.className = `browser-card__button browser-card__button--${variant}`;
     queueButton.textContent = model.action.label;
     queueButton.disabled = Boolean(model.action.disabled);
-    const handleClick =
-      typeof model.action?.onClick === 'function'
-        ? model.action.onClick
-        : definition.action.onClick;
-    if (typeof handleClick === 'function') {
+    if (typeof model.action?.onClick === 'function') {
       queueButton.addEventListener('click', () => {
         if (queueButton.disabled) return;
-        handleClick();
+        model.action.onClick();
       });
     }
     actions.appendChild(queueButton);
   }
-  card.appendChild(actions);
+
+  if (model.action?.guidance) {
+    const note = document.createElement('p');
+    note.className = 'browser-card__note';
+    note.textContent = model.action.guidance;
+    actions.appendChild(note);
+  }
+
+  if (actions.childElementCount > 0) {
+    card.appendChild(actions);
+  }
 
   if (Array.isArray(model.commitments) && model.commitments.length) {
     const commitmentsSection = createCardSection(

--- a/tests/ui/cardsModel.test.js
+++ b/tests/ui/cardsModel.test.js
@@ -131,6 +131,42 @@ test('buildHustleModels surfaces multi-day offers with daily requirements', () =
   assert.equal(entry.meta.includes('Manual completion'), true, 'summary should reflect manual completion rule');
 });
 
+test('buildHustleModels provides guidance when no offers or manual rerolls exist', () => {
+  const hustles = [
+    {
+      id: 'empty-market',
+      name: 'Empty Market Hustle',
+      description: 'Wait for tomorrow\'s leads.',
+      time: 2,
+      payout: { amount: 80 },
+      action: {
+        label: 'Legacy Run',
+        onClick: () => {}
+      }
+    }
+  ];
+
+  const models = buildHustleModels(hustles, {
+    getState: () => ({ day: 3 }),
+    describeRequirements: () => [],
+    getUsage: () => null,
+    formatHours: value => `${value}h`,
+    formatMoney: value => value.toFixed(0),
+    getOffers: () => [],
+    getAcceptedOffers: () => [],
+    collectCommitments: () => [],
+    rollOffers: null
+  });
+
+  assert.equal(models.length, 1);
+  const [model] = models;
+  assert.equal(model.offers.length, 0);
+  assert.equal(model.action.label, 'Check back tomorrow');
+  assert.equal(model.action.disabled, true);
+  assert.equal(model.action.onClick, null);
+  assert.match(model.action.guidance, /tomorrow/i);
+});
+
 test('buildUpgradeModels groups families in sorted order', () => {
   const upgrades = [
     {


### PR DESCRIPTION
## Summary
- replace hustle card fallbacks with reroll/guidance states so we never fire legacy instant actions
- update the hustle browser view to respect model-provided handlers and show friendly guidance copy
- document the expectation and add coverage for the empty-market guidance path

## Testing
- node --test tests/ui/cardsModel.test.js
- node --test tests/ui/dashboard/quickActions.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2d7253c8c832cb9c4568ffd80d367