### PR TITLE
Prevent duplicate study entries after daily log

### DIFF
--- a/tests/ui/dashboard/knowledge.test.js
+++ b/tests/ui/dashboard/knowledge.test.js
@@ -94,3 +94,82 @@ test('buildStudyEnrollmentActionModel surfaces active study commitments', () => 
   assert.equal(entry.progress.instanceId, instanceId);
   assert.ok(model.hoursAvailableLabel.includes('h'));
 });
+
+test('buildStudyEnrollmentActionModel hides study entries once the day is logged', () => {
+  resetRegistry();
+
+  const trackId = 'outlineMastery';
+  const track = KNOWLEDGE_TRACKS[trackId];
+  const actionId = `study-${trackId}`;
+  const instanceId = 'study-instance';
+
+  loadRegistry({
+    hustles: [
+      {
+        id: actionId,
+        name: track.name,
+        tag: { type: 'study' },
+        description: track.description,
+        progress: {
+          type: 'study',
+          completion: 'manual',
+          hoursPerDay: track.hoursPerDay,
+          daysRequired: track.days
+        }
+      }
+    ],
+    assets: [],
+    upgrades: []
+  });
+
+  const state = buildDefaultState();
+  state.day = 11;
+  state.timeLeft = 6;
+  state.money = 200;
+
+  state.progress.knowledge = state.progress.knowledge || {};
+  state.progress.knowledge[trackId] = {
+    daysCompleted: 4,
+    studiedToday: true,
+    completed: false,
+    enrolled: true,
+    totalDays: track.days,
+    hoursPerDay: track.hoursPerDay,
+    tuitionCost: track.tuition ?? 0,
+    enrolledOnDay: state.day - 4,
+    skillRewarded: false
+  };
+
+  state.actions = state.actions || {};
+  state.actions[actionId] = {
+    id: actionId,
+    instances: [
+      {
+        id: instanceId,
+        name: track.name,
+        accepted: true,
+        completed: false,
+        acceptedOnDay: state.day - 4,
+        progress: {
+          definitionId: actionId,
+          instanceId,
+          studyTrackId: trackId,
+          type: 'study',
+          hoursPerDay: track.hoursPerDay,
+          daysRequired: track.days,
+          hoursLogged: track.hoursPerDay * 4,
+          hoursRemaining: Math.max(0, (track.days - 4) * track.hoursPerDay),
+          stepHours: track.hoursPerDay,
+          daysCompleted: 4,
+          remainingDays: Math.max(0, track.days - 4),
+          completion: 'manual',
+          dailyLog: { [state.day]: track.hoursPerDay },
+          metadata: { day: state.day }
+        }
+      }
+    ]
+  };
+
+  const model = buildStudyEnrollmentActionModel(state);
+  assert.equal(model.entries.length, 0, 'study entry should be hidden after logging for the day');
+});


### PR DESCRIPTION
## Summary
- filter outstanding action entries so study tracks logged for the day no longer appear
- add a regression test covering the hidden study action scenario

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e31713fccc832c92139ba2d7e03abd