### PR TITLE
Refactor instant hustle helpers into modular files

### DIFF
--- a/src/game/content/schema/assetActions.js
+++ b/src/game/content/schema/assetActions.js
@@ -1,52 +1,9 @@
-import { formatHours, formatMoney, toNumber } from '../../../core/helpers.js';
-import { countActiveAssetInstances, getActionState, getState } from '../../../core/state.js';
-import { executeAction } from '../../actions.js';
-import { addMoney, spendMoney } from '../../currency.js';
-import { checkDayEnd } from '../../lifecycle.js';
-import { recordCostContribution, recordPayoutContribution, recordTimeContribution } from '../../metrics.js';
-import { summarizeAssetRequirements } from '../../requirements.js';
-import { spendTime } from '../../time.js';
-import { awardSkillProgress } from '../../skills/index.js';
-import {
-  applyInstantHustleEducationBonus,
-  describeInstantHustleEducationBonuses,
-  formatEducationBonusSummary
-} from '../../educationEffects.js';
-import { getHustleEffectMultiplier } from '../../upgrades/effects/index.js';
-import { applyModifiers } from '../../data/economyMath.js';
-import { applyMetric, normalizeHustleMetrics } from './metrics.js';
-import { logEducationPayoffSummary, logHustleBlocked } from './logMessaging.js';
-import { markDirty } from '../../../core/events/invalidationBus.js';
-import { advanceActionInstance, completeActionInstance } from '../../actions/progress/instances.js';
+import { toNumber } from '../../../core/helpers.js';
+import { normalizeHustleMetrics } from './metrics.js';
 import { createContractTemplate } from '../../actions/templates/contract.js';
-
-function formatHourDetail(hours, effective) {
-  if (!hours) return '⏳ Time: <strong>Instant</strong>';
-  const base = formatHours(hours);
-  if (Number.isFinite(Number(effective)) && Math.abs(effective - hours) > 0.01) {
-    return `⏳ Time: <strong>${formatHours(effective)}</strong> (base ${base})`;
-  }
-  return `⏳ Time: <strong>${base}</strong>`;
-}
-
-function formatCostDetail(cost) {
-  if (!cost) return null;
-  return `💵 Cost: <strong>$${formatMoney(cost)}</strong>`;
-}
-
-function formatPayoutDetail(payout) {
-  if (!payout || !payout.amount) return null;
-  const base = `💰 Payout: <strong>$${formatMoney(payout.amount)}</strong>`;
-  if (payout.delaySeconds) {
-    return `${base} after ${payout.delaySeconds}s`;
-  }
-  return base;
-}
-
-function meetsAssetRequirements(requirements = [], state = getState()) {
-  if (!requirements?.length) return true;
-  return requirements.every(req => countActiveAssetInstances(req.assetId, state) >= toNumber(req.count, 1));
-}
+import { buildProgressDefaults, buildDefaultState } from './assetActions/progressDefaults.js';
+import { buildDetailResolvers } from './assetActions/formatting.js';
+import { createDailyLimitTracker, createExecutionHooks } from './assetActions/execution.js';
 
 export function createInstantHustle(config) {
   const metadata = {
@@ -70,80 +27,15 @@ export function createInstantHustle(config) {
       : null
   };
 
-  function resolveDailyUsage(state = getState(), { sync = false } = {}) {
-    const actionState = getActionState(metadata.id, state);
-    const currentDay = Number(state?.day) || 1;
+  const { resolveDailyUsage, updateDailyUsage } = createDailyLimitTracker(metadata);
 
-    if (!metadata.dailyLimit) {
-      return {
-        actionState,
-        currentDay,
-        limit: null,
-        used: Number(actionState.runsToday) || 0,
-        remaining: null
-      };
-    }
-
-    const lastRunDay = Number(actionState.lastRunDay) || 0;
-    const usedToday = lastRunDay === currentDay ? Number(actionState.runsToday) || 0 : 0;
-
-    if (sync && lastRunDay !== currentDay) {
-      actionState.lastRunDay = currentDay;
-      actionState.runsToday = usedToday;
-    }
-
-    return {
-      actionState,
-      currentDay,
-      limit: metadata.dailyLimit,
-      used: usedToday,
-      remaining: Math.max(0, metadata.dailyLimit - usedToday)
-    };
-  }
-
-  function updateDailyUsage(state) {
-    if (!metadata.dailyLimit) return null;
-    const usage = resolveDailyUsage(state, { sync: true });
-    const nextUsed = Math.min(metadata.dailyLimit, usage.used + 1);
-    usage.actionState.lastRunDay = usage.currentDay;
-    usage.actionState.runsToday = nextUsed;
-    const remaining = Math.max(0, metadata.dailyLimit - nextUsed);
-    return {
-      limit: metadata.dailyLimit,
-      used: nextUsed,
-      remaining,
-      day: usage.currentDay
-    };
-  }
-
-  const progressDefaults = {
-    type: 'instant',
-    completion: 'instant',
-    ...(config.progress || {})
-  };
-
-  if (progressDefaults.hoursRequired == null) {
-    const baseHours = Number(metadata.time);
-    if (Number.isFinite(baseHours) && baseHours >= 0) {
-      progressDefaults.hoursRequired = baseHours;
-    }
-  }
+  const progressDefaults = buildProgressDefaults({ metadata, config });
 
   const baseDefinition = {
     ...config,
     type: 'hustle',
     tag: config.tag || { label: 'Instant', type: 'instant' },
-    defaultState: (() => {
-      const base = { ...(config.defaultState || {}) };
-      if (!Array.isArray(base.instances)) {
-        base.instances = [];
-      }
-      if (metadata.dailyLimit) {
-        if (typeof base.runsToday !== 'number') base.runsToday = 0;
-        if (typeof base.lastRunDay !== 'number') base.lastRunDay = 0;
-      }
-      return base;
-    })(),
+    defaultState: buildDefaultState({ config, metadata }),
     dailyLimit: metadata.dailyLimit,
     skills: metadata.skills,
     progress: config.progress,
@@ -183,254 +75,31 @@ export function createInstantHustle(config) {
 
   definition.tags = Array.isArray(config.tags) ? config.tags.slice() : [];
 
-  function resolveEffectiveTime(state = getState()) {
-    if (!metadata.time) return metadata.time;
-    const { multiplier } = getHustleEffectMultiplier(definition, 'setup_time_mult', {
-      state,
-      actionType: 'setup'
-    });
-    const adjusted = metadata.time * (Number.isFinite(multiplier) ? multiplier : 1);
-    return Number.isFinite(adjusted) ? Math.max(0, adjusted) : metadata.time;
-  }
-
-  function describeEffectiveTime() {
-    return formatHourDetail(metadata.time, resolveEffectiveTime());
-  }
-
-  function applyHustlePayoutMultiplier(amount, context) {
-    if (!amount) {
-      return { amount: 0, multiplier: 1, sources: [] };
-    }
-    const effect = getHustleEffectMultiplier(definition, 'payout_mult', {
-      state: context.state,
-      actionType: 'payout'
-    });
-    if (!effect) {
-      return { amount, multiplier: 1, sources: [] };
-    }
-
-    const baseMultiplier = Number.isFinite(effect.multiplier) ? effect.multiplier : 1;
-    if (Array.isArray(effect.modifiers) && effect.modifiers.length) {
-      const result = applyModifiers(amount, effect.modifiers, { clamp: effect.clamp });
-      const finalAmount = Number.isFinite(result?.value) ? result.value : amount;
-      const appliedSources = result.applied
-        .filter(entry => entry.type === 'multiplier')
-        .map(entry => ({ id: entry.id, label: entry.label, multiplier: entry.value }));
-      return {
-        amount: finalAmount,
-        multiplier: Number.isFinite(result?.multiplier) ? result.multiplier : baseMultiplier,
-        sources: appliedSources
-      };
-    }
-
-    if (!Number.isFinite(baseMultiplier) || baseMultiplier === 1) {
-      return { amount, multiplier: 1, sources: [] };
-    }
-    return { amount: amount * baseMultiplier, multiplier: baseMultiplier, sources: effect.sources || [] };
-  }
+  const hooks = createExecutionHooks({
+    definition,
+    metadata,
+    config,
+    resolveDailyUsage,
+    updateDailyUsage
+  });
 
   definition.dailyLimit = metadata.dailyLimit;
   definition.getDailyUsage = state => resolveDailyUsage(state, { sync: false });
 
-  const baseDetails = [];
-  if (metadata.time > 0) {
-    baseDetails.push(() => describeEffectiveTime());
-  }
-  if (metadata.cost > 0) {
-    const detail = formatCostDetail(metadata.cost);
-    if (detail) baseDetails.push(() => detail);
-  }
-  const payoutDetail = formatPayoutDetail(metadata.payout);
-  if (payoutDetail) {
-    baseDetails.push(() => payoutDetail);
-  }
-  if (metadata.requirements.length) {
-    baseDetails.push(() => `Requires: <strong>${summarizeAssetRequirements(metadata.requirements)}</strong>`);
-  }
-
-  if (metadata.dailyLimit) {
-    baseDetails.push(() => {
-      const usage = resolveDailyUsage(getState(), { sync: false });
-      const remaining = usage?.remaining ?? metadata.dailyLimit;
-      const limit = usage?.limit ?? metadata.dailyLimit;
-      const status = remaining > 0
-        ? `${remaining}/${limit} runs left today`
-        : 'Daily limit reached today';
-      return `🗓️ Daily limit: <strong>${limit} per day</strong> (${status})`;
-    });
-  }
-
-  const educationDetails = describeInstantHustleEducationBonuses(config.id);
-
-  definition.details = [...baseDetails, ...educationDetails, ...(config.details || [])];
+  definition.details = buildDetailResolvers({
+    metadata,
+    config,
+    resolveDailyUsage,
+    resolveEffectiveTime: hooks.resolveEffectiveTime
+  });
 
   const actionClassName = config.actionClassName || 'primary';
-
-  function getDisabledReason(state) {
-    if (metadata.dailyLimit) {
-      const usage = resolveDailyUsage(state, { sync: true });
-      if (usage.remaining <= 0) {
-        const runsLabel = metadata.dailyLimit === 1
-          ? 'once'
-          : `${metadata.dailyLimit} times`;
-        return `Daily limit reached: ${definition.name} can only run ${runsLabel} per day. Fresh slots unlock tomorrow.`;
-      }
-    }
-    const effectiveTime = resolveEffectiveTime(state);
-    if (effectiveTime > 0 && state.timeLeft < effectiveTime) {
-      return `You need at least ${formatHours(effectiveTime)} free before starting ${definition.name}.`;
-    }
-    if (metadata.cost > 0 && state.money < metadata.cost) {
-      return `You need $${formatMoney(metadata.cost)} before funding ${definition.name}.`;
-    }
-    if (!meetsAssetRequirements(metadata.requirements, state)) {
-      return `You still need: ${summarizeAssetRequirements(metadata.requirements, state)}.`;
-    }
-    return null;
-  }
-
-  function runHustle(context) {
-    const effectiveTime = resolveEffectiveTime(context.state);
-    context.effectiveTime = effectiveTime;
-    if (effectiveTime > 0) {
-      spendTime(effectiveTime);
-      applyMetric(recordTimeContribution, metadata.metrics.time, { hours: effectiveTime });
-    }
-    if (metadata.cost > 0) {
-      spendMoney(metadata.cost);
-      applyMetric(recordCostContribution, metadata.metrics.cost, { amount: metadata.cost });
-    }
-
-    context.skipDefaultPayout = () => {
-      context.__skipDefaultPayout = true;
-    };
-
-    config.onExecute?.(context);
-
-    if (metadata.skills) {
-      context.skillXpAwarded = awardSkillProgress({
-        skills: metadata.skills,
-        timeSpentHours: effectiveTime,
-        moneySpent: metadata.cost,
-        label: definition.name
-      });
-    }
-
-    if (metadata.payout && metadata.payout.grantOnAction && !context.__skipDefaultPayout) {
-      const basePayout = metadata.payout.amount;
-      const { amount: educationAdjusted, applied: appliedBonuses } = applyInstantHustleEducationBonus({
-        hustleId: metadata.id,
-        baseAmount: basePayout,
-        state: context.state
-      });
-
-      context.basePayout = basePayout;
-      context.educationAdjustedPayout = educationAdjusted;
-      context.appliedEducationBoosts = appliedBonuses;
-
-      const upgradeResult = applyHustlePayoutMultiplier(educationAdjusted, context);
-      const upgradedAmount = upgradeResult.amount;
-      const roundedPayout = Math.max(0, Math.round(upgradedAmount));
-
-      context.upgradeMultiplier = upgradeResult.multiplier;
-      context.upgradeSources = upgradeResult.sources;
-      context.finalPayout = roundedPayout;
-      context.payoutGranted = roundedPayout;
-
-      const template = metadata.payout.message;
-      let message;
-      if (typeof template === 'function') {
-        message = template(context);
-      } else if (template) {
-        message = template;
-      } else {
-        const bonusNote = appliedBonuses.length ? ' Education bonus included!' : '';
-        const upgradeNote = upgradeResult.sources.length ? ' Upgrades amplified the payout!' : '';
-        message = `${definition.name} paid $${formatMoney(roundedPayout)}.${bonusNote}${upgradeNote}`;
-      }
-
-      addMoney(roundedPayout, message, metadata.payout.logType);
-      applyMetric(recordPayoutContribution, metadata.metrics.payout, { amount: roundedPayout });
-
-      if (appliedBonuses.length) {
-        const summary = formatEducationBonusSummary(appliedBonuses);
-        logEducationPayoffSummary(summary);
-      }
-    }
-
-    const updatedUsage = updateDailyUsage(context.state);
-    if (updatedUsage) {
-      context.limitUsage = updatedUsage;
-      markDirty('actions');
-    }
-
-    config.onComplete?.(context);
-    markDirty('cards');
-  }
 
   definition.action = {
     label: config.actionLabel || 'Run Hustle',
     className: actionClassName,
-    disabled: () => {
-      const state = getState();
-      if (!state) return true;
-      return Boolean(getDisabledReason(state));
-    },
-    onClick: () => {
-      executeAction(() => {
-        const state = getState();
-        if (!state) return;
-        const reason = getDisabledReason(state);
-        if (reason) {
-          logHustleBlocked(reason);
-          return;
-        }
-        const context = {
-          definition,
-          state,
-          metadata,
-          get usage() {
-            return resolveDailyUsage(state, { sync: false });
-          }
-        };
-        const effectiveTime = resolveEffectiveTime(state);
-        const deadlineDay = metadata.dailyLimit ? Number(state?.day) || null : null;
-        const progressOverrides = definition.progress ? { ...definition.progress } : { ...config.progress };
-        if (deadlineDay != null) {
-          progressOverrides.deadlineDay = deadlineDay;
-        }
-        const instance = definition.acceptInstance({
-          state,
-          metadata,
-          overrides: {
-            hoursRequired: effectiveTime > 0 ? effectiveTime : 0,
-            deadlineDay,
-            progress: progressOverrides
-          }
-        });
-        if (instance) {
-          context.instance = instance;
-          const logDay = Number(state?.day) || instance.acceptedOnDay;
-          advanceActionInstance(definition, instance, {
-            state,
-            day: logDay,
-            hours: effectiveTime,
-            autoComplete: false,
-            completionContext: context,
-            metadata
-          });
-        }
-        runHustle(context);
-        context.completionDay = Number(state?.day) || instance?.acceptedOnDay || null;
-        const completionMode = (definition.progress || config.progress || {}).completion;
-        const shouldDeferCompletion = completionMode === 'deferred' || completionMode === 'manual';
-        if (instance && !shouldDeferCompletion) {
-          completeActionInstance(definition, instance, context);
-        }
-        config.onRun?.(context);
-      });
-      checkDayEnd();
-    }
+    disabled: hooks.disabled,
+    onClick: hooks.handleActionClick
   };
   definition.action.isLegacyInstant = true;
   definition.action.hiddenFromMarket = true;

--- a/src/game/content/schema/assetActions/execution.js
+++ b/src/game/content/schema/assetActions/execution.js
@@ -1,0 +1,294 @@
+import { formatHours, formatMoney, toNumber } from '../../../../core/helpers.js';
+import { countActiveAssetInstances, getActionState, getState } from '../../../../core/state.js';
+import { markDirty } from '../../../../core/events/invalidationBus.js';
+import { executeAction } from '../../../actions.js';
+import { addMoney, spendMoney } from '../../../currency.js';
+import { checkDayEnd } from '../../../lifecycle.js';
+import { recordCostContribution, recordPayoutContribution, recordTimeContribution } from '../../../metrics.js';
+import { summarizeAssetRequirements } from '../../../requirements.js';
+import { spendTime } from '../../../time.js';
+import { awardSkillProgress } from '../../../skills/index.js';
+import {
+  applyInstantHustleEducationBonus,
+  formatEducationBonusSummary
+} from '../../../educationEffects.js';
+import { getHustleEffectMultiplier } from '../../../upgrades/effects/index.js';
+import { applyModifiers } from '../../../data/economyMath.js';
+import { applyMetric } from '../metrics.js';
+import { logEducationPayoffSummary, logHustleBlocked } from '../logMessaging.js';
+import { advanceActionInstance, completeActionInstance } from '../../../actions/progress/instances.js';
+
+function meetsAssetRequirements(requirements = [], state = getState()) {
+  if (!requirements?.length) return true;
+  return requirements.every(req => countActiveAssetInstances(req.assetId, state) >= toNumber(req.count, 1));
+}
+
+export function createDailyLimitTracker(metadata) {
+  function resolveDailyUsage(state = getState(), { sync = false } = {}) {
+    const actionState = getActionState(metadata.id, state);
+    const currentDay = Number(state?.day) || 1;
+
+    if (!metadata.dailyLimit) {
+      return {
+        actionState,
+        currentDay,
+        limit: null,
+        used: Number(actionState.runsToday) || 0,
+        remaining: null
+      };
+    }
+
+    const lastRunDay = Number(actionState.lastRunDay) || 0;
+    const usedToday = lastRunDay === currentDay ? Number(actionState.runsToday) || 0 : 0;
+
+    if (sync && lastRunDay !== currentDay) {
+      actionState.lastRunDay = currentDay;
+      actionState.runsToday = usedToday;
+    }
+
+    return {
+      actionState,
+      currentDay,
+      limit: metadata.dailyLimit,
+      used: usedToday,
+      remaining: Math.max(0, metadata.dailyLimit - usedToday)
+    };
+  }
+
+  function updateDailyUsage(state) {
+    if (!metadata.dailyLimit) return null;
+    const usage = resolveDailyUsage(state, { sync: true });
+    const nextUsed = Math.min(metadata.dailyLimit, usage.used + 1);
+    usage.actionState.lastRunDay = usage.currentDay;
+    usage.actionState.runsToday = nextUsed;
+    const remaining = Math.max(0, metadata.dailyLimit - nextUsed);
+    return {
+      limit: metadata.dailyLimit,
+      used: nextUsed,
+      remaining,
+      day: usage.currentDay
+    };
+  }
+
+  return { resolveDailyUsage, updateDailyUsage };
+}
+
+export function createExecutionHooks({
+  definition,
+  metadata,
+  config,
+  resolveDailyUsage,
+  updateDailyUsage
+}) {
+  function resolveEffectiveTime(state = getState()) {
+    if (!metadata.time) return metadata.time;
+    const { multiplier } = getHustleEffectMultiplier(definition, 'setup_time_mult', {
+      state,
+      actionType: 'setup'
+    });
+    const adjusted = metadata.time * (Number.isFinite(multiplier) ? multiplier : 1);
+    return Number.isFinite(adjusted) ? Math.max(0, adjusted) : metadata.time;
+  }
+
+  function getDisabledReason(state) {
+    if (metadata.dailyLimit) {
+      const usage = resolveDailyUsage(state, { sync: true });
+      if (usage.remaining <= 0) {
+        const runsLabel = metadata.dailyLimit === 1 ? 'once' : `${metadata.dailyLimit} times`;
+        return `Daily limit reached: ${definition.name} can only run ${runsLabel} per day. Fresh slots unlock tomorrow.`;
+      }
+    }
+    const effectiveTime = resolveEffectiveTime(state);
+    if (effectiveTime > 0 && state.timeLeft < effectiveTime) {
+      return `You need at least ${formatHours(effectiveTime)} free before starting ${definition.name}.`;
+    }
+    if (metadata.cost > 0 && state.money < metadata.cost) {
+      return `You need $${formatMoney(metadata.cost)} before funding ${definition.name}.`;
+    }
+    if (!meetsAssetRequirements(metadata.requirements, state)) {
+      return `You still need: ${summarizeAssetRequirements(metadata.requirements, state)}.`;
+    }
+    return null;
+  }
+
+  function applyHustlePayoutMultiplier(amount, context) {
+    if (!amount) {
+      return { amount: 0, multiplier: 1, sources: [] };
+    }
+    const effect = getHustleEffectMultiplier(definition, 'payout_mult', {
+      state: context.state,
+      actionType: 'payout'
+    });
+    if (!effect) {
+      return { amount, multiplier: 1, sources: [] };
+    }
+
+    const baseMultiplier = Number.isFinite(effect.multiplier) ? effect.multiplier : 1;
+    if (Array.isArray(effect.modifiers) && effect.modifiers.length) {
+      const result = applyModifiers(amount, effect.modifiers, { clamp: effect.clamp });
+      const finalAmount = Number.isFinite(result?.value) ? result.value : amount;
+      const appliedSources = result.applied
+        .filter(entry => entry.type === 'multiplier')
+        .map(entry => ({ id: entry.id, label: entry.label, multiplier: entry.value }));
+      return {
+        amount: finalAmount,
+        multiplier: Number.isFinite(result?.multiplier) ? result.multiplier : baseMultiplier,
+        sources: appliedSources
+      };
+    }
+
+    if (!Number.isFinite(baseMultiplier) || baseMultiplier === 1) {
+      return { amount, multiplier: 1, sources: [] };
+    }
+    return { amount: amount * baseMultiplier, multiplier: baseMultiplier, sources: effect.sources || [] };
+  }
+
+  function runHustle(context) {
+    const effectiveTime = resolveEffectiveTime(context.state);
+    context.effectiveTime = effectiveTime;
+    if (effectiveTime > 0) {
+      spendTime(effectiveTime);
+      applyMetric(recordTimeContribution, metadata.metrics.time, { hours: effectiveTime });
+    }
+    if (metadata.cost > 0) {
+      spendMoney(metadata.cost);
+      applyMetric(recordCostContribution, metadata.metrics.cost, { amount: metadata.cost });
+    }
+
+    context.skipDefaultPayout = () => {
+      context.__skipDefaultPayout = true;
+    };
+
+    config.onExecute?.(context);
+
+    if (metadata.skills) {
+      context.skillXpAwarded = awardSkillProgress({
+        skills: metadata.skills,
+        timeSpentHours: effectiveTime,
+        moneySpent: metadata.cost,
+        label: definition.name
+      });
+    }
+
+    if (metadata.payout && metadata.payout.grantOnAction && !context.__skipDefaultPayout) {
+      const basePayout = metadata.payout.amount;
+      const { amount: educationAdjusted, applied: appliedBonuses } = applyInstantHustleEducationBonus({
+        hustleId: metadata.id,
+        baseAmount: basePayout,
+        state: context.state
+      });
+
+      context.basePayout = basePayout;
+      context.educationAdjustedPayout = educationAdjusted;
+      context.appliedEducationBoosts = appliedBonuses;
+
+      const upgradeResult = applyHustlePayoutMultiplier(educationAdjusted, context);
+      const upgradedAmount = upgradeResult.amount;
+      const roundedPayout = Math.max(0, Math.round(upgradedAmount));
+
+      context.upgradeMultiplier = upgradeResult.multiplier;
+      context.upgradeSources = upgradeResult.sources;
+      context.finalPayout = roundedPayout;
+      context.payoutGranted = roundedPayout;
+
+      const template = metadata.payout.message;
+      let message;
+      if (typeof template === 'function') {
+        message = template(context);
+      } else if (template) {
+        message = template;
+      } else {
+        const bonusNote = appliedBonuses.length ? ' Education bonus included!' : '';
+        const upgradeNote = upgradeResult.sources.length ? ' Upgrades amplified the payout!' : '';
+        message = `${definition.name} paid $${formatMoney(roundedPayout)}.${bonusNote}${upgradeNote}`;
+      }
+
+      addMoney(roundedPayout, message, metadata.payout.logType);
+      applyMetric(recordPayoutContribution, metadata.metrics.payout, { amount: roundedPayout });
+
+      if (appliedBonuses.length) {
+        const summary = formatEducationBonusSummary(appliedBonuses);
+        logEducationPayoffSummary(summary);
+      }
+    }
+
+    const updatedUsage = updateDailyUsage(context.state);
+    if (updatedUsage) {
+      context.limitUsage = updatedUsage;
+      markDirty('actions');
+    }
+
+    config.onComplete?.(context);
+    markDirty('cards');
+  }
+
+  function disabled() {
+    const state = getState();
+    if (!state) return true;
+    return Boolean(getDisabledReason(state));
+  }
+
+  function handleActionClick() {
+    executeAction(() => {
+      const state = getState();
+      if (!state) return;
+      const reason = getDisabledReason(state);
+      if (reason) {
+        logHustleBlocked(reason);
+        return;
+      }
+      const context = {
+        definition,
+        state,
+        metadata,
+        get usage() {
+          return resolveDailyUsage(state, { sync: false });
+        }
+      };
+      const effectiveTime = resolveEffectiveTime(state);
+      const deadlineDay = metadata.dailyLimit ? Number(state?.day) || null : null;
+      const progressOverrides = definition.progress ? { ...definition.progress } : { ...(config.progress || {}) };
+      if (deadlineDay != null) {
+        progressOverrides.deadlineDay = deadlineDay;
+      }
+      const instance = definition.acceptInstance({
+        state,
+        metadata,
+        overrides: {
+          hoursRequired: effectiveTime > 0 ? effectiveTime : 0,
+          deadlineDay,
+          progress: progressOverrides
+        }
+      });
+      if (instance) {
+        context.instance = instance;
+        const logDay = Number(state?.day) || instance.acceptedOnDay;
+        advanceActionInstance(definition, instance, {
+          state,
+          day: logDay,
+          hours: effectiveTime,
+          autoComplete: false,
+          completionContext: context,
+          metadata
+        });
+      }
+      runHustle(context);
+      context.completionDay = Number(state?.day) || instance?.acceptedOnDay || null;
+      const completionMode = (definition.progress || config.progress || {}).completion;
+      const shouldDeferCompletion = completionMode === 'deferred' || completionMode === 'manual';
+      if (instance && !shouldDeferCompletion) {
+        completeActionInstance(definition, instance, context);
+      }
+      config.onRun?.(context);
+    });
+    checkDayEnd();
+  }
+
+  return {
+    resolveEffectiveTime,
+    getDisabledReason,
+    runHustle,
+    disabled,
+    handleActionClick
+  };
+}

--- a/src/game/content/schema/assetActions/formatting.js
+++ b/src/game/content/schema/assetActions/formatting.js
@@ -1,0 +1,61 @@
+import { formatHours, formatMoney } from '../../../../core/helpers.js';
+import { summarizeAssetRequirements } from '../../../requirements.js';
+import { describeInstantHustleEducationBonuses } from '../../../educationEffects.js';
+
+export function formatHourDetail(hours, effective) {
+  if (!hours) return '⏳ Time: <strong>Instant</strong>';
+  const base = formatHours(hours);
+  if (Number.isFinite(Number(effective)) && Math.abs(effective - hours) > 0.01) {
+    return `⏳ Time: <strong>${formatHours(effective)}</strong> (base ${base})`;
+  }
+  return `⏳ Time: <strong>${base}</strong>`;
+}
+
+export function formatCostDetail(cost) {
+  if (!cost) return null;
+  return `💵 Cost: <strong>$${formatMoney(cost)}</strong>`;
+}
+
+export function formatPayoutDetail(payout) {
+  if (!payout || !payout.amount) return null;
+  const base = `💰 Payout: <strong>$${formatMoney(payout.amount)}</strong>`;
+  if (payout.delaySeconds) {
+    return `${base} after ${payout.delaySeconds}s`;
+  }
+  return base;
+}
+
+export function buildDetailResolvers({
+  metadata,
+  config,
+  resolveDailyUsage,
+  resolveEffectiveTime
+}) {
+  const baseDetails = [];
+  if (metadata.time > 0) {
+    baseDetails.push(() => formatHourDetail(metadata.time, resolveEffectiveTime()));
+  }
+  if (metadata.cost > 0) {
+    const detail = formatCostDetail(metadata.cost);
+    if (detail) baseDetails.push(() => detail);
+  }
+  const payoutDetail = formatPayoutDetail(metadata.payout);
+  if (payoutDetail) {
+    baseDetails.push(() => payoutDetail);
+  }
+  if (metadata.requirements.length) {
+    baseDetails.push(() => `Requires: <strong>${summarizeAssetRequirements(metadata.requirements)}</strong>`);
+  }
+  if (metadata.dailyLimit) {
+    baseDetails.push(() => {
+      const usage = resolveDailyUsage();
+      const remaining = usage?.remaining ?? metadata.dailyLimit;
+      const limit = usage?.limit ?? metadata.dailyLimit;
+      const status = remaining > 0 ? `${remaining}/${limit} runs left today` : 'Daily limit reached today';
+      return `🗓️ Daily limit: <strong>${limit} per day</strong> (${status})`;
+    });
+  }
+
+  const educationDetails = describeInstantHustleEducationBonuses(config.id);
+  return [...baseDetails, ...educationDetails, ...(config.details || [])];
+}

--- a/src/game/content/schema/assetActions/progressDefaults.js
+++ b/src/game/content/schema/assetActions/progressDefaults.js
@@ -1,0 +1,28 @@
+export function buildProgressDefaults({ metadata, config }) {
+  const progressDefaults = {
+    type: 'instant',
+    completion: 'instant',
+    ...(config.progress || {})
+  };
+
+  if (progressDefaults.hoursRequired == null) {
+    const baseHours = Number(metadata.time);
+    if (Number.isFinite(baseHours) && baseHours >= 0) {
+      progressDefaults.hoursRequired = baseHours;
+    }
+  }
+
+  return progressDefaults;
+}
+
+export function buildDefaultState({ config, metadata }) {
+  const base = { ...(config.defaultState || {}) };
+  if (!Array.isArray(base.instances)) {
+    base.instances = [];
+  }
+  if (metadata.dailyLimit) {
+    if (typeof base.runsToday !== 'number') base.runsToday = 0;
+    if (typeof base.lastRunDay !== 'number') base.lastRunDay = 0;
+  }
+  return base;
+}

--- a/tests/game/assetActions.modules.test.js
+++ b/tests/game/assetActions.modules.test.js
@@ -1,0 +1,102 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ensureTestDom } from '../helpers/setupDom.js';
+
+ensureTestDom();
+
+const stateModule = await import('../../src/core/state.js');
+const { initializeState, getState } = stateModule;
+const registryService = await import('../../src/game/registryService.js');
+const { ensureRegistryReady } = await import('../../src/game/registryBootstrap.js');
+const { createInstantHustle } = await import('../../src/game/content/schema/assetActions.js');
+const { createDailyLimitTracker } = await import('../../src/game/content/schema/assetActions/execution.js');
+
+function ensureConfigured() {
+  registryService.resetRegistry();
+  ensureRegistryReady();
+}
+
+test('daily limit tracker resets usage each new day', () => {
+  ensureConfigured();
+  initializeState();
+  const state = getState();
+  const metadata = { id: 'limitTracker', dailyLimit: 2 };
+  const { resolveDailyUsage, updateDailyUsage } = createDailyLimitTracker(metadata);
+
+  let usage = resolveDailyUsage(state, { sync: true });
+  assert.equal(usage.used, 0);
+  assert.equal(usage.remaining, 2);
+
+  const updated = updateDailyUsage(state);
+  assert.equal(updated.used, 1);
+  assert.equal(updated.remaining, 1);
+
+  usage = resolveDailyUsage(state, { sync: false });
+  assert.equal(usage.used, 1);
+  assert.equal(usage.remaining, 1);
+
+  state.day = 2;
+  usage = resolveDailyUsage(state, { sync: true });
+  assert.equal(usage.used, 0);
+  assert.equal(usage.remaining, 2);
+});
+
+test('execution hooks grant payouts and emit log messages', () => {
+  ensureConfigured();
+  initializeState();
+  const state = getState();
+  state.money = 0;
+  state.log.length = 0;
+
+  const definition = createInstantHustle({
+    id: 'payoutRun',
+    name: 'Payout Run',
+    time: 0,
+    cost: 0,
+    payout: {
+      amount: 42,
+      grantOnAction: true,
+      logType: 'hustle',
+      message: context => `Paid ${context.finalPayout}`
+    }
+  });
+
+  definition.action.onClick();
+
+  assert.equal(state.money, 42);
+  assert.ok(state.log.length > 0, 'payout should log a message');
+  const payoutLog = state.log[state.log.length - 1];
+  assert.equal(payoutLog.message, 'Paid 42');
+  assert.equal(payoutLog.type, 'hustle');
+});
+
+test('blocked hustle runs emit warning logs', () => {
+  ensureConfigured();
+  initializeState();
+  const state = getState();
+  state.money = 0;
+  state.log.length = 0;
+
+  const definition = createInstantHustle({
+    id: 'limitRun',
+    name: 'Limit Run',
+    time: 0,
+    cost: 0,
+    dailyLimit: 1,
+    payout: {
+      amount: 10,
+      grantOnAction: true,
+      logType: 'hustle',
+      message: 'First payout'
+    }
+  });
+
+  definition.action.onClick();
+  const logsAfterFirstRun = state.log.length;
+  definition.action.onClick();
+
+  assert.equal(state.log.length, logsAfterFirstRun + 1);
+  const blockedLog = state.log[state.log.length - 1];
+  assert.match(blockedLog.message, /Daily limit reached/);
+  assert.equal(blockedLog.type, 'warning');
+});


### PR DESCRIPTION
## Summary
- extract formatting, progress defaults, and execution logic for instant hustles into dedicated modules
- update createInstantHustle to compose the new helpers and re-export a slim API
- add tests covering daily limits, payout logging, and blocked-run messaging for instant hustles

## Testing
- node --test
- Manual testing not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e3e06a1858832c82c95dbf5dcc6b61