### PR TITLE
Refactor todo grouping into shared service

### DIFF
--- a/src/ui/views/browser/apps/timodoro/model.js
+++ b/src/ui/views/browser/apps/timodoro/model.js
@@ -155,6 +155,12 @@ export function buildTimodoroViewModel(state = {}, summary = {}, todoModel = {})
   const breakdownEntries = buildBreakdown(summary, todoModel, state);
   const todoEntries = Array.isArray(todoModel?.entries) ? todoModel.entries : [];
   const todoEmptyMessage = todoModel?.emptyMessage;
+  const todoHoursAvailable = Number.isFinite(todoModel?.hoursAvailable)
+    ? Math.max(0, todoModel.hoursAvailable)
+    : null;
+  const todoMoneyAvailable = Number.isFinite(todoModel?.moneyAvailable)
+    ? Math.max(0, todoModel.moneyAvailable)
+    : null;
 
   const availableLabel = todoModel?.hoursAvailableLabel
     || formatHours(Number(todoModel?.hoursAvailable) || Number(state?.timeLeft) || 0);
@@ -173,6 +179,8 @@ export function buildTimodoroViewModel(state = {}, summary = {}, todoModel = {})
     breakdownEntries,
     todoEntries,
     todoEmptyMessage,
+    todoHoursAvailable,
+    todoMoneyAvailable,
     hoursAvailableLabel: availableLabel,
     hoursSpentLabel: spentLabel,
     meta

--- a/src/ui/views/browser/widgets/todoDom.js
+++ b/src/ui/views/browser/widgets/todoDom.js
@@ -1,3 +1,5 @@
+import { DEFAULT_TODO_EMPTY_MESSAGE } from '../../../actions/taskGrouping.js';
+
 function toArray(value) {
   if (Array.isArray(value)) {
     return value;
@@ -125,7 +127,7 @@ function updateNote(note, model = {}, pendingCount = 0) {
     return;
   }
 
-  note.textContent = model.emptyMessage || 'Queue a hustle or upgrade to add new tasks.';
+  note.textContent = model.emptyMessage || DEFAULT_TODO_EMPTY_MESSAGE;
 }
 
 function createTask(entry, model, onComplete) {

--- a/tests/ui/workspaces/timodoroWorkspacePresenter.test.js
+++ b/tests/ui/workspaces/timodoroWorkspacePresenter.test.js
@@ -67,6 +67,7 @@ test('timodoro component renders layout and populates lists', t => {
       {
         title: 'Draft pitch deck',
         durationText: '2h focus',
+        durationHours: 2,
         meta: 'Client work',
         moneyCost: 120,
         focusCategory: 'hustle'
@@ -76,9 +77,16 @@ test('timodoro component renders layout and populates lists', t => {
         durationText: '1h study',
         meta: 'Curriculum update',
         focusCategory: 'education'
+      },
+      {
+        title: 'Overbooked sprint',
+        durationText: '5h focus',
+        durationHours: 5,
+        focusCategory: 'hustle'
       }
     ],
     todoEmptyMessage: 'Queue a hustle or upgrade to add new tasks.',
+    todoHoursAvailable: 2,
     completedGroups: {
       hustles: [{ name: 'Logo sprint', detail: '2h logged' }],
       education: [],
@@ -113,6 +121,11 @@ test('timodoro component renders layout and populates lists', t => {
   ];
   assert.equal(todoItems.length, 1, 'todo tab renders active backlog');
   assert.equal(todoItems[0].querySelector('.timodoro-list__name')?.textContent, 'Draft pitch deck');
+  assert.equal(
+    todoItems.find(item => item.querySelector('.timodoro-list__name')?.textContent === 'Overbooked sprint'),
+    undefined,
+    'filters out tasks exceeding available focus hours'
+  );
   assert.ok(
     todoItems[0].querySelector('.timodoro-list__meta')?.textContent.includes('Cost $120'),
     'todo item includes cost detail'
@@ -293,6 +306,8 @@ test('buildTimodoroViewModel composes summary, recurring, and meta data', () => 
     'Queue something inspiring.',
     'passes through todo empty state message'
   );
+  assert.equal(viewModel.todoHoursAvailable, 3, 'includes raw todo hours available');
+  assert.equal(viewModel.todoMoneyAvailable, null, 'omits money when unavailable');
 
   assert.equal(viewModel.summaryEntries.length, 3, 'summary entries include hours, earnings, time used');
   assert.equal(viewModel.breakdownEntries.length, 3, 'breakdown includes active, upkeep, remaining');


### PR DESCRIPTION
## Summary
- add a reusable `buildTodoGrouping` helper to centralize focus-bucket ordering, progress hooks, and availability filtering
- update the todo widget and Timodoro workspace to consume the shared grouping output and constants for empty-state copy
- extend todo widget and Timodoro presenter tests to cover shared grouping behavior and filtering rules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2d74184a0832ca88bf6d06508652e