### PR TITLE
Extend knowledge hustle deadlines for multi-day enrollments

### DIFF
--- a/src/game/hustles/knowledgeHustles.js
+++ b/src/game/hustles/knowledgeHustles.js
@@ -237,7 +237,8 @@ export function createKnowledgeHustles() {
           seatPolicy
         };
 
-        const durationDays = tuition > 0 ? 0 : 30;
+        const limitedSeatDuration = Math.max(0, (Number(track.days) || 1) - 1);
+        const durationDays = tuition > 0 ? limitedSeatDuration : 30;
 
         return {
           slotsPerRoll: 1,


### PR DESCRIPTION
## Summary
- extend hustle acceptance to compute multi-day deadlines from the required duration instead of offer expiry
- keep progress and enrollment metadata aligned with the extended deadline so claimed seats display accurate remaining days
- lengthen limited-seat knowledge hustle market durations so offers stay visible while a seat is occupied

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3b23131f4832c8f9d799f950bf4da