### PR TITLE
Align hustle market payouts with $9 hourly rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ Online Hustle Simulator is a browser-based incremental game about orchestrating 
 - **Gallery Licensing Summit** – Pay $240 upfront; 2.25h/day for 5 days (log manually) to pitch curators (+30% Event Photo Gig bookings and +22% Stock Photo Gallery passive income).
 - **Syndication Residency** – Pay $300 upfront; 2h/day for 6 days (log manually) cultivating partnerships (+20% Freelance Writing payouts, +$2 Street Promo Sprint stipends, and +18% Personal Blog Network income).
 
+### Hustle Market Pay Scale
+- Instant hustles now use a baseline $9/hour rate so short gigs and multi-day contracts deliver consistent value for the time you log.
+- Offer payouts are calculated from the posted schedule: `hoursPerDay × daysRequired × $9`, rounded to the nearest cent when needed.
+- Visit any hustle card in the browser workspace to review the adjusted payouts before accepting an offer, then track the $9/hour rewards in the Finance dashboard after completion.
+
 ### Passive Ventures (Daily Payouts)
 Each asset supports multiple instances, tracks setup progress, and rolls a daily income range once active. Quality actions unique to each asset increase payouts and stability, and you can liquidate any instance directly from the card—or from the category roster—for yesterday’s payout ×3 × (Quality level + 1). Celebratory events can trigger immediately after quality work, granting a small, tapering income bump that keeps momentum flowing between day-end payouts. The asset briefing modal doubles as an instance inspector, outlining status, upkeep, yesterday’s earnings, and which upgrades are owned or still locked.
 - Select quality actions now include a visible cooldown so big-impact moves (SEO sprints, ad bursts, and marketplace pitches) can only be run every few in-game days, nudging players to rotate through their portfolio.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Economy: Hustle market offers now calculate payouts at $9/hour, aligning base incomes and variant rewards with the time each contract demands.【F:src/game/hustles/definitions/instantHustles.js†L1-L918】【F:docs/normalized_economy.json†L508-L744】
 - Hustles: Contract templates now publish multi-variant market metadata (hours-per-day, duration windows, payout schedules, copies) so daily rolls surface retainers alongside quick gigs.【F:src/game/hustles/definitions/instantHustles.js†L19-L855】
 - Tooling: `rollDailyOffers` records per-template audit summaries, exposes `getMarketRollAuditLog()`, and attaches `window.__HUSTLE_MARKET_DEBUG__` helpers for playtests.【F:src/game/hustles/market.js†L12-L755】
 - Docs: Refreshed the economy guide, hustle market notes, and added a dedicated playtest script covering bootstrap, rerolls, and contract completion loops.【F:docs/economy.md†L80-L121】【F:docs/features/hustle-market.md†L94-L126】【F:docs/features/hustle-market-playtest.md†L1-L64】

--- a/docs/features/hustle-market.md
+++ b/docs/features/hustle-market.md
@@ -19,6 +19,11 @@
   - `progressLabel` lets variants override the default log title so accepted instances read naturally in the todo list.
 - If no variants are provided the `rollDailyOffers` helper fabricates a default variant that mirrors the template. When variants exist, multiple offers can coexist so long as each variant is represented at most once per active window.
 
+## Payout Balancing
+- Hustle market payouts are standardized at $9/hour based on the total time commitment a variant advertises.
+- Each offer now derives its reward directly from the schedule: `hoursPerDay × daysRequired × $9`, falling back to total-hour metadata when variants specify explicit requirements instead of per-day cadence.
+- This shift keeps retainers, weekend gigs, and same-day sprints aligned so designers can tweak hours without recalculating economy targets by hand.
+
 ## Rolling Logic
 - `rollDailyOffers({ templates, day, now, state, rng })` clones any existing offers whose `expiresOnDay` is still in the future, then fills the configured number of template slots by selecting weighted variants (defaulting to equal weights). Variant copy counts can consume multiple slots per roll while template and variant `maxActive` values prevent overfilling.
 - Each new offer captures:

--- a/docs/normalized_economy.json
+++ b/docs/normalized_economy.json
@@ -521,7 +521,7 @@
     },
     "audienceCall": {
       "name": "Audience Q&A Blast",
-      "base_income": 12,
+      "base_income": 9,
       "variance": 0,
       "setup_time": 60,
       "setup_cost": 0,
@@ -546,7 +546,7 @@
     },
     "bundlePush": {
       "name": "Bundle Promo Push",
-      "base_income": 48,
+      "base_income": 22.5,
       "variance": 0,
       "setup_time": 150,
       "setup_cost": 0,
@@ -574,7 +574,7 @@
     },
     "surveySprint": {
       "name": "Micro Survey Dash",
-      "base_income": 1,
+      "base_income": 2.25,
       "variance": 0,
       "setup_time": 15,
       "setup_cost": 0,
@@ -593,7 +593,7 @@
     },
     "eventPhotoGig": {
       "name": "Event Photo Gig",
-      "base_income": 72,
+      "base_income": 31.5,
       "variance": 0,
       "setup_time": 210,
       "setup_cost": 0,
@@ -618,7 +618,7 @@
     },
     "popUpWorkshop": {
       "name": "Pop-Up Workshop",
-      "base_income": 38,
+      "base_income": 22.5,
       "variance": 0,
       "setup_time": 150,
       "setup_cost": 0,
@@ -650,7 +650,7 @@
     },
     "vlogEditRush": {
       "name": "Vlog Edit Rush",
-      "base_income": 24,
+      "base_income": 13.5,
       "variance": 0,
       "setup_time": 90,
       "setup_cost": 0,
@@ -675,7 +675,7 @@
     },
     "dropshipPackParty": {
       "name": "Dropship Pack Party",
-      "base_income": 28,
+      "base_income": 18,
       "variance": 0,
       "setup_time": 120,
       "setup_cost": 8,
@@ -699,7 +699,7 @@
     },
     "saasBugSquash": {
       "name": "SaaS Bug Squash",
-      "base_income": 30,
+      "base_income": 9,
       "variance": 0,
       "setup_time": 60,
       "setup_cost": 0,
@@ -727,7 +727,7 @@
     },
     "audiobookNarration": {
       "name": "Audiobook Narration",
-      "base_income": 44,
+      "base_income": 24.75,
       "variance": 0,
       "setup_time": 165,
       "setup_cost": 0,
@@ -751,7 +751,7 @@
     },
     "streetPromoSprint": {
       "name": "Street Team Promo",
-      "base_income": 18,
+      "base_income": 6.75,
       "variance": 0,
       "setup_time": 45,
       "setup_cost": 5,

--- a/src/game/hustles/definitions/instantHustles.js
+++ b/src/game/hustles/definitions/instantHustles.js
@@ -13,6 +13,33 @@ const saasBugSquashConfig = hustleConfigs.saasBugSquash; // Spec: docs/normalize
 const audiobookNarrationConfig = hustleConfigs.audiobookNarration; // Spec: docs/normalized_economy.json → hustles.audiobookNarration
 const streetPromoSprintConfig = hustleConfigs.streetPromoSprint; // Spec: docs/normalized_economy.json → hustles.streetPromoSprint
 
+const HOURLY_RATE = 9;
+
+const computeHourlyPayout = hours => {
+  const safeHours = Number.isFinite(Number(hours)) ? Number(hours) : 0;
+  return Math.round(safeHours * HOURLY_RATE * 100) / 100;
+};
+
+const createBaseHustleSnapshot = config => {
+  const hours = Number.isFinite(Number(config?.timeHours)) ? Number(config.timeHours) : 0;
+  return {
+    hours,
+    payout: computeHourlyPayout(hours)
+  };
+};
+
+const freelanceBase = createBaseHustleSnapshot(freelanceConfig);
+const audienceCallBase = createBaseHustleSnapshot(audienceCallConfig);
+const bundlePushBase = createBaseHustleSnapshot(bundlePushConfig);
+const surveySprintBase = createBaseHustleSnapshot(surveySprintConfig);
+const eventPhotoGigBase = createBaseHustleSnapshot(eventPhotoGigConfig);
+const popUpWorkshopBase = createBaseHustleSnapshot(popUpWorkshopConfig);
+const vlogEditRushBase = createBaseHustleSnapshot(vlogEditRushConfig);
+const dropshipPackPartyBase = createBaseHustleSnapshot(dropshipPackPartyConfig);
+const saasBugSquashBase = createBaseHustleSnapshot(saasBugSquashConfig);
+const audiobookNarrationBase = createBaseHustleSnapshot(audiobookNarrationConfig);
+const streetPromoSprintBase = createBaseHustleSnapshot(streetPromoSprintConfig);
+
 const instantHustleDefinitions = [
   {
     id: 'freelance',
@@ -22,10 +49,10 @@ const instantHustleDefinitions = [
     tags: freelanceConfig.tags,
     time: freelanceConfig.timeHours, // Spec: docs/normalized_economy.json → hustles.freelance.setup_time
     payout: {
-      amount: freelanceConfig.payout, // Spec: docs/normalized_economy.json → hustles.freelance.base_income
+      amount: freelanceBase.payout, // Spec: docs/normalized_economy.json → hustles.freelance.base_income
       logType: 'hustle',
       message: context => {
-        const payout = context?.finalPayout ?? context?.payoutGranted ?? freelanceConfig.payout;
+        const payout = context?.finalPayout ?? context?.payoutGranted ?? freelanceBase.payout;
         const bonusNote = context?.appliedEducationBoosts?.length
           ? ' Your storytelling drills juiced the rate!'
           : '';
@@ -36,9 +63,9 @@ const instantHustleDefinitions = [
       slotsPerRoll: 2,
       maxActive: 4,
       metadata: {
-        requirements: { hours: freelanceConfig.timeHours },
-        payout: { amount: freelanceConfig.payout, schedule: 'onCompletion' },
-        hoursPerDay: freelanceConfig.timeHours,
+        requirements: { hours: freelanceBase.hours },
+        payout: { amount: freelanceBase.payout, schedule: 'onCompletion' },
+        hoursPerDay: freelanceBase.hours,
         daysRequired: 1,
         progressLabel: 'Write the commissioned piece'
       },
@@ -50,10 +77,10 @@ const instantHustleDefinitions = [
           copies: 2,
           durationDays: 0,
           metadata: {
-            payoutAmount: freelanceConfig.payout,
+            payoutAmount: freelanceBase.payout,
             payoutSchedule: 'onCompletion',
-            requirements: { hours: freelanceConfig.timeHours },
-            hoursPerDay: freelanceConfig.timeHours,
+            requirements: { hours: freelanceBase.hours },
+            hoursPerDay: freelanceBase.hours,
             daysRequired: 1,
             progressLabel: 'Draft the rush article'
           }
@@ -64,10 +91,10 @@ const instantHustleDefinitions = [
           description: 'Outline, draft, and polish a three-installment story arc for a premium client.',
           durationDays: 2,
           metadata: {
-            payoutAmount: Math.round(freelanceConfig.payout * 2.5),
+            payoutAmount: computeHourlyPayout(freelanceBase.hours * 3),
             payoutSchedule: 'onCompletion',
-            requirements: { hours: freelanceConfig.timeHours * 3 },
-            hoursPerDay: freelanceConfig.timeHours,
+            requirements: { hours: freelanceBase.hours * 3 },
+            hoursPerDay: freelanceBase.hours,
             daysRequired: 3,
             progressLabel: 'Outline and polish the mini-series'
           }
@@ -79,10 +106,10 @@ const instantHustleDefinitions = [
           availableAfterDays: 1,
           durationDays: 3,
           metadata: {
-            payoutAmount: 80,
+            payoutAmount: computeHourlyPayout(freelanceBase.hours * 4),
             payoutSchedule: 'onCompletion',
-            requirements: { hours: freelanceConfig.timeHours * 4 },
-            hoursPerDay: freelanceConfig.timeHours,
+            requirements: { hours: freelanceBase.hours * 4 },
+            hoursPerDay: freelanceBase.hours,
             daysRequired: 4,
             progressLabel: 'Deliver the retainer lineup'
           }
@@ -106,10 +133,10 @@ const instantHustleDefinitions = [
     requirements: audienceCallConfig.requirements,
     dailyLimit: audienceCallConfig.dailyLimit, // Spec: docs/normalized_economy.json → hustles.audienceCall.daily_limit
     payout: {
-      amount: audienceCallConfig.payout, // Spec: docs/normalized_economy.json → hustles.audienceCall.base_income
+      amount: audienceCallBase.payout, // Spec: docs/normalized_economy.json → hustles.audienceCall.base_income
       logType: 'hustle',
       message: context => {
-        const payout = context?.finalPayout ?? context?.payoutGranted ?? audienceCallConfig.payout;
+        const payout = context?.finalPayout ?? context?.payoutGranted ?? audienceCallBase.payout;
         const bonusNote = context?.appliedEducationBoosts?.length
           ? ' Spotlight-ready banter brought in extra tips.'
           : '';
@@ -120,9 +147,9 @@ const instantHustleDefinitions = [
       slotsPerRoll: 2,
       maxActive: 3,
       metadata: {
-        requirements: { hours: audienceCallConfig.timeHours },
-        payout: { amount: audienceCallConfig.payout, schedule: 'onCompletion' },
-        hoursPerDay: audienceCallConfig.timeHours,
+        requirements: { hours: audienceCallBase.hours },
+        payout: { amount: audienceCallBase.payout, schedule: 'onCompletion' },
+        hoursPerDay: audienceCallBase.hours,
         daysRequired: 1,
         progressLabel: 'Host the Q&A stream'
       },
@@ -134,10 +161,10 @@ const instantHustleDefinitions = [
           copies: 2,
           durationDays: 0,
           metadata: {
-            payoutAmount: audienceCallConfig.payout,
+            payoutAmount: audienceCallBase.payout,
             payoutSchedule: 'onCompletion',
-            requirements: { hours: audienceCallConfig.timeHours },
-            hoursPerDay: audienceCallConfig.timeHours,
+            requirements: { hours: audienceCallBase.hours },
+            hoursPerDay: audienceCallBase.hours,
             daysRequired: 1,
             progressLabel: 'Host the flash AMA'
           }
@@ -148,10 +175,10 @@ const instantHustleDefinitions = [
           description: 'Break a dense topic into two cozy livestreams with downloadable extras.',
           durationDays: 1,
           metadata: {
-            payoutAmount: 24,
+            payoutAmount: computeHourlyPayout(audienceCallBase.hours * 2),
             payoutSchedule: 'onCompletion',
-            requirements: { hours: audienceCallConfig.timeHours * 2 },
-            hoursPerDay: audienceCallConfig.timeHours,
+            requirements: { hours: audienceCallBase.hours * 2 },
+            hoursPerDay: audienceCallBase.hours,
             daysRequired: 2,
             progressLabel: 'Run the mini workshop series'
           }
@@ -163,10 +190,10 @@ const instantHustleDefinitions = [
           availableAfterDays: 1,
           durationDays: 3,
           metadata: {
-            payoutAmount: 40,
+            payoutAmount: computeHourlyPayout(audienceCallBase.hours * 4.5),
             payoutSchedule: 'onCompletion',
-            requirements: { hours: audienceCallConfig.timeHours * 4 },
-            hoursPerDay: audienceCallConfig.timeHours * 1.5,
+            requirements: { hours: audienceCallBase.hours * 4.5 },
+            hoursPerDay: audienceCallBase.hours * 1.5,
             daysRequired: 3,
             progressLabel: 'Coach the cohort Q&A'
           }
@@ -189,10 +216,10 @@ const instantHustleDefinitions = [
     time: bundlePushConfig.timeHours, // Spec: docs/normalized_economy.json → hustles.bundlePush.setup_time
     requirements: bundlePushConfig.requirements,
     payout: {
-      amount: bundlePushConfig.payout, // Spec: docs/normalized_economy.json → hustles.bundlePush.base_income
+      amount: bundlePushBase.payout, // Spec: docs/normalized_economy.json → hustles.bundlePush.base_income
       logType: 'hustle',
       message: context => {
-        const payout = context?.finalPayout ?? context?.payoutGranted ?? bundlePushConfig.payout;
+        const payout = context?.finalPayout ?? context?.payoutGranted ?? bundlePushBase.payout;
         const bonusNote = context?.appliedEducationBoosts?.length
           ? ' Funnel math mastery made every upsell sparkle.'
           : '';
@@ -203,9 +230,9 @@ const instantHustleDefinitions = [
       slotsPerRoll: 2,
       maxActive: 3,
       metadata: {
-        requirements: { hours: bundlePushConfig.timeHours },
-        payout: { amount: bundlePushConfig.payout, schedule: 'onCompletion' },
-        hoursPerDay: bundlePushConfig.timeHours,
+        requirements: { hours: bundlePushBase.hours },
+        payout: { amount: bundlePushBase.payout, schedule: 'onCompletion' },
+        hoursPerDay: bundlePushBase.hours,
         daysRequired: 1,
         progressLabel: 'Bundle the featured offer'
       },
@@ -216,10 +243,10 @@ const instantHustleDefinitions = [
           description: 'Pair blog hits with a one-day bonus bundle and shout it across every channel.',
           durationDays: 0,
           metadata: {
-            payoutAmount: bundlePushConfig.payout,
+            payoutAmount: bundlePushBase.payout,
             payoutSchedule: 'onCompletion',
-            requirements: { hours: bundlePushConfig.timeHours },
-            hoursPerDay: bundlePushConfig.timeHours,
+            requirements: { hours: bundlePushBase.hours },
+            hoursPerDay: bundlePushBase.hours,
             daysRequired: 1,
             progressLabel: 'Run the flash sale blast'
           }
@@ -230,9 +257,9 @@ const instantHustleDefinitions = [
           description: 'Spin up a three-day partner push with curated bundles for every audience segment.',
           durationDays: 2,
           metadata: {
-            payoutAmount: 72,
+            payoutAmount: computeHourlyPayout(bundlePushBase.hours * 2.4),
             payoutSchedule: 'onCompletion',
-            requirements: { hours: bundlePushConfig.timeHours * 2.4 },
+            requirements: { hours: bundlePushBase.hours * 2.4 },
             hoursPerDay: 2,
             daysRequired: 3,
             progressLabel: 'Host the cross-promo roadshow'
@@ -245,10 +272,10 @@ const instantHustleDefinitions = [
           availableAfterDays: 1,
           durationDays: 4,
           metadata: {
-            payoutAmount: 120,
+            payoutAmount: computeHourlyPayout(bundlePushBase.hours * 5),
             payoutSchedule: 'onCompletion',
-            requirements: { hours: bundlePushConfig.timeHours * 5 },
-            hoursPerDay: bundlePushConfig.timeHours,
+            requirements: { hours: bundlePushBase.hours * 5 },
+            hoursPerDay: bundlePushBase.hours,
             daysRequired: 5,
             progressLabel: 'Optimize the evergreen funnel'
           }
@@ -271,10 +298,10 @@ const instantHustleDefinitions = [
     time: surveySprintConfig.timeHours, // Spec: docs/normalized_economy.json → hustles.surveySprint.setup_time
     dailyLimit: surveySprintConfig.dailyLimit, // Spec: docs/normalized_economy.json → hustles.surveySprint.daily_limit
     payout: {
-      amount: surveySprintConfig.payout, // Spec: docs/normalized_economy.json → hustles.surveySprint.base_income
+      amount: surveySprintBase.payout, // Spec: docs/normalized_economy.json → hustles.surveySprint.base_income
       logType: 'hustle',
       message: context => {
-        const payout = context?.finalPayout ?? context?.payoutGranted ?? surveySprintConfig.payout;
+        const payout = context?.finalPayout ?? context?.payoutGranted ?? surveySprintBase.payout;
         const bonusNote = context?.appliedEducationBoosts?.length
           ? ' Guerrilla research savvy bumped the stipend.'
           : '';
@@ -285,9 +312,9 @@ const instantHustleDefinitions = [
       slotsPerRoll: 3,
       maxActive: 5,
       metadata: {
-        requirements: { hours: surveySprintConfig.timeHours },
-        payout: { amount: surveySprintConfig.payout, schedule: 'onCompletion' },
-        hoursPerDay: surveySprintConfig.timeHours,
+        requirements: { hours: surveySprintBase.hours },
+        payout: { amount: surveySprintBase.payout, schedule: 'onCompletion' },
+        hoursPerDay: surveySprintBase.hours,
         daysRequired: 1,
         progressLabel: 'Complete the survey dash'
       },
@@ -299,10 +326,10 @@ const instantHustleDefinitions = [
           copies: 3,
           durationDays: 0,
           metadata: {
-            payoutAmount: surveySprintConfig.payout,
+            payoutAmount: surveySprintBase.payout,
             payoutSchedule: 'onCompletion',
-            requirements: { hours: surveySprintConfig.timeHours },
-            hoursPerDay: surveySprintConfig.timeHours,
+            requirements: { hours: surveySprintBase.hours },
+            hoursPerDay: surveySprintBase.hours,
             daysRequired: 1,
             progressLabel: 'Complete the coffee break survey'
           }
@@ -314,7 +341,7 @@ const instantHustleDefinitions = [
           copies: 2,
           durationDays: 1,
           metadata: {
-            payoutAmount: 3,
+            payoutAmount: computeHourlyPayout(1),
             payoutSchedule: 'onCompletion',
             requirements: { hours: 1 },
             hoursPerDay: 0.5,
@@ -329,7 +356,7 @@ const instantHustleDefinitions = [
           availableAfterDays: 1,
           durationDays: 2,
           metadata: {
-            payoutAmount: 5,
+            payoutAmount: computeHourlyPayout(2.25),
             payoutSchedule: 'onCompletion',
             requirements: { hours: 2.25 },
             hoursPerDay: 0.75,
@@ -355,10 +382,10 @@ const instantHustleDefinitions = [
     time: eventPhotoGigConfig.timeHours, // Spec: docs/normalized_economy.json → hustles.eventPhotoGig.setup_time
     requirements: eventPhotoGigConfig.requirements,
     payout: {
-      amount: eventPhotoGigConfig.payout, // Spec: docs/normalized_economy.json → hustles.eventPhotoGig.base_income
+      amount: eventPhotoGigBase.payout, // Spec: docs/normalized_economy.json → hustles.eventPhotoGig.base_income
       logType: 'hustle',
       message: context => {
-        const payout = context?.finalPayout ?? context?.payoutGranted ?? eventPhotoGigConfig.payout;
+        const payout = context?.finalPayout ?? context?.payoutGranted ?? eventPhotoGigBase.payout;
         const bonusNote = context?.appliedEducationBoosts?.length
           ? ' Curated portfolios impressed every client.'
           : '';
@@ -369,9 +396,9 @@ const instantHustleDefinitions = [
       slotsPerRoll: 1,
       maxActive: 2,
       metadata: {
-        requirements: { hours: eventPhotoGigConfig.timeHours },
-        payout: { amount: eventPhotoGigConfig.payout, schedule: 'onCompletion' },
-        hoursPerDay: eventPhotoGigConfig.timeHours,
+        requirements: { hours: eventPhotoGigBase.hours },
+        payout: { amount: eventPhotoGigBase.payout, schedule: 'onCompletion' },
+        hoursPerDay: eventPhotoGigBase.hours,
         daysRequired: 1,
         progressLabel: 'Shoot the event gallery'
       },
@@ -382,10 +409,10 @@ const instantHustleDefinitions = [
           description: 'Capture a lively pop-up showcase with a single-day gallery sprint.',
           durationDays: 0,
           metadata: {
-            payoutAmount: eventPhotoGigConfig.payout,
+            payoutAmount: eventPhotoGigBase.payout,
             payoutSchedule: 'onCompletion',
-            requirements: { hours: eventPhotoGigConfig.timeHours },
-            hoursPerDay: eventPhotoGigConfig.timeHours,
+            requirements: { hours: eventPhotoGigBase.hours },
+            hoursPerDay: eventPhotoGigBase.hours,
             daysRequired: 1,
             progressLabel: 'Deliver the pop-up gallery'
           }
@@ -396,7 +423,7 @@ const instantHustleDefinitions = [
           description: 'Cover a two-day festival run with daily highlight reels and VIP portraits.',
           durationDays: 2,
           metadata: {
-            payoutAmount: 120,
+            payoutAmount: computeHourlyPayout(9),
             payoutSchedule: 'onCompletion',
             requirements: { hours: 9 },
             hoursPerDay: 3,
@@ -411,7 +438,7 @@ const instantHustleDefinitions = [
           availableAfterDays: 1,
           durationDays: 4,
           metadata: {
-            payoutAmount: 180,
+            payoutAmount: computeHourlyPayout(15),
             payoutSchedule: 'onCompletion',
             requirements: { hours: 15 },
             hoursPerDay: 3,
@@ -437,10 +464,10 @@ const instantHustleDefinitions = [
     time: popUpWorkshopConfig.timeHours, // Spec: docs/normalized_economy.json → hustles.popUpWorkshop.setup_time
     requirements: popUpWorkshopConfig.requirements,
     payout: {
-      amount: popUpWorkshopConfig.payout, // Spec: docs/normalized_economy.json → hustles.popUpWorkshop.base_income
+      amount: popUpWorkshopBase.payout, // Spec: docs/normalized_economy.json → hustles.popUpWorkshop.base_income
       logType: 'hustle',
       message: context => {
-        const payout = context?.finalPayout ?? context?.payoutGranted ?? popUpWorkshopConfig.payout;
+        const payout = context?.finalPayout ?? context?.payoutGranted ?? popUpWorkshopBase.payout;
         const bonusNote = context?.appliedEducationBoosts?.length
           ? ' Teaching polish turned browsers into buyers.'
           : '';
@@ -451,9 +478,9 @@ const instantHustleDefinitions = [
       slotsPerRoll: 2,
       maxActive: 4,
       metadata: {
-        requirements: { hours: popUpWorkshopConfig.timeHours },
-        payout: { amount: popUpWorkshopConfig.payout, schedule: 'onCompletion' },
-        hoursPerDay: popUpWorkshopConfig.timeHours,
+        requirements: { hours: popUpWorkshopBase.hours },
+        payout: { amount: popUpWorkshopBase.payout, schedule: 'onCompletion' },
+        hoursPerDay: popUpWorkshopBase.hours,
         daysRequired: 1,
         progressLabel: 'Teach the workshop curriculum'
       },
@@ -465,10 +492,10 @@ const instantHustleDefinitions = [
           copies: 2,
           durationDays: 0,
           metadata: {
-            payoutAmount: popUpWorkshopConfig.payout,
+            payoutAmount: popUpWorkshopBase.payout,
             payoutSchedule: 'onCompletion',
-            requirements: { hours: popUpWorkshopConfig.timeHours },
-            hoursPerDay: popUpWorkshopConfig.timeHours,
+            requirements: { hours: popUpWorkshopBase.hours },
+            hoursPerDay: popUpWorkshopBase.hours,
             daysRequired: 1,
             progressLabel: 'Run the evening intensive'
           }
@@ -479,10 +506,10 @@ const instantHustleDefinitions = [
           description: 'Stretch the curriculum into a cozy two-day cohort with templates and recaps.',
           durationDays: 1,
           metadata: {
-            payoutAmount: 60,
+            payoutAmount: computeHourlyPayout(5),
             payoutSchedule: 'onCompletion',
             requirements: { hours: 5 },
-            hoursPerDay: popUpWorkshopConfig.timeHours,
+            hoursPerDay: popUpWorkshopBase.hours,
             daysRequired: 2,
             progressLabel: 'Guide the weekend workshop'
           }
@@ -494,7 +521,7 @@ const instantHustleDefinitions = [
           availableAfterDays: 1,
           durationDays: 3,
           metadata: {
-            payoutAmount: 95,
+            payoutAmount: computeHourlyPayout(8),
             payoutSchedule: 'onCompletion',
             requirements: { hours: 8 },
             hoursPerDay: 2,
@@ -520,10 +547,10 @@ const instantHustleDefinitions = [
     time: vlogEditRushConfig.timeHours, // Spec: docs/normalized_economy.json → hustles.vlogEditRush.setup_time
     requirements: vlogEditRushConfig.requirements,
     payout: {
-      amount: vlogEditRushConfig.payout, // Spec: docs/normalized_economy.json → hustles.vlogEditRush.base_income
+      amount: vlogEditRushBase.payout, // Spec: docs/normalized_economy.json → hustles.vlogEditRush.base_income
       logType: 'hustle',
       message: context => {
-        const payout = context?.finalPayout ?? context?.payoutGranted ?? vlogEditRushConfig.payout;
+        const payout = context?.finalPayout ?? context?.payoutGranted ?? vlogEditRushBase.payout;
         const bonusNote = context?.appliedEducationBoosts?.length
           ? ' Post-production precision shaved hours off the deadline.'
           : '';
@@ -534,9 +561,9 @@ const instantHustleDefinitions = [
       slotsPerRoll: 2,
       maxActive: 4,
       metadata: {
-        requirements: { hours: vlogEditRushConfig.timeHours },
-        payout: { amount: vlogEditRushConfig.payout, schedule: 'onCompletion' },
-        hoursPerDay: vlogEditRushConfig.timeHours,
+        requirements: { hours: vlogEditRushBase.hours },
+        payout: { amount: vlogEditRushBase.payout, schedule: 'onCompletion' },
+        hoursPerDay: vlogEditRushBase.hours,
         daysRequired: 1,
         progressLabel: 'Edit the partner episode'
       },
@@ -548,10 +575,10 @@ const instantHustleDefinitions = [
           copies: 2,
           durationDays: 0,
           metadata: {
-            payoutAmount: vlogEditRushConfig.payout,
+            payoutAmount: vlogEditRushBase.payout,
             payoutSchedule: 'onCompletion',
-            requirements: { hours: vlogEditRushConfig.timeHours },
-            hoursPerDay: vlogEditRushConfig.timeHours,
+            requirements: { hours: vlogEditRushBase.hours },
+            hoursPerDay: vlogEditRushBase.hours,
             daysRequired: 1,
             progressLabel: 'Deliver the rush cut'
           }
@@ -562,10 +589,10 @@ const instantHustleDefinitions = [
           description: 'Turn around two episodes with shared motion graphics and reusable transitions.',
           durationDays: 1,
           metadata: {
-            payoutAmount: 40,
+            payoutAmount: computeHourlyPayout(3),
             payoutSchedule: 'onCompletion',
             requirements: { hours: 3 },
-            hoursPerDay: vlogEditRushConfig.timeHours,
+            hoursPerDay: vlogEditRushBase.hours,
             daysRequired: 2,
             progressLabel: 'Deliver the batch edit package'
           }
@@ -577,7 +604,7 @@ const instantHustleDefinitions = [
           availableAfterDays: 1,
           durationDays: 3,
           metadata: {
-            payoutAmount: 70,
+            payoutAmount: computeHourlyPayout(7),
             payoutSchedule: 'onCompletion',
             requirements: { hours: 7 },
             hoursPerDay: 1.75,
@@ -604,10 +631,10 @@ const instantHustleDefinitions = [
     cost: dropshipPackPartyConfig.cost, // Spec: docs/normalized_economy.json → hustles.dropshipPackParty.setup_cost
     requirements: dropshipPackPartyConfig.requirements,
     payout: {
-      amount: dropshipPackPartyConfig.payout, // Spec: docs/normalized_economy.json → hustles.dropshipPackParty.base_income
+      amount: dropshipPackPartyBase.payout, // Spec: docs/normalized_economy.json → hustles.dropshipPackParty.base_income
       logType: 'hustle',
       message: context => {
-        const payout = context?.finalPayout ?? context?.payoutGranted ?? dropshipPackPartyConfig.payout;
+        const payout = context?.finalPayout ?? context?.payoutGranted ?? dropshipPackPartyBase.payout;
         const bonusNote = context?.appliedEducationBoosts?.length
           ? ' Logistics drills kept the conveyor humming.'
           : '';
@@ -618,9 +645,9 @@ const instantHustleDefinitions = [
       slotsPerRoll: 2,
       maxActive: 4,
       metadata: {
-        requirements: { hours: dropshipPackPartyConfig.timeHours },
-        payout: { amount: dropshipPackPartyConfig.payout, schedule: 'onCompletion' },
-        hoursPerDay: dropshipPackPartyConfig.timeHours,
+        requirements: { hours: dropshipPackPartyBase.hours },
+        payout: { amount: dropshipPackPartyBase.payout, schedule: 'onCompletion' },
+        hoursPerDay: dropshipPackPartyBase.hours,
         daysRequired: 1,
         progressLabel: 'Pack the surprise boxes'
       },
@@ -632,10 +659,10 @@ const instantHustleDefinitions = [
           copies: 2,
           durationDays: 0,
           metadata: {
-            payoutAmount: dropshipPackPartyConfig.payout,
+            payoutAmount: dropshipPackPartyBase.payout,
             payoutSchedule: 'onCompletion',
-            requirements: { hours: dropshipPackPartyConfig.timeHours },
-            hoursPerDay: dropshipPackPartyConfig.timeHours,
+            requirements: { hours: dropshipPackPartyBase.hours },
+            hoursPerDay: dropshipPackPartyBase.hours,
             daysRequired: 1,
             progressLabel: 'Handle the flash pack party'
           }
@@ -646,7 +673,7 @@ const instantHustleDefinitions = [
           description: 'Keep the warehouse humming through a two-day influencer spotlight.',
           durationDays: 1,
           metadata: {
-            payoutAmount: 50,
+            payoutAmount: computeHourlyPayout(5),
             payoutSchedule: 'onCompletion',
             requirements: { hours: 5 },
             hoursPerDay: 2.5,
@@ -661,7 +688,7 @@ const instantHustleDefinitions = [
           availableAfterDays: 1,
           durationDays: 3,
           metadata: {
-            payoutAmount: 90,
+            payoutAmount: computeHourlyPayout(10),
             payoutSchedule: 'onCompletion',
             requirements: { hours: 10 },
             hoursPerDay: 2.5,
@@ -688,10 +715,10 @@ const instantHustleDefinitions = [
     time: saasBugSquashConfig.timeHours, // Spec: docs/normalized_economy.json → hustles.saasBugSquash.setup_time
     requirements: saasBugSquashConfig.requirements,
     payout: {
-      amount: saasBugSquashConfig.payout, // Spec: docs/normalized_economy.json → hustles.saasBugSquash.base_income
+      amount: saasBugSquashBase.payout, // Spec: docs/normalized_economy.json → hustles.saasBugSquash.base_income
       logType: 'hustle',
       message: context => {
-        const payout = context?.finalPayout ?? context?.payoutGranted ?? saasBugSquashConfig.payout;
+        const payout = context?.finalPayout ?? context?.payoutGranted ?? saasBugSquashBase.payout;
         const bonusNote = context?.appliedEducationBoosts?.length
           ? ' Architectural insights made debugging a breeze.'
           : '';
@@ -702,9 +729,9 @@ const instantHustleDefinitions = [
       slotsPerRoll: 2,
       maxActive: 3,
       metadata: {
-        requirements: { hours: saasBugSquashConfig.timeHours },
-        payout: { amount: saasBugSquashConfig.payout, schedule: 'onCompletion' },
-        hoursPerDay: saasBugSquashConfig.timeHours,
+        requirements: { hours: saasBugSquashBase.hours },
+        payout: { amount: saasBugSquashBase.payout, schedule: 'onCompletion' },
+        hoursPerDay: saasBugSquashBase.hours,
         daysRequired: 1,
         progressLabel: 'Deploy the emergency fix'
       },
@@ -716,10 +743,10 @@ const instantHustleDefinitions = [
           copies: 2,
           durationDays: 0,
           metadata: {
-            payoutAmount: saasBugSquashConfig.payout,
+            payoutAmount: saasBugSquashBase.payout,
             payoutSchedule: 'onCompletion',
-            requirements: { hours: saasBugSquashConfig.timeHours },
-            hoursPerDay: saasBugSquashConfig.timeHours,
+            requirements: { hours: saasBugSquashBase.hours },
+            hoursPerDay: saasBugSquashBase.hours,
             daysRequired: 1,
             progressLabel: 'Ship the emergency hotfix'
           }
@@ -730,7 +757,7 @@ const instantHustleDefinitions = [
           description: 'Audit the service, expand tests, and close regression gaps over two days.',
           durationDays: 1,
           metadata: {
-            payoutAmount: 55,
+            payoutAmount: computeHourlyPayout(2.5),
             payoutSchedule: 'onCompletion',
             requirements: { hours: 2.5 },
             hoursPerDay: 1.25,
@@ -745,7 +772,7 @@ const instantHustleDefinitions = [
           availableAfterDays: 1,
           durationDays: 3,
           metadata: {
-            payoutAmount: 90,
+            payoutAmount: computeHourlyPayout(6),
             payoutSchedule: 'onCompletion',
             requirements: { hours: 6 },
             hoursPerDay: 1.5,
@@ -771,10 +798,10 @@ const instantHustleDefinitions = [
     time: audiobookNarrationConfig.timeHours, // Spec: docs/normalized_economy.json → hustles.audiobookNarration.setup_time
     requirements: audiobookNarrationConfig.requirements,
     payout: {
-      amount: audiobookNarrationConfig.payout, // Spec: docs/normalized_economy.json → hustles.audiobookNarration.base_income
+      amount: audiobookNarrationBase.payout, // Spec: docs/normalized_economy.json → hustles.audiobookNarration.base_income
       logType: 'hustle',
       message: context => {
-        const payout = context?.finalPayout ?? context?.payoutGranted ?? audiobookNarrationConfig.payout;
+        const payout = context?.finalPayout ?? context?.payoutGranted ?? audiobookNarrationBase.payout;
         const bonusNote = context?.appliedEducationBoosts?.length
           ? ' Narrative confidence kept the script soaring.'
           : '';
@@ -785,9 +812,9 @@ const instantHustleDefinitions = [
       slotsPerRoll: 1,
       maxActive: 2,
       metadata: {
-        requirements: { hours: audiobookNarrationConfig.timeHours },
-        payout: { amount: audiobookNarrationConfig.payout, schedule: 'onCompletion' },
-        hoursPerDay: audiobookNarrationConfig.timeHours,
+        requirements: { hours: audiobookNarrationBase.hours },
+        payout: { amount: audiobookNarrationBase.payout, schedule: 'onCompletion' },
+        hoursPerDay: audiobookNarrationBase.hours,
         daysRequired: 1,
         progressLabel: 'Narrate the featured chapter'
       },
@@ -798,10 +825,10 @@ const instantHustleDefinitions = [
           description: 'Record a standout sample chapter with layered ambience and polish.',
           durationDays: 0,
           metadata: {
-            payoutAmount: audiobookNarrationConfig.payout,
+            payoutAmount: audiobookNarrationBase.payout,
             payoutSchedule: 'onCompletion',
-            requirements: { hours: audiobookNarrationConfig.timeHours },
-            hoursPerDay: audiobookNarrationConfig.timeHours,
+            requirements: { hours: audiobookNarrationBase.hours },
+            hoursPerDay: audiobookNarrationBase.hours,
             daysRequired: 1,
             progressLabel: 'Cut the sample session'
           }
@@ -812,7 +839,7 @@ const instantHustleDefinitions = [
           description: 'Deliver two feature chapters with bonus pickups and breath edits.',
           durationDays: 1,
           metadata: {
-            payoutAmount: 70,
+            payoutAmount: computeHourlyPayout(5),
             payoutSchedule: 'onCompletion',
             requirements: { hours: 5 },
             hoursPerDay: 2.5,
@@ -827,7 +854,7 @@ const instantHustleDefinitions = [
           availableAfterDays: 1,
           durationDays: 4,
           metadata: {
-            payoutAmount: 120,
+            payoutAmount: computeHourlyPayout(12.5),
             payoutSchedule: 'onCompletion',
             requirements: { hours: 12.5 },
             hoursPerDay: 2.5,
@@ -854,10 +881,10 @@ const instantHustleDefinitions = [
     cost: streetPromoSprintConfig.cost, // Spec: docs/normalized_economy.json → hustles.streetPromoSprint.setup_cost
     requirements: streetPromoSprintConfig.requirements,
     payout: {
-      amount: streetPromoSprintConfig.payout, // Spec: docs/normalized_economy.json → hustles.streetPromoSprint.base_income
+      amount: streetPromoSprintBase.payout, // Spec: docs/normalized_economy.json → hustles.streetPromoSprint.base_income
       logType: 'hustle',
       message: context => {
-        const payout = context?.finalPayout ?? context?.payoutGranted ?? streetPromoSprintConfig.payout;
+        const payout = context?.finalPayout ?? context?.payoutGranted ?? streetPromoSprintBase.payout;
         const bonusNote = context?.appliedEducationBoosts?.length
           ? ' Guerrilla tactics drew a bigger crowd.'
           : '';
@@ -868,9 +895,9 @@ const instantHustleDefinitions = [
       slotsPerRoll: 3,
       maxActive: 5,
       metadata: {
-        requirements: { hours: streetPromoSprintConfig.timeHours },
-        payout: { amount: streetPromoSprintConfig.payout, schedule: 'onCompletion' },
-        hoursPerDay: streetPromoSprintConfig.timeHours,
+        requirements: { hours: streetPromoSprintBase.hours },
+        payout: { amount: streetPromoSprintBase.payout, schedule: 'onCompletion' },
+        hoursPerDay: streetPromoSprintBase.hours,
         daysRequired: 1,
         progressLabel: 'Hit the street team route'
       },
@@ -882,10 +909,10 @@ const instantHustleDefinitions = [
           copies: 3,
           durationDays: 0,
           metadata: {
-            payoutAmount: streetPromoSprintConfig.payout,
+            payoutAmount: streetPromoSprintBase.payout,
             payoutSchedule: 'onCompletion',
-            requirements: { hours: streetPromoSprintConfig.timeHours },
-            hoursPerDay: streetPromoSprintConfig.timeHours,
+            requirements: { hours: streetPromoSprintBase.hours },
+            hoursPerDay: streetPromoSprintBase.hours,
             daysRequired: 1,
             progressLabel: 'Cover the lunch rush route'
           }
@@ -897,7 +924,7 @@ const instantHustleDefinitions = [
           copies: 2,
           durationDays: 1,
           metadata: {
-            payoutAmount: 32,
+            payoutAmount: computeHourlyPayout(2),
             payoutSchedule: 'onCompletion',
             requirements: { hours: 2 },
             hoursPerDay: 1,
@@ -912,7 +939,7 @@ const instantHustleDefinitions = [
           availableAfterDays: 1,
           durationDays: 3,
           metadata: {
-            payoutAmount: 60,
+            payoutAmount: computeHourlyPayout(5),
             payoutSchedule: 'onCompletion',
             requirements: { hours: 5 },
             hoursPerDay: 1.25,

--- a/tests/hustles.test.js
+++ b/tests/hustles.test.js
@@ -154,7 +154,7 @@ test('education flat bonuses add to audience call payouts', () => {
   baseState.timeLeft = 10;
   getAssetState('blog', baseState).instances = [{ status: 'active' }];
   ACTIONS.find(hustle => hustle.id === 'audienceCall').action.onClick();
-  assert.equal(baseState.money, 12, 'baseline Q&A payout should be $12 without training');
+  assert.equal(baseState.money, 9, 'baseline Q&A payout should be $9 without training');
 
   resetState();
 
@@ -166,7 +166,7 @@ test('education flat bonuses add to audience call payouts', () => {
   brandVoice.completed = true;
   ACTIONS.find(hustle => hustle.id === 'audienceCall').action.onClick();
 
-  assert.equal(boostedState.money, 16, 'brand voice lab should add a $4 tip boost');
+  assert.equal(boostedState.money, 13, 'brand voice lab should add a $4 tip boost');
   assert.match(
     boostedState.log.at(-1).message,
     /Brand Voice Lab/,
@@ -183,7 +183,7 @@ test('curriculum design studio multiplies workshop payouts', () => {
   getAssetState('blog', baseState).instances = [{ status: 'active' }];
   getAssetState('ebook', baseState).instances = [{ status: 'active' }];
   ACTIONS.find(hustle => hustle.id === 'popUpWorkshop').action.onClick();
-  assert.equal(baseState.money, 38, 'baseline workshop payout should be $38 without study');
+  assert.equal(baseState.money, 23, 'baseline workshop payout should be $23 without study');
 
   resetState();
 
@@ -196,7 +196,7 @@ test('curriculum design studio multiplies workshop payouts', () => {
   curriculum.completed = true;
   ACTIONS.find(hustle => hustle.id === 'popUpWorkshop').action.onClick();
 
-  assert.equal(boostedState.money, 49, 'curriculum design studio should add a 30% multiplier (rounded)');
+  assert.equal(boostedState.money, 29, 'curriculum design studio should add a 30% multiplier (rounded)');
   assert.match(
     boostedState.log.at(-1).message,
     /Curriculum Design Studio/,
@@ -265,13 +265,13 @@ test('audience call can only run once per day', () => {
   const audience = ACTIONS.find(hustle => hustle.id === 'audienceCall');
   audience.action.onClick();
 
-  assert.equal(state.money, 12, 'first run should pay out');
+  assert.equal(state.money, 9, 'first run should pay out');
   assert.equal(getActionState('audienceCall').runsToday, 1, 'daily counter should increment after the first run');
 
   const beforeLogLength = state.log.length;
   audience.action.onClick();
 
-  assert.equal(state.money, 12, 'second run should be blocked by the daily limit');
+  assert.equal(state.money, 9, 'second run should be blocked by the daily limit');
   assert.equal(getActionState('audienceCall').runsToday, 1, 'daily counter should not increase after hitting the cap');
   assert.equal(state.log.length, beforeLogLength + 1, 'player should receive a log warning when capped');
   assert.match(state.log.at(-1).message, /Daily limit/, 'log should mention the daily limit reason');
@@ -283,7 +283,7 @@ test('audience call can only run once per day', () => {
 
   const beforeMoney = state.money;
   audience.action.onClick();
-  assert.equal(state.money, beforeMoney + 12, 'limit should reset the following day');
+  assert.equal(state.money, beforeMoney + 9, 'limit should reset the following day');
   assert.equal(getActionState('audienceCall').runsToday, 1, 'counter should start over on the new day');
 });
 
@@ -300,7 +300,7 @@ test('survey sprint caps at four runs per day', () => {
     survey.action.onClick();
   }
 
-  assert.equal(state.money, 4, 'four successful runs should pay out $4 total');
+  assert.equal(state.money, 8, 'four successful runs should pay out $8 total');
   assert.equal(getActionState('surveySprint').runsToday, 4, 'counter should reflect four completed runs');
 
   const beforeMoney = state.money;
@@ -319,6 +319,6 @@ test('survey sprint caps at four runs per day', () => {
 
   const afterResetMoney = state.money;
   survey.action.onClick();
-  assert.equal(state.money, afterResetMoney + 1, 'new day should allow survey sprint again');
+  assert.equal(state.money, afterResetMoney + 2, 'new day should allow survey sprint again');
   assert.equal(getActionState('surveySprint').runsToday, 1, 'counter should restart after reset');
 });


### PR DESCRIPTION
## Summary
- standardize hustle payouts around a shared $9/hour helper and propagate the derived amounts to every offer variant
- refresh the normalized economy data plus README and hustle market docs to explain the new hourly balance
- update hustle regression tests so baseline and boosted payouts match the new values

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e301902a3c832c88a039dcee3fb2cd