### PR TITLE
Refactor outstanding action helpers and queue metrics

### DIFF
--- a/src/ui/actions/outstanding.js
+++ b/src/ui/actions/outstanding.js
@@ -1,0 +1,484 @@
+import { formatHours } from '../../core/helpers.js';
+import { getState } from '../../core/state.js';
+import { getActionDefinition } from '../../game/registryService.js';
+import {
+  clampToZero,
+  coerceDay,
+  coercePositiveNumber,
+  firstPositiveNumber,
+  formatDuration,
+  formatPayoutSummary
+} from './utils.js';
+
+function resolveCategoryLabel(...values) {
+  for (const value of values) {
+    if (typeof value !== 'string') continue;
+    const trimmed = value.trim();
+    if (!trimmed) continue;
+    const lowered = trimmed.toLowerCase();
+    if (lowered.startsWith('study') || lowered.startsWith('education')) {
+      return 'study';
+    }
+    if (lowered.startsWith('maint')) {
+      return 'maintenance';
+    }
+    return lowered;
+  }
+  return null;
+}
+
+function resolveStudyTrackIdFromProgress(progress = {}) {
+  if (!progress || typeof progress !== 'object') {
+    return null;
+  }
+
+  const metadata = typeof progress.metadata === 'object' && progress.metadata !== null
+    ? progress.metadata
+    : {};
+
+  const candidates = [
+    progress.studyTrackId,
+    progress.trackId,
+    metadata.studyTrackId,
+    metadata.trackId
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+  }
+
+  const identifiers = [progress.definitionId, metadata.definitionId];
+  for (const identifier of identifiers) {
+    if (typeof identifier === 'string' && identifier.startsWith('study-')) {
+      return identifier.slice('study-'.length);
+    }
+  }
+
+  return null;
+}
+
+function collectMarketIndexes(state = {}) {
+  const market = state?.hustleMarket || {};
+  const offers = Array.isArray(market.offers) ? market.offers : [];
+  const accepted = Array.isArray(market.accepted) ? market.accepted : [];
+
+  const offersById = new Map();
+  offers.forEach(offer => {
+    if (offer?.id) {
+      offersById.set(offer.id, offer);
+    }
+  });
+
+  const acceptedByInstance = new Map();
+  const acceptedByOffer = new Map();
+  accepted.forEach(entry => {
+    if (entry?.instanceId) {
+      acceptedByInstance.set(entry.instanceId, entry);
+    }
+    if (entry?.offerId) {
+      acceptedByOffer.set(entry.offerId, entry);
+    }
+  });
+
+  return { offersById, acceptedByInstance, acceptedByOffer };
+}
+
+function buildProgressSnapshot({
+  state,
+  definition,
+  instance,
+  accepted,
+  offer
+}) {
+  if (!instance) {
+    return null;
+  }
+
+  const progress = typeof instance.progress === 'object' && instance.progress !== null
+    ? instance.progress
+    : {};
+
+  const hoursRequiredCandidates = [
+    instance.hoursRequired,
+    progress.hoursRequired,
+    accepted?.hoursRequired,
+    offer?.metadata?.hoursRequired,
+    offer?.metadata?.requirements?.hours,
+    offer?.metadata?.requirements?.timeHours,
+    definition?.time,
+    definition?.action?.timeCost
+  ];
+  let hoursRequired = hoursRequiredCandidates.reduce((result, value) => {
+    if (result != null) {
+      return result;
+    }
+    const numeric = coercePositiveNumber(value, null);
+    return Number.isFinite(numeric) ? numeric : null;
+  }, null);
+
+  const hoursLogged = coercePositiveNumber(
+    progress.hoursLogged != null ? progress.hoursLogged : instance.hoursLogged,
+    0
+  );
+
+  const metadataProgress = typeof accepted?.metadata?.progress === 'object' && accepted.metadata.progress !== null
+    ? accepted.metadata.progress
+    : typeof offer?.metadata?.progress === 'object' && offer.metadata.progress !== null
+      ? offer.metadata.progress
+      : {};
+
+  const hoursPerDay = firstPositiveNumber(
+    progress.hoursPerDay,
+    accepted?.metadata?.hoursPerDay,
+    metadataProgress.hoursPerDay,
+    accepted?.metadata?.progress?.hoursPerDay,
+    offer?.metadata?.hoursPerDay,
+    offer?.metadata?.progress?.hoursPerDay
+  );
+  if (progress && hoursPerDay != null && (!Number.isFinite(progress.hoursPerDay) || progress.hoursPerDay <= 0)) {
+    progress.hoursPerDay = hoursPerDay;
+  }
+
+  const daysCompleted = coercePositiveNumber(progress.daysCompleted, 0);
+
+  const rawDaysRequired = firstPositiveNumber(
+    progress.daysRequired,
+    metadataProgress.daysRequired,
+    accepted?.metadata?.daysRequired,
+    accepted?.metadata?.progress?.daysRequired,
+    offer?.metadata?.daysRequired,
+    offer?.metadata?.progress?.daysRequired
+  );
+  const daysRequired = rawDaysRequired != null ? Math.max(1, Math.floor(rawDaysRequired)) : null;
+  if (progress && daysRequired != null && (!Number.isFinite(progress.daysRequired) || progress.daysRequired <= 0)) {
+    progress.daysRequired = daysRequired;
+  }
+
+  if ((hoursRequired == null || hoursRequired <= 0)
+    && Number.isFinite(hoursPerDay)
+    && hoursPerDay > 0
+    && Number.isFinite(daysRequired)
+    && daysRequired > 0) {
+    const derivedHoursRequired = hoursPerDay * daysRequired;
+    hoursRequired = derivedHoursRequired;
+    if (progress && (!Number.isFinite(progress.hoursRequired) || progress.hoursRequired <= 0)) {
+      progress.hoursRequired = derivedHoursRequired;
+    }
+  }
+
+  const hoursRemaining = hoursRequired != null
+    ? Math.max(0, hoursRequired - hoursLogged)
+    : null;
+
+  const completionCandidates = [
+    progress.completion,
+    progress.completionMode,
+    metadataProgress.completionMode,
+    metadataProgress.completion,
+    accepted?.metadata?.completionMode,
+    accepted?.metadata?.progress?.completionMode,
+    accepted?.metadata?.progress?.completion,
+    offer?.metadata?.completionMode,
+    offer?.metadata?.progress?.completionMode,
+    offer?.metadata?.progress?.completion,
+    definition?.progress?.completion
+  ];
+  let completionMode = null;
+  for (const candidate of completionCandidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      completionMode = candidate.trim();
+      break;
+    }
+  }
+  if (!completionMode) {
+    completionMode = progress.type === 'instant' ? 'instant' : 'manual';
+  }
+  if (progress) {
+    if (typeof progress.completion !== 'string' || !progress.completion.trim()) {
+      progress.completion = completionMode;
+    }
+    progress.completionMode = completionMode;
+  }
+
+  let stepHours = Number.isFinite(hoursPerDay) && hoursPerDay > 0 ? hoursPerDay : null;
+  if (!Number.isFinite(stepHours) || stepHours <= 0) {
+    if (hoursRemaining != null && hoursRemaining > 0 && Number.isFinite(daysRequired) && daysRequired > 0) {
+      const remainingDays = Math.max(1, daysRequired - Math.max(0, daysCompleted));
+      stepHours = hoursRemaining / remainingDays;
+    } else if (hoursRemaining != null && hoursRemaining > 0) {
+      stepHours = hoursRemaining;
+    } else if (Number.isFinite(hoursPerDay) && hoursPerDay > 0) {
+      stepHours = hoursPerDay;
+    }
+  }
+  if (!Number.isFinite(stepHours) || stepHours <= 0) {
+    stepHours = hoursRequired != null && hoursRequired > 0 ? hoursRequired : 1;
+  }
+  if (hoursRemaining != null && hoursRemaining > 0) {
+    stepHours = Math.min(stepHours, hoursRemaining);
+  } else if (hoursRemaining != null && hoursRemaining <= 0) {
+    stepHours = completionMode === 'manual' && Number.isFinite(hoursPerDay) && hoursPerDay > 0
+      ? hoursPerDay
+      : 0;
+  }
+
+  const deadlineCandidates = [
+    instance.deadlineDay,
+    progress.deadlineDay,
+    accepted?.deadlineDay,
+    offer?.claimDeadlineDay,
+    offer?.expiresOnDay
+  ]
+    .map(value => coerceDay(value, null))
+    .filter(value => value != null);
+
+  const earliestDeadline = deadlineCandidates.length ? Math.min(...deadlineCandidates) : null;
+  const currentDay = coerceDay(state?.day, 1) || 1;
+  const remainingDays = earliestDeadline != null
+    ? Math.max(0, earliestDeadline - currentDay + 1)
+    : null;
+
+  const payoutAmount = coercePositiveNumber(
+    accepted?.payout?.amount != null ? accepted.payout.amount : offer?.metadata?.payoutAmount,
+    null
+  );
+  const payoutSchedule = accepted?.payout?.schedule
+    || offer?.metadata?.payoutSchedule
+    || 'onCompletion';
+
+  const percentComplete = hoursRequired && hoursRequired > 0
+    ? Math.max(0, Math.min(1, hoursLogged / hoursRequired))
+    : null;
+
+  return {
+    definitionId: definition?.id || instance.definitionId || accepted?.definitionId || offer?.definitionId,
+    instanceId: instance.id,
+    offerId: accepted?.offerId || offer?.id || null,
+    templateId: accepted?.templateId || offer?.templateId || definition?.id || null,
+    hoursLogged,
+    hoursRequired,
+    hoursRemaining,
+    stepHours,
+    hoursPerDay: Number.isFinite(hoursPerDay) && hoursPerDay > 0 ? hoursPerDay : null,
+    daysCompleted,
+    daysRequired,
+    remainingDays,
+    deadlineDay: earliestDeadline,
+    payoutAmount,
+    payoutSchedule,
+    completion: completionMode,
+    percentComplete,
+    metadata: accepted?.metadata || offer?.claimMetadata || offer?.metadata || {},
+    lastWorkedDay: coerceDay(progress.lastWorkedDay, null),
+    acceptedOnDay: coerceDay(instance.acceptedOnDay, null)
+  };
+}
+
+function createOutstandingEntry({
+  state,
+  definition,
+  instance,
+  accepted,
+  offer,
+  order
+}) {
+  const progress = buildProgressSnapshot({ state, definition, instance, accepted, offer });
+  if (!progress) {
+    return null;
+  }
+
+  const remainingRuns = progress.hoursRemaining != null && progress.stepHours > 0
+    ? Math.max(1, Math.ceil(progress.hoursRemaining / progress.stepHours))
+    : (progress.hoursRemaining === 0 && progress.completion === 'manual' ? 1 : null);
+
+  if (progress.hoursRemaining != null && progress.hoursRemaining <= 0 && progress.completion !== 'manual') {
+    return null;
+  }
+
+  const variantLabel = offer?.variant?.label || progress.metadata?.variantLabel || '';
+  const baseName = instance?.name || definition?.name || definition?.id || 'Accepted hustle';
+  const title = variantLabel ? `${variantLabel}` : baseName;
+  const description = offer?.variant?.description || progress.metadata?.description || '';
+
+  const metaParts = [];
+  if (Number.isFinite(progress.percentComplete)) {
+    const percent = Math.round(progress.percentComplete * 100);
+    metaParts.push(`${Math.max(0, Math.min(100, percent))}% logged`);
+  }
+  if (progress.hoursRemaining != null) {
+    metaParts.push(`${formatHours(progress.hoursRemaining)} left`);
+  }
+  if (progress.remainingDays != null) {
+    metaParts.push(`${progress.remainingDays} day${progress.remainingDays === 1 ? '' : 's'} remaining`);
+  }
+  if (Number.isFinite(progress.payoutAmount) && progress.payoutAmount > 0) {
+    metaParts.push(formatPayoutSummary(progress.payoutAmount, progress.payoutSchedule));
+  }
+  if (!metaParts.length && progress.hoursRequired != null) {
+    metaParts.push(`${formatHours(progress.hoursLogged)} logged of ${formatHours(progress.hoursRequired)}`);
+  }
+
+  const metaClass = progress.remainingDays != null && progress.remainingDays <= 1
+    ? 'todo-widget__meta--warning'
+    : progress.remainingDays != null && progress.remainingDays <= 3
+      ? 'todo-widget__meta--alert'
+      : undefined;
+
+  const category = resolveCategoryLabel(
+    progress.metadata?.templateCategory,
+    progress.metadata?.category,
+    accepted?.metadata?.templateCategory,
+    offer?.templateCategory,
+    definition?.category
+  );
+  const focusCategory = category || 'commitment';
+
+  return {
+    id: `instance:${instance.id}`,
+    title,
+    subtitle: description,
+    meta: metaParts.join(' • '),
+    metaClass,
+    durationHours: progress.stepHours,
+    durationText: formatDuration(progress.stepHours),
+    moneyCost: 0,
+    payout: progress.payoutAmount || 0,
+    payoutText: formatPayoutSummary(progress.payoutAmount, progress.payoutSchedule),
+    repeatable: remainingRuns == null ? true : remainingRuns > 1,
+    remainingRuns,
+    focusCategory,
+    focusBucket: 'commitment',
+    orderIndex: order,
+    progress,
+    instanceId: instance.id,
+    definitionId: progress.definitionId,
+    offerId: progress.offerId,
+    category: focusCategory,
+    raw: {
+      definition,
+      instance,
+      accepted,
+      offer
+    }
+  };
+}
+
+export function collectOutstandingActionEntries(state = getState()) {
+  const workingState = state || getState() || {};
+  const actions = workingState?.actions || {};
+  const { offersById, acceptedByInstance, acceptedByOffer } = collectMarketIndexes(workingState);
+
+  const entries = [];
+  const actionIds = Object.keys(actions);
+
+  actionIds.forEach((actionId, index) => {
+    const actionState = actions[actionId];
+    if (!actionState) return;
+    const instances = Array.isArray(actionState.instances) ? actionState.instances : [];
+    if (!instances.length) return;
+
+    const definition = getActionDefinition(actionId);
+    instances.forEach((instance, instanceIndex) => {
+      if (!instance || instance.completed) return;
+      if (instance.status && instance.status !== 'active' && instance.status !== 'pending') {
+        return;
+      }
+
+      const accepted = acceptedByInstance.get(instance.id)
+        || acceptedByOffer.get(instance.offerId)
+        || null;
+      if (!accepted && !instance.accepted) {
+        return;
+      }
+
+      const offer = accepted?.offerId ? offersById.get(accepted.offerId) : null;
+      const entry = createOutstandingEntry({
+        state: workingState,
+        definition,
+        instance,
+        accepted,
+        offer,
+        order: -(index * 10 + instanceIndex)
+      });
+      if (entry) {
+        const trackId = resolveStudyTrackIdFromProgress(entry.progress);
+        if (trackId) {
+          const knowledge = workingState?.progress?.knowledge || {};
+          if (knowledge[trackId]?.studiedToday) {
+            return;
+          }
+        }
+        entries.push(entry);
+      }
+    });
+  });
+
+  entries.sort((a, b) => {
+    const daysA = a?.progress?.remainingDays ?? Infinity;
+    const daysB = b?.progress?.remainingDays ?? Infinity;
+    if (daysA !== daysB) {
+      return daysA - daysB;
+    }
+    const payoutA = Number.isFinite(a?.payout) ? a.payout : 0;
+    const payoutB = Number.isFinite(b?.payout) ? b.payout : 0;
+    if (payoutA !== payoutB) {
+      return payoutB - payoutA;
+    }
+    return (a.orderIndex || 0) - (b.orderIndex || 0);
+  });
+
+  return entries;
+}
+
+export function createAutoCompletedEntries(summary = {}) {
+  const entries = Array.isArray(summary?.timeBreakdown) ? summary.timeBreakdown : [];
+  return entries
+    .map((entry, index) => {
+      const hours = clampToZero(entry?.hours);
+      if (hours <= 0) return null;
+      const category = typeof entry?.category === 'string' ? entry.category.toLowerCase() : '';
+      const tracksMaintenance = category.startsWith('maintenance');
+      const tracksStudy = category.startsWith('study') || category.startsWith('education');
+      if (!tracksMaintenance && !tracksStudy) {
+        return null;
+      }
+
+      const title = entry?.label
+        || entry?.definition?.label
+        || entry?.definition?.name
+        || 'Scheduled work';
+      const key = entry?.key || `${category || 'auto'}-${index}`;
+      return {
+        id: `auto:${key}`,
+        title,
+        durationHours: hours,
+        durationText: formatHours(hours),
+        category
+      };
+    })
+    .filter(Boolean);
+}
+
+export function applyAutoCompletedEntries(target = {}, summary = {}) {
+  if (!target || typeof target !== 'object') {
+    return target;
+  }
+  const autoCompletedEntries = createAutoCompletedEntries(summary);
+  if (autoCompletedEntries.length) {
+    target.autoCompletedEntries = autoCompletedEntries;
+  } else {
+    delete target.autoCompletedEntries;
+  }
+  return target;
+}
+
+export default {
+  collectOutstandingActionEntries,
+  createAutoCompletedEntries,
+  applyAutoCompletedEntries
+};

--- a/src/ui/actions/queueService.js
+++ b/src/ui/actions/queueService.js
@@ -319,6 +319,30 @@ export function mergeQueueMetrics(target = {}, metrics = {}, state = {}) {
   return target;
 }
 
+export function mergeQueueSnapshotMetrics(target = {}, snapshots = [], state = {}) {
+  if (!target || typeof target !== 'object') {
+    return target;
+  }
+  const list = Array.isArray(snapshots) ? snapshots : [];
+  list.forEach(snapshot => {
+    if (!snapshot || typeof snapshot !== 'object') {
+      return;
+    }
+    if (snapshot.metrics) {
+      mergeQueueMetrics(target, snapshot.metrics, state);
+    }
+  });
+  return target;
+}
+
+export function applyFinalQueueMetrics(target = {}, state = {}) {
+  if (!target || typeof target !== 'object') {
+    return target;
+  }
+  Object.assign(target, buildQueueMetrics(state, target));
+  return target;
+}
+
 export default {
   normalizeBucketName,
   resolveFocusBucket,
@@ -329,5 +353,7 @@ export default {
   compareByRoi,
   rankEntriesByRoi,
   buildQueueMetrics,
-  mergeQueueMetrics
+  mergeQueueMetrics,
+  mergeQueueSnapshotMetrics,
+  applyFinalQueueMetrics
 };

--- a/src/ui/actions/registry.js
+++ b/src/ui/actions/registry.js
@@ -1,20 +1,13 @@
-import { formatHours } from '../../core/helpers.js';
 import { getState } from '../../core/state.js';
-import { getActionDefinition } from '../../game/registryService.js';
+import { coerceNumber, normalizeActionEntries } from './utils.js';
 import {
-  clampToZero,
-  coerceDay,
-  coerceNumber,
-  coercePositiveNumber,
-  firstPositiveNumber,
-  formatDuration,
-  formatPayoutSummary,
-  normalizeActionEntries
-} from './utils.js';
-import {
-  buildQueueMetrics,
-  mergeQueueMetrics
+  mergeQueueSnapshotMetrics,
+  applyFinalQueueMetrics
 } from './queueService.js';
+import {
+  applyAutoCompletedEntries,
+  collectOutstandingActionEntries
+} from './outstanding.js';
 import {
   registerActionProvider,
   clearActionProviders,
@@ -22,460 +15,6 @@ import {
 } from './providers.js';
 
 const DEFAULT_EMPTY_MESSAGE = 'Queue a hustle or upgrade to add new tasks.';
-
-function resolveCategoryLabel(...values) {
-  for (const value of values) {
-    if (typeof value !== 'string') continue;
-    const trimmed = value.trim();
-    if (!trimmed) continue;
-    const lowered = trimmed.toLowerCase();
-    if (lowered.startsWith('study') || lowered.startsWith('education')) {
-      return 'study';
-    }
-    if (lowered.startsWith('maint')) {
-      return 'maintenance';
-    }
-    return lowered;
-  }
-  return null;
-}
-
-function resolveStudyTrackIdFromProgress(progress = {}) {
-  if (!progress || typeof progress !== 'object') {
-    return null;
-  }
-
-  const metadata = typeof progress.metadata === 'object' && progress.metadata !== null
-    ? progress.metadata
-    : {};
-
-  const candidates = [
-    progress.studyTrackId,
-    progress.trackId,
-    metadata.studyTrackId,
-    metadata.trackId
-  ];
-
-  for (const candidate of candidates) {
-    if (typeof candidate === 'string') {
-      const trimmed = candidate.trim();
-      if (trimmed) {
-        return trimmed;
-      }
-    }
-  }
-
-  const identifiers = [progress.definitionId, metadata.definitionId];
-  for (const identifier of identifiers) {
-    if (typeof identifier === 'string' && identifier.startsWith('study-')) {
-      return identifier.slice('study-'.length);
-    }
-  }
-
-  return null;
-}
-
-function collectMarketIndexes(state = {}) {
-  const market = state?.hustleMarket || {};
-  const offers = Array.isArray(market.offers) ? market.offers : [];
-  const accepted = Array.isArray(market.accepted) ? market.accepted : [];
-
-  const offersById = new Map();
-  offers.forEach(offer => {
-    if (offer?.id) {
-      offersById.set(offer.id, offer);
-    }
-  });
-
-  const acceptedByInstance = new Map();
-  const acceptedByOffer = new Map();
-  accepted.forEach(entry => {
-    if (entry?.instanceId) {
-      acceptedByInstance.set(entry.instanceId, entry);
-    }
-    if (entry?.offerId) {
-      acceptedByOffer.set(entry.offerId, entry);
-    }
-  });
-
-  return { offersById, acceptedByInstance, acceptedByOffer };
-}
-
-function buildProgressSnapshot({
-  state,
-  definition,
-  instance,
-  accepted,
-  offer
-}) {
-  if (!instance) {
-    return null;
-  }
-
-  const progress = typeof instance.progress === 'object' && instance.progress !== null
-    ? instance.progress
-    : {};
-
-  const hoursRequiredCandidates = [
-    instance.hoursRequired,
-    progress.hoursRequired,
-    accepted?.hoursRequired,
-    offer?.metadata?.hoursRequired,
-    offer?.metadata?.requirements?.hours,
-    offer?.metadata?.requirements?.timeHours,
-    definition?.time,
-    definition?.action?.timeCost
-  ];
-  let hoursRequired = hoursRequiredCandidates.reduce((result, value) => {
-    if (result != null) {
-      return result;
-    }
-    const numeric = coercePositiveNumber(value, null);
-    return Number.isFinite(numeric) ? numeric : null;
-  }, null);
-
-  const hoursLogged = coercePositiveNumber(
-    progress.hoursLogged != null ? progress.hoursLogged : instance.hoursLogged,
-    0
-  );
-
-  const metadataProgress = typeof accepted?.metadata?.progress === 'object' && accepted.metadata.progress !== null
-    ? accepted.metadata.progress
-    : typeof offer?.metadata?.progress === 'object' && offer.metadata.progress !== null
-      ? offer.metadata.progress
-      : {};
-
-  const hoursPerDay = firstPositiveNumber(
-    progress.hoursPerDay,
-    accepted?.metadata?.hoursPerDay,
-    metadataProgress.hoursPerDay,
-    accepted?.metadata?.progress?.hoursPerDay,
-    offer?.metadata?.hoursPerDay,
-    offer?.metadata?.progress?.hoursPerDay
-  );
-  if (progress && hoursPerDay != null && (!Number.isFinite(progress.hoursPerDay) || progress.hoursPerDay <= 0)) {
-    progress.hoursPerDay = hoursPerDay;
-  }
-
-  const daysCompleted = coercePositiveNumber(progress.daysCompleted, 0);
-
-  const rawDaysRequired = firstPositiveNumber(
-    progress.daysRequired,
-    metadataProgress.daysRequired,
-    accepted?.metadata?.daysRequired,
-    accepted?.metadata?.progress?.daysRequired,
-    offer?.metadata?.daysRequired,
-    offer?.metadata?.progress?.daysRequired
-  );
-  const daysRequired = rawDaysRequired != null ? Math.max(1, Math.floor(rawDaysRequired)) : null;
-  if (progress && daysRequired != null && (!Number.isFinite(progress.daysRequired) || progress.daysRequired <= 0)) {
-    progress.daysRequired = daysRequired;
-  }
-
-  if ((hoursRequired == null || hoursRequired <= 0)
-    && Number.isFinite(hoursPerDay)
-    && hoursPerDay > 0
-    && Number.isFinite(daysRequired)
-    && daysRequired > 0) {
-    const derivedHoursRequired = hoursPerDay * daysRequired;
-    hoursRequired = derivedHoursRequired;
-    if (progress && (!Number.isFinite(progress.hoursRequired) || progress.hoursRequired <= 0)) {
-      progress.hoursRequired = derivedHoursRequired;
-    }
-  }
-
-  const hoursRemaining = hoursRequired != null
-    ? Math.max(0, hoursRequired - hoursLogged)
-    : null;
-
-  const completionCandidates = [
-    progress.completion,
-    progress.completionMode,
-    metadataProgress.completionMode,
-    metadataProgress.completion,
-    accepted?.metadata?.completionMode,
-    accepted?.metadata?.progress?.completionMode,
-    accepted?.metadata?.progress?.completion,
-    offer?.metadata?.completionMode,
-    offer?.metadata?.progress?.completionMode,
-    offer?.metadata?.progress?.completion,
-    definition?.progress?.completion
-  ];
-  let completionMode = null;
-  for (const candidate of completionCandidates) {
-    if (typeof candidate === 'string' && candidate.trim()) {
-      completionMode = candidate.trim();
-      break;
-    }
-  }
-  if (!completionMode) {
-    completionMode = progress.type === 'instant' ? 'instant' : 'manual';
-  }
-  if (progress) {
-    if (typeof progress.completion !== 'string' || !progress.completion.trim()) {
-      progress.completion = completionMode;
-    }
-    progress.completionMode = completionMode;
-  }
-
-  let stepHours = Number.isFinite(hoursPerDay) && hoursPerDay > 0 ? hoursPerDay : null;
-  if (!Number.isFinite(stepHours) || stepHours <= 0) {
-    if (hoursRemaining != null && hoursRemaining > 0 && Number.isFinite(daysRequired) && daysRequired > 0) {
-      const remainingDays = Math.max(1, daysRequired - Math.max(0, daysCompleted));
-      stepHours = hoursRemaining / remainingDays;
-    } else if (hoursRemaining != null && hoursRemaining > 0) {
-      stepHours = hoursRemaining;
-    } else if (Number.isFinite(hoursPerDay) && hoursPerDay > 0) {
-      stepHours = hoursPerDay;
-    }
-  }
-  if (!Number.isFinite(stepHours) || stepHours <= 0) {
-    stepHours = hoursRequired != null && hoursRequired > 0 ? hoursRequired : 1;
-  }
-  if (hoursRemaining != null && hoursRemaining > 0) {
-    stepHours = Math.min(stepHours, hoursRemaining);
-  } else if (hoursRemaining != null && hoursRemaining <= 0) {
-    stepHours = completionMode === 'manual' && Number.isFinite(hoursPerDay) && hoursPerDay > 0
-      ? hoursPerDay
-      : 0;
-  }
-
-  const deadlineCandidates = [
-    instance.deadlineDay,
-    progress.deadlineDay,
-    accepted?.deadlineDay,
-    offer?.claimDeadlineDay,
-    offer?.expiresOnDay
-  ]
-    .map(value => coerceDay(value, null))
-    .filter(value => value != null);
-
-  const earliestDeadline = deadlineCandidates.length ? Math.min(...deadlineCandidates) : null;
-  const currentDay = coerceDay(state?.day, 1) || 1;
-  const remainingDays = earliestDeadline != null
-    ? Math.max(0, earliestDeadline - currentDay + 1)
-    : null;
-
-  const payoutAmount = coercePositiveNumber(
-    accepted?.payout?.amount != null ? accepted.payout.amount : offer?.metadata?.payoutAmount,
-    null
-  );
-  const payoutSchedule = accepted?.payout?.schedule
-    || offer?.metadata?.payoutSchedule
-    || 'onCompletion';
-
-  const percentComplete = hoursRequired && hoursRequired > 0
-    ? Math.max(0, Math.min(1, hoursLogged / hoursRequired))
-    : null;
-
-  return {
-    definitionId: definition?.id || instance.definitionId || accepted?.definitionId || offer?.definitionId,
-    instanceId: instance.id,
-    offerId: accepted?.offerId || offer?.id || null,
-    templateId: accepted?.templateId || offer?.templateId || definition?.id || null,
-    hoursLogged,
-    hoursRequired,
-    hoursRemaining,
-    stepHours,
-    hoursPerDay: Number.isFinite(hoursPerDay) && hoursPerDay > 0 ? hoursPerDay : null,
-    daysCompleted,
-    daysRequired,
-    remainingDays,
-    deadlineDay: earliestDeadline,
-    payoutAmount,
-    payoutSchedule,
-    completion: completionMode,
-    percentComplete,
-    metadata: accepted?.metadata || offer?.claimMetadata || offer?.metadata || {},
-    lastWorkedDay: coerceDay(progress.lastWorkedDay, null),
-    acceptedOnDay: coerceDay(instance.acceptedOnDay, null)
-  };
-}
-
-function createOutstandingEntry({
-  state,
-  definition,
-  instance,
-  accepted,
-  offer,
-  order
-}) {
-  const progress = buildProgressSnapshot({ state, definition, instance, accepted, offer });
-  if (!progress) {
-    return null;
-  }
-
-  const remainingRuns = progress.hoursRemaining != null && progress.stepHours > 0
-    ? Math.max(1, Math.ceil(progress.hoursRemaining / progress.stepHours))
-    : (progress.hoursRemaining === 0 && progress.completion === 'manual' ? 1 : null);
-
-  if (progress.hoursRemaining != null && progress.hoursRemaining <= 0 && progress.completion !== 'manual') {
-    return null;
-  }
-
-  const variantLabel = offer?.variant?.label || progress.metadata?.variantLabel || '';
-  const baseName = instance?.name || definition?.name || definition?.id || 'Accepted hustle';
-  const title = variantLabel ? `${variantLabel}` : baseName;
-  const description = offer?.variant?.description || progress.metadata?.description || '';
-
-  const metaParts = [];
-  if (Number.isFinite(progress.percentComplete)) {
-    const percent = Math.round(progress.percentComplete * 100);
-    metaParts.push(`${Math.max(0, Math.min(100, percent))}% logged`);
-  }
-  if (progress.hoursRemaining != null) {
-    metaParts.push(`${formatHours(progress.hoursRemaining)} left`);
-  }
-  if (progress.remainingDays != null) {
-    metaParts.push(`${progress.remainingDays} day${progress.remainingDays === 1 ? '' : 's'} remaining`);
-  }
-  if (Number.isFinite(progress.payoutAmount) && progress.payoutAmount > 0) {
-    metaParts.push(formatPayoutSummary(progress.payoutAmount, progress.payoutSchedule));
-  }
-  if (!metaParts.length && progress.hoursRequired != null) {
-    metaParts.push(`${formatHours(progress.hoursLogged)} logged of ${formatHours(progress.hoursRequired)}`);
-  }
-
-  const metaClass = progress.remainingDays != null && progress.remainingDays <= 1
-    ? 'todo-widget__meta--warning'
-    : progress.remainingDays != null && progress.remainingDays <= 3
-      ? 'todo-widget__meta--alert'
-      : undefined;
-
-  const category = resolveCategoryLabel(
-    progress.metadata?.templateCategory,
-    progress.metadata?.category,
-    accepted?.metadata?.templateCategory,
-    offer?.templateCategory,
-    definition?.category
-  );
-  const focusCategory = category || 'commitment';
-
-  return {
-    id: `instance:${instance.id}`,
-    title,
-    subtitle: description,
-    meta: metaParts.join(' • '),
-    metaClass,
-    durationHours: progress.stepHours,
-    durationText: formatDuration(progress.stepHours),
-    moneyCost: 0,
-    payout: progress.payoutAmount || 0,
-    payoutText: formatPayoutSummary(progress.payoutAmount, progress.payoutSchedule),
-    repeatable: remainingRuns == null ? true : remainingRuns > 1,
-    remainingRuns,
-    focusCategory,
-    focusBucket: 'commitment',
-    orderIndex: order,
-    progress,
-    instanceId: instance.id,
-    definitionId: progress.definitionId,
-    offerId: progress.offerId,
-    category: focusCategory,
-    raw: {
-      definition,
-      instance,
-      accepted,
-      offer
-    }
-  };
-}
-
-export function collectOutstandingActionEntries(state = getState()) {
-  const workingState = state || getState() || {};
-  const actions = workingState?.actions || {};
-  const { offersById, acceptedByInstance, acceptedByOffer } = collectMarketIndexes(workingState);
-
-  const entries = [];
-  const actionIds = Object.keys(actions);
-
-  actionIds.forEach((actionId, index) => {
-    const actionState = actions[actionId];
-    if (!actionState) return;
-    const instances = Array.isArray(actionState.instances) ? actionState.instances : [];
-    if (!instances.length) return;
-
-    const definition = getActionDefinition(actionId);
-    instances.forEach((instance, instanceIndex) => {
-      if (!instance || instance.completed) return;
-      if (instance.status && instance.status !== 'active' && instance.status !== 'pending') {
-        return;
-      }
-
-      const accepted = acceptedByInstance.get(instance.id)
-        || acceptedByOffer.get(instance.offerId)
-        || null;
-      if (!accepted && !instance.accepted) {
-        return;
-      }
-
-      const offer = accepted?.offerId ? offersById.get(accepted.offerId) : null;
-      const entry = createOutstandingEntry({
-        state: workingState,
-        definition,
-        instance,
-        accepted,
-        offer,
-        order: -(index * 10 + instanceIndex)
-      });
-      if (entry) {
-        const trackId = resolveStudyTrackIdFromProgress(entry.progress);
-        if (trackId) {
-          const knowledge = workingState?.progress?.knowledge || {};
-          if (knowledge[trackId]?.studiedToday) {
-            return;
-          }
-        }
-        entries.push(entry);
-      }
-    });
-  });
-
-  entries.sort((a, b) => {
-    const daysA = a?.progress?.remainingDays ?? Infinity;
-    const daysB = b?.progress?.remainingDays ?? Infinity;
-    if (daysA !== daysB) {
-      return daysA - daysB;
-    }
-    const payoutA = Number.isFinite(a?.payout) ? a.payout : 0;
-    const payoutB = Number.isFinite(b?.payout) ? b.payout : 0;
-    if (payoutA !== payoutB) {
-      return payoutB - payoutA;
-    }
-    return (a.orderIndex || 0) - (b.orderIndex || 0);
-  });
-
-  return entries;
-}
-
-function createAutoCompletedEntries(summary = {}) {
-  const entries = Array.isArray(summary?.timeBreakdown) ? summary.timeBreakdown : [];
-  return entries
-    .map((entry, index) => {
-      const hours = clampToZero(entry?.hours);
-      if (hours <= 0) return null;
-      const category = typeof entry?.category === 'string' ? entry.category.toLowerCase() : '';
-      const tracksMaintenance = category.startsWith('maintenance');
-      const tracksStudy = category.startsWith('study') || category.startsWith('education');
-      if (!tracksMaintenance && !tracksStudy) {
-        return null;
-      }
-
-      const title = entry?.label
-        || entry?.definition?.label
-        || entry?.definition?.name
-        || 'Scheduled work';
-      const key = entry?.key || `${category || 'auto'}-${index}`;
-      return {
-        id: `auto:${key}`,
-        title,
-        durationHours: hours,
-        durationText: formatHours(hours),
-        category
-      };
-    })
-    .filter(Boolean);
-}
 
 function selectPreferredEntry(candidate, existing) {
   const candidateHasHandler = typeof candidate?.onClick === 'function';
@@ -530,10 +69,8 @@ function dedupeEntries(entries = []) {
 
 export function buildActionQueue({ state, summary = {} } = {}) {
   const resolvedState = state || getState() || {};
-  const queue = {
-    entries: [],
-    autoCompletedEntries: createAutoCompletedEntries(summary)
-  };
+  const queue = { entries: [] };
+  applyAutoCompletedEntries(queue, summary);
 
   const activeDay = coerceNumber(resolvedState?.day, null);
   queue.day = Number.isFinite(activeDay) ? activeDay : null;
@@ -553,8 +90,9 @@ export function buildActionQueue({ state, summary = {} } = {}) {
       }
       queue.entries.push(entry);
     });
-    mergeQueueMetrics(queue, snapshot.metrics, resolvedState);
   });
+
+  mergeQueueSnapshotMetrics(queue, snapshots, resolvedState);
 
   queue.entries = dedupeEntries(queue.entries);
 
@@ -562,11 +100,7 @@ export function buildActionQueue({ state, summary = {} } = {}) {
     queue.emptyMessage = DEFAULT_EMPTY_MESSAGE;
   }
 
-  Object.assign(queue, buildQueueMetrics(resolvedState, queue));
-
-  if (!queue.autoCompletedEntries.length) {
-    delete queue.autoCompletedEntries;
-  }
+  applyFinalQueueMetrics(queue, resolvedState);
 
   if (!queue.scroller) {
     delete queue.scroller;
@@ -583,6 +117,5 @@ export default {
   clearActionProviders,
   collectActionProviders,
   buildActionQueue,
-  normalizeActionEntries,
-  collectOutstandingActionEntries
+  normalizeActionEntries
 };

--- a/src/ui/cards/model/finance/opportunities.js
+++ b/src/ui/cards/model/finance/opportunities.js
@@ -3,7 +3,7 @@ import { getDailyIncomeRange } from '../../../../game/assets/payout.js';
 import { getUpgradeSnapshot } from '../upgrades.js';
 import { describeHustleRequirements } from '../../../../game/hustles/helpers.js';
 import { getAvailableOffers, getClaimedOffers } from '../../../../game/hustles.js';
-import { collectOutstandingActionEntries } from '../../../actions/registry.js';
+import { collectOutstandingActionEntries } from '../../../actions/outstanding.js';
 import { ensureArray, toCurrency } from './utils.js';
 
 function resolveOfferHours(offer, definition) {

--- a/src/ui/cards/model/hustles.js
+++ b/src/ui/cards/model/hustles.js
@@ -3,7 +3,7 @@ import { formatHours, formatMoney } from '../../../core/helpers.js';
 import { describeHustleRequirements, getHustleDailyUsage } from '../../../game/hustles/helpers.js';
 import { getAvailableOffers, getClaimedOffers, acceptHustleOffer, rollDailyOffers } from '../../../game/hustles.js';
 import { executeAction } from '../../../game/actions.js';
-import { collectOutstandingActionEntries } from '../../actions/registry.js';
+import { collectOutstandingActionEntries } from '../../actions/outstanding.js';
 import { describeHustleOfferMeta, describeSeatAvailability } from '../../hustles/offerHelpers.js';
 import { describeRequirementGuidance } from '../../hustles/requirements.js';
 

--- a/src/ui/dashboard/knowledge.js
+++ b/src/ui/dashboard/knowledge.js
@@ -11,7 +11,7 @@ import { advanceActionInstance, completeActionInstance } from '../../game/action
 import { getActionDefinition } from '../../game/registryService.js';
 import { spendTime } from '../../game/time.js';
 import { checkDayEnd } from '../../game/lifecycle.js';
-import { collectOutstandingActionEntries } from '../actions/registry.js';
+import { collectOutstandingActionEntries } from '../actions/outstanding.js';
 import { registerActionProvider } from '../actions/providers.js';
 
 function resolveProgressStep(entry = {}) {

--- a/src/ui/dashboard/quickActions.js
+++ b/src/ui/dashboard/quickActions.js
@@ -1,6 +1,6 @@
 import { formatHours } from '../../core/helpers.js';
 import { clampNumber } from './formatters.js';
-import { collectOutstandingActionEntries } from '../actions/registry.js';
+import { collectOutstandingActionEntries } from '../actions/outstanding.js';
 import { buildQueueMetrics } from '../actions/queueService.js';
 import { registerActionProvider } from '../actions/providers.js';
 import { executeAction } from '../../game/actions.js';

--- a/tests/ui/update.integration.test.js
+++ b/tests/ui/update.integration.test.js
@@ -862,8 +862,8 @@ test('accepting a hustle offer from dashboard quick actions refreshes the todo q
   const instanceId = acceptedEntries[0]?.instanceId;
   assert.ok(instanceId, 'expected claimed hustle entry to include an instance id');
 
-  const actionsRegistry = await import('../../src/ui/actions/registry.js');
-  const outstandingEntries = actionsRegistry.collectOutstandingActionEntries(state);
+  const outstandingModule = await import('../../src/ui/actions/outstanding.js');
+  const outstandingEntries = outstandingModule.collectOutstandingActionEntries(state);
   const hasOutstanding = outstandingEntries.some(entry => entry?.id === `instance:${instanceId}`);
   assert.ok(hasOutstanding, 'expected outstanding entry for the accepted hustle');
 


### PR DESCRIPTION
## Summary
- move outstanding action collection and auto-complete utilities into `src/ui/actions/outstanding.js`
- update `queueService` with helpers for merging snapshot metrics and finalizing queue metrics used by the registry
- switch dashboard models, cards, and tests to import `collectOutstandingActionEntries` from the new helper module

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68e3a894e97c832ca3766b96a7eb3531