### PR TITLE
Wrap manual hustle rerolls in executeAction

### DIFF
--- a/src/ui/cards/model/hustles.js
+++ b/src/ui/cards/model/hustles.js
@@ -276,7 +276,10 @@ export default function buildHustleModels(definitions = [], helpers = {}) {
         label: rerollLabel,
         disabled: false,
         className: 'secondary',
-        onClick: () => rollOffers({ templates: [definition], day: currentDay, state }),
+        onClick: () =>
+          executeActionFn(() => {
+            rollOffers({ templates: [definition], day: currentDay, state });
+          }),
         guidance: rerollGuidance
       };
     } else {


### PR DESCRIPTION
## Summary
- wrap the manual DownWork reroll handler in executeAction so UI refreshes after rolling offers
- add a regression test to ensure manual rerolls trigger executeAction and rollOffers

## Testing
- npm test
- Manual testing not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e3198d7c98832cab13f5212a57e2c6