### PR TITLE
Align manual actions with canonical registry

### DIFF
--- a/docs/features/hustle-market.md
+++ b/docs/features/hustle-market.md
@@ -6,7 +6,7 @@
 - Persist market state so day transitions can detect whether a reroll is required or if existing contracts still apply.
 
 ## Template & Variant Structure
-- All instant hustles continue to live in `HUSTLE_TEMPLATES` (alias `HUSTLES`) so the registry keeps a stable snapshot of every market-ready gig. Study tracks flow through the broader `ACTIONS` export but never appear in the daily market roll.
+- All instant hustles continue to live in `HUSTLE_TEMPLATES`, a filtered view of the canonical `ACTIONS` registry, so the market keeps a stable snapshot of every gig-ready template. Study tracks flow through the broader `ACTIONS` export but never appear in the daily market roll.
 - Templates may define a `market` block with:
   - `variants`: optional array of variant configs (id, label, weight, duration, availableAfterDays, metadata, definitionId).
   - `durationDays` and `availableAfterDays`: defaults applied when variants omit explicit values.
@@ -55,7 +55,7 @@
 - Manual QA steps for the exchange now live in `docs/features/hustle-market-playtest.md`, covering bootstrap validation, daily rerolls, and acceptance/completion flows so every release can run through a repeatable script.
 
 ## Registry Loading
-- `loadDefaultRegistry` now registers the immutable template list (`HUSTLE_TEMPLATES`) so day-to-day market rolls no longer mutate the definitions.
+- `loadDefaultRegistry` now registers the canonical `ACTIONS` list (with `HUSTLE_TEMPLATES` derived automatically) so day-to-day market rolls no longer mutate the definitions.
 - Tests cover: slice normalization, seeding, expiry rerolls, and delayed availability to protect future tuning changes.
 
 ## UI Surface Updates

--- a/src/core/state/registry.js
+++ b/src/core/state/registry.js
@@ -8,8 +8,55 @@ import {
 
 let registry = { actions: [], hustles: [], assets: [], upgrades: [] };
 
+function isHustleDefinition(definition) {
+  if (!definition || typeof definition !== 'object') {
+    return false;
+  }
+  const category = typeof definition.category === 'string'
+    ? definition.category.trim().toLowerCase()
+    : null;
+  if (category === 'hustle') {
+    return true;
+  }
+  const templateKind = typeof definition.templateKind === 'string'
+    ? definition.templateKind.trim().toLowerCase()
+    : null;
+  if (templateKind === 'hustle') {
+    return true;
+  }
+  const type = typeof definition.type === 'string'
+    ? definition.type.trim().toLowerCase()
+    : null;
+  if (type === 'hustle') {
+    return true;
+  }
+  if (definition.market) {
+    return true;
+  }
+  const tagType = typeof definition.tag?.type === 'string'
+    ? definition.tag.type.trim().toLowerCase()
+    : null;
+  return tagType === 'instant';
+}
+
+function deriveHustles(actions = [], fallback = []) {
+  if (!Array.isArray(actions) || !actions.length) {
+    return Array.isArray(fallback) ? fallback : [];
+  }
+  const hustles = actions.filter(isHustleDefinition);
+  if (hustles.length) {
+    return hustles;
+  }
+  return Array.isArray(fallback) ? fallback : [];
+}
+
 export function configureRegistry() {
-  registry = getRegistryDefinitions();
+  const snapshot = getRegistryDefinitions();
+  const actions = Array.isArray(snapshot.actions) ? snapshot.actions : [];
+  if (!Array.isArray(snapshot.hustles) || snapshot.hustles.length === 0) {
+    snapshot.hustles = deriveHustles(actions, snapshot.hustles);
+  }
+  registry = snapshot;
 }
 
 export function getRegistrySnapshot() {

--- a/src/game/actions/definitions.js
+++ b/src/game/actions/definitions.js
@@ -1,18 +1,12 @@
 import { createInstantHustle } from '../content/schema.js';
 import { getInstantHustleDefinitions } from '../hustles/definitions/instantHustles.js';
 import { createKnowledgeHustles } from '../hustles/knowledgeHustles.js';
-import { createContractTemplate, createStudyTemplate } from './templates/contract.js';
+import { createStudyTemplate } from './templates/contract.js';
 
 function prepareInstantActions() {
   return getInstantHustleDefinitions().map(config => {
-    const definition = createContractTemplate(createInstantHustle(config), {
-      progress: {
-        type: 'instant',
-        completion: 'instant',
-        hoursRequired: Number(config.time || config.action?.timeCost || 0)
-      }
-    });
-    definition.kind = 'action';
+    const definition = createInstantHustle(config);
+    definition.kind = definition.kind || 'action';
     return definition;
   });
 }
@@ -20,12 +14,14 @@ function prepareInstantActions() {
 function prepareStudyActions() {
   return createKnowledgeHustles().map(definition => {
     const template = createStudyTemplate(definition, {
+      templateKind: 'manual',
+      category: definition.category || 'study',
       progress: {
         hoursPerDay: definition.studyHoursPerDay || definition.hoursPerDay || null,
         daysRequired: definition.studyDays || definition.days || null
       }
     });
-    template.kind = 'action';
+    template.kind = template.kind || 'action';
     return template;
   });
 }

--- a/src/game/actions/templates/contract.js
+++ b/src/game/actions/templates/contract.js
@@ -1,4 +1,47 @@
+import { structuredClone } from '../../../core/helpers.js';
 import { acceptActionInstance } from '../progress.js';
+
+function findFirstNumber(...values) {
+  for (const value of values) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function cloneMarketMetadata(metadata) {
+  if (!metadata || typeof metadata !== 'object') {
+    return null;
+  }
+  try {
+    return structuredClone(metadata);
+  } catch (_error) {
+    // Fallback to a shallow copy if structuredClone cannot serialize the object.
+    return { ...metadata };
+  }
+}
+
+function mergeMarketMetadata(base, overrides) {
+  const baseClone = cloneMarketMetadata(base);
+  const overrideClone = cloneMarketMetadata(overrides);
+  if (!baseClone) return overrideClone;
+  if (!overrideClone) return baseClone;
+  const merged = { ...baseClone, ...overrideClone };
+  if (baseClone.metadata || overrideClone.metadata) {
+    merged.metadata = {
+      ...(baseClone.metadata || {}),
+      ...(overrideClone.metadata || {})
+    };
+  }
+  if (overrideClone.variants) {
+    merged.variants = overrideClone.variants;
+  } else if (baseClone.variants) {
+    merged.variants = baseClone.variants;
+  }
+  return merged;
+}
 
 function cloneDefaultState(defaultState = {}) {
   const base = typeof defaultState === 'object' && defaultState !== null
@@ -100,6 +143,55 @@ function mergeOverrides(baseOverrides = {}, incomingOverrides = {}) {
   return merged;
 }
 
+function normalizeTimeDescriptor(template, progress = {}) {
+  const hoursRequired = findFirstNumber(
+    progress.hoursRequired,
+    template.time,
+    template.action?.timeCost
+  );
+  const descriptor = {};
+  if (hoursRequired != null) {
+    descriptor.hours = hoursRequired;
+  }
+  if (Number.isFinite(progress.hoursPerDay) && progress.hoursPerDay > 0) {
+    descriptor.hoursPerDay = progress.hoursPerDay;
+  }
+  if (Number.isFinite(progress.daysRequired) && progress.daysRequired > 0) {
+    descriptor.daysRequired = Math.floor(progress.daysRequired);
+  }
+  if (progress.deadlineDay != null) {
+    descriptor.deadlineDay = Math.max(1, Math.floor(Number(progress.deadlineDay)) || 1);
+  }
+  return Object.keys(descriptor).length ? descriptor : null;
+}
+
+function normalizePayoutDescriptor(template) {
+  const payout = template.payout || template.action?.payout;
+  if (!payout || typeof payout !== 'object') {
+    return null;
+  }
+  const amount = findFirstNumber(payout.amount, payout.value, payout.baseAmount);
+  if (amount == null) {
+    return null;
+  }
+  const descriptor = { amount };
+  const delay = findFirstNumber(payout.delaySeconds, payout.waitSeconds, payout.delay);
+  if (delay != null && delay > 0) {
+    descriptor.delaySeconds = delay;
+  }
+  const schedule = payout.schedule || payout.payoutSchedule;
+  descriptor.schedule = typeof schedule === 'string' && schedule.trim().length
+    ? schedule
+    : 'onCompletion';
+  if (payout.grantOnAction != null) {
+    descriptor.grantOnAction = payout.grantOnAction !== false;
+  }
+  if (typeof payout.logType === 'string' && payout.logType.trim()) {
+    descriptor.logType = payout.logType;
+  }
+  return descriptor;
+}
+
 function normalizeAcceptHooks(options = {}) {
   const hooks = [];
   if (Array.isArray(options.hooks)) {
@@ -121,6 +213,10 @@ export function createContractTemplate(definition, options = {}) {
     defaultState: cloneDefaultState(definition?.defaultState)
   };
 
+  if (!template.kind) {
+    template.kind = 'action';
+  }
+
   const normalizedLimit = normalizeDailyLimit(options.dailyLimit ?? template.dailyLimit);
   template.dailyLimit = normalizedLimit;
 
@@ -136,6 +232,58 @@ export function createContractTemplate(definition, options = {}) {
     template.progress = mergedProgress;
   } else {
     delete template.progress;
+  }
+
+  const resolvedTemplateKind = options.templateKind ?? definition?.templateKind ?? template?.templateKind ?? null;
+  if (resolvedTemplateKind) {
+    template.templateKind = resolvedTemplateKind;
+  }
+
+  const resolvedCategory = options.category ?? definition?.category ?? template?.category ?? null;
+  if (resolvedCategory) {
+    template.category = resolvedCategory;
+  } else if (template.category === undefined) {
+    template.category = null;
+  }
+
+  const mergedMarket = mergeMarketMetadata(template.market, options.market);
+  if (mergedMarket) {
+    template.market = mergedMarket;
+  } else {
+    delete template.market;
+  }
+
+  const progressDescriptor = mergedProgress ? cloneProgress(mergedProgress) : null;
+  const descriptors = typeof template.descriptors === 'object' && template.descriptors !== null
+    ? { ...template.descriptors }
+    : {};
+
+  if (progressDescriptor) {
+    descriptors.progress = progressDescriptor;
+  }
+
+  const timeDescriptor = normalizeTimeDescriptor(template, progressDescriptor || options.progress || {});
+  if (timeDescriptor) {
+    descriptors.time = timeDescriptor;
+    if (timeDescriptor.hours != null) {
+      template.time = timeDescriptor.hours;
+    }
+  } else if (template.time != null) {
+    const resolvedTime = findFirstNumber(template.time, template.action?.timeCost, progressDescriptor?.hoursRequired);
+    if (resolvedTime != null) {
+      template.time = resolvedTime;
+    }
+  }
+
+  const payoutDescriptor = normalizePayoutDescriptor(template);
+  if (payoutDescriptor) {
+    descriptors.payout = payoutDescriptor;
+  }
+
+  if (Object.keys(descriptors).length) {
+    template.descriptors = descriptors;
+  } else if (template.descriptors) {
+    delete template.descriptors;
   }
 
   const baseAcceptOverrides = mergeOverrides(options.accept?.overrides, {});
@@ -180,6 +328,8 @@ export function createStudyTemplate(definition, options = {}) {
   const availability = options.availability || { type: 'enrollable' };
   return createContractTemplate(definition, {
     ...options,
+    templateKind: options.templateKind ?? 'manual',
+    category: options.category ?? definition?.category ?? 'study',
     progress: progressDefaults,
     availability
   });

--- a/src/game/content/schema/assetActions.js
+++ b/src/game/content/schema/assetActions.js
@@ -122,6 +122,13 @@ export function createInstantHustle(config) {
     ...(config.progress || {})
   };
 
+  if (progressDefaults.hoursRequired == null) {
+    const baseHours = Number(metadata.time);
+    if (Number.isFinite(baseHours) && baseHours >= 0) {
+      progressDefaults.hoursRequired = baseHours;
+    }
+  }
+
   const baseDefinition = {
     ...config,
     type: 'hustle',
@@ -139,7 +146,8 @@ export function createInstantHustle(config) {
     })(),
     dailyLimit: metadata.dailyLimit,
     skills: metadata.skills,
-    progress: config.progress
+    progress: config.progress,
+    time: metadata.time
   };
 
   const acceptHooks = [];
@@ -155,6 +163,9 @@ export function createInstantHustle(config) {
   }
 
   const definition = createContractTemplate(baseDefinition, {
+    templateKind: 'manual',
+    category: config.category || 'hustle',
+    market: config.market,
     dailyLimit: metadata.dailyLimit,
     availability: config.availability,
     progress: progressDefaults,

--- a/src/game/hustles.js
+++ b/src/game/hustles.js
@@ -12,7 +12,6 @@ import { definitionRequirementsMet } from './requirements/checks.js';
 import { describeHustleRequirements } from './hustles/helpers.js';
 
 export const HUSTLE_TEMPLATES = INSTANT_ACTIONS;
-export const HUSTLES = HUSTLE_TEMPLATES;
 export const KNOWLEDGE_HUSTLES = STUDY_ACTIONS;
 
 export { ACTIONS, INSTANT_ACTIONS, STUDY_ACTIONS };

--- a/src/game/registryLoader.js
+++ b/src/game/registryLoader.js
@@ -1,13 +1,12 @@
 import { loadRegistry } from './registryService.js';
 import { ASSETS } from './assets/index.js';
-import { ACTIONS, HUSTLE_TEMPLATES } from './hustles.js';
+import { ACTIONS } from './hustles.js';
 import { UPGRADES } from './upgrades.js';
 
 export function loadDefaultRegistry() {
   return loadRegistry({
     actions: ACTIONS,
     assets: ASSETS,
-    hustles: HUSTLE_TEMPLATES,
     upgrades: UPGRADES
   });
 }


### PR DESCRIPTION
## Summary
- add manual action descriptors and metadata to contract templates and instant hustles
- register hustles and study tracks through the shared ACTIONS list and remove the legacy HUSTLES alias
- derive the hustle view from canonical actions in the registry service/state and refresh the hustle market docs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2ff22b4c4832c96f938c1bdf8b3e3