### PR TITLE
Filter todo queue to accepted hustles only

### DIFF
--- a/src/ui/actions/registry.js
+++ b/src/ui/actions/registry.js
@@ -477,6 +477,18 @@ export function buildActionQueue({ state, summary = {} } = {}) {
     applyMetrics(queue, snapshot.metrics);
   });
 
+  const filteredEntries = queue.entries.filter(entry => {
+    const focusBucket = typeof entry?.focusBucket === 'string' ? entry.focusBucket.toLowerCase() : '';
+    const focusCategory = typeof entry?.focusCategory === 'string' ? entry.focusCategory.toLowerCase() : '';
+    if (focusBucket === 'commitment' || focusCategory === 'commitment') {
+      return true;
+    }
+    const id = typeof entry?.id === 'string' ? entry.id : '';
+    return id.startsWith('instance:');
+  });
+
+  queue.entries = filteredEntries;
+
   if (!queue.entries.length && !queue.emptyMessage) {
     queue.emptyMessage = DEFAULT_EMPTY_MESSAGE;
   }

--- a/src/ui/dashboard/quickActions.js
+++ b/src/ui/dashboard/quickActions.js
@@ -386,13 +386,14 @@ registerActionProvider(({ state }) => {
   const entries = (Array.isArray(model?.entries) ? model.entries : []).map((entry, index) => ({
     ...entry,
     meta: [entry?.subtitle, entry?.meta].filter(Boolean).join(' • ') || entry?.meta || '',
-    focusCategory: entry?.focusCategory || 'upgrade',
+    focusCategory: entry?.focusCategory || 'commitment',
+    focusBucket: entry?.focusBucket || 'commitment',
     orderIndex: Number.isFinite(entry?.orderIndex) ? entry.orderIndex : index
   }));
 
   return {
     id: 'asset-upgrades',
-    focusCategory: 'upgrade',
+    focusCategory: 'commitment',
     entries,
     metrics: {
       emptyMessage: model?.emptyMessage,

--- a/tests/ui/actions/registry.test.js
+++ b/tests/ui/actions/registry.test.js
@@ -13,7 +13,7 @@ test('registerActionProvider supplies normalized entries to the queue', () => {
   try {
     registerActionProvider(() => ({
       id: 'test-provider',
-      focusCategory: 'hustle',
+      focusCategory: 'commitment',
       entries: [
         {
           id: 'custom-entry',
@@ -33,7 +33,7 @@ test('registerActionProvider supplies normalized entries to the queue', () => {
     const entry = queue.entries[0];
     assert.equal(entry.durationHours, 2);
     assert.equal(entry.durationText, formatHours(2));
-    assert.equal(entry.focusCategory, 'hustle');
+    assert.equal(entry.focusCategory, 'commitment');
     assert.equal(queue.emptyMessage, 'custom empty');
     assert.equal(queue.hoursAvailable, 2);
     assert.equal(queue.hoursAvailableLabel, formatHours(2));
@@ -55,7 +55,7 @@ test('registerActionProvider retains the original entry as raw payload', () => {
 
     registerActionProvider(() => ({
       id: 'raw-provider',
-      focusCategory: 'hustle',
+      focusCategory: 'commitment',
       entries: [originalEntry],
       metrics: {}
     }));
@@ -75,6 +75,7 @@ test('clearActionProviders restore removes temporary providers', () => {
   try {
     registerActionProvider(() => ({
       id: 'temporary-provider',
+      focusCategory: 'commitment',
       entries: [
         {
           id: 'temp-entry',
@@ -100,6 +101,7 @@ test('providers with higher priority contribute entries first', () => {
   try {
     registerActionProvider(() => ({
       id: 'low-priority',
+      focusCategory: 'commitment',
       entries: [
         { id: 'low', title: 'Low priority' }
       ],
@@ -108,6 +110,7 @@ test('providers with higher priority contribute entries first', () => {
 
     registerActionProvider(() => ({
       id: 'high-priority-a',
+      focusCategory: 'commitment',
       entries: [
         { id: 'high-a', title: 'High priority A' }
       ],
@@ -116,6 +119,7 @@ test('providers with higher priority contribute entries first', () => {
 
     registerActionProvider(() => ({
       id: 'high-priority-b',
+      focusCategory: 'commitment',
       entries: [
         { id: 'high-b', title: 'High priority B' }
       ],
@@ -127,6 +131,31 @@ test('providers with higher priority contribute entries first', () => {
       queue.entries.map(entry => entry.id),
       ['high-a', 'high-b', 'low']
     );
+  } finally {
+    restore();
+  }
+});
+
+test('buildActionQueue omits non-commitment provider entries', () => {
+  const restore = clearActionProviders();
+  try {
+    registerActionProvider(() => ({
+      id: 'non-commitment-provider',
+      focusCategory: 'hustle',
+      entries: [
+        { id: 'offer-action', title: 'Accept hustle', timeCost: 1 }
+      ],
+      metrics: {
+        emptyMessage: 'custom empty',
+        hoursAvailable: 4
+      }
+    }));
+
+    const queue = buildActionQueue({ state: {} });
+    assert.equal(queue.entries.length, 0);
+    assert.equal(queue.emptyMessage, 'custom empty');
+    assert.equal(queue.hoursAvailable, 4);
+    assert.equal(queue.hoursAvailableLabel, formatHours(4));
   } finally {
     restore();
   }
@@ -192,8 +221,9 @@ test('normalizeActionEntries preserves explicit focus buckets', () => {
   try {
     registerActionProvider(() => ({
       id: 'bucket-provider',
+      focusCategory: 'commitment',
       entries: [
-        { id: 'queue-bucketed', focusBucket: 'study', focusCategory: 'hustle' }
+        { id: 'queue-bucketed', focusBucket: 'study', focusCategory: 'commitment' }
       ],
       metrics: {}
     }));


### PR DESCRIPTION
## Summary
- filter the todo action queue so only commitment (accepted hustle) entries remain
- keep queue metrics while omitting non-commitment providers and extend tests accordingly

## Testing
- npm test -- tests/ui/actions/registry.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2f7445394832c9ffde50cc4a38fc2