### PR TITLE
Hide hustle offers from todo queue

### DIFF
--- a/src/ui/actions/registry.js
+++ b/src/ui/actions/registry.js
@@ -473,7 +473,13 @@ export function buildActionQueue({ state, summary = {} } = {}) {
   }
 
   snapshots.forEach(snapshot => {
-    queue.entries.push(...snapshot.entries);
+    const snapshotEntries = Array.isArray(snapshot?.entries) ? snapshot.entries : [];
+    snapshotEntries.forEach(entry => {
+      if (entry?.excludeFromQueue || entry?.raw?.excludeFromQueue) {
+        return;
+      }
+      queue.entries.push(entry);
+    });
     applyMetrics(queue, snapshot.metrics);
   });
 

--- a/src/ui/actions/utils.js
+++ b/src/ui/actions/utils.js
@@ -163,6 +163,9 @@ export function normalizeActionEntries(source = []) {
       if (entry?.durationText && entry.durationText !== normalizedEntry.durationText) {
         normalizedEntry.durationText = entry.durationText;
       }
+      if (entry?.excludeFromQueue === true) {
+        normalizedEntry.excludeFromQueue = true;
+      }
 
       const rawTime = coerceNumber(entry?.timeCost, null);
       if (Number.isFinite(rawTime)) {

--- a/src/ui/dashboard/quickActions.js
+++ b/src/ui/dashboard/quickActions.js
@@ -137,6 +137,7 @@ export function buildQuickActions(state) {
       remainingDays,
       schedule,
       offer,
+      excludeFromQueue: true,
       disabled: !requirementsMet,
       disabledReason: lockGuidance || 'Meet the prerequisites before accepting this hustle.'
     };
@@ -160,7 +161,8 @@ export function buildQuickActions(state) {
       repeatable: false,
       remainingRuns: 0,
       remainingDays: null,
-      schedule: 'onCompletion'
+      schedule: 'onCompletion',
+      excludeFromQueue: true
     });
   }
 
@@ -319,7 +321,8 @@ export function buildQuickActionModel(state = {}) {
     repeatable: action.repeatable,
     remainingRuns: action.remainingRuns,
     disabled: action.disabled,
-    disabledReason: action.disabledReason
+    disabledReason: action.disabledReason,
+    excludeFromQueue: action.excludeFromQueue === true
   }));
   const baseHours = clampNumber(state.baseTime) + clampNumber(state.bonusTime) + clampNumber(state.dailyBonusTime);
   const hoursAvailable = Math.max(0, clampNumber(state.timeLeft));

--- a/tests/ui/actions/registry.test.js
+++ b/tests/ui/actions/registry.test.js
@@ -42,6 +42,26 @@ test('registerActionProvider supplies normalized entries to the queue', () => {
   }
 });
 
+test('buildActionQueue omits entries flagged to be excluded', () => {
+  const restore = clearActionProviders();
+  try {
+    registerActionProvider(() => ({
+      id: 'hidden-provider',
+      entries: [
+        { id: 'hidden-entry', title: 'Hidden Action', excludeFromQueue: true },
+        { id: 'visible-entry', title: 'Visible Action' }
+      ],
+      metrics: {}
+    }));
+
+    const queue = buildActionQueue({ state: {} });
+    assert.equal(queue.entries.length, 1);
+    assert.equal(queue.entries[0].id, 'visible-entry');
+  } finally {
+    restore();
+  }
+});
+
 test('registerActionProvider retains the original entry as raw payload', () => {
   const restore = clearActionProviders();
   try {

--- a/tests/ui/views/browser/dashboardPresenter.test.js
+++ b/tests/ui/views/browser/dashboardPresenter.test.js
@@ -40,9 +40,14 @@ test('renderTodo falls back to the current state when none is provided', async (
 
     assert.ok(capturedModel, 'todo widget should receive a model to render');
     assert.ok(Array.isArray(capturedModel.entries), 'model should include queue entries');
+    assert.equal(capturedModel.entries.length, 0, 'queue should be empty when no tasks are accepted');
     const guidanceEntry = capturedModel.entries.find(entry => entry?.id === 'hustles:no-offers');
-    assert.ok(guidanceEntry, 'queue should include the no-offers guidance when no state is supplied');
-    assert.equal(guidanceEntry.buttonLabel, 'Check back tomorrow');
+    assert.ok(!guidanceEntry, 'queue should hide hustle offer guidance from the todo list');
+    assert.equal(
+      capturedModel.emptyMessage,
+      'No ready actions. Check upgrades or ventures.',
+      'empty message should guide the player toward other actions'
+    );
   } finally {
     todoWidget.init = originalInit;
     todoWidget.render = originalRender;


### PR DESCRIPTION
## Summary
- hide hustle acceptance quick actions from the todo queue by flagging them for exclusion
- filter action provider entries marked as excluded and carry the flag through normalization
- update dashboard tests to expect an empty todo list when no contracts are accepted

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2fb471738832c84813055cc3653eb