### PR TITLE
Fix duplicate course tasks in todo queue

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix: Deduplicated TODO queue entries so Learnly study sessions only appear once per day, preventing accidental double logs.
 - Hustles: Rebalanced multi-day contract payouts around base hourly earnings (with a 5% commitment bonus) and introduced the Data Entry Blitz gig with 4h and 8h variants for steady $5/hour work.
 - Hustles: Contract templates now publish multi-variant market metadata (hours-per-day, duration windows, payout schedules, copies) so daily rolls surface retainers alongside quick gigs.【F:src/game/hustles/definitions/instantHustles.js†L19-L855】
 - Tooling: `rollDailyOffers` records per-template audit summaries, exposes `getMarketRollAuditLog()`, and attaches `window.__HUSTLE_MARKET_DEBUG__` helpers for playtests.【F:src/game/hustles/market.js†L12-L755】

--- a/src/ui/actions/registry.js
+++ b/src/ui/actions/registry.js
@@ -455,6 +455,57 @@ function ensureResourceLabels(queue, state = {}) {
   }
 }
 
+function selectPreferredEntry(candidate, existing) {
+  const candidateHasHandler = typeof candidate?.onClick === 'function';
+  const existingHasHandler = typeof existing?.onClick === 'function';
+
+  if (candidateHasHandler && !existingHasHandler) {
+    return candidate;
+  }
+
+  if (!candidateHasHandler && existingHasHandler) {
+    return existing;
+  }
+
+  return existing;
+}
+
+function dedupeEntries(entries = []) {
+  if (!Array.isArray(entries) || entries.length <= 1) {
+    return entries;
+  }
+
+  const unique = [];
+  const seen = new Map();
+
+  entries.forEach(entry => {
+    if (!entry || typeof entry !== 'object') {
+      return;
+    }
+
+    const id = entry.id;
+    if (!id) {
+      unique.push(entry);
+      return;
+    }
+
+    const record = seen.get(id);
+    if (!record) {
+      const index = unique.push(entry) - 1;
+      seen.set(id, { index, entry });
+      return;
+    }
+
+    const preferred = selectPreferredEntry(entry, record.entry);
+    if (preferred !== record.entry) {
+      unique[record.index] = preferred;
+      seen.set(id, { index: record.index, entry: preferred });
+    }
+  });
+
+  return unique;
+}
+
 export function buildActionQueue({ state, summary = {} } = {}) {
   const resolvedState = state || getState() || {};
   const queue = {
@@ -482,6 +533,8 @@ export function buildActionQueue({ state, summary = {} } = {}) {
     });
     applyMetrics(queue, snapshot.metrics);
   });
+
+  queue.entries = dedupeEntries(queue.entries);
 
   if (!queue.entries.length && !queue.emptyMessage) {
     queue.emptyMessage = DEFAULT_EMPTY_MESSAGE;

--- a/tests/ui/actions/registry.test.js
+++ b/tests/ui/actions/registry.test.js
@@ -191,6 +191,34 @@ test('buildActionQueue includes the active day when provided', () => {
   }
 });
 
+test('buildActionQueue deduplicates entries by id and prefers interactive handlers', () => {
+  const restore = clearActionProviders();
+  try {
+    registerActionProvider(() => ({
+      id: 'duplicate-provider',
+      entries: [
+        { id: 'study-track', title: 'Study session', durationHours: 2 },
+        {
+          id: 'study-track',
+          title: 'Interactive study session',
+          durationHours: 2,
+          onClick: () => true
+        }
+      ],
+      metrics: {}
+    }));
+
+    const queue = buildActionQueue({ state: {} });
+    assert.equal(queue.entries.length, 1);
+    const [entry] = queue.entries;
+    assert.equal(entry.id, 'study-track');
+    assert.equal(entry.title, 'Interactive study session');
+    assert.equal(typeof entry.onClick, 'function');
+  } finally {
+    restore();
+  }
+});
+
 test('normalizeActionEntries mirrors todo normalization rules', () => {
   const entries = normalizeActionEntries([
     { id: 'direct', timeCost: 3, payout: 90 }


### PR DESCRIPTION
## Summary
- dedupe TODO queue entries so duplicate study sessions from Learnly no longer appear
- prefer the interactive version of duplicate entries to keep course logging working
- cover the regression with a node:test case and note the fix in the changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e31104f034832ca55ee08d6ec0d69e