### PR TITLE
Hide locked offers on DownWork

### DIFF
--- a/src/ui/views/browser/apps/hustles.js
+++ b/src/ui/views/browser/apps/hustles.js
@@ -195,7 +195,13 @@ function createHustleCard(definition, model) {
   card.dataset.time = String(model.metrics?.time?.value ?? 0);
   card.dataset.payout = String(model.metrics?.payout?.value ?? 0);
   card.dataset.roi = String(model.metrics?.roi ?? 0);
-  card.dataset.available = model.filters?.available ? 'true' : 'false';
+  const visibleOffers = Array.isArray(model.offers)
+    ? model.offers.filter(offer => !offer?.locked)
+    : [];
+  const visibleUpcoming = Array.isArray(model.upcoming)
+    ? model.upcoming.filter(offer => !offer?.locked)
+    : [];
+  card.dataset.available = visibleOffers.length > 0 ? 'true' : 'false';
   if (model.filters?.limitRemaining !== null && model.filters?.limitRemaining !== undefined) {
     card.dataset.limitRemaining = String(model.filters.limitRemaining);
   }
@@ -289,14 +295,14 @@ function createHustleCard(definition, model) {
     card.appendChild(commitmentsSection);
   }
 
-  if (Array.isArray(model.offers) && model.offers.length) {
+  if (visibleOffers.length) {
     const offersSection = createCardSection(
       'Ready to accept',
       'Fresh hustles just landed! Grab the one that sparks your curiosity.'
     );
     const list = document.createElement('ul');
     list.className = 'browser-card__list';
-    model.offers.forEach(offer => {
+    visibleOffers.forEach(offer => {
       const item = createOfferItem(offer);
       list.appendChild(item);
     });
@@ -304,14 +310,14 @@ function createHustleCard(definition, model) {
     card.appendChild(offersSection);
   }
 
-  if (Array.isArray(model.upcoming) && model.upcoming.length) {
+  if (visibleUpcoming.length) {
     const upcomingSection = createCardSection(
       'Coming tomorrow',
       'These leads unlock with the next market refresh. Prep your pitch now!'
     );
     const list = document.createElement('ul');
     list.className = 'browser-card__list';
-    model.upcoming.forEach(offer => {
+    visibleUpcoming.forEach(offer => {
       const item = createOfferItem(offer, { upcoming: true });
       list.appendChild(item);
     });
@@ -349,7 +355,10 @@ export default function renderHustles(context = {}, definitions = [], models = [
     const model = modelMap.get(definition.id);
     if (!model) return;
 
-    if (model.filters?.available) {
+    const visibleOffersCount = Array.isArray(model.offers)
+      ? model.offers.filter(offer => !offer?.locked).length
+      : 0;
+    if (visibleOffersCount > 0) {
       availableCount += 1;
     }
 
@@ -357,8 +366,11 @@ export default function renderHustles(context = {}, definitions = [], models = [
       commitmentCount += model.commitments.length;
     }
 
-    if (Array.isArray(model.upcoming)) {
-      upcomingCount += model.upcoming.length;
+    const visibleUpcomingCount = Array.isArray(model.upcoming)
+      ? model.upcoming.filter(offer => !offer?.locked).length
+      : 0;
+    if (visibleUpcomingCount > 0) {
+      upcomingCount += visibleUpcomingCount;
     }
 
     const card = createHustleCard(definition, model);

--- a/tests/ui/views/browser/hustlesApp.test.js
+++ b/tests/ui/views/browser/hustlesApp.test.js
@@ -104,6 +104,112 @@ test('renderHustles highlights accept CTA and upcoming list', () => {
   }
 });
 
+test('renderHustles omits locked offers from DownWork feed', () => {
+  const dom = setupDom();
+  const context = {
+    ensurePageContent: (_page, builder) => {
+      const body = document.createElement('div');
+      builder({ body });
+      document.body.appendChild(body);
+      return { body };
+    }
+  };
+
+  const definitions = [
+    {
+      id: 'locked-filter',
+      name: 'Locked Filter Hustle',
+      description: 'Only unlocked offers should appear.',
+      action: { label: 'Legacy' }
+    }
+  ];
+
+  const models = [
+    {
+      id: 'locked-filter',
+      name: 'Locked Filter Hustle',
+      description: 'Only unlocked offers should appear.',
+      badges: [],
+      metrics: {
+        time: { value: 1, label: '1h' },
+        payout: { value: 25, label: '$25' },
+        roi: 25
+      },
+      requirements: { summary: 'No requirements', items: [] },
+      action: {
+        label: 'Accept Open Offer',
+        disabled: false,
+        className: 'primary',
+        onClick: () => {}
+      },
+      available: true,
+      offers: [
+        {
+          id: 'offer-locked',
+          label: 'Locked Ready Offer',
+          description: 'Hidden because locked.',
+          meta: 'Locked meta',
+          payout: 25,
+          ready: true,
+          availableIn: 0,
+          expiresIn: 2,
+          locked: true
+        },
+        {
+          id: 'offer-open',
+          label: 'Open Ready Offer',
+          description: 'Visible offer.',
+          meta: 'Open now',
+          payout: 25,
+          ready: true,
+          availableIn: 0,
+          expiresIn: 2,
+          locked: false
+        }
+      ],
+      upcoming: [
+        {
+          id: 'offer-locked-upcoming',
+          label: 'Locked Upcoming Offer',
+          description: 'Hidden upcoming offer.',
+          meta: 'Locked upcoming',
+          ready: false,
+          availableIn: 2,
+          expiresIn: 3,
+          locked: true
+        },
+        {
+          id: 'offer-open-upcoming',
+          label: 'Open Upcoming Offer',
+          description: 'Visible upcoming offer.',
+          meta: 'Unlocks soon',
+          ready: false,
+          availableIn: 1,
+          expiresIn: 4,
+          locked: false
+        }
+      ],
+      commitments: [],
+      filters: { available: true }
+    }
+  ];
+
+  try {
+    renderHustles(context, definitions, models);
+
+    const titles = [...document.querySelectorAll('.hustle-card__title')]
+      .map(node => node.textContent);
+    assert.ok(titles.includes('Open Ready Offer'), 'expected unlocked offer to remain visible');
+    assert.ok(!titles.includes('Locked Ready Offer'), 'expected locked offer to be hidden');
+    assert.ok(titles.includes('Open Upcoming Offer'), 'expected unlocked upcoming to remain visible');
+    assert.ok(!titles.includes('Locked Upcoming Offer'), 'expected locked upcoming offer to be hidden');
+  } finally {
+    dom.window.close();
+    delete globalThis.window;
+    delete globalThis.document;
+  }
+});
+
 test('renderHustles falls back to empty-state language when no offers exist', () => {
   const dom = setupDom();
   const context = {


### PR DESCRIPTION
## Summary
- hide locked hustle offers from the DownWork workspace lists
- align hustle card availability metadata with the visible offers
- add coverage to confirm locked offers are filtered out of the feed

## Testing
- npm test -- tests/ui/views/browser/hustlesApp.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e30ed2dd34832cbdf18ed0a02d41f2