### PR TITLE
Modularize study enrollment orchestrator flows

### DIFF
--- a/src/game/requirements/orchestrator/marketSeats.js
+++ b/src/game/requirements/orchestrator/marketSeats.js
@@ -1,0 +1,143 @@
+import { formatMoney, structuredClone } from '../../../core/helpers.js';
+import {
+  ensureDailyOffersForDay,
+  getAvailableOffers,
+  getClaimedOffers,
+  acceptHustleOffer,
+  releaseClaimedHustleOffer
+} from '../../hustles.js';
+
+function sortByAvailableDay(a, b) {
+  return (a.availableOnDay || Infinity) - (b.availableOnDay || Infinity);
+}
+
+export function createMarketSeatManager({ getState, addLog }) {
+  function claimSeat({ track, tuition, currentDay, definitionId }) {
+    const state = getState();
+    if (!state) {
+      return { success: false, reason: 'missing_state' };
+    }
+
+    ensureDailyOffersForDay({ state });
+
+    const offers = getAvailableOffers(state, { includeUpcoming: true }).filter(offer => {
+      return offer.definitionId === definitionId && offer.claimed !== true;
+    });
+
+    const availableOffer = offers
+      .filter(offer => offer.availableOnDay <= currentDay)
+      .sort(sortByAvailableDay)[0] || null;
+    const upcomingOffer = offers
+      .filter(offer => offer.availableOnDay > currentDay)
+      .sort(sortByAvailableDay)[0] || null;
+
+    if (!availableOffer) {
+      if (upcomingOffer) {
+        addLog(
+          `${track.name} opens new seats on day ${upcomingOffer.availableOnDay}. Save the date!`,
+          'info'
+        );
+      } else {
+        addLog(`Seats for ${track.name} are booked today. Check back tomorrow!`, 'warning');
+      }
+      return { success: false, reason: 'no_offer' };
+    }
+
+    const metadata = structuredClone(availableOffer.metadata || {});
+    const baseProgress = typeof metadata.progress === 'object' && metadata.progress !== null
+      ? metadata.progress
+      : {};
+    const seatPolicy = metadata.seatPolicy || (tuition > 0 ? 'limited' : 'always-on');
+
+    metadata.studyTrackId = track.id;
+    metadata.trackId = track.id;
+    metadata.tuitionCost = tuition;
+    metadata.tuitionDue = tuition;
+    metadata.educationBonuses = structuredClone(track.instantBoosts || []);
+    metadata.enrolledOnDay = currentDay;
+    metadata.progress = {
+      ...baseProgress,
+      studyTrackId: track.id,
+      trackId: track.id,
+      label: baseProgress.label || `Study ${track.name}`,
+      completion: baseProgress.completion || 'manual'
+    };
+    metadata.enrollment = {
+      ...(typeof metadata.enrollment === 'object' && metadata.enrollment !== null
+        ? metadata.enrollment
+        : {}),
+      seatPolicy,
+      enrolledOnDay: currentDay
+    };
+
+    const accepted = acceptHustleOffer({
+      ...availableOffer,
+      metadata
+    }, { state });
+
+    if (!accepted) {
+      addLog(`Someone else snagged the last seat in ${track.name} moments before you.`, 'warning');
+      return { success: false, reason: 'claim_failed' };
+    }
+
+    const acceptedMetadata = typeof accepted.metadata === 'object' && accepted.metadata !== null
+      ? accepted.metadata
+      : {};
+
+    accepted.metadata = {
+      ...acceptedMetadata,
+      studyTrackId: track.id,
+      trackId: track.id,
+      tuitionCost: tuition,
+      tuitionDue: tuition,
+      tuitionPaid: tuition,
+      tuitionPaidOnDay: currentDay,
+      enrolledOnDay: currentDay,
+      educationBonuses: structuredClone(track.instantBoosts || []),
+      seatPolicy
+    };
+
+    accepted.metadata.progress = {
+      ...(acceptedMetadata.progress || {}),
+      ...metadata.progress
+    };
+
+    accepted.metadata.enrollment = {
+      ...(acceptedMetadata.enrollment || {}),
+      ...metadata.enrollment
+    };
+
+    if (tuition > 0) {
+      addLog(`Reserved a seat in ${track.name} for $${formatMoney(tuition)} upfront.`, 'info');
+    }
+
+    return { success: true, offer: accepted };
+  }
+
+  function releaseSeats({ trackId, trackName, state = getState() }) {
+    if (!state) {
+      return { released: 0 };
+    }
+
+    const claimedStudyOffers = getClaimedOffers(state, { includeExpired: true })
+      .filter(entry => entry?.metadata?.studyTrackId === trackId);
+
+    let released = 0;
+    for (const offer of claimedStudyOffers) {
+      releaseClaimedHustleOffer({ offerId: offer.offerId, acceptedId: offer.id }, { state });
+      released += 1;
+    }
+
+    if (released > 0) {
+      const label = trackName || trackId;
+      addLog(`Released ${released} ${released === 1 ? 'seat' : 'seats'} back to the market for ${label}.`, 'info');
+    }
+
+    return { released };
+  }
+
+  return {
+    claimSeat,
+    releaseSeats
+  };
+}

--- a/src/game/requirements/orchestrator/studyEnrollment.js
+++ b/src/game/requirements/orchestrator/studyEnrollment.js
@@ -1,0 +1,100 @@
+import { formatMoney } from '../../../core/helpers.js';
+
+export function createStudyEnrollment({
+  getState,
+  getKnowledgeProgress,
+  knowledgeTracks,
+  addLog,
+  markDirty,
+  seatManager,
+  tuitionLogging,
+  getStudyActionId,
+  removeActiveStudyInstance,
+  STUDY_DIRTY_SECTIONS
+}) {
+  function enrollInKnowledgeTrack(id) {
+    const state = getState();
+    const track = knowledgeTracks[id];
+    if (!state || !track) {
+      return { success: false, reason: 'missing' };
+    }
+
+    const progress = getKnowledgeProgress(id);
+    if (progress.completed) {
+      addLog(`${track.name} is already complete. Grab a celebratory pastry instead.`, 'info');
+      return { success: false, reason: 'completed' };
+    }
+    if (progress.enrolled) {
+      addLog(`You're already enrolled in ${track.name}.`, 'info');
+      return { success: false, reason: 'enrolled' };
+    }
+
+    const tuition = Number(track.tuition) || 0;
+    if (tuition > 0 && state.money < tuition) {
+      addLog(`You need $${formatMoney(tuition)} ready to enroll in ${track.name}.`, 'warning');
+      return { success: false, reason: 'money' };
+    }
+
+    const definitionId = getStudyActionId(track.id);
+    const currentDay = Math.max(1, Math.floor(Number(state.day) || 1));
+
+    const seatResult = seatManager.claimSeat({
+      track,
+      tuition,
+      currentDay,
+      definitionId
+    });
+
+    if (!seatResult.success) {
+      return { success: false, reason: seatResult.reason };
+    }
+
+    if (tuition > 0) {
+      tuitionLogging.payTuition({ track, tuition, progress, currentDay });
+    }
+
+    progress.enrolled = true;
+    progress.enrolledOnDay = currentDay;
+    progress.studiedToday = false;
+
+    if (tuition <= 0 && typeof progress.tuitionPaid !== 'number') {
+      progress.tuitionPaid = Number(progress.tuitionPaid) || 0;
+    }
+
+    tuitionLogging.logEnrollmentSuccess({ track, tuition });
+    markDirty(STUDY_DIRTY_SECTIONS);
+
+    return { success: true, offer: seatResult.offer };
+  }
+
+  function dropKnowledgeTrack(id) {
+    const state = getState();
+    const track = knowledgeTracks[id];
+    if (!state || !track) {
+      return { success: false, reason: 'missing' };
+    }
+
+    const progress = getKnowledgeProgress(id, state);
+    if (!progress.enrolled || progress.completed) {
+      addLog(`You're not currently enrolled in ${track.name}.`, 'info');
+      return { success: false, reason: 'not_enrolled' };
+    }
+
+    progress.enrolled = false;
+    progress.studiedToday = false;
+    progress.enrolledOnDay = null;
+
+    removeActiveStudyInstance(id, state);
+    seatManager.releaseSeats({ trackId: track.id, trackName: track.name, state });
+
+    addLog(`You dropped ${track.name}. Tuition stays paid, but your schedule opens back up.`, 'warning');
+    markDirty(STUDY_DIRTY_SECTIONS);
+
+    return { success: true };
+  }
+
+  return {
+    enrollInKnowledgeTrack,
+    dropKnowledgeTrack
+  };
+}

--- a/src/game/requirements/orchestrator/tuitionLogging.js
+++ b/src/game/requirements/orchestrator/tuitionLogging.js
@@ -1,0 +1,38 @@
+import { formatHours, formatMoney } from '../../../core/helpers.js';
+
+export function createTuitionLogging({ spendMoney, recordCostContribution, addLog }) {
+  function payTuition({ track, tuition, progress, currentDay }) {
+    if (tuition <= 0) {
+      return { paid: false };
+    }
+
+    spendMoney(tuition);
+    recordCostContribution({
+      key: `study:${track.id}:tuition`,
+      label: `🎓 ${track.name} tuition`,
+      amount: tuition,
+      category: 'investment'
+    });
+
+    progress.tuitionPaid = (Number(progress.tuitionPaid) || 0) + tuition;
+    progress.tuitionPaidOnDay = currentDay;
+
+    return { paid: true };
+  }
+
+  function logEnrollmentSuccess({ track, tuition }) {
+    const tuitionMessage = tuition > 0
+      ? `Tuition paid for $${formatMoney(tuition)}.`
+      : 'No tuition due.';
+
+    addLog(
+      `You claimed a seat in ${track.name}! ${tuitionMessage} Log ${formatHours(track.hoursPerDay)} each day from the action queue to progress.`,
+      'info'
+    );
+  }
+
+  return {
+    payTuition,
+    logEnrollmentSuccess
+  };
+}

--- a/tests/requirements.test.js
+++ b/tests/requirements.test.js
@@ -421,6 +421,39 @@ test('dropping a knowledge track releases the claimed hustle offer', () => {
     false,
     'dropping should release the study offer seat'
   );
+
+  const releaseLog = state.log.find(entry => /Released 1 seat/i.test(entry?.message || ''));
+  assert.ok(releaseLog, 'dropping should log the seat release via the market manager');
+  assert.ok(releaseLog.message.includes(track.name), 'seat release log should reference the track name');
+  assert.match(state.log.at(-1)?.message || '', /You dropped/, 'final log should confirm the drop');
+});
+
+test('tuition enrollment deducts money, records contributions, and logs success messaging', () => {
+  resetState();
+  const state = getState();
+  const track = KNOWLEDGE_TRACKS.outlineMastery;
+  const enrollmentDay = state.day;
+  state.money = track.tuition + 500;
+  state.timeLeft = Math.max(state.timeLeft || 0, (track.hoursPerDay || 0) + 4);
+
+  const startingMoney = state.money;
+  const enrollResult = enrollInKnowledgeTrack(track.id);
+  assert.ok(enrollResult?.success, 'enrollment should succeed with sufficient tuition');
+
+  const progress = getKnowledgeProgress(track.id);
+  assert.equal(progress.tuitionPaid, track.tuition, 'tuition should be tracked on progress state');
+  assert.equal(progress.tuitionPaidOnDay, enrollmentDay, 'tuition day should match enrollment day');
+  assert.equal(state.money, startingMoney - track.tuition, 'tuition should deduct from money immediately');
+
+  const costKey = `study:${track.id}:tuition`;
+  const dailyMetrics = state.metrics?.daily?.costs || {};
+  assert.ok(dailyMetrics[costKey], 'daily metrics should include the tuition cost contribution');
+  assert.equal(dailyMetrics[costKey].amount, track.tuition, 'tuition contribution should match the paid amount');
+
+  const reservationLog = state.log.find(entry => /Reserved a seat/i.test(entry?.message || ''));
+  assert.ok(reservationLog, 'market seat manager should log the seat reservation and tuition payment');
+  const successLog = state.log.find(entry => /You claimed a seat/i.test(entry?.message || ''));
+  assert.ok(successLog, 'tuition logger should emit an enrollment success message');
 });
 
 test('knowledge track rollover invalidates study panels for completions and stalls', () => {


### PR DESCRIPTION
## Summary
- extract market seat management, tuition handling, and enrollment helpers into dedicated orchestrator submodules
- compose the requirements orchestrator from the new modules to keep enrollment and cleanup flows focused
- expand requirements tests to verify seat release logging and tuition deductions

## Testing
- npm test -- tests/requirements.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e3c79e7d58832c82b1766a6133536a