### PR TITLE
Fix DownWork contract acceptance refresh

### DIFF
--- a/src/game/hustles.js
+++ b/src/game/hustles.js
@@ -10,6 +10,7 @@ import {
 } from '../core/state/slices/hustleMarket.js';
 import { definitionRequirementsMet } from './requirements/checks.js';
 import { describeHustleRequirements } from './hustles/helpers.js';
+import { markDirty } from '../core/events/invalidationBus.js';
 
 export const HUSTLE_TEMPLATES = INSTANT_ACTIONS;
 export const KNOWLEDGE_HUSTLES = STUDY_ACTIONS;
@@ -270,7 +271,7 @@ export function acceptHustleOffer(offerOrId, { state = getState() } = {}) {
     payoutDetails.amount = payoutAmount;
   }
 
-  return claimHustleMarketOffer(workingState, offer.id, {
+  const acceptedEntry = claimHustleMarketOffer(workingState, offer.id, {
     acceptedOnDay,
     deadlineDay: deadlineDay ?? offer.availableOnDay,
     hoursRequired: hoursRequired != null ? hoursRequired : instance.hoursRequired,
@@ -278,4 +279,14 @@ export function acceptHustleOffer(offerOrId, { state = getState() } = {}) {
     payout: payoutDetails,
     metadata
   });
+
+  if (acceptedEntry) {
+    markDirty({
+      dashboard: true,
+      cards: true,
+      headerAction: true
+    });
+  }
+
+  return acceptedEntry;
 }


### PR DESCRIPTION
## Summary
- mark hustle offer acceptance as dirty for the dashboard, cards, and header action presenters so widgets refresh after claiming a contract

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e307a78e3c832cbbda2d8cb9735889