### PR TITLE
Gate orchestrated study enrollment messaging

### DIFF
--- a/src/game/hustles/knowledgeHustles.js
+++ b/src/game/hustles/knowledgeHustles.js
@@ -138,12 +138,19 @@ function createStudyAcceptHook(track) {
         }
       }
 
-      addLog(
-        `You claimed a seat in ${track.name}! ${
-          tuition > 0 ? `Tuition paid for $${formatMoney(tuition)}.` : 'No tuition due.'
-        } Log ${formatHours(track.hoursPerDay)} each day from the action queue to progress.`,
-        'info'
+      const orchestratorHandledMessaging = Boolean(
+        metadata?.enrollment?.orchestratorHandlesMessaging
+          ?? acceptedEntry?.metadata?.enrollment?.orchestratorHandlesMessaging
       );
+
+      if (!orchestratorHandledMessaging) {
+        addLog(
+          `You claimed a seat in ${track.name}! ${
+            tuition > 0 ? `Tuition paid for $${formatMoney(tuition)}.` : 'No tuition due.'
+          } Log ${formatHours(track.hoursPerDay)} each day from the action queue to progress.`,
+          'info'
+        );
+      }
 
       markDirty(STUDY_DIRTY_SECTIONS);
 

--- a/src/game/requirements/orchestrator/marketSeats.js
+++ b/src/game/requirements/orchestrator/marketSeats.js
@@ -67,7 +67,8 @@ export function createMarketSeatManager({ getState, addLog }) {
         ? metadata.enrollment
         : {}),
       seatPolicy,
-      enrolledOnDay: currentDay
+      enrolledOnDay: currentDay,
+      orchestratorHandlesMessaging: true
     };
 
     const accepted = acceptHustleOffer({
@@ -104,7 +105,8 @@ export function createMarketSeatManager({ getState, addLog }) {
 
     accepted.metadata.enrollment = {
       ...(acceptedMetadata.enrollment || {}),
-      ...metadata.enrollment
+      ...metadata.enrollment,
+      orchestratorHandlesMessaging: true
     };
 
     if (tuition > 0) {

--- a/tests/requirements.test.js
+++ b/tests/requirements.test.js
@@ -380,10 +380,8 @@ test('study enrollment hooks charge tuition and enrich accepted metadata', () =>
   );
 
   const newLogs = state.log.slice(logBaseline);
-  assert.ok(
-    newLogs.some(entry => /claimed a seat/i.test(entry?.message || '')),
-    'enrollment hook should log a celebratory message'
-  );
+  const celebratoryLogs = newLogs.filter(entry => /claimed a seat/i.test(entry?.message || ''));
+  assert.equal(celebratoryLogs.length, 1, 'enrollment should log the celebratory message exactly once');
 
   const dirty = consumeDirty();
   STUDY_DIRTY_SECTIONS.forEach(section => {


### PR DESCRIPTION
## Summary
- gate the study acceptance hustle log when orchestrator messaging is active
- tag orchestrated seat claims so the acceptance hook skips duplicate enrollment logs
- extend the enrollment test to confirm a single celebratory log entry is emitted

## Testing
- npm test -- tests/requirements.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e5680f1530832c94a3ab60fb63e689