### PR TITLE
Refactor action slice helpers into dedicated modules

### DIFF
--- a/docs/features/action-instances.md
+++ b/docs/features/action-instances.md
@@ -13,7 +13,7 @@ availability limits, progress metadata, and an `instances` ledger so the game ca
 
 ## Notable Details
 - Action templates live in `src/game/actions/definitions.js` and currently wrap instant hustles and study sessions.
-- The `actions` state slice (see `src/core/state/slices/actions.js`) merges legacy hustle counters and initializes a fresh
+- The `actions` state slice (see `src/core/state/slices/actions/index.js`) merges legacy hustle counters and initializes a fresh
   `instances` array for every action ID.
 - `createInstantHustle` now creates an accepted instance via `acceptActionInstance` before executing, and `completeActionInstance`
   stores the final payout, hours logged, and applied bonuses.

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -11,7 +11,7 @@ import { ensureEventState } from './state/events.js';
 import {
   ensureSlice as ensureActionSlice,
   getSliceState as getActionSliceState
-} from './state/slices/actions.js';
+} from './state/slices/actions/index.js';
 import {
   ensureSlice as ensureHustleSlice,
   getSliceState as getHustleSliceState

--- a/src/core/state/slices/actions/index.js
+++ b/src/core/state/slices/actions/index.js
@@ -1,0 +1,2 @@
+export { getInstanceProgressSnapshot } from './progress.js';
+export { ensureSlice, getSliceState } from './registry.js';

--- a/src/core/state/slices/actions/progress.js
+++ b/src/core/state/slices/actions/progress.js
@@ -1,0 +1,237 @@
+import { toNumber } from '../../../helpers.js';
+
+export function normalizeProgressLog(log = {}) {
+  const normalized = {};
+  for (const [dayKey, value] of Object.entries(log || {})) {
+    const day = Math.max(1, Math.floor(Number(dayKey)) || 1);
+    const hours = Number(value);
+    if (!Number.isFinite(hours) || hours < 0) continue;
+    normalized[day] = Number.isFinite(normalized[day]) ? normalized[day] + hours : hours;
+  }
+  return normalized;
+}
+
+export function normalizeInstanceProgress(definition, instance = {}) {
+  const template = typeof definition?.progress === 'object' && definition.progress !== null
+    ? definition.progress
+    : {};
+  const source = typeof instance.progress === 'object' && instance.progress !== null
+    ? instance.progress
+    : {};
+
+  const progress = {};
+  progress.type = typeof source.type === 'string' ? source.type : template.type || 'instant';
+  const fallbackCompletion = template.completion || (progress.type === 'instant' ? 'instant' : 'deferred');
+  progress.completion = typeof source.completion === 'string' ? source.completion : fallbackCompletion;
+
+  const hoursRequiredSource = toNumber(source.hoursRequired, null);
+  const hoursRequiredTemplate = toNumber(template.hoursRequired, null);
+  const hoursRequiredInstance = toNumber(instance.hoursRequired, null);
+  const resolvedHoursRequired = hoursRequiredSource != null
+    ? hoursRequiredSource
+    : hoursRequiredTemplate != null
+      ? hoursRequiredTemplate
+      : hoursRequiredInstance;
+  progress.hoursRequired = Number.isFinite(resolvedHoursRequired) && resolvedHoursRequired >= 0
+    ? resolvedHoursRequired
+    : null;
+
+  const hoursPerDaySource = toNumber(source.hoursPerDay, null);
+  const hoursPerDayTemplate = toNumber(template.hoursPerDay, null);
+  const resolvedHoursPerDay = hoursPerDaySource != null ? hoursPerDaySource : hoursPerDayTemplate;
+  progress.hoursPerDay = Number.isFinite(resolvedHoursPerDay) && resolvedHoursPerDay > 0 ? resolvedHoursPerDay : null;
+
+  const daysRequiredSource = toNumber(source.daysRequired, null);
+  const daysRequiredTemplate = toNumber(template.daysRequired, null);
+  const resolvedDaysRequired = daysRequiredSource != null ? daysRequiredSource : daysRequiredTemplate;
+  progress.daysRequired = Number.isFinite(resolvedDaysRequired) && resolvedDaysRequired > 0
+    ? Math.floor(resolvedDaysRequired)
+    : null;
+
+  let deadline = source.deadlineDay;
+  if (deadline == null) {
+    deadline = template.deadlineDay;
+  }
+  if (deadline == null) {
+    deadline = instance.deadlineDay;
+  }
+  progress.deadlineDay = Number.isFinite(deadline) && deadline > 0 ? Math.floor(deadline) : null;
+
+  const normalizedLog = normalizeProgressLog(source.dailyLog);
+  progress.dailyLog = normalizedLog;
+  let totalHours = 0;
+  let lastWorked = null;
+  for (const [dayKey, value] of Object.entries(normalizedLog)) {
+    const day = Math.max(1, Math.floor(Number(dayKey)) || 1);
+    const hours = Number(value);
+    if (!Number.isFinite(hours) || hours < 0) continue;
+    totalHours += hours;
+    if (lastWorked == null || day > lastWorked) {
+      lastWorked = day;
+    }
+  }
+
+  const hoursLoggedSource = toNumber(source.hoursLogged, null);
+  const hoursLoggedInstance = toNumber(instance.hoursLogged, null);
+  const resolvedHoursLogged = hoursLoggedSource != null
+    ? hoursLoggedSource
+    : Number.isFinite(totalHours)
+      ? totalHours
+      : hoursLoggedInstance;
+  progress.hoursLogged = Number.isFinite(resolvedHoursLogged) && resolvedHoursLogged >= 0 ? resolvedHoursLogged : 0;
+
+  const hoursPerDay = Number(progress.hoursPerDay);
+  if (Number.isFinite(hoursPerDay) && hoursPerDay > 0) {
+    const threshold = hoursPerDay - 0.0001;
+    progress.daysCompleted = Object.values(normalizedLog).filter(hours => Number(hours) >= threshold).length;
+  } else {
+    const daysCompletedSource = toNumber(source.daysCompleted, null);
+    progress.daysCompleted = Number.isFinite(daysCompletedSource) && daysCompletedSource >= 0
+      ? Math.floor(daysCompletedSource)
+      : 0;
+  }
+
+  if (lastWorked != null) {
+    progress.lastWorkedDay = lastWorked;
+  } else if (source.lastWorkedDay != null) {
+    const parsed = Math.floor(Number(source.lastWorkedDay));
+    progress.lastWorkedDay = Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  } else {
+    progress.lastWorkedDay = null;
+  }
+
+  progress.completed = source.completed === true || instance.completed === true;
+  if (source.completedOnDay != null) {
+    const parsed = Math.floor(Number(source.completedOnDay));
+    progress.completedOnDay = Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+  } else if (progress.completed && instance.completedOnDay != null) {
+    const parsed = Math.floor(Number(instance.completedOnDay));
+    progress.completedOnDay = Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+  }
+
+  return progress;
+}
+
+export function getInstanceProgressSnapshot(instance = {}) {
+  if (!instance || typeof instance !== 'object') {
+    return null;
+  }
+
+  const progress = typeof instance.progress === 'object' && instance.progress !== null
+    ? instance.progress
+    : {};
+
+  const snapshot = {};
+
+  snapshot.definitionId = typeof instance.definitionId === 'string'
+    ? instance.definitionId
+    : typeof progress.definitionId === 'string'
+      ? progress.definitionId
+      : null;
+
+  snapshot.instanceId = typeof instance.id === 'string'
+    ? instance.id
+    : typeof progress.instanceId === 'string'
+      ? progress.instanceId
+      : null;
+
+  const resolvedHoursLogged = toNumber(progress.hoursLogged, toNumber(instance.hoursLogged, 0));
+  snapshot.hoursLogged = Number.isFinite(resolvedHoursLogged) && resolvedHoursLogged >= 0
+    ? resolvedHoursLogged
+    : 0;
+
+  const hoursRequiredCandidates = [
+    progress.hoursRequired,
+    instance.hoursRequired,
+    progress.totalHours
+  ];
+  let hoursRequired = null;
+  for (const candidate of hoursRequiredCandidates) {
+    const numeric = toNumber(candidate, null);
+    if (Number.isFinite(numeric) && numeric >= 0) {
+      hoursRequired = numeric;
+      break;
+    }
+  }
+  snapshot.hoursRequired = hoursRequired;
+
+  snapshot.hoursRemaining = snapshot.hoursRequired != null
+    ? Math.max(0, snapshot.hoursRequired - snapshot.hoursLogged)
+    : null;
+
+  const parsedHoursPerDay = toNumber(progress.hoursPerDay, null);
+  snapshot.hoursPerDay = Number.isFinite(parsedHoursPerDay) && parsedHoursPerDay > 0
+    ? parsedHoursPerDay
+    : null;
+
+  const parsedDaysCompleted = toNumber(progress.daysCompleted, null);
+  snapshot.daysCompleted = Number.isFinite(parsedDaysCompleted) && parsedDaysCompleted >= 0
+    ? Math.floor(parsedDaysCompleted)
+    : 0;
+
+  const parsedDaysRequired = toNumber(progress.daysRequired, null);
+  snapshot.daysRequired = Number.isFinite(parsedDaysRequired) && parsedDaysRequired > 0
+    ? Math.floor(parsedDaysRequired)
+    : null;
+
+  const progressType = typeof progress.type === 'string' && progress.type.trim()
+    ? progress.type.trim()
+    : null;
+  snapshot.type = progressType;
+
+  const completionCandidates = [progress.completion, progress.completionMode];
+  let completionMode = null;
+  for (const candidate of completionCandidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      completionMode = candidate.trim();
+      break;
+    }
+  }
+  if (!completionMode) {
+    completionMode = progressType === 'instant' ? 'instant' : 'manual';
+  }
+  snapshot.completion = completionMode;
+  snapshot.completionMode = completionMode;
+
+  snapshot.percentComplete = snapshot.hoursRequired && snapshot.hoursRequired > 0
+    ? Math.max(0, Math.min(1, snapshot.hoursLogged / snapshot.hoursRequired))
+    : null;
+
+  const parsedLastWorked = toNumber(progress.lastWorkedDay, null);
+  snapshot.lastWorkedDay = Number.isFinite(parsedLastWorked) && parsedLastWorked > 0
+    ? Math.floor(parsedLastWorked)
+    : null;
+
+  const parsedDeadline = toNumber(progress.deadlineDay, null);
+  snapshot.deadlineDay = Number.isFinite(parsedDeadline) && parsedDeadline > 0
+    ? Math.floor(parsedDeadline)
+    : null;
+
+  const parsedAcceptedOn = toNumber(progress.acceptedOnDay ?? instance.acceptedOnDay, null);
+  snapshot.acceptedOnDay = Number.isFinite(parsedAcceptedOn) && parsedAcceptedOn > 0
+    ? Math.floor(parsedAcceptedOn)
+    : null;
+
+  const completed = progress.completed === true
+    || instance.completed === true
+    || progress.status === 'completed'
+    || instance.status === 'completed';
+  snapshot.completed = completed;
+
+  const parsedCompletedOn = toNumber(progress.completedOnDay ?? instance.completedOnDay, null);
+  snapshot.completedOnDay = Number.isFinite(parsedCompletedOn) && parsedCompletedOn > 0
+    ? Math.floor(parsedCompletedOn)
+    : completed
+      ? snapshot.acceptedOnDay
+      : null;
+
+  snapshot.metadata = typeof progress.metadata === 'object' && progress.metadata !== null
+    ? progress.metadata
+    : {};
+
+  if (progress.dailyLog && typeof progress.dailyLog === 'object') {
+    snapshot.dailyLog = progress.dailyLog;
+  }
+
+  return snapshot;
+}

--- a/src/core/state/slices/actions/registry.js
+++ b/src/core/state/slices/actions/registry.js
@@ -1,0 +1,18 @@
+import { createRegistrySliceManager } from '../factory.js';
+import {
+  createDefaultActionState,
+  normalizeActionState,
+  migrateLegacyHustleProgress,
+  resolveDefinition
+} from './instances.js';
+
+const { ensureSlice, getSliceState } = createRegistrySliceManager({
+  sliceKey: 'actions',
+  registryKey: 'actions',
+  definitionLookup: resolveDefinition,
+  defaultFactory: definition => createDefaultActionState(definition),
+  normalizer: (definition, entry, context) => normalizeActionState(definition, entry, context),
+  ensureHook: migrateLegacyHustleProgress
+});
+
+export { ensureSlice, getSliceState };

--- a/src/ui/actions/outstanding/progressSnapshots.js
+++ b/src/ui/actions/outstanding/progressSnapshots.js
@@ -3,7 +3,7 @@ import {
   coercePositiveNumber,
   firstPositiveNumber
 } from '../utils.js';
-import { getInstanceProgressSnapshot } from '../../../core/state/slices/actions.js';
+import { getInstanceProgressSnapshot } from '../../../core/state/slices/actions/index.js';
 
 export function resolveStudyTrackIdFromProgress(progress = {}) {
   if (!progress || typeof progress !== 'object') {

--- a/tests/core/state/slices/actions/instances.test.js
+++ b/tests/core/state/slices/actions/instances.test.js
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  shouldRetireInstance,
+  normalizeActionState
+} from '../../../../../src/core/state/slices/actions/instances.js';
+
+const definition = {
+  id: 'writing-gig',
+  defaultState: {
+    runsToday: 0,
+    lastRunDay: 0,
+    instances: []
+  },
+  progress: {
+    type: 'scheduled',
+    completion: 'manual',
+    hoursPerDay: 2,
+    daysRequired: 3,
+    hoursRequired: 6
+  }
+};
+
+test('shouldRetireInstance keeps recent completions but retires stale history', () => {
+  const currentDay = 10;
+  assert.equal(shouldRetireInstance({ completedOnDay: 10 }, currentDay), false);
+  assert.equal(shouldRetireInstance({ completedOnDay: 9 }, currentDay), true);
+  assert.equal(shouldRetireInstance({ progress: { completedOnDay: 8 } }, currentDay), true);
+  assert.equal(shouldRetireInstance({ progress: { lastWorkedDay: 10 } }, currentDay), false);
+});
+
+test('normalizeActionState trims retired instances while preserving active progress', () => {
+  const context = { state: { day: 10 } };
+  const entry = {
+    runsToday: 5,
+    instances: [
+      {
+        id: 'active',
+        status: 'active',
+        accepted: true,
+        acceptedOnDay: 9,
+        hoursRequired: 6,
+        hoursLogged: 2
+      },
+      {
+        id: 'recent-complete',
+        status: 'completed',
+        completed: true,
+        completedOnDay: 10,
+        hoursRequired: 6,
+        hoursLogged: 6
+      },
+      {
+        id: 'stale-complete',
+        status: 'completed',
+        completed: true,
+        completedOnDay: 8,
+        hoursRequired: 6,
+        hoursLogged: 6
+      }
+    ]
+  };
+
+  const normalized = normalizeActionState(definition, entry, context);
+  assert.equal(normalized.runsToday, 5);
+  assert.equal(normalized.instances.length, 2, 'stale completions should be retired');
+  const ids = normalized.instances.map(instance => instance.id).sort();
+  assert.deepEqual(ids, ['active', 'recent-complete']);
+  const active = normalized.instances.find(instance => instance.id === 'active');
+  assert.equal(active.progress.hoursPerDay, 2, 'active instance progress should be normalized');
+  assert.equal(active.progress.daysRequired, 3);
+});

--- a/tests/core/state/slices/actions/progress.test.js
+++ b/tests/core/state/slices/actions/progress.test.js
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  normalizeProgressLog,
+  normalizeInstanceProgress,
+  getInstanceProgressSnapshot
+} from '../../../../../src/core/state/slices/actions/progress.js';
+
+const definition = {
+  id: 'practice-session',
+  progress: {
+    type: 'scheduled',
+    completion: 'manual',
+    hoursPerDay: 2,
+    daysRequired: 3,
+    hoursRequired: 6
+  }
+};
+
+test('normalizeProgressLog aggregates hours per day and ignores invalid entries', () => {
+  const log = {
+    1: 1.25,
+    2: '1.5',
+    '-3': 4,
+    4: -1,
+    extra: 'nope'
+  };
+
+  const normalized = normalizeProgressLog(log);
+  assert.deepEqual(normalized, { 1: 5.25, 2: 1.5 });
+});
+
+test('normalizeInstanceProgress merges template defaults and derives hours from log', () => {
+  const instance = {
+    hoursRequired: '7',
+    deadlineDay: 5,
+    progress: {
+      hoursPerDay: null,
+      daysCompleted: '1',
+      hoursLogged: null,
+      lastWorkedDay: 0,
+      dailyLog: {
+        1: 2,
+        2: '3.5',
+        6: 'invalid'
+      }
+    }
+  };
+
+  const progress = normalizeInstanceProgress(definition, instance);
+  assert.equal(progress.type, 'scheduled');
+  assert.equal(progress.completion, 'manual');
+  assert.equal(progress.hoursPerDay, null, 'null source should resolve to zero and clear hoursPerDay');
+  assert.equal(progress.hoursRequired, 6, 'template hours should win when source progress is unset');
+  assert.equal(progress.daysRequired, 3, 'template daysRequired should be carried forward');
+  assert.equal(progress.deadlineDay, 5, 'deadline should be copied from instance when provided');
+  assert.equal(progress.hoursLogged, 0, 'explicit progress hours override derived totals');
+  assert.equal(progress.daysCompleted, 1, 'fallback daysCompleted should be respected when hours per day is unknown');
+  assert.equal(progress.lastWorkedDay, 2, 'last worked day should mirror the final valid log day');
+});
+
+test('getInstanceProgressSnapshot reflects normalized progress metrics', () => {
+  const instance = {
+    id: 'instance-1',
+    definitionId: definition.id,
+    hoursRequired: 6,
+    acceptedOnDay: 3,
+    progress: normalizeInstanceProgress(definition, {
+      hoursLogged: 4,
+      progress: {
+        hoursPerDay: 2,
+        daysCompleted: 2,
+        dailyLog: { 1: 2, 2: 2 },
+        lastWorkedDay: 4
+      }
+    })
+  };
+
+  const snapshot = getInstanceProgressSnapshot(instance);
+  assert.equal(snapshot.definitionId, definition.id);
+  assert.equal(snapshot.instanceId, 'instance-1');
+  assert.equal(snapshot.hoursLogged, 4);
+  assert.equal(snapshot.hoursRequired, 6);
+  assert.equal(snapshot.hoursRemaining, 2);
+  assert.equal(snapshot.daysCompleted, 2);
+  assert.equal(snapshot.daysRequired, 3);
+  assert.equal(snapshot.lastWorkedDay, 2);
+  assert.equal(snapshot.completion, 'manual');
+  assert.equal(snapshot.percentComplete, 4 / 6);
+});

--- a/tests/core/state/slices/actions/registry.test.js
+++ b/tests/core/state/slices/actions/registry.test.js
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ensureSlice, getSliceState } from '../../../../../src/core/state/slices/actions/index.js';
+import { configureRegistry } from '../../../../../src/core/state/registry.js';
+import { loadRegistry, resetRegistry } from '../../../../../src/game/registryService.js';
+
+const definition = {
+  id: 'client-delivery',
+  category: 'hustle',
+  defaultState: {
+    runsToday: 0,
+    lastRunDay: 0,
+    instances: []
+  },
+  progress: {
+    type: 'scheduled',
+    completion: 'manual',
+    hoursPerDay: 2,
+    daysRequired: 2,
+    hoursRequired: 4
+  }
+};
+
+test('ensureSlice wires registry defaults and migrates legacy hustle state', () => {
+  resetRegistry();
+  loadRegistry({ actions: [definition], assets: [], upgrades: [] });
+  configureRegistry();
+
+  const state = {
+    day: 6,
+    actions: {},
+    hustles: {
+      [definition.id]: {
+        runsToday: 3,
+        lastRunDay: 5,
+        instances: [
+          {
+            id: 'legacy',
+            accepted: true,
+            acceptedOnDay: 4,
+            status: 'active',
+            hoursRequired: 4,
+            hoursLogged: 2
+          }
+        ],
+        legacyNote: 'keep-me'
+      }
+    },
+    progress: { knowledge: {} }
+  };
+
+  const slice = ensureSlice(state);
+  assert.strictEqual(slice, state.actions, 'ensureSlice should return the canonical slice map');
+  const entry = getSliceState(state, definition.id);
+  assert.equal(entry.runsToday, 3, 'legacy runs should migrate when defaults are untouched');
+  assert.equal(entry.lastRunDay, 5, 'legacy last run should migrate when defaults are untouched');
+  assert.equal(entry.legacyNote, 'keep-me', 'custom fields should be preserved during migration');
+  assert.equal(entry.instances.length, 1, 'legacy instances should be normalized onto the slice');
+  const [instance] = entry.instances;
+  assert.equal(instance.progress.hoursPerDay, 2, 'normalized instance should reference definition progress defaults');
+  assert.equal(instance.accepted, true);
+});

--- a/tests/stateSlices.test.js
+++ b/tests/stateSlices.test.js
@@ -4,7 +4,7 @@ import { getGameTestHarness } from './helpers/gameTestHarness.js';
 import {
   ensureSlice as ensureActionSlice,
   getSliceState as getActionSliceState
-} from '../src/core/state/slices/actions.js';
+} from '../src/core/state/slices/actions/index.js';
 import {
   ensureSlice as ensureAssetSlice,
   getSliceState as getAssetSliceState

--- a/tests/ui/actions/outstanding.progress.test.js
+++ b/tests/ui/actions/outstanding.progress.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { buildDefaultState } from '../../../src/core/state.js';
-import { ensureSlice, getInstanceProgressSnapshot } from '../../../src/core/state/slices/actions.js';
+import { ensureSlice, getInstanceProgressSnapshot } from '../../../src/core/state/slices/actions/index.js';
 import { collectOutstandingActionEntries } from '../../../src/ui/actions/outstanding.js';
 import { loadRegistry, resetRegistry } from '../../../src/game/registryService.js';
 


### PR DESCRIPTION
## Summary
- extract progress, instance management, and registry wiring helpers into dedicated `actions/` submodules
- re-export the minimal `ensureSlice`, `getSliceState`, and `getInstanceProgressSnapshot` surface through `actions/index.js`
- update imports and add focused tests covering progress normalization, instance retention, and registry migration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e3bc5d2130832c90ab531aa33c5ab9