### PR TITLE
Refine hustle offer grouping and seat-aware UI

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- UI: Hustle quick actions group market variants, surface commitment length and expiry, and card views now spotlight seat limits and market categories across Hustles and Learnly.
 - Hustles: Rebalanced multi-day contract payouts around base hourly earnings (with a 5% commitment bonus) and introduced the Data Entry Blitz gig with 4h and 8h variants for steady $5/hour work.
 - Hustles: Contract templates now publish multi-variant market metadata (hours-per-day, duration windows, payout schedules, copies) so daily rolls surface retainers alongside quick gigs.【F:src/game/hustles/definitions/instantHustles.js†L19-L855】
 - Tooling: `rollDailyOffers` records per-template audit summaries, exposes `getMarketRollAuditLog()`, and attaches `window.__HUSTLE_MARKET_DEBUG__` helpers for playtests.【F:src/game/hustles/market.js†L12-L755】

--- a/docs/features/hustle-market.md
+++ b/docs/features/hustle-market.md
@@ -70,4 +70,5 @@
 - When manual rerolls are disabled (and no offers exist), hustle cards swap the queue button for a cheerful "Check back tomorrow" hint instead of falling back to hidden instant actions.
 - Celebratory copy now leads the experience—"Fresh hustles just landed!"—whenever offers, upcoming slots, or commitments exist, only falling back to the quiet reroll language when the market is truly empty.
 - Dashboard quick actions surface active offers only. When the market is empty they present a "Check back tomorrow" guidance tile instead of invoking hidden instant-action fallbacks.
+- Dashboard and browser surfaces group offers by template/variant, note multi-day commitments, and call out seat policies so limited cohorts feel tangible while category filters keep the grid organized.
 - `createInstantHustle` still exposes an `action.onClick` for tests and tooling, but it is flagged with `isLegacyInstant`/`hiddenFromMarket` and UI layers ignore it when building hustle cards or quick actions so production surfaces depend exclusively on offer acceptance.

--- a/src/ui/actions/registry.js
+++ b/src/ui/actions/registry.js
@@ -19,6 +19,23 @@ import {
 
 const DEFAULT_EMPTY_MESSAGE = 'Queue a hustle or upgrade to add new tasks.';
 
+function resolveCategoryLabel(...values) {
+  for (const value of values) {
+    if (typeof value !== 'string') continue;
+    const trimmed = value.trim();
+    if (!trimmed) continue;
+    const lowered = trimmed.toLowerCase();
+    if (lowered.startsWith('study') || lowered.startsWith('education')) {
+      return 'study';
+    }
+    if (lowered.startsWith('maint')) {
+      return 'maintenance';
+    }
+    return lowered;
+  }
+  return null;
+}
+
 function collectMarketIndexes(state = {}) {
   const market = state?.hustleMarket || {};
   const offers = Array.isArray(market.offers) ? market.offers : [];
@@ -286,6 +303,15 @@ function createOutstandingEntry({
       ? 'todo-widget__meta--alert'
       : undefined;
 
+  const category = resolveCategoryLabel(
+    progress.metadata?.templateCategory,
+    progress.metadata?.category,
+    accepted?.metadata?.templateCategory,
+    offer?.templateCategory,
+    definition?.category
+  );
+  const focusCategory = category || 'commitment';
+
   return {
     id: `instance:${instance.id}`,
     title,
@@ -299,13 +325,14 @@ function createOutstandingEntry({
     payoutText: formatPayoutSummary(progress.payoutAmount, progress.payoutSchedule),
     repeatable: remainingRuns == null ? true : remainingRuns > 1,
     remainingRuns,
-    focusCategory: 'commitment',
+    focusCategory,
     focusBucket: 'commitment',
     orderIndex: order,
     progress,
     instanceId: instance.id,
     definitionId: progress.definitionId,
     offerId: progress.offerId,
+    category: focusCategory,
     raw: {
       definition,
       instance,

--- a/src/ui/dashboard/quickActions.js
+++ b/src/ui/dashboard/quickActions.js
@@ -181,8 +181,15 @@ export function buildQuickActions(state) {
     const normalizedCategory = normalizeCategory(group.category || definition?.market?.category || 'hustle');
     const remainingRuns = availableOffers.length > 0 ? availableOffers.length : 1;
 
+    const actionId = primaryOffer?.id || `offer-group:${group.id}`;
+    const offerIds = Array.isArray(group.offers)
+      ? group.offers.map(entry => entry?.id).filter(Boolean)
+      : [];
+
     return {
-      id: `offer-group:${group.id}`,
+      id: actionId,
+      groupId: group.id,
+      offerIds,
       label,
       primaryLabel: 'Accept',
       description,

--- a/src/ui/dashboard/quickActions.js
+++ b/src/ui/dashboard/quickActions.js
@@ -195,8 +195,9 @@ export function buildQuickActions(state) {
       description,
       onClick: () => {
         let result = null;
+        const offerId = primaryOffer?.id || primaryOffer;
         executeAction(() => {
-          result = acceptHustleOffer(primaryOffer, { state: workingState });
+          result = acceptHustleOffer(offerId, { state: workingState });
         });
         return result;
       },

--- a/src/ui/views/browser/apps/hustles.js
+++ b/src/ui/views/browser/apps/hustles.js
@@ -138,6 +138,10 @@ function describeCommitmentMeta(commitment) {
   if (commitment.payoutText) {
     parts.push(commitment.payoutText);
   }
+  const daysRequired = commitment.progress?.daysRequired ?? commitment.daysRequired;
+  if (Number.isFinite(daysRequired) && daysRequired > 0) {
+    parts.push(`${daysRequired}-day commitment`);
+  }
   if (commitment.remainingDays != null) {
     parts.push(describeDeadlineLabel(commitment.progress || commitment));
   }
@@ -199,6 +203,9 @@ function createHustleCard(definition, model) {
   if (model.filters?.limitRemaining !== null && model.filters?.limitRemaining !== undefined) {
     card.dataset.limitRemaining = String(model.filters.limitRemaining);
   }
+  if (model.filters?.category) {
+    card.dataset.category = model.filters.category;
+  }
 
   const header = document.createElement('header');
   header.className = 'browser-card__header';
@@ -236,6 +243,13 @@ function createHustleCard(definition, model) {
   meta.className = 'browser-card__meta';
   meta.textContent = model.requirements?.summary || 'No requirements';
   card.appendChild(meta);
+
+  if (model.seat?.summary) {
+    const seat = document.createElement('p');
+    seat.className = 'browser-card__note';
+    seat.textContent = model.seat.summary;
+    card.appendChild(seat);
+  }
 
   if (model.limit?.summary) {
     const limit = document.createElement('p');

--- a/src/ui/views/browser/components/learnly/context.js
+++ b/src/ui/views/browser/components/learnly/context.js
@@ -1,4 +1,5 @@
 import { describeTrackEducationBonuses } from '../../../../../game/educationEffects.js';
+import { describeSeatAvailability } from '../../../../../ui/hustles/offerHelpers.js';
 import { CATEGORY_DEFINITIONS } from './constants.js';
 
 const CATEGORY_BY_SKILL = CATEGORY_DEFINITIONS.reduce((map, category) => {
@@ -76,6 +77,26 @@ function buildCourse(track, definitionMap) {
       : Boolean(action.disabled)
     : Boolean(track.action?.disabled);
 
+  const market = definition?.market || {};
+  const marketMetadata = market?.metadata || {};
+  const seatPolicy = (() => {
+    const direct = marketMetadata.seatPolicy;
+    if (typeof direct === 'string' && direct.trim()) {
+      return direct.trim();
+    }
+    if (Array.isArray(market?.variants)) {
+      for (const variant of market.variants) {
+        const variantPolicy = variant?.metadata?.seatPolicy || variant?.metadata?.enrollment?.seatPolicy;
+        if (typeof variantPolicy === 'string' && variantPolicy.trim()) {
+          return variantPolicy.trim();
+        }
+      }
+    }
+    return null;
+  })();
+
+  const seatSummary = describeSeatAvailability({ seatPolicy }) || null;
+
   return {
     id: track.id,
     definitionId: track.definitionId,
@@ -109,7 +130,9 @@ function buildCourse(track, definitionMap) {
             disabled: Boolean(track.action.disabled),
             onClick: null
           }
-        : null
+        : null,
+    seatPolicy,
+    seatSummary
   };
 }
 

--- a/src/ui/views/browser/components/learnly/views/shared/courseCard.js
+++ b/src/ui/views/browser/components/learnly/views/shared/courseCard.js
@@ -54,11 +54,15 @@ function createCourseCard({
 
   const stats = document.createElement('dl');
   stats.className = 'learnly-card__stats';
-  [
+  const statEntries = [
     { term: 'Tuition', detail: tuitionLabel || (course.tuition > 0 ? formatCurrency(course.tuition) : 'Included') },
     { term: 'Daily time', detail: `${formatHours(course.hoursPerDay)} / day` },
     { term: 'Course length', detail: formatDays(course.days) }
-  ].forEach(entry => {
+  ];
+  if (course.seatSummary) {
+    statEntries.push({ term: 'Seats', detail: course.seatSummary });
+  }
+  statEntries.forEach(entry => {
     const dt = document.createElement('dt');
     dt.textContent = entry.term;
     const dd = document.createElement('dd');

--- a/tests/ui/dashboard/quickActions.test.js
+++ b/tests/ui/dashboard/quickActions.test.js
@@ -49,8 +49,8 @@ test('buildQuickActions returns active offers with meta details', () => {
   const offerAction = actions.find(item => item.offer);
   assert.ok(offerAction, 'expected market offer to be present');
   assert.equal(offerAction.primaryLabel, 'Accept');
-  assert.ok(offerAction.meta.includes('$120'));
-  assert.ok(offerAction.meta.includes('1 day'));
+  assert.match(offerAction.meta, /\$120/);
+  assert.match(offerAction.meta, /Expires in/i);
 });
 
 test('buildQuickActions disables offers when requirements are unmet', () => {
@@ -103,7 +103,7 @@ test('quick action offer summary highlights payout schedule and remaining days',
     remainingDays: 2,
     formatMoneyFn: value => value.toString()
   });
-  assert.equal(summary, '$300 / day • 4h • 2 days left');
+  assert.equal(summary, '$300 / day • 4h • Expires in 2 days');
 });
 
 test('hustle offer summary includes availability, focus, and completion cues', () => {


### PR DESCRIPTION
## Summary
- group hustle quick actions by template variant while surfacing expiry windows, seat availability, and commitment length metadata
- extend hustle card and Learnly course rendering to expose seat policies, market categories, and richer multi-day commitment copy
- capture new action categories when building outstanding tasks and document the updated seat-aware UI

## Testing
- node --test tests/ui/dashboard/quickActions.test.js
- node --test tests/ui/cardsModel.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e30f7146e8832c9df15c35eb99ba79