### PR TITLE
Pay hustle market contracts on completion

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Economy: Completing hustle market contracts now grants their promised payouts immediately when logged hours are finished, updating money totals and payout metrics.
 - Fix: Learnly study tasks now respect their configured daily hours so courses can't be cleared by completing a 0h log.
 - Tooling: Added a Streamlit balancing workbench (`tools/balancingWorkbench/`) with live sliders, ROI charts, and PNG exports to accelerate economy tuning sessions.
 - Tooling: Balancing workbench can now simulate multi-asset lineups and upgrade combos, with a handy summary of setup hours, upkeep, and bonus time.

--- a/docs/features/hustle-market.md
+++ b/docs/features/hustle-market.md
@@ -37,6 +37,7 @@
 - `acceptHustleOffer(offerId, { state })` reads the offer metadata, accepts an action instance through `acceptActionInstance`, marks the offer as claimed, and records an accepted entry with `acceptedOnDay`, `deadlineDay`, required hours, and payout schedule.
 - Progress metadata is piped directly into `acceptActionInstance` so accepted entries inherit `hoursPerDay`, `daysRequired`, and manual completion flags. The todo queue uses these hints to compute step hours and keeps manual tasks visible even when hour goals are satisfied.
 - Claimed offers continue to persist until their deadlines elapse so completion logging and payout scheduling remain traceable.
+- When a claimed contract logs its final hours, `completeActionInstance` now resolves the linked hustle entry, pays any `onCompletion` payout immediately through `addMoney`, records the grant on the accepted entry, and forwards the amount into daily payout metrics.
 
 ## Availability Queries
 - `getAvailableOffers(state, { day, includeUpcoming, includeClaimed })` returns a cloned list of active offers for the requested day. Setting `includeUpcoming: true` keeps offers whose availability window starts in the future (useful for dashboards showing "coming soon"). Passing `includeClaimed: true` allows UI layers to render offers that have been claimed but not yet completed.

--- a/src/core/state/slices/hustleMarket.js
+++ b/src/core/state/slices/hustleMarket.js
@@ -182,6 +182,14 @@ function normalizeAcceptedOffer(entry, { fallbackDay = 1 } = {}) {
     payout.schedule = 'onCompletion';
   }
 
+  const payoutAwarded = entry.payoutAwarded != null
+    ? clampNonNegativeNumber(entry.payoutAwarded, payout.amount ?? 0)
+    : null;
+  const payoutPaid = entry.payoutPaid === true;
+  const payoutPaidOnDay = entry.payoutPaidOnDay != null
+    ? clampDay(entry.payoutPaidOnDay, acceptedOnDay)
+    : null;
+
   const instanceId = typeof entry.instanceId === 'string' && entry.instanceId
     ? entry.instanceId
     : null;
@@ -214,6 +222,9 @@ function normalizeAcceptedOffer(entry, { fallbackDay = 1 } = {}) {
     hoursRequired,
     instanceId,
     payout,
+    payoutAwarded,
+    payoutPaid,
+    payoutPaidOnDay,
     status: entry.status === 'complete' ? 'complete' : 'active',
     metadata,
     completedOnDay,
@@ -448,7 +459,7 @@ export function completeHustleMarketInstance(state, instanceId, {
   hoursLogged
 } = {}) {
   if (!state || !instanceId) {
-    return false;
+    return null;
   }
 
   const fallbackDay = clampDay(completionDay ?? state.day ?? 1, 1);
@@ -456,7 +467,7 @@ export function completeHustleMarketInstance(state, instanceId, {
 
   const entry = marketState.accepted.find(item => item.instanceId === instanceId);
   if (!entry) {
-    return false;
+    return null;
   }
 
   const resolvedCompletionDay = clampDay(completionDay ?? fallbackDay, entry.acceptedOnDay);
@@ -491,7 +502,7 @@ export function completeHustleMarketInstance(state, instanceId, {
 
   ensureHustleMarketState(state, { fallbackDay });
 
-  return true;
+  return marketState.accepted.find(item => item.instanceId === instanceId) || null;
 }
 
 export { DEFAULT_STATE as DEFAULT_HUSTLE_MARKET_STATE };


### PR DESCRIPTION
## Summary
- extend hustle market state normalization to retain payout grant details and surface the accepted entry when completing an instance
- award on-completion hustle payouts through `addMoney`, update payout metrics, and mark accepted contracts as paid to prevent double rewards
- cover the flow with a hustle market test that logs contract hours and asserts the player receives the promised payout

## Testing
- npm test -- tests/hustleMarket.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2f07ef18c832cb3b948bb151e89f5