### PR TITLE
Add shared study track resolver helper

### DIFF
--- a/src/ui/actions/outstanding/index.js
+++ b/src/ui/actions/outstanding/index.js
@@ -4,7 +4,7 @@ import { getActionDefinition } from '../../../game/registryService.js';
 import { clampToZero } from '../utils.js';
 import collectMarketIndexes from './marketIndexes.js';
 import createOutstandingEntry from './entryBuilders.js';
-import { resolveStudyTrackIdFromProgress } from './progressSnapshots.js';
+import { resolveStudyTrackId } from '../studyTracks.js';
 
 export function collectOutstandingActionEntries(state = getState()) {
   const workingState = state || getState() || {};
@@ -44,7 +44,7 @@ export function collectOutstandingActionEntries(state = getState()) {
         order: -(index * 10 + instanceIndex)
       });
       if (entry) {
-        const trackId = resolveStudyTrackIdFromProgress(entry.progress);
+        const trackId = resolveStudyTrackId(entry.progress, entry?.raw?.definition, entry);
         if (trackId) {
           const knowledge = workingState?.progress?.knowledge || {};
           if (knowledge[trackId]?.studiedToday) {

--- a/src/ui/actions/outstanding/progressSnapshots.js
+++ b/src/ui/actions/outstanding/progressSnapshots.js
@@ -5,41 +5,6 @@ import {
 } from '../utils.js';
 import { getInstanceProgressSnapshot } from '../../../core/state/slices/actions.js';
 
-export function resolveStudyTrackIdFromProgress(progress = {}) {
-  if (!progress || typeof progress !== 'object') {
-    return null;
-  }
-
-  const metadata = typeof progress.metadata === 'object' && progress.metadata !== null
-    ? progress.metadata
-    : {};
-
-  const candidates = [
-    progress.studyTrackId,
-    progress.trackId,
-    metadata.studyTrackId,
-    metadata.trackId
-  ];
-
-  for (const candidate of candidates) {
-    if (typeof candidate === 'string') {
-      const trimmed = candidate.trim();
-      if (trimmed) {
-        return trimmed;
-      }
-    }
-  }
-
-  const identifiers = [progress.definitionId, metadata.definitionId];
-  for (const identifier of identifiers) {
-    if (typeof identifier === 'string' && identifier.startsWith('study-')) {
-      return identifier.slice('study-'.length);
-    }
-  }
-
-  return null;
-}
-
 export function buildProgressSnapshot({
   state,
   definition,

--- a/src/ui/actions/studyTracks.js
+++ b/src/ui/actions/studyTracks.js
@@ -1,0 +1,187 @@
+const STUDY_TRACK_PREFIX = 'study-';
+
+function normalizeTrackValue(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (trimmed.startsWith(STUDY_TRACK_PREFIX)) {
+    const stripped = trimmed.slice(STUDY_TRACK_PREFIX.length).trim();
+    return stripped || null;
+  }
+  return trimmed;
+}
+
+function normalizeDefinitionValue(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed || !trimmed.startsWith(STUDY_TRACK_PREFIX)) {
+    return null;
+  }
+  const stripped = trimmed.slice(STUDY_TRACK_PREFIX.length).trim();
+  return stripped || null;
+}
+
+function collectArrayCandidates(values = []) {
+  if (!Array.isArray(values)) {
+    return null;
+  }
+  for (const value of values) {
+    const candidate = normalizeTrackValue(value);
+    if (candidate) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+export function resolveStudyTrackId(...inputs) {
+  const queue = [];
+  const visited = new Set();
+
+  const enqueue = value => {
+    if (!value || typeof value !== 'object') {
+      return;
+    }
+    if (visited.has(value)) {
+      return;
+    }
+    visited.add(value);
+    queue.push(value);
+  };
+
+  for (const input of inputs) {
+    if (!input) {
+      continue;
+    }
+    if (typeof input === 'string') {
+      const candidate = normalizeTrackValue(input);
+      if (candidate) {
+        return candidate;
+      }
+      continue;
+    }
+    if (Array.isArray(input)) {
+      const candidate = collectArrayCandidates(input);
+      if (candidate) {
+        return candidate;
+      }
+      input.forEach(item => {
+        if (item && typeof item === 'object') {
+          enqueue(item);
+        }
+      });
+      continue;
+    }
+    if (typeof input === 'object') {
+      enqueue(input);
+    }
+  }
+
+  while (queue.length) {
+    const current = queue.shift();
+    if (!current) {
+      continue;
+    }
+
+    const trackCandidates = [
+      current.studyTrackId,
+      current.trackId,
+      current?.metadata?.studyTrackId,
+      current?.metadata?.trackId,
+      current?.progress?.studyTrackId,
+      current?.progress?.trackId,
+      current?.progress?.metadata?.studyTrackId,
+      current?.progress?.metadata?.trackId
+    ];
+
+    for (const candidate of trackCandidates) {
+      const resolved = normalizeTrackValue(candidate);
+      if (resolved) {
+        return resolved;
+      }
+    }
+
+    const arrayCandidates = [
+      current.trackIds,
+      current?.metadata?.trackIds,
+      current?.progress?.trackIds,
+      current?.progress?.metadata?.trackIds
+    ];
+
+    for (const values of arrayCandidates) {
+      const resolved = collectArrayCandidates(values);
+      if (resolved) {
+        return resolved;
+      }
+    }
+
+    const definitionCandidates = [
+      current.definitionId,
+      current?.metadata?.definitionId,
+      current?.progress?.definitionId,
+      current?.progress?.metadata?.definitionId,
+      current.id
+    ];
+
+    for (const candidate of definitionCandidates) {
+      const resolved = normalizeDefinitionValue(candidate);
+      if (resolved) {
+        return resolved;
+      }
+    }
+
+    const nestedValues = [
+      current.metadata,
+      current.progress,
+      current.definition,
+      current.entry,
+      current.instance,
+      current.offer,
+      current.accepted,
+      current.claimMetadata,
+      current.source,
+      current.details,
+      current.data,
+      current.context
+    ];
+
+    for (const nested of nestedValues) {
+      if (!nested) {
+        continue;
+      }
+      if (Array.isArray(nested)) {
+        for (const item of nested) {
+          if (typeof item === 'string') {
+            const resolved = normalizeTrackValue(item);
+            if (resolved) {
+              return resolved;
+            }
+            const definitionResolved = normalizeDefinitionValue(item);
+            if (definitionResolved) {
+              return definitionResolved;
+            }
+          } else if (item && typeof item === 'object') {
+            enqueue(item);
+          }
+        }
+      } else if (typeof nested === 'string') {
+        const resolved = normalizeTrackValue(nested) || normalizeDefinitionValue(nested);
+        if (resolved) {
+          return resolved;
+        }
+      } else if (typeof nested === 'object') {
+        enqueue(nested);
+      }
+    }
+  }
+
+  return null;
+}
+
+export default { resolveStudyTrackId };

--- a/src/ui/actions/taskGrouping.js
+++ b/src/ui/actions/taskGrouping.js
@@ -15,6 +15,7 @@ import {
   resolveFocusBucket as resolveFocusBucketBase,
   sortBuckets as sortBucketsBase
 } from './queueService.js';
+import { resolveStudyTrackId } from './studyTracks.js';
 
 export const DEFAULT_TODO_EMPTY_MESSAGE = 'Queue a hustle or upgrade to add new tasks.';
 
@@ -283,25 +284,7 @@ export function createProgressHandler(entry = {}) {
       definition?.progress?.type === 'study' ||
       progress?.type === 'study';
     if (isStudy) {
-      const resolvedTrackId = (() => {
-        const directIdCandidates = [
-          definition.studyTrackId,
-          progress?.studyTrackId,
-          progress?.trackId,
-          definition?.progress?.studyTrackId,
-          definition?.progress?.trackId
-        ].filter(id => typeof id === 'string' && id.trim().length > 0);
-        if (directIdCandidates.length > 0) {
-          return directIdCandidates[0];
-        }
-        const stripStudyPrefix = value =>
-          typeof value === 'string' && value.startsWith('study-') ? value.slice('study-'.length) : null;
-        return (
-          stripStudyPrefix(definition?.id) ||
-          stripStudyPrefix(progress?.definitionId) ||
-          null
-        );
-      })();
+      const resolvedTrackId = resolveStudyTrackId(progress, definition, entry);
 
       if (resolvedTrackId) {
         allocateDailyStudy({ trackIds: [resolvedTrackId] });

--- a/tests/ui/actions/studyTracks.test.js
+++ b/tests/ui/actions/studyTracks.test.js
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveStudyTrackId } from '../../../src/ui/actions/studyTracks.js';
+
+test('resolveStudyTrackId prioritizes explicit studyTrackId values', () => {
+  const trackId = resolveStudyTrackId({ studyTrackId: 'writing' });
+  assert.equal(trackId, 'writing');
+});
+
+test('resolveStudyTrackId falls back to trackId fields and trims whitespace', () => {
+  const trackId = resolveStudyTrackId({ trackId: '  design  ' });
+  assert.equal(trackId, 'design');
+});
+
+test('resolveStudyTrackId reads metadata fields and strips prefixes', () => {
+  const progress = {
+    metadata: {
+      definitionId: 'study-analytics'
+    }
+  };
+  const trackId = resolveStudyTrackId(progress);
+  assert.equal(trackId, 'analytics');
+});
+
+test('resolveStudyTrackId inspects nested progress metadata', () => {
+  const entry = {
+    progress: {
+      metadata: {
+        studyTrackId: 'focus'
+      }
+    }
+  };
+  const trackId = resolveStudyTrackId(entry);
+  assert.equal(trackId, 'focus');
+});
+
+test('resolveStudyTrackId uses definition identifiers when prefixed', () => {
+  const entry = {
+    definitionId: 'study-research',
+    progress: {
+      definitionId: 'study-ignore'
+    }
+  };
+  const trackId = resolveStudyTrackId(entry);
+  assert.equal(trackId, 'research');
+});
+
+test('resolveStudyTrackId returns null when no identifiers are present', () => {
+  assert.equal(resolveStudyTrackId({ metadata: { label: 'Nope' } }), null);
+});


### PR DESCRIPTION
## Summary
- add a shared study track resolver helper that normalizes identifiers from direct fields, metadata, and prefixed values
- switch outstanding actions, dashboard knowledge handlers, and task grouping to use the shared resolver
- add unit tests covering resolver behavior across progress metadata and definition fallbacks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3bc6252e4832c8a5a2d49b188be72