### PR TITLE
Refactor hustle normalization helpers and add tests

### DIFF
--- a/src/game/data/hustleMarketConfig.js
+++ b/src/game/data/hustleMarketConfig.js
@@ -1,19 +1,14 @@
 import { structuredClone } from '../../core/helpers.js';
+import {
+  clampMarketDaySpan,
+  clampMarketPositiveInteger
+} from '../hustles/normalizers.js';
 
 const DEFAULT_SEATS = 1;
 
 const toNumber = value => {
   const numeric = Number(value);
   return Number.isFinite(numeric) ? numeric : 0;
-};
-
-const toPositive = (value, fallback = 1) => {
-  const numeric = Number(value);
-  if (!Number.isFinite(numeric) || numeric <= 0) {
-    const fallbackNumeric = Number(fallback);
-    return Number.isFinite(fallbackNumeric) && fallbackNumeric > 0 ? Math.floor(fallbackNumeric) : 1;
-  }
-  return Math.floor(numeric);
 };
 
 const buildBaseMetadata = ({ hoursRequired, payoutAmount, progressLabel, hoursPerDay, daysRequired }) => {
@@ -69,6 +64,8 @@ const buildVariant = ({
   }
   if (daysRequired == null) {
     delete mergedMetadata.daysRequired;
+  } else {
+    mergedMetadata.daysRequired = clampMarketPositiveInteger(daysRequired, 1);
   }
   if (!progressLabel) {
     delete mergedMetadata.progressLabel;
@@ -79,8 +76,8 @@ const buildVariant = ({
     label,
     description,
     copies,
-    durationDays,
-    availableAfterDays,
+    durationDays: clampMarketDaySpan(durationDays, 0),
+    availableAfterDays: clampMarketDaySpan(availableAfterDays, 0),
     metadata: mergedMetadata
   };
 
@@ -89,7 +86,7 @@ const buildVariant = ({
   }
 
   if (seats != null) {
-    variant.seats = toPositive(seats, DEFAULT_SEATS);
+    variant.seats = clampMarketPositiveInteger(seats, DEFAULT_SEATS);
   }
 
   return variant;

--- a/src/game/hustles/normalizers.js
+++ b/src/game/hustles/normalizers.js
@@ -1,0 +1,76 @@
+import { structuredClone } from '../../core/helpers.js';
+
+function toNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function clampMarketDay(value, fallback = 1) {
+  const parsed = toNumber(value);
+  if (parsed == null || parsed <= 0) {
+    const fallbackParsed = toNumber(fallback);
+    if (fallbackParsed == null || fallbackParsed <= 0) {
+      return 1;
+    }
+    return Math.floor(fallbackParsed);
+  }
+  return Math.floor(parsed);
+}
+
+export function clampMarketDaySpan(value, fallback = 0) {
+  const parsed = toNumber(value);
+  if (parsed == null || parsed < 0) {
+    const fallbackParsed = toNumber(fallback);
+    if (fallbackParsed == null || fallbackParsed < 0) {
+      return 0;
+    }
+    return Math.floor(fallbackParsed);
+  }
+  return Math.floor(parsed);
+}
+
+export function clampMarketNonNegativeNumber(value, fallback = 0) {
+  const parsed = toNumber(value);
+  if (parsed == null || parsed < 0) {
+    const fallbackParsed = toNumber(fallback);
+    if (fallbackParsed == null || fallbackParsed < 0) {
+      return 0;
+    }
+    return fallbackParsed;
+  }
+  return parsed;
+}
+
+export function clampMarketPositiveInteger(value, fallback = 1) {
+  const parsed = toNumber(value);
+  if (parsed == null || parsed <= 0) {
+    const fallbackParsed = toNumber(fallback);
+    if (fallbackParsed == null || fallbackParsed <= 0) {
+      return 1;
+    }
+    return Math.floor(fallbackParsed);
+  }
+  return Math.floor(parsed);
+}
+
+export function clampMarketWeight(value, fallback = 1) {
+  const parsed = toNumber(value);
+  if (parsed == null || parsed <= 0) {
+    const fallbackParsed = toNumber(fallback);
+    if (fallbackParsed == null || fallbackParsed <= 0) {
+      return 1;
+    }
+    return fallbackParsed;
+  }
+  return parsed;
+}
+
+export function cloneMarketMetadata(source, fallback = {}) {
+  if (source && typeof source === 'object') {
+    return structuredClone(source);
+  }
+  if (fallback && typeof fallback === 'object') {
+    return structuredClone(fallback);
+  }
+  return {};
+}

--- a/tests/game/hustles/normalizers.test.js
+++ b/tests/game/hustles/normalizers.test.js
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  clampMarketDay,
+  clampMarketDaySpan,
+  clampMarketNonNegativeNumber,
+  clampMarketPositiveInteger,
+  clampMarketWeight,
+  cloneMarketMetadata
+} from '../../../src/game/hustles/normalizers.js';
+
+test('clampMarketDay enforces positive integer fallbacks', () => {
+  assert.equal(clampMarketDay(3.9, 1), 3);
+  assert.equal(clampMarketDay(-2, 4), 4);
+  assert.equal(clampMarketDay('not-a-number', 0), 1);
+});
+
+test('clampMarketDaySpan clamps negative spans and floors decimals', () => {
+  assert.equal(clampMarketDaySpan(5.7, 0), 5);
+  assert.equal(clampMarketDaySpan(-1, 2), 2);
+  assert.equal(clampMarketDaySpan(null, 'ignored'), 0);
+});
+
+test('clampMarketNonNegativeNumber keeps positive values and uses fallback otherwise', () => {
+  assert.equal(clampMarketNonNegativeNumber(2.5, 0), 2.5);
+  assert.equal(clampMarketNonNegativeNumber(-3, 1.25), 1.25);
+  assert.equal(clampMarketNonNegativeNumber('bad', -4), 0);
+});
+
+test('clampMarketPositiveInteger floors decimals and uses safe fallback', () => {
+  assert.equal(clampMarketPositiveInteger(6.4, 1), 6);
+  assert.equal(clampMarketPositiveInteger(0, 3), 3);
+  assert.equal(clampMarketPositiveInteger('bad', 'also-bad'), 1);
+});
+
+test('clampMarketWeight respects fallback when invalid', () => {
+  assert.equal(clampMarketWeight(0.5, 2), 0.5);
+  assert.equal(clampMarketWeight(-2, 3.5), 3.5);
+  assert.equal(clampMarketWeight('bad', 0), 1);
+});
+
+test('cloneMarketMetadata returns deep clones and fallbacks', () => {
+  const original = { nested: { value: 1 } };
+  const clone = cloneMarketMetadata(original);
+  assert.notEqual(clone, original);
+  assert.notEqual(clone.nested, original.nested);
+  clone.nested.value = 2;
+  assert.equal(original.nested.value, 1);
+
+  const fallback = { fallback: true };
+  const clonedFallback = cloneMarketMetadata(null, fallback);
+  assert.notEqual(clonedFallback, fallback);
+  clonedFallback.fallback = false;
+  assert.equal(fallback.fallback, true);
+
+  const emptyClone = cloneMarketMetadata(null);
+  assert.deepEqual(emptyClone, {});
+});


### PR DESCRIPTION
## Summary
- add a shared hustle normalizers module that standardizes clamping helpers and metadata cloning
- refactor hustle market config, runtime market logic, and the state slice to reuse the shared utilities
- add unit coverage for the new helpers to lock in the shared normalization behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e39e1b7b58832cb11eab925569281c