### PR TITLE
Refactor action market commands into dedicated modules

### DIFF
--- a/src/core/state.js
+++ b/src/core/state.js
@@ -31,9 +31,8 @@ import {
 } from './state/slices/hustleMarket/index.js';
 import {
   ensureActionMarketState,
-  ensureActionMarketCategoryState,
   createDefaultActionMarketState
-} from './state/slices/actionMarket/index.js';
+} from './state/slices/actionMarket/state.js';
 import { isAutoReadType } from './logAutoReadTypes.js';
 
 function normalizeLogEntry(entry) {
@@ -97,7 +96,7 @@ class StateManager {
     ensureUpgradeSlice(target);
     ensureProgressSlice(target);
     ensureActionMarketState(target);
-    ensureActionMarketCategoryState(target, 'hustle', { fallbackDay: target.day || 1 });
+    ensureHustleMarketState(target, { fallbackDay: target.day || 1 });
 
     target.totals = target.totals || {};
     const earned = Number(target.totals.earned);

--- a/src/core/state/slices/actionMarket/commands.js
+++ b/src/core/state/slices/actionMarket/commands.js
@@ -1,0 +1,139 @@
+import { clampMarketDay as clampDay } from '../../../../game/hustles/normalizers.js';
+import {
+  ensureActionMarketCategoryState,
+  ensureActionMarketState
+} from './state.js';
+import {
+  decorateOfferWithAccepted
+} from './offers.js';
+import {
+  completeAcceptedEntry,
+  createAcceptedEntryFromOffer,
+  normalizeActionMarketAcceptedEntry,
+  removeAcceptedEntries
+} from './accepted.js';
+
+export function claimActionMarketOffer(state, category, offerId, details = {}) {
+  if (!state || !offerId) {
+    return null;
+  }
+
+  const fallbackDay = details.acceptedOnDay || state.day || 1;
+  const marketState = ensureActionMarketCategoryState(state, category, { fallbackDay });
+  const offer = marketState.offers.find(entry => entry.id === offerId);
+  if (!offer) {
+    return null;
+  }
+
+  const acceptedEntry = createAcceptedEntryFromOffer(offer, {
+    ...details,
+    acceptedOnDay: details.acceptedOnDay ?? state.day ?? offer.availableOnDay
+  }, {
+    fallbackDay: state.day || 1,
+    category: marketState.category
+  });
+
+  if (!acceptedEntry) {
+    return null;
+  }
+
+  const existingIndex = marketState.accepted.findIndex(entry => entry.offerId === offer.id);
+  if (existingIndex >= 0) {
+    marketState.accepted[existingIndex] = acceptedEntry;
+  } else {
+    marketState.accepted.push(acceptedEntry);
+  }
+
+  decorateOfferWithAccepted(offer, acceptedEntry);
+
+  ensureActionMarketCategoryState(state, marketState.category, {
+    fallbackDay: state.day || acceptedEntry.acceptedOnDay || 1
+  });
+  return acceptedEntry;
+}
+
+export function releaseActionMarketOffer(state, category, identifiers = {}) {
+  if (!state) {
+    return false;
+  }
+
+  const { offerId, acceptedId, instanceId } = identifiers || {};
+  if (!offerId && !acceptedId && !instanceId) {
+    return false;
+  }
+
+  const fallbackDay = clampDay(state.day ?? 1, 1);
+  const marketState = ensureActionMarketCategoryState(state, category, { fallbackDay });
+
+  const removedEntries = removeAcceptedEntries(marketState, identifiers);
+  if (removedEntries.length === 0) {
+    return false;
+  }
+
+  removedEntries.forEach(entry => {
+    const offer = marketState.offers.find(item => item && item.id === entry.offerId);
+    if (!offer) {
+      return;
+    }
+    decorateOfferWithAccepted(offer, null);
+  });
+
+  ensureActionMarketCategoryState(state, category, { fallbackDay });
+  return true;
+}
+
+export function completeActionMarketInstance(state, category, instanceId, {
+  completionDay,
+  hoursLogged
+} = {}) {
+  if (!state || !instanceId) {
+    return null;
+  }
+
+  const categoryKey = typeof category === 'string'
+    ? (category.trim().length ? category.trim() : 'default')
+    : 'default';
+  const marketStateRoot = ensureActionMarketState(state);
+  const existingCategoryState = marketStateRoot.categories?.[categoryKey];
+  const staleEntry = existingCategoryState?.accepted?.find?.(item => item?.instanceId === instanceId) || null;
+
+  const fallbackDay = clampDay(completionDay ?? state.day ?? staleEntry?.acceptedOnDay ?? 1, 1);
+  const marketState = ensureActionMarketCategoryState(state, category, { fallbackDay });
+
+  let entry = marketState.accepted.find(item => item.instanceId === instanceId);
+  if (!entry && staleEntry) {
+    const normalized = normalizeActionMarketAcceptedEntry(staleEntry, {
+      fallbackDay,
+      category: marketState.category
+    });
+    if (normalized) {
+      if (normalized.status !== 'complete' && normalized.deadlineDay < fallbackDay) {
+        normalized.status = 'expired';
+        normalized.expired = true;
+      } else if ('expired' in normalized) {
+        delete normalized.expired;
+      }
+      marketState.accepted.push(normalized);
+      entry = normalized;
+    }
+  }
+  if (!entry) {
+    return null;
+  }
+
+  completeAcceptedEntry(entry, {
+    completionDay,
+    hoursLogged,
+    fallbackDay
+  });
+
+  const offer = marketState.offers.find(item => item.id === entry.offerId);
+  if (offer) {
+    decorateOfferWithAccepted(offer, entry);
+  }
+
+  ensureActionMarketCategoryState(state, category, { fallbackDay });
+
+  return marketState.accepted.find(item => item.instanceId === instanceId) || null;
+}
+

--- a/src/core/state/slices/actionMarket/hustleCompat.js
+++ b/src/core/state/slices/actionMarket/hustleCompat.js
@@ -1,0 +1,87 @@
+import {
+  DEFAULT_ACTION_MARKET_CATEGORY_STATE,
+  clearActionMarketCategoryState,
+  cloneActionMarketCategoryState,
+  createDefaultActionMarketCategoryState,
+  ensureActionMarketCategoryState
+} from './state.js';
+import {
+  claimActionMarketOffer,
+  completeActionMarketInstance,
+  releaseActionMarketOffer
+} from './commands.js';
+import {
+  getActionMarketAvailableOffers,
+  getActionMarketClaimedOffers,
+  getActionMarketOfferById
+} from './selectors.js';
+
+export const DEFAULT_HUSTLE_MARKET_STATE = DEFAULT_ACTION_MARKET_CATEGORY_STATE;
+
+export function createDefaultHustleMarketState() {
+  return createDefaultActionMarketCategoryState({ category: 'hustle' });
+}
+
+export function ensureHustleMarketState(state, options = {}) {
+  const categoryState = ensureActionMarketCategoryState(state, 'hustle', options);
+  mirrorHustleMarketState(state, categoryState);
+  return categoryState;
+}
+
+export function getHustleMarketState(state, options = {}) {
+  return ensureHustleMarketState(state, options);
+}
+
+export function cloneHustleMarketState(state) {
+  return cloneActionMarketCategoryState(state, 'hustle');
+}
+
+export function clearHustleMarketState(state) {
+  clearActionMarketCategoryState(state, 'hustle');
+}
+
+export function mirrorHustleMarketState(state, categoryState = null) {
+  if (!state || typeof state !== 'object') {
+    return;
+  }
+
+  const marketState = state.actionMarket;
+  const categories = marketState?.categories;
+  if (!marketState || typeof marketState !== 'object' || !categories || typeof categories !== 'object') {
+    return;
+  }
+
+  const resolvedCategory = categoryState || categories.hustle || state.hustleMarket || null;
+  if (resolvedCategory) {
+    categories.hustle = resolvedCategory;
+    state.hustleMarket = resolvedCategory;
+  } else if (!state.hustleMarket) {
+    state.hustleMarket = ensureActionMarketCategoryState(state, 'hustle');
+    categories.hustle = state.hustleMarket;
+  }
+}
+
+export function claimHustleMarketOffer(state, offerId, details = {}) {
+  return claimActionMarketOffer(state, 'hustle', offerId, details);
+}
+
+export function releaseHustleMarketOffer(state, identifiers = {}) {
+  return releaseActionMarketOffer(state, 'hustle', identifiers);
+}
+
+export function getMarketOfferById(state, offerId, options = {}) {
+  return getActionMarketOfferById(state, 'hustle', offerId, options);
+}
+
+export function getMarketAvailableOffers(state, options = {}) {
+  return getActionMarketAvailableOffers(state, 'hustle', options);
+}
+
+export function getMarketClaimedOffers(state, options = {}) {
+  return getActionMarketClaimedOffers(state, 'hustle', options);
+}
+
+export function completeHustleMarketInstance(state, instanceId, details = {}) {
+  return completeActionMarketInstance(state, 'hustle', instanceId, details);
+}
+

--- a/src/core/state/slices/actionMarket/index.js
+++ b/src/core/state/slices/actionMarket/index.js
@@ -1,32 +1,3 @@
-import { clampMarketDay as clampDay } from '../../../../game/hustles/normalizers.js';
-import {
-  DEFAULT_ACTION_MARKET_CATEGORY_STATE,
-  DEFAULT_ACTION_MARKET_STATE,
-  clearActionMarketCategoryState,
-  cloneActionMarketCategoryState,
-  createDefaultActionMarketCategoryState,
-  createDefaultActionMarketState,
-  ensureActionMarketCategoryState,
-  ensureActionMarketState,
-  getActionMarketCategoryState,
-  ensureHustleMarketStateCompatibility,
-  createDefaultHustleMarketStateCompatibility,
-  cloneHustleMarketStateCompatibility,
-  clearHustleMarketStateCompatibility
-} from './state.js';
-import {
-  cloneOffer,
-  decorateOfferWithAccepted,
-  normalizeActionMarketOffer
-} from './offers.js';
-import {
-  completeAcceptedEntry,
-  createAcceptedEntryFromOffer,
-  getClaimedEntries,
-  normalizeActionMarketAcceptedEntry,
-  removeAcceptedEntries
-} from './accepted.js';
-
 export {
   DEFAULT_ACTION_MARKET_STATE,
   DEFAULT_ACTION_MARKET_CATEGORY_STATE,
@@ -36,214 +7,42 @@ export {
   createDefaultActionMarketState,
   createDefaultActionMarketCategoryState,
   cloneActionMarketCategoryState,
-  clearActionMarketCategoryState,
-  normalizeActionMarketOffer,
+  clearActionMarketCategoryState
+} from './state.js';
+
+export {
+  claimActionMarketOffer,
+  releaseActionMarketOffer,
+  completeActionMarketInstance
+} from './commands.js';
+
+export {
+  getActionMarketOfferById,
+  getActionMarketAvailableOffers,
+  getActionMarketClaimedOffers
+} from './selectors.js';
+
+export {
+  DEFAULT_HUSTLE_MARKET_STATE,
+  createDefaultHustleMarketState,
+  ensureHustleMarketState,
+  getHustleMarketState,
+  cloneHustleMarketState,
+  clearHustleMarketState,
+  mirrorHustleMarketState,
+  claimHustleMarketOffer,
+  releaseHustleMarketOffer,
+  getMarketOfferById,
+  getMarketAvailableOffers,
+  getMarketClaimedOffers,
+  completeHustleMarketInstance
+} from './hustleCompat.js';
+
+export {
+  normalizeActionMarketOffer
+} from './offers.js';
+
+export {
   normalizeActionMarketAcceptedEntry
-};
+} from './accepted.js';
 
-export function claimActionMarketOffer(state, category, offerId, details = {}) {
-  if (!state || !offerId) {
-    return null;
-  }
-
-  const fallbackDay = details.acceptedOnDay || state.day || 1;
-  const marketState = ensureActionMarketCategoryState(state, category, { fallbackDay });
-  const offer = marketState.offers.find(entry => entry.id === offerId);
-  if (!offer) {
-    return null;
-  }
-
-  const acceptedEntry = createAcceptedEntryFromOffer(offer, {
-    ...details,
-    acceptedOnDay: details.acceptedOnDay ?? state.day ?? offer.availableOnDay
-  }, {
-    fallbackDay: state.day || 1,
-    category: marketState.category
-  });
-
-  if (!acceptedEntry) {
-    return null;
-  }
-
-  const existingIndex = marketState.accepted.findIndex(entry => entry.offerId === offer.id);
-  if (existingIndex >= 0) {
-    marketState.accepted[existingIndex] = acceptedEntry;
-  } else {
-    marketState.accepted.push(acceptedEntry);
-  }
-
-  decorateOfferWithAccepted(offer, acceptedEntry);
-
-  ensureActionMarketCategoryState(state, marketState.category, {
-    fallbackDay: state.day || acceptedEntry.acceptedOnDay || 1
-  });
-  return acceptedEntry;
-}
-
-export function releaseActionMarketOffer(state, category, identifiers = {}) {
-  if (!state) {
-    return false;
-  }
-
-  const { offerId, acceptedId, instanceId } = identifiers || {};
-  if (!offerId && !acceptedId && !instanceId) {
-    return false;
-  }
-
-  const fallbackDay = clampDay(state.day ?? 1, 1);
-  const marketState = ensureActionMarketCategoryState(state, category, { fallbackDay });
-
-  const removedEntries = removeAcceptedEntries(marketState, identifiers);
-  if (removedEntries.length === 0) {
-    return false;
-  }
-
-  removedEntries.forEach(entry => {
-    const offer = marketState.offers.find(item => item && item.id === entry.offerId);
-    if (!offer) {
-      return;
-    }
-    decorateOfferWithAccepted(offer, null);
-  });
-
-  ensureActionMarketCategoryState(state, category, { fallbackDay });
-  return true;
-}
-
-export function getActionMarketOfferById(state, category, offerId, options = {}) {
-  if (!state || !offerId) {
-    return null;
-  }
-  const fallbackDay = clampDay(options.day ?? state.day ?? 1, 1);
-  const marketState = ensureActionMarketCategoryState(state, category, { fallbackDay });
-  const offer = marketState.offers.find(entry => entry.id === offerId);
-  return offer ? cloneOffer(offer) : null;
-}
-
-export function getActionMarketAvailableOffers(state, category, {
-  day,
-  includeUpcoming = false,
-  includeClaimed = false
-} = {}) {
-  if (!state) {
-    return [];
-  }
-  const fallbackDay = clampDay(day ?? state.day ?? 1, 1);
-  const marketState = ensureActionMarketCategoryState(state, category, { fallbackDay });
-  return marketState.offers
-    .filter(offer => {
-      if (offer.status === 'complete') {
-        return false;
-      }
-      if (!includeClaimed && offer.claimed) {
-        return false;
-      }
-      if (includeUpcoming) {
-        return offer.expiresOnDay >= fallbackDay;
-      }
-      return offer.availableOnDay <= fallbackDay && offer.expiresOnDay >= fallbackDay;
-    })
-    .map(offer => cloneOffer(offer));
-}
-
-export function getActionMarketClaimedOffers(state, category, {
-  day,
-  includeExpired = false,
-  includeCompleted = false
-} = {}) {
-  if (!state) {
-    return [];
-  }
-  const fallbackDay = clampDay(day ?? state.day ?? 1, 1);
-  const marketState = ensureActionMarketCategoryState(state, category, { fallbackDay });
-  return getClaimedEntries(marketState, fallbackDay, { includeExpired, includeCompleted });
-}
-
-export function completeActionMarketInstance(state, category, instanceId, {
-  completionDay,
-  hoursLogged
-} = {}) {
-  if (!state || !instanceId) {
-    return null;
-  }
-
-  const categoryKey = typeof category === 'string'
-    ? (category.trim().length ? category.trim() : 'default')
-    : 'default';
-  const marketStateRoot = ensureActionMarketState(state);
-  const existingCategoryState = marketStateRoot.categories?.[categoryKey];
-  const staleEntry = existingCategoryState?.accepted?.find?.(item => item?.instanceId === instanceId) || null;
-
-  const fallbackDay = clampDay(completionDay ?? state.day ?? staleEntry?.acceptedOnDay ?? 1, 1);
-  const marketState = ensureActionMarketCategoryState(state, category, { fallbackDay });
-
-  let entry = marketState.accepted.find(item => item.instanceId === instanceId);
-  if (!entry && staleEntry) {
-    const normalized = normalizeActionMarketAcceptedEntry(staleEntry, {
-      fallbackDay,
-      category: marketState.category
-    });
-    if (normalized) {
-      if (normalized.status !== 'complete' && normalized.deadlineDay < fallbackDay) {
-        normalized.status = 'expired';
-        normalized.expired = true;
-      } else if ('expired' in normalized) {
-        delete normalized.expired;
-      }
-      marketState.accepted.push(normalized);
-      entry = normalized;
-    }
-  }
-  if (!entry) {
-    return null;
-  }
-
-  completeAcceptedEntry(entry, {
-    completionDay,
-    hoursLogged,
-    fallbackDay
-  });
-
-  const offer = marketState.offers.find(item => item.id === entry.offerId);
-  if (offer) {
-    decorateOfferWithAccepted(offer, entry);
-  }
-
-  ensureActionMarketCategoryState(state, category, { fallbackDay });
-
-  return marketState.accepted.find(item => item.instanceId === instanceId) || null;
-}
-
-// Compatibility exports for the legacy hustle market modules.
-export const DEFAULT_HUSTLE_MARKET_STATE = DEFAULT_ACTION_MARKET_CATEGORY_STATE;
-export const createDefaultHustleMarketState = createDefaultHustleMarketStateCompatibility;
-export const ensureHustleMarketState = ensureHustleMarketStateCompatibility;
-export const cloneHustleMarketState = cloneHustleMarketStateCompatibility;
-export const clearHustleMarketState = clearHustleMarketStateCompatibility;
-export const getHustleMarketState = (state, options = {}) => ensureHustleMarketStateCompatibility(state, options);
-
-export function claimHustleMarketOffer(state, offerId, details = {}) {
-  return claimActionMarketOffer(state, 'hustle', offerId, details);
-}
-
-export function releaseHustleMarketOffer(state, identifiers = {}) {
-  return releaseActionMarketOffer(state, 'hustle', identifiers);
-}
-
-export function getMarketOfferById(state, offerId, options = {}) {
-  return getActionMarketOfferById(state, 'hustle', offerId, options);
-}
-
-export function getMarketAvailableOffers(state, options = {}) {
-  return getActionMarketAvailableOffers(state, 'hustle', options);
-}
-
-export function getMarketClaimedOffers(state, options = {}) {
-  return getActionMarketClaimedOffers(state, 'hustle', options);
-}
-
-export function completeHustleMarketInstance(state, instanceId, details = {}) {
-  return completeActionMarketInstance(state, 'hustle', instanceId, details);
-}
-
-export { normalizeActionMarketAcceptedEntry as normalizeAcceptedOffer };

--- a/src/core/state/slices/actionMarket/selectors.js
+++ b/src/core/state/slices/actionMarket/selectors.js
@@ -1,0 +1,54 @@
+import { clampMarketDay as clampDay } from '../../../../game/hustles/normalizers.js';
+import { ensureActionMarketCategoryState } from './state.js';
+import { cloneOffer } from './offers.js';
+import { getClaimedEntries } from './accepted.js';
+
+export function getActionMarketOfferById(state, category, offerId, options = {}) {
+  if (!state || !offerId) {
+    return null;
+  }
+  const fallbackDay = clampDay(options.day ?? state.day ?? 1, 1);
+  const marketState = ensureActionMarketCategoryState(state, category, { fallbackDay });
+  const offer = marketState.offers.find(entry => entry.id === offerId);
+  return offer ? cloneOffer(offer) : null;
+}
+
+export function getActionMarketAvailableOffers(state, category, {
+  day,
+  includeUpcoming = false,
+  includeClaimed = false
+} = {}) {
+  if (!state) {
+    return [];
+  }
+  const fallbackDay = clampDay(day ?? state.day ?? 1, 1);
+  const marketState = ensureActionMarketCategoryState(state, category, { fallbackDay });
+  return marketState.offers
+    .filter(offer => {
+      if (offer.status === 'complete') {
+        return false;
+      }
+      if (!includeClaimed && offer.claimed) {
+        return false;
+      }
+      if (includeUpcoming) {
+        return offer.expiresOnDay >= fallbackDay;
+      }
+      return offer.availableOnDay <= fallbackDay && offer.expiresOnDay >= fallbackDay;
+    })
+    .map(offer => cloneOffer(offer));
+}
+
+export function getActionMarketClaimedOffers(state, category, {
+  day,
+  includeExpired = false,
+  includeCompleted = false
+} = {}) {
+  if (!state) {
+    return [];
+  }
+  const fallbackDay = clampDay(day ?? state.day ?? 1, 1);
+  const marketState = ensureActionMarketCategoryState(state, category, { fallbackDay });
+  return getClaimedEntries(marketState, fallbackDay, { includeExpired, includeCompleted });
+}
+

--- a/src/core/state/slices/actionMarket/state.js
+++ b/src/core/state/slices/actionMarket/state.js
@@ -139,6 +139,19 @@ export function ensureActionMarketState(state) {
     marketState.categories = {};
   }
 
+  const hustleCategory = marketState.categories.hustle;
+  const hustleState = state.hustleMarket;
+
+  if (hustleState && typeof hustleState === 'object') {
+    if (!hustleCategory || typeof hustleCategory !== 'object') {
+      marketState.categories.hustle = hustleState;
+    } else {
+      state.hustleMarket = hustleCategory;
+    }
+  } else if (hustleCategory && typeof hustleCategory === 'object') {
+    state.hustleMarket = hustleCategory;
+  }
+
   return marketState;
 }
 

--- a/src/core/state/slices/actionMarket/state.js
+++ b/src/core/state/slices/actionMarket/state.js
@@ -139,12 +139,6 @@ export function ensureActionMarketState(state) {
     marketState.categories = {};
   }
 
-  if (state.hustleMarket && !marketState.categories.hustle) {
-    marketState.categories.hustle = state.hustleMarket;
-  } else if (!state.hustleMarket && marketState.categories.hustle) {
-    state.hustleMarket = marketState.categories.hustle;
-  }
-
   return marketState;
 }
 
@@ -160,10 +154,6 @@ export function ensureActionMarketCategoryState(state, category = 'default', opt
     fallbackDay: options.fallbackDay,
     category: key
   });
-
-  if (key === 'hustle') {
-    state.hustleMarket = categoryState;
-  }
 
   return categoryState;
 }
@@ -190,12 +180,6 @@ export function clearActionMarketCategoryState(state, category = 'default') {
   categoryState.lastRolledOnDay = 0;
   categoryState.offers = [];
   categoryState.accepted = [];
-}
-
-export function ensureHustleMarketStateCompatibility(state, options = {}) {
-  const categoryState = ensureActionMarketCategoryState(state, 'hustle', options);
-  state.hustleMarket = categoryState;
-  return categoryState;
 }
 
 export function createDefaultHustleMarketStateCompatibility() {

--- a/src/core/state/slices/actionMarket/state.js
+++ b/src/core/state/slices/actionMarket/state.js
@@ -125,6 +125,53 @@ function normalizeCategoryState(categoryState, {
   return categoryState;
 }
 
+function isActionMarketCategory(value) {
+  return value && typeof value === 'object';
+}
+
+function categoryHasEntries(category) {
+  if (!isActionMarketCategory(category)) {
+    return false;
+  }
+
+  const offers = Array.isArray(category.offers) ? category.offers.length : 0;
+  const accepted = Array.isArray(category.accepted) ? category.accepted.length : 0;
+  return offers > 0 || accepted > 0;
+}
+
+function synchronizeHustleCategory(state, marketState) {
+  const categories = marketState.categories;
+  const hustleCategory = isActionMarketCategory(categories.hustle)
+    ? categories.hustle
+    : null;
+  const hustleState = isActionMarketCategory(state.hustleMarket)
+    ? state.hustleMarket
+    : null;
+
+  if (hustleCategory && hustleState && hustleCategory !== hustleState) {
+    if (categoryHasEntries(hustleState) && !categoryHasEntries(hustleCategory)) {
+      categories.hustle = hustleState;
+    } else {
+      state.hustleMarket = hustleCategory;
+    }
+  } else if (hustleState && !hustleCategory) {
+    categories.hustle = hustleState;
+  } else if (hustleCategory && !hustleState) {
+    state.hustleMarket = hustleCategory;
+  }
+
+  const resolved = isActionMarketCategory(categories.hustle)
+    ? categories.hustle
+    : isActionMarketCategory(state.hustleMarket)
+      ? state.hustleMarket
+      : null;
+
+  if (resolved) {
+    categories.hustle = resolved;
+    state.hustleMarket = resolved;
+  }
+}
+
 export function ensureActionMarketState(state) {
   if (!state) {
     return createDefaultActionMarketState();
@@ -139,18 +186,7 @@ export function ensureActionMarketState(state) {
     marketState.categories = {};
   }
 
-  const hustleCategory = marketState.categories.hustle;
-  const hustleState = state.hustleMarket;
-
-  if (hustleState && typeof hustleState === 'object') {
-    if (!hustleCategory || typeof hustleCategory !== 'object') {
-      marketState.categories.hustle = hustleState;
-    } else {
-      state.hustleMarket = hustleCategory;
-    }
-  } else if (hustleCategory && typeof hustleCategory === 'object') {
-    state.hustleMarket = hustleCategory;
-  }
+  synchronizeHustleCategory(state, marketState);
 
   return marketState;
 }

--- a/src/game/content/schema/assetActions.js
+++ b/src/game/content/schema/assetActions.js
@@ -4,10 +4,8 @@ import { applyMetric, normalizeHustleMetrics } from './metrics.js';
 import { logEducationPayoffSummary } from './logMessaging.js';
 import { markDirty } from '../../../core/events/invalidationBus.js';
 import { createContractTemplate } from '../../actions/templates/contract.js';
-import {
-  ensureActionMarketCategoryState,
-  getActionMarketAvailableOffers
-} from '../../../core/state/slices/actionMarket/index.js';
+import { ensureActionMarketCategoryState } from '../../../core/state/slices/actionMarket/state.js';
+import { getActionMarketAvailableOffers } from '../../../core/state/slices/actionMarket/selectors.js';
 import { rollDailyOffers } from '../../hustles/market.js';
 import { buildProgressDefaults, buildDefaultState } from './assetActions/progressDefaults.js';
 import { buildDetailResolvers } from './assetActions/formatting.js';

--- a/src/game/hustles.js
+++ b/src/game/hustles.js
@@ -9,13 +9,15 @@ import {
   resolveOfferPayoutAmount,
   resolveOfferPayoutSchedule
 } from './hustles/offerUtils.js';
+import { ensureActionMarketCategoryState } from '../core/state/slices/actionMarket/state.js';
 import {
-  ensureActionMarketCategoryState,
   claimActionMarketOffer,
-  getActionMarketOfferById,
-  getActionMarketClaimedOffers,
   releaseActionMarketOffer
-} from '../core/state/slices/actionMarket/index.js';
+} from '../core/state/slices/actionMarket/commands.js';
+import {
+  getActionMarketOfferById,
+  getActionMarketClaimedOffers
+} from '../core/state/slices/actionMarket/selectors.js';
 import { definitionRequirementsMet } from './requirements/checks.js';
 import { describeHustleRequirements } from './hustles/helpers.js';
 import { logHustleBlocked } from './content/schema/logMessaging.js';

--- a/src/game/hustles/market.js
+++ b/src/game/hustles/market.js
@@ -5,12 +5,12 @@ import {
   clampMarketPositiveInteger
 } from './normalizers.js';
 import { getState } from '../../core/state.js';
+import { ensureActionMarketCategoryState } from '../../core/state/slices/actionMarket/state.js';
+import { normalizeActionMarketOffer } from '../../core/state/slices/actionMarket/index.js';
 import {
-  ensureActionMarketCategoryState,
-  normalizeActionMarketOffer,
   getActionMarketAvailableOffers,
   getActionMarketClaimedOffers
-} from '../../core/state/slices/actionMarket/index.js';
+} from '../../core/state/slices/actionMarket/selectors.js';
 import {
   attachAuditDebugTools,
   getMarketRollAuditLog,

--- a/tests/hustleMarket.test.js
+++ b/tests/hustleMarket.test.js
@@ -9,14 +9,16 @@ const {
   normalizeHustleMarketOffer,
   normalizeAcceptedOffer
 } = await import('../src/core/state/slices/hustleMarket/index.js');
-const actionMarketModule = await import('../src/core/state/slices/actionMarket/index.js');
+const actionMarketState = await import('../src/core/state/slices/actionMarket/state.js');
+const actionMarketCommands = await import('../src/core/state/slices/actionMarket/commands.js');
+const actionMarketSelectors = await import('../src/core/state/slices/actionMarket/selectors.js');
+const { normalizeActionMarketOffer } = await import('../src/core/state/slices/actionMarket/offers.js');
+const { ensureActionMarketCategoryState } = actionMarketState;
+const { claimActionMarketOffer } = actionMarketCommands;
 const {
-  ensureActionMarketCategoryState,
   getActionMarketAvailableOffers,
-  claimActionMarketOffer,
-  getActionMarketClaimedOffers,
-  normalizeActionMarketOffer
-} = actionMarketModule;
+  getActionMarketClaimedOffers
+} = actionMarketSelectors;
 const { hustlesModule, stateModule } = harness;
 const {
   rollDailyOffers,


### PR DESCRIPTION
## Summary
- add dedicated command, selector, and hustle compatibility modules for the action market slice
- streamline the action market state helpers to focus on normalization while delegating hustle mirroring to the new adapter
- update hustle gameplay modules and tests to consume the reorganized API surface

## Testing
- node --test tests/hustleMarket.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e44a7f3fa8832ca0130859443dcf81