### PR TITLE
Refactor action registry helpers into dedicated modules

### DIFF
--- a/src/ui/actions/providers.js
+++ b/src/ui/actions/providers.js
@@ -1,0 +1,79 @@
+import { coerceNumber, normalizeActionEntries } from './utils.js';
+
+let providers = [];
+let providerSequence = 0;
+
+export function registerActionProvider(provider, priority = 0) {
+  if (typeof provider !== 'function') {
+    return () => {};
+  }
+  const record = {
+    handler: provider,
+    priority: coerceNumber(priority),
+    order: providerSequence++
+  };
+  providers.push(record);
+  let active = true;
+  return () => {
+    if (!active) return;
+    active = false;
+    providers = providers.filter(item => item !== record);
+  };
+}
+
+export function clearActionProviders() {
+  const previous = providers.slice();
+  providers = [];
+  return () => {
+    providers = previous.slice();
+  };
+}
+
+export function collectActionProviders({ state = {}, summary = {} } = {}) {
+  const snapshots = [];
+
+  const activeProviders = providers
+    .slice()
+    .sort((a, b) => {
+      if (b.priority !== a.priority) {
+        return b.priority - a.priority;
+      }
+      return a.order - b.order;
+    });
+
+  activeProviders.forEach(provider => {
+    const handler = provider?.handler;
+    if (typeof handler !== 'function') return;
+
+    let result;
+    try {
+      result = handler({ state, summary });
+    } catch (error) {
+      result = null;
+    }
+
+    if (!result) return;
+
+    const focusCategory = result.focusCategory || null;
+    const normalized = normalizeActionEntries(result.entries).map((entry, index) => ({
+      ...entry,
+      focusCategory: entry.focusCategory || focusCategory,
+      orderIndex: Number.isFinite(entry.orderIndex) ? entry.orderIndex : index
+    }));
+
+    snapshots.push({
+      id: result.id || null,
+      focusCategory,
+      entries: normalized,
+      metrics: result.metrics || {}
+    });
+  });
+
+  return snapshots;
+}
+
+export default {
+  registerActionProvider,
+  clearActionProviders,
+  collectActionProviders
+};

--- a/src/ui/actions/registry.js
+++ b/src/ui/actions/registry.js
@@ -1,70 +1,23 @@
-import { formatHours, formatMoney } from '../../core/helpers.js';
+import { formatHours } from '../../core/helpers.js';
 import { getState } from '../../core/state.js';
 import { getActionDefinition } from '../../game/registryService.js';
+import {
+  clampToZero,
+  coerceDay,
+  coerceNumber,
+  coercePositiveNumber,
+  firstPositiveNumber,
+  formatDuration,
+  formatPayoutSummary,
+  normalizeActionEntries
+} from './utils.js';
+import {
+  registerActionProvider,
+  clearActionProviders,
+  collectActionProviders
+} from './providers.js';
 
 const DEFAULT_EMPTY_MESSAGE = 'Queue a hustle or upgrade to add new tasks.';
-
-let providers = [];
-let providerSequence = 0;
-
-function coerceNumber(value, fallback = 0) {
-  const numeric = Number(value);
-  return Number.isFinite(numeric) ? numeric : fallback;
-}
-
-function clampToZero(value) {
-  return Math.max(0, coerceNumber(value));
-}
-
-function formatDuration(hours) {
-  const numeric = coerceNumber(hours);
-  if (numeric <= 0) {
-    return formatHours(0);
-  }
-  return formatHours(Math.max(0, numeric));
-}
-
-function coerceDay(value, fallback = null) {
-  const numeric = Number(value);
-  if (!Number.isFinite(numeric) || numeric <= 0) {
-    return fallback;
-  }
-  return Math.max(1, Math.floor(numeric));
-}
-
-function coercePositiveNumber(value, fallback = 0) {
-  const numeric = Number(value);
-  if (!Number.isFinite(numeric) || numeric < 0) {
-    return fallback;
-  }
-  return numeric;
-}
-
-function firstPositiveNumber(...values) {
-  for (const value of values) {
-    const numeric = Number(value);
-    if (Number.isFinite(numeric) && numeric > 0) {
-      return numeric;
-    }
-  }
-  return null;
-}
-
-function formatPayoutSummary(amount, schedule) {
-  if (!Number.isFinite(amount) || amount <= 0) {
-    if (schedule && schedule !== 'onCompletion') {
-      return schedule;
-    }
-    return '';
-  }
-  if (!schedule || schedule === 'onCompletion') {
-    return `$${formatMoney(amount)} on completion`;
-  }
-  if (schedule === 'daily') {
-    return `$${formatMoney(amount)} / day`;
-  }
-  return `$${formatMoney(amount)} (${schedule})`;
-}
 
 function collectMarketIndexes(state = {}) {
   const market = state?.hustleMarket || {};
@@ -410,139 +363,6 @@ export function collectOutstandingActionEntries(state = getState()) {
   return entries;
 }
 
-export function normalizeActionEntries(source = []) {
-  const entries = Array.isArray(source?.entries)
-    ? source.entries
-    : Array.isArray(source)
-      ? source
-      : [];
-
-  return entries
-    .map((entry, index) => {
-      const id = entry?.id ?? `todo-${index}`;
-      if (!id) return null;
-
-      const durationHours = coerceNumber(entry?.durationHours ?? entry?.timeCost);
-      const normalizedDuration = durationHours > 0 ? durationHours : 0;
-      const durationText = entry?.durationText || formatDuration(normalizedDuration);
-
-      const payoutText = entry?.payoutText || entry?.payoutLabel || '';
-      const meta = entry?.meta || [payoutText, durationText].filter(Boolean).join(' • ');
-
-      const rawRemaining = entry?.remainingRuns == null
-        ? null
-        : coerceNumber(entry.remainingRuns, null);
-      const hasRemaining = Number.isFinite(rawRemaining);
-      const remainingRuns = hasRemaining ? Math.max(0, rawRemaining) : null;
-      const repeatable = Boolean(entry?.repeatable) || (hasRemaining && remainingRuns > 1);
-
-      const moneyCost = coerceNumber(entry?.moneyCost);
-      const normalizedMoney = moneyCost > 0 ? moneyCost : 0;
-
-      const rawPayout = coerceNumber(entry?.payout);
-      const normalizedPayout = rawPayout > 0 ? rawPayout : 0;
-      const moneyPerHour = normalizedDuration > 0
-        ? normalizedPayout / normalizedDuration
-        : normalizedPayout;
-
-      const focusCategory = entry?.focusCategory || entry?.category || entry?.type || null;
-      const rawUpgradeRemaining = coerceNumber(
-        entry?.upgradeRemaining ?? entry?.remaining ?? entry?.requirementsRemaining,
-        null
-      );
-      const upgradeRemaining = Number.isFinite(rawUpgradeRemaining)
-        ? Math.max(0, rawUpgradeRemaining)
-        : null;
-      const orderIndex = Number.isFinite(entry?.orderIndex) ? entry.orderIndex : index;
-
-      const normalizedEntry = {
-        id,
-        title: entry?.title || 'Action',
-        meta,
-        onClick: typeof entry?.onClick === 'function' ? entry.onClick : null,
-        durationHours: normalizedDuration,
-        durationText,
-        moneyCost: normalizedMoney,
-        repeatable,
-        remainingRuns,
-        payout: normalizedPayout,
-        moneyPerHour: Number.isFinite(moneyPerHour) ? moneyPerHour : 0,
-        focusCategory,
-        upgradeRemaining,
-        orderIndex
-      };
-
-      if (entry && typeof entry === 'object') {
-        Object.keys(entry).forEach(key => {
-          if (typeof key === 'string' && key.toLowerCase().includes('bucket')) {
-            normalizedEntry[key] = entry[key];
-          }
-        });
-      }
-
-      if (entry?.subtitle) {
-        normalizedEntry.subtitle = entry.subtitle;
-      }
-      if (entry?.description) {
-        normalizedEntry.description = entry.description;
-      }
-      if (entry?.buttonLabel) {
-        normalizedEntry.buttonLabel = entry.buttonLabel;
-      }
-      if (entry?.primaryLabel && !normalizedEntry.buttonLabel) {
-        normalizedEntry.buttonLabel = entry.primaryLabel;
-      }
-      if (entry?.metaClass) {
-        normalizedEntry.metaClass = entry.metaClass;
-      }
-      if (entry?.defaultLabel) {
-        normalizedEntry.defaultLabel = entry.defaultLabel;
-      }
-      if (entry?.payoutText) {
-        normalizedEntry.payoutText = entry.payoutText;
-      }
-      if (entry?.durationText && entry.durationText !== normalizedEntry.durationText) {
-        normalizedEntry.durationText = entry.durationText;
-      }
-
-      const rawTime = coerceNumber(entry?.timeCost, null);
-      if (Number.isFinite(rawTime)) {
-        normalizedEntry.timeCost = Math.max(0, rawTime);
-      }
-
-      if (!normalizedEntry.timeCost && normalizedEntry.durationHours > 0) {
-        normalizedEntry.timeCost = normalizedEntry.durationHours;
-      }
-
-      const rawMoney = coerceNumber(entry?.moneyCost, null);
-      if (Number.isFinite(rawMoney) && rawMoney > 0) {
-        normalizedEntry.moneyCost = rawMoney;
-      }
-
-      if (!normalizedEntry.payoutText && entry?.payoutText) {
-        normalizedEntry.payoutText = entry.payoutText;
-      }
-
-      if (entry?.progress && typeof entry.progress === 'object') {
-        normalizedEntry.progress = { ...entry.progress };
-      }
-      if (entry?.instanceId) {
-        normalizedEntry.instanceId = entry.instanceId;
-      }
-      if (entry?.definitionId) {
-        normalizedEntry.definitionId = entry.definitionId;
-      }
-      if (entry?.offerId) {
-        normalizedEntry.offerId = entry.offerId;
-      }
-
-      normalizedEntry.raw = entry;
-
-      return normalizedEntry;
-    })
-    .filter(Boolean);
-}
-
 function createAutoCompletedEntries(summary = {}) {
   const entries = Array.isArray(summary?.timeBreakdown) ? summary.timeBreakdown : [];
   return entries
@@ -570,75 +390,6 @@ function createAutoCompletedEntries(summary = {}) {
       };
     })
     .filter(Boolean);
-}
-
-export function registerActionProvider(provider, priority = 0) {
-  if (typeof provider !== 'function') {
-    return () => {};
-  }
-  const record = {
-    handler: provider,
-    priority: coerceNumber(priority),
-    order: providerSequence++
-  };
-  providers.push(record);
-  let active = true;
-  return () => {
-    if (!active) return;
-    active = false;
-    providers = providers.filter(item => item !== record);
-  };
-}
-
-export function clearActionProviders() {
-  const previous = providers.slice();
-  providers = [];
-  return () => {
-    providers = previous.slice();
-  };
-}
-
-export function collectActionProviders({ state = {}, summary = {} } = {}) {
-  const snapshots = [];
-
-  const activeProviders = providers
-    .slice()
-    .sort((a, b) => {
-      if (b.priority !== a.priority) {
-        return b.priority - a.priority;
-      }
-      return a.order - b.order;
-    });
-
-  activeProviders.forEach(provider => {
-    const handler = provider?.handler;
-    if (typeof handler !== 'function') return;
-
-    let result;
-    try {
-      result = handler({ state, summary });
-    } catch (error) {
-      result = null;
-    }
-
-    if (!result) return;
-
-    const focusCategory = result.focusCategory || null;
-    const normalized = normalizeActionEntries(result.entries).map((entry, index) => ({
-      ...entry,
-      focusCategory: entry.focusCategory || focusCategory,
-      orderIndex: Number.isFinite(entry.orderIndex) ? entry.orderIndex : index
-    }));
-
-    snapshots.push({
-      id: result.id || null,
-      focusCategory,
-      entries: normalized,
-      metrics: result.metrics || {}
-    });
-  });
-
-  return snapshots;
 }
 
 function applyMetrics(target, metrics = {}) {
@@ -730,6 +481,9 @@ export function buildActionQueue({ state, summary = {} } = {}) {
 
   return queue;
 }
+
+export { registerActionProvider, clearActionProviders, collectActionProviders } from './providers.js';
+export { normalizeActionEntries } from './utils.js';
 
 export default {
   registerActionProvider,

--- a/src/ui/actions/utils.js
+++ b/src/ui/actions/utils.js
@@ -1,0 +1,204 @@
+import { formatHours, formatMoney } from '../../core/helpers.js';
+
+export function coerceNumber(value, fallback = 0) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+export function clampToZero(value) {
+  return Math.max(0, coerceNumber(value));
+}
+
+export function formatDuration(hours) {
+  const numeric = coerceNumber(hours);
+  if (numeric <= 0) {
+    return formatHours(0);
+  }
+  return formatHours(Math.max(0, numeric));
+}
+
+export function coerceDay(value, fallback = null) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return fallback;
+  }
+  return Math.max(1, Math.floor(numeric));
+}
+
+export function coercePositiveNumber(value, fallback = 0) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric < 0) {
+    return fallback;
+  }
+  return numeric;
+}
+
+export function firstPositiveNumber(...values) {
+  for (const value of values) {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric) && numeric > 0) {
+      return numeric;
+    }
+  }
+  return null;
+}
+
+export function formatPayoutSummary(amount, schedule) {
+  if (!Number.isFinite(amount) || amount <= 0) {
+    if (schedule && schedule !== 'onCompletion') {
+      return schedule;
+    }
+    return '';
+  }
+  if (!schedule || schedule === 'onCompletion') {
+    return `$${formatMoney(amount)} on completion`;
+  }
+  if (schedule === 'daily') {
+    return `$${formatMoney(amount)} / day`;
+  }
+  return `$${formatMoney(amount)} (${schedule})`;
+}
+
+export function normalizeActionEntries(source = []) {
+  const entries = Array.isArray(source?.entries)
+    ? source.entries
+    : Array.isArray(source)
+      ? source
+      : [];
+
+  return entries
+    .map((entry, index) => {
+      const id = entry?.id ?? `todo-${index}`;
+      if (!id) return null;
+
+      const durationHours = coerceNumber(entry?.durationHours ?? entry?.timeCost);
+      const normalizedDuration = durationHours > 0 ? durationHours : 0;
+      const durationText = entry?.durationText || formatDuration(normalizedDuration);
+
+      const payoutText = entry?.payoutText || entry?.payoutLabel || '';
+      const meta = entry?.meta || [payoutText, durationText].filter(Boolean).join(' • ');
+
+      const rawRemaining = entry?.remainingRuns == null
+        ? null
+        : coerceNumber(entry.remainingRuns, null);
+      const hasRemaining = Number.isFinite(rawRemaining);
+      const remainingRuns = hasRemaining ? Math.max(0, rawRemaining) : null;
+      const repeatable = Boolean(entry?.repeatable) || (hasRemaining && remainingRuns > 1);
+
+      const moneyCost = coerceNumber(entry?.moneyCost);
+      const normalizedMoney = moneyCost > 0 ? moneyCost : 0;
+
+      const rawPayout = coerceNumber(entry?.payout);
+      const normalizedPayout = rawPayout > 0 ? rawPayout : 0;
+      const moneyPerHour = normalizedDuration > 0
+        ? normalizedPayout / normalizedDuration
+        : normalizedPayout;
+
+      const focusCategory = entry?.focusCategory || entry?.category || entry?.type || null;
+      const rawUpgradeRemaining = coerceNumber(
+        entry?.upgradeRemaining ?? entry?.remaining ?? entry?.requirementsRemaining,
+        null
+      );
+      const upgradeRemaining = Number.isFinite(rawUpgradeRemaining)
+        ? Math.max(0, rawUpgradeRemaining)
+        : null;
+      const orderIndex = Number.isFinite(entry?.orderIndex) ? entry.orderIndex : index;
+
+      const normalizedEntry = {
+        id,
+        title: entry?.title || 'Action',
+        meta,
+        onClick: typeof entry?.onClick === 'function' ? entry.onClick : null,
+        durationHours: normalizedDuration,
+        durationText,
+        moneyCost: normalizedMoney,
+        repeatable,
+        remainingRuns,
+        payout: normalizedPayout,
+        moneyPerHour: Number.isFinite(moneyPerHour) ? moneyPerHour : 0,
+        focusCategory,
+        upgradeRemaining,
+        orderIndex
+      };
+
+      if (entry && typeof entry === 'object') {
+        Object.keys(entry).forEach(key => {
+          if (typeof key === 'string' && key.toLowerCase().includes('bucket')) {
+            normalizedEntry[key] = entry[key];
+          }
+        });
+      }
+
+      if (entry?.subtitle) {
+        normalizedEntry.subtitle = entry.subtitle;
+      }
+      if (entry?.description) {
+        normalizedEntry.description = entry.description;
+      }
+      if (entry?.buttonLabel) {
+        normalizedEntry.buttonLabel = entry.buttonLabel;
+      }
+      if (entry?.primaryLabel && !normalizedEntry.buttonLabel) {
+        normalizedEntry.buttonLabel = entry.primaryLabel;
+      }
+      if (entry?.metaClass) {
+        normalizedEntry.metaClass = entry.metaClass;
+      }
+      if (entry?.defaultLabel) {
+        normalizedEntry.defaultLabel = entry.defaultLabel;
+      }
+      if (entry?.payoutText) {
+        normalizedEntry.payoutText = entry.payoutText;
+      }
+      if (entry?.durationText && entry.durationText !== normalizedEntry.durationText) {
+        normalizedEntry.durationText = entry.durationText;
+      }
+
+      const rawTime = coerceNumber(entry?.timeCost, null);
+      if (Number.isFinite(rawTime)) {
+        normalizedEntry.timeCost = Math.max(0, rawTime);
+      }
+
+      if (!normalizedEntry.timeCost && normalizedEntry.durationHours > 0) {
+        normalizedEntry.timeCost = normalizedEntry.durationHours;
+      }
+
+      const rawMoney = coerceNumber(entry?.moneyCost, null);
+      if (Number.isFinite(rawMoney) && rawMoney > 0) {
+        normalizedEntry.moneyCost = rawMoney;
+      }
+
+      if (!normalizedEntry.payoutText && entry?.payoutText) {
+        normalizedEntry.payoutText = entry.payoutText;
+      }
+
+      if (entry?.progress && typeof entry.progress === 'object') {
+        normalizedEntry.progress = { ...entry.progress };
+      }
+      if (entry?.instanceId) {
+        normalizedEntry.instanceId = entry.instanceId;
+      }
+      if (entry?.definitionId) {
+        normalizedEntry.definitionId = entry.definitionId;
+      }
+      if (entry?.offerId) {
+        normalizedEntry.offerId = entry.offerId;
+      }
+
+      normalizedEntry.raw = entry;
+
+      return normalizedEntry;
+    })
+    .filter(Boolean);
+}
+
+export default {
+  coerceNumber,
+  clampToZero,
+  formatDuration,
+  coerceDay,
+  coercePositiveNumber,
+  firstPositiveNumber,
+  formatPayoutSummary,
+  normalizeActionEntries
+};

--- a/src/ui/dashboard/knowledge.js
+++ b/src/ui/dashboard/knowledge.js
@@ -11,7 +11,8 @@ import { advanceActionInstance, completeActionInstance } from '../../game/action
 import { getActionDefinition } from '../../game/registryService.js';
 import { spendTime } from '../../game/time.js';
 import { checkDayEnd } from '../../game/lifecycle.js';
-import { registerActionProvider, collectOutstandingActionEntries } from '../actions/registry.js';
+import { collectOutstandingActionEntries } from '../actions/registry.js';
+import { registerActionProvider } from '../actions/providers.js';
 
 function resolveProgressStep(entry = {}) {
   const progress = entry?.progress || {};

--- a/src/ui/dashboard/model.js
+++ b/src/ui/dashboard/model.js
@@ -13,7 +13,7 @@ import {
   buildNotificationModel,
   buildEventLogModel
 } from './notificationsModel.js';
-import { collectActionProviders } from '../actions/registry.js';
+import { collectActionProviders } from '../actions/providers.js';
 
 export function buildDashboardViewModel(state, summary = {}) {
   if (!state) return null;

--- a/src/ui/dashboard/quickActions.js
+++ b/src/ui/dashboard/quickActions.js
@@ -10,7 +10,8 @@ import {
 } from '../../game/assets/quality/actions.js';
 import { getNextQualityLevel } from '../../game/assets/quality/levels.js';
 import { instanceLabel } from '../../game/assets/details.js';
-import { registerActionProvider, collectOutstandingActionEntries } from '../actions/registry.js';
+import { collectOutstandingActionEntries } from '../actions/registry.js';
+import { registerActionProvider } from '../actions/providers.js';
 import { getAvailableOffers, acceptHustleOffer } from '../../game/hustles.js';
 
 function getQualitySnapshot(instance = {}) {

--- a/src/ui/headerAction/model.js
+++ b/src/ui/headerAction/model.js
@@ -1,6 +1,6 @@
 import { buildAssetUpgradeRecommendations, buildQuickActions } from '../dashboard/quickActions.js';
 import { formatHours } from '../../core/helpers.js';
-import { collectActionProviders } from '../actions/registry.js';
+import { collectActionProviders } from '../actions/providers.js';
 
 function formatActionLabel(base, timeCost) {
   if (!base) return '';

--- a/src/ui/views/browser/components/digishelf/inventoryTable.js
+++ b/src/ui/views/browser/components/digishelf/inventoryTable.js
@@ -1,5 +1,5 @@
 import createStatusBadge from './statusBadge.js';
-import { collectActionProviders } from '../../../../actions/registry.js';
+import { collectActionProviders } from '../../../../actions/providers.js';
 
 const QUICK_ACTION_LABELS = {
   ebook: {

--- a/src/ui/views/browser/widgets/todoWidget.js
+++ b/src/ui/views/browser/widgets/todoWidget.js
@@ -1,6 +1,6 @@
 import { formatHours } from '../../../../core/helpers.js';
 import { endDay } from '../../../../game/lifecycle.js';
-import { normalizeActionEntries } from '../../../actions/registry.js';
+import { normalizeActionEntries } from '../../../actions/utils.js';
 import {
   applyFocusOrdering,
   attachProgressHandlers,

--- a/tests/ui/actions/registry.test.js
+++ b/tests/ui/actions/registry.test.js
@@ -1,12 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { formatHours } from '../../../src/core/helpers.js';
+import { buildActionQueue } from '../../../src/ui/actions/registry.js';
 import {
-  buildActionQueue,
   registerActionProvider,
-  clearActionProviders,
-  normalizeActionEntries
-} from '../../../src/ui/actions/registry.js';
+  clearActionProviders
+} from '../../../src/ui/actions/providers.js';
+import { normalizeActionEntries } from '../../../src/ui/actions/utils.js';
 
 test('registerActionProvider supplies normalized entries to the queue', () => {
   const restore = clearActionProviders();

--- a/tests/ui/headerAction/model.test.js
+++ b/tests/ui/headerAction/model.test.js
@@ -4,7 +4,7 @@ import { buildHeaderActionModel } from '../../../src/ui/headerAction/model.js';
 import {
   registerActionProvider,
   clearActionProviders
-} from '../../../src/ui/actions/registry.js';
+} from '../../../src/ui/actions/providers.js';
 
 function createNoop() {
   return () => {};

--- a/tests/ui/views/browser/components/digishelf/inventoryTable.test.js
+++ b/tests/ui/views/browser/components/digishelf/inventoryTable.test.js
@@ -5,7 +5,7 @@ import renderInventoryTable from '../../../../../../src/ui/views/browser/compone
 import {
   registerActionProvider,
   clearActionProviders
-} from '../../../../../../src/ui/actions/registry.js';
+} from '../../../../../../src/ui/actions/providers.js';
 
 function setupDom() {
   const dom = new JSDOM('<!doctype html><html><body></body></html>');


### PR DESCRIPTION
## Summary
- extract numeric coercion and formatting helpers into `src/ui/actions/utils.js`
- move action provider registration logic into `src/ui/actions/providers.js` and simplify the registry
- update UI modules and tests to use the reorganized exports while keeping the action queue builder focused

## Testing
- npm test -- tests/ui/actions/registry.test.js tests/ui/headerAction/model.test.js tests/ui/views/browser/components/digishelf/inventoryTable.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2d743a3a0832c8dad2343b49874d2