### PR TITLE
Preserve expired hustle entries for late completion payouts

### DIFF
--- a/tests/gameLifecycle.test.js
+++ b/tests/gameLifecycle.test.js
@@ -274,7 +274,7 @@ test('endDay resets action counters even when legacy hustle map is absent', () =
   assert.equal(state.day, startingDay + 1, 'day should increment when ending the day');
 });
 
-test('ensureHustleMarketState prunes expired offers and accepted entries', () => {
+test('ensureHustleMarketState prunes expired offers and marks expired accepted entries', () => {
   const now = Date.now();
   state.day = 5;
   const today = state.day;
@@ -327,10 +327,14 @@ test('ensureHustleMarketState prunes expired offers and accepted entries', () =>
 
   assert.equal(state.hustleMarket.offers.length, 1, 'expired offers should be removed from the market');
   assert.equal(state.hustleMarket.offers[0].id, 'active-offer', 'active offers should remain available');
-  assert.equal(state.hustleMarket.accepted.length, 1, 'accepted entries past their deadline should be pruned');
-  assert.equal(
-    state.hustleMarket.accepted[0].offerId,
-    'active-offer',
-    'only active accepted entries should remain after pruning'
-  );
+  assert.equal(state.hustleMarket.accepted.length, 2, 'accepted entries should be preserved for late completion processing');
+
+  const expiredEntry = state.hustleMarket.accepted.find(entry => entry.id === 'accepted-expired');
+  assert.ok(expiredEntry, 'expired accepted entries should remain in the market state');
+  assert.equal(expiredEntry.status, 'expired', 'expired accepted entries should be marked expired');
+  assert.equal(expiredEntry.expired, true, 'expired accepted entries should have the expired flag set');
+
+  const activeEntry = state.hustleMarket.accepted.find(entry => entry.id === 'accepted-active');
+  assert.ok(activeEntry, 'active accepted entries should remain after pruning');
+  assert.equal(activeEntry.offerId, 'active-offer', 'active accepted entries should remain linked to their offer');
 });


### PR DESCRIPTION
## Summary
- mark expired accepted action market entries instead of pruning them so they can be completed later
- let late completions recover the stored accepted entry before payout processing
- add a regression test that completes a multi-day hustle after the deadline and verifies the payout

## Testing
- node --test tests/hustleMarket.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e3f392e230832ca800cef44b30382b