### PR TITLE
Refactor hustle offer helpers into shared utilities

### DIFF
--- a/src/game/hustles.js
+++ b/src/game/hustles.js
@@ -3,6 +3,13 @@ import { rollDailyOffers, getAvailableOffers, getClaimedOffers, getMarketRollAud
 import { getState } from '../core/state.js';
 import { structuredClone } from '../core/helpers.js';
 import {
+  resolveFirstNumber,
+  resolveFirstString,
+  resolveOfferHours,
+  resolveOfferPayoutAmount,
+  resolveOfferPayoutSchedule
+} from './hustles/offerUtils.js';
+import {
   ensureHustleMarketState,
   claimHustleMarketOffer,
   getMarketOfferById,
@@ -73,63 +80,6 @@ export function ensureDailyOffersForDay({
 }
 
 const TEMPLATE_BY_ID = new Map(HUSTLE_TEMPLATES.map(template => [template.id, template]));
-
-function resolveFirstNumber(...values) {
-  for (const value of values) {
-    const parsed = Number(value);
-    if (Number.isFinite(parsed) && parsed >= 0) {
-      return parsed;
-    }
-  }
-  return null;
-}
-
-function resolveFirstString(...values) {
-  for (const value of values) {
-    if (typeof value === 'string' && value.trim().length) {
-      return value.trim();
-    }
-  }
-  return null;
-}
-
-function resolveOfferHours(offer, template) {
-  const metadata = offer?.metadata || {};
-  const requirements = typeof metadata.requirements === 'object' && metadata.requirements !== null
-    ? metadata.requirements
-    : {};
-  return resolveFirstNumber(
-    metadata.hoursRequired,
-    requirements.hours,
-    requirements.timeHours,
-    metadata.timeHours,
-    template?.time,
-    template?.action?.timeCost
-  );
-}
-
-function resolveOfferPayoutAmount(offer, template) {
-  const metadata = offer?.metadata || {};
-  const payout = typeof metadata.payout === 'object' && metadata.payout !== null
-    ? metadata.payout
-    : {};
-  return resolveFirstNumber(
-    metadata.payoutAmount,
-    payout.amount,
-    template?.payout?.amount
-  );
-}
-
-function resolveOfferPayoutSchedule(offer) {
-  const metadata = offer?.metadata || {};
-  const payout = typeof metadata.payout === 'object' && metadata.payout !== null
-    ? metadata.payout
-    : {};
-  return resolveFirstString(
-    metadata.payoutSchedule,
-    payout.schedule
-  ) || 'onCompletion';
-}
 
 export function acceptHustleOffer(offerOrId, { state = getState() } = {}) {
   const workingState = state || getState();

--- a/src/game/hustles/offerUtils.js
+++ b/src/game/hustles/offerUtils.js
@@ -1,0 +1,103 @@
+const asArray = value => {
+  if (value == null) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+};
+
+const toMetadataObject = value => (value && typeof value === 'object' ? value : {});
+
+export function resolveFirstNumber(...values) {
+  for (const value of values) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+export function resolveFirstString(...values) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim().length) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+function gatherMetadataSources(primary, additional = []) {
+  const sources = [];
+  for (const entry of asArray(primary)) {
+    if (entry) {
+      sources.push(toMetadataObject(entry));
+    }
+  }
+  for (const entry of asArray(additional)) {
+    if (entry) {
+      sources.push(toMetadataObject(entry));
+    }
+  }
+  return sources;
+}
+
+const gatherRequirementSources = sources => sources.map(source => {
+  const { requirements } = source || {};
+  return requirements && typeof requirements === 'object' ? requirements : {};
+});
+
+export function resolveOfferHoursFromMetadata(metadataSources, template, extraCandidates = []) {
+  const sources = gatherMetadataSources(metadataSources);
+  const requirementSources = gatherRequirementSources(sources);
+  const extra = asArray(extraCandidates);
+  return resolveFirstNumber(
+    ...sources.flatMap(source => [source.hoursRequired, source.timeHours, source.hours]),
+    ...requirementSources.flatMap(requirements => [requirements.hours, requirements.timeHours]),
+    ...extra,
+    template?.time,
+    template?.action?.timeCost
+  );
+}
+
+export function resolveOfferHours(offerOrMetadata, template, { metadataSources = [], extraCandidates = [] } = {}) {
+  const baseMetadata = offerOrMetadata && typeof offerOrMetadata === 'object'
+    ? (offerOrMetadata.metadata ?? offerOrMetadata)
+    : {};
+  const sources = gatherMetadataSources([baseMetadata, ...asArray(metadataSources)]);
+  return resolveOfferHoursFromMetadata(sources, template, extraCandidates);
+}
+
+export function resolveOfferPayoutAmountFromMetadata(metadataSources, template, extraCandidates = []) {
+  const sources = gatherMetadataSources(metadataSources);
+  const extra = asArray(extraCandidates);
+  return resolveFirstNumber(
+    ...sources.flatMap(source => [source.payoutAmount, source.payout?.amount]),
+    ...extra,
+    template?.payout?.amount
+  );
+}
+
+export function resolveOfferPayoutAmount(offerOrMetadata, template, { metadataSources = [], extraCandidates = [] } = {}) {
+  const baseMetadata = offerOrMetadata && typeof offerOrMetadata === 'object'
+    ? (offerOrMetadata.metadata ?? offerOrMetadata)
+    : {};
+  const sources = gatherMetadataSources([baseMetadata, ...asArray(metadataSources)]);
+  return resolveOfferPayoutAmountFromMetadata(sources, template, extraCandidates);
+}
+
+export function resolveOfferPayoutScheduleFromMetadata(metadataSources, fallback = 'onCompletion', extraCandidates = []) {
+  const sources = gatherMetadataSources(metadataSources);
+  const extra = asArray(extraCandidates);
+  return resolveFirstString(
+    ...sources.flatMap(source => [source.payoutSchedule, source.payout?.schedule]),
+    ...extra
+  ) || fallback;
+}
+
+export function resolveOfferPayoutSchedule(offerOrMetadata, { metadataSources = [], extraCandidates = [], fallback = 'onCompletion' } = {}) {
+  const baseMetadata = offerOrMetadata && typeof offerOrMetadata === 'object'
+    ? (offerOrMetadata.metadata ?? offerOrMetadata)
+    : {};
+  const sources = gatherMetadataSources([baseMetadata, ...asArray(metadataSources)]);
+  return resolveOfferPayoutScheduleFromMetadata(sources, fallback, extraCandidates);
+}


### PR DESCRIPTION
## Summary
- add a shared offerUtils module that centralizes number/string resolution helpers for hustle offers
- refactor hustle market generation, acceptance flows, and config metadata to consume the new shared helpers
- extend hustle market tests to validate that offers and accepted entries rely on the unified utilities

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3a896a180832c89f1f018838efcc5