### PR TITLE
Fix Learnly study actions requiring configured hours

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix: Learnly study tasks now respect their configured daily hours so courses can't be cleared by completing a 0h log.
 - Tooling: Added a Streamlit balancing workbench (`tools/balancingWorkbench/`) with live sliders, ROI charts, and PNG exports to accelerate economy tuning sessions.
 - Tooling: Balancing workbench can now simulate multi-asset lineups and upgrade combos, with a handy summary of setup hours, upkeep, and bonus time.
 - Governance: Gameplay PRs that adjust economy constants must update `docs/EconomySpec.md`, rerun `npm run rebuild-economy-docs`, and attach the refreshed appendix before review.

--- a/src/ui/actions/registry.js
+++ b/src/ui/actions/registry.js
@@ -70,7 +70,7 @@ function buildProgressSnapshot({
     definition?.time,
     definition?.action?.timeCost
   ];
-  const hoursRequired = hoursRequiredCandidates.reduce((result, value) => {
+  let hoursRequired = hoursRequiredCandidates.reduce((result, value) => {
     if (result != null) {
       return result;
     }
@@ -82,10 +82,6 @@ function buildProgressSnapshot({
     progress.hoursLogged != null ? progress.hoursLogged : instance.hoursLogged,
     0
   );
-
-  const hoursRemaining = hoursRequired != null
-    ? Math.max(0, hoursRequired - hoursLogged)
-    : null;
 
   const metadataProgress = typeof accepted?.metadata?.progress === 'object' && accepted.metadata.progress !== null
     ? accepted.metadata.progress
@@ -119,6 +115,22 @@ function buildProgressSnapshot({
   if (progress && daysRequired != null && (!Number.isFinite(progress.daysRequired) || progress.daysRequired <= 0)) {
     progress.daysRequired = daysRequired;
   }
+
+  if ((hoursRequired == null || hoursRequired <= 0)
+    && Number.isFinite(hoursPerDay)
+    && hoursPerDay > 0
+    && Number.isFinite(daysRequired)
+    && daysRequired > 0) {
+    const derivedHoursRequired = hoursPerDay * daysRequired;
+    hoursRequired = derivedHoursRequired;
+    if (progress && (!Number.isFinite(progress.hoursRequired) || progress.hoursRequired <= 0)) {
+      progress.hoursRequired = derivedHoursRequired;
+    }
+  }
+
+  const hoursRemaining = hoursRequired != null
+    ? Math.max(0, hoursRequired - hoursLogged)
+    : null;
 
   const completionCandidates = [
     progress.completion,


### PR DESCRIPTION
## Summary
- derive fallback study action hours so Learnly courses no longer auto-complete after a 0h log
- document the Learnly fix in the changelog

## Testing
- node --test tests/ui/views/browser/cardsPresenter.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2ecc051f0832cbacc64257c584cb0