### PR TITLE
Prevent reseeding retired study instances

### DIFF
--- a/src/core/state/slices/actions/instances.js
+++ b/src/core/state/slices/actions/instances.js
@@ -263,6 +263,8 @@ export function seedKnowledgeStudyInstances({ state, sliceState }) {
     return;
   }
 
+  const currentDay = Math.max(1, Math.floor(Number(state?.day) || 1));
+
   for (const [trackId, progress] of Object.entries(knowledge)) {
     if (!progress) continue;
     const isEnrolled = progress.enrolled === true;
@@ -281,7 +283,7 @@ export function seedKnowledgeStudyInstances({ state, sliceState }) {
 
     const track = KNOWLEDGE_TRACKS[trackId];
     const instance = buildLegacyStudyInstance(definition, track, progress, state);
-    if (instance) {
+    if (instance && !shouldRetireInstance(instance, currentDay)) {
       entry.instances.push(instance);
     }
   }


### PR DESCRIPTION
## Summary
- guard legacy study seeding to skip completed instances outside the retention window
- extend requirements tests to ensure retired study actions stay empty after normalization

## Testing
- node --test tests/requirements.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e56817f1c4832c971205aad6736497