### PR TITLE
Refactor asset action execution helpers

### DIFF
--- a/src/game/content/schema/assetActions/acceptanceCost.js
+++ b/src/game/content/schema/assetActions/acceptanceCost.js
@@ -1,0 +1,43 @@
+import { getState } from '../../../../core/state.js';
+import { spendMoney } from '../../../currency.js';
+import { recordCostContribution } from '../../../metrics.js';
+import { applyMetric } from '../metrics.js';
+
+export function createAcceptanceCostApplier({ metadata }) {
+  return function applyAcceptanceCost({ state = getState(), instance } = {}) {
+    if (!metadata.cost || metadata.cost <= 0) {
+      if (instance) {
+        instance.__pendingAcceptanceCost = 0;
+      }
+      return { paid: 0 };
+    }
+
+    const workingState = state || getState();
+    if (!workingState) {
+      return { paid: 0 };
+    }
+
+    const pending = Number(instance?.__pendingAcceptanceCost ?? metadata.cost);
+    if (!Number.isFinite(pending) || pending <= 0) {
+      if (instance) {
+        instance.__pendingAcceptanceCost = 0;
+      }
+      return { paid: 0 };
+    }
+
+    if (instance?.__acceptanceCostApplied) {
+      return { paid: 0 };
+    }
+
+    spendMoney(pending);
+    applyMetric(recordCostContribution, metadata.metrics?.cost, { amount: pending });
+
+    if (instance) {
+      instance.costPaid = (instance.costPaid || 0) + pending;
+      instance.__pendingAcceptanceCost = 0;
+      instance.__acceptanceCostApplied = true;
+    }
+
+    return { paid: pending };
+  };
+}

--- a/src/game/content/schema/assetActions/dailyLimitTracker.js
+++ b/src/game/content/schema/assetActions/dailyLimitTracker.js
@@ -1,0 +1,130 @@
+import { getActionState, getState } from '../../../../core/state.js';
+
+function sanitizePendingCount(value, max) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return 0;
+  }
+  if (!Number.isFinite(max)) {
+    return Math.floor(numeric);
+  }
+  return Math.max(0, Math.min(Math.floor(numeric), Math.floor(max)));
+}
+
+export function createDailyLimitTracker(metadata) {
+  function resolveDailyUsage(state = getState(), { sync = false } = {}) {
+    const actionState = getActionState(metadata.id, state);
+    const currentDay = Number(state?.day) || 1;
+
+    const lastRunDay = Number(actionState.lastRunDay) || 0;
+    const baseRuns = Number(actionState.runsToday) || 0;
+    const sanitizedRuns = Math.max(0, baseRuns);
+    const usedToday = metadata.dailyLimit
+      ? (lastRunDay === currentDay ? sanitizedRuns : 0)
+      : sanitizedRuns;
+
+    const pendingDay = Number(actionState.pendingAcceptsDay) || 0;
+    const pendingBase = pendingDay === currentDay ? actionState.pendingAccepts : 0;
+    const pendingToday = sanitizePendingCount(pendingBase, metadata.dailyLimit);
+
+    if (sync) {
+      if (metadata.dailyLimit) {
+        if (lastRunDay !== currentDay) {
+          actionState.lastRunDay = currentDay;
+          actionState.runsToday = usedToday;
+        }
+        if (pendingDay !== currentDay) {
+          actionState.pendingAcceptsDay = pendingToday > 0 ? currentDay : null;
+          actionState.pendingAccepts = pendingToday;
+        } else if (actionState.pendingAccepts !== pendingToday) {
+          actionState.pendingAccepts = pendingToday;
+        }
+      } else if (!Number.isFinite(baseRuns) || baseRuns < 0) {
+        actionState.runsToday = 0;
+      }
+      if (pendingToday === 0 && metadata.dailyLimit) {
+        actionState.pendingAccepts = 0;
+        actionState.pendingAcceptsDay = null;
+      }
+    }
+
+    if (!metadata.dailyLimit) {
+      return {
+        actionState,
+        currentDay,
+        limit: null,
+        used: Math.max(0, baseRuns),
+        pending: pendingToday,
+        remaining: null
+      };
+    }
+
+    const remaining = Math.max(0, metadata.dailyLimit - usedToday - pendingToday);
+
+    return {
+      actionState,
+      currentDay,
+      limit: metadata.dailyLimit,
+      used: usedToday,
+      pending: pendingToday,
+      remaining
+    };
+  }
+
+  function reserveDailyUsage(state = getState()) {
+    if (!metadata.dailyLimit) return null;
+    const usage = resolveDailyUsage(state, { sync: true });
+    if (usage.remaining <= 0) {
+      return null;
+    }
+    const available = metadata.dailyLimit - usage.used;
+    const nextPending = Math.min(available, usage.pending + 1);
+    usage.actionState.pendingAccepts = nextPending;
+    usage.actionState.pendingAcceptsDay = usage.currentDay;
+    const remaining = Math.max(0, metadata.dailyLimit - usage.used - nextPending);
+    return {
+      limit: metadata.dailyLimit,
+      used: usage.used,
+      pending: nextPending,
+      remaining,
+      day: usage.currentDay
+    };
+  }
+
+  function releaseDailyUsage(state = getState()) {
+    if (!metadata.dailyLimit) return null;
+    const usage = resolveDailyUsage(state, { sync: true });
+    const nextPending = usage.pending > 0 ? usage.pending - 1 : 0;
+    usage.actionState.pendingAccepts = nextPending;
+    usage.actionState.pendingAcceptsDay = nextPending > 0 ? usage.currentDay : null;
+    const remaining = Math.max(0, metadata.dailyLimit - usage.used - nextPending);
+    return {
+      limit: metadata.dailyLimit,
+      used: usage.used,
+      pending: nextPending,
+      remaining,
+      day: usage.currentDay
+    };
+  }
+
+  function consumeDailyUsage(state = getState()) {
+    if (!metadata.dailyLimit) return null;
+    const usage = resolveDailyUsage(state, { sync: true });
+    const nextPending = usage.pending > 0 ? usage.pending - 1 : 0;
+    const nextUsed = Math.min(metadata.dailyLimit, usage.used + 1);
+    usage.actionState.lastRunDay = usage.currentDay;
+    usage.actionState.runsToday = nextUsed;
+    usage.actionState.pendingAccepts = nextPending;
+    usage.actionState.pendingAcceptsDay = nextPending > 0 ? usage.currentDay : null;
+    const remaining = Math.max(0, metadata.dailyLimit - nextUsed - nextPending);
+    return {
+      limit: metadata.dailyLimit,
+      used: nextUsed,
+      pending: nextPending,
+      remaining,
+      day: usage.currentDay
+    };
+  }
+
+  return { resolveDailyUsage, reserveDailyUsage, releaseDailyUsage, consumeDailyUsage };
+}

--- a/src/game/content/schema/assetActions/payoutProcessing.js
+++ b/src/game/content/schema/assetActions/payoutProcessing.js
@@ -1,0 +1,104 @@
+import { formatMoney } from '../../../../core/helpers.js';
+import { addMoney } from '../../../currency.js';
+import { applyInstantHustleEducationBonus, formatEducationBonusSummary } from '../../../educationEffects.js';
+import { applyModifiers } from '../../../data/economyMath.js';
+import { recordPayoutContribution } from '../../../metrics.js';
+import { getHustleEffectMultiplier } from '../../../upgrades/effects/index.js';
+import { applyMetric } from '../metrics.js';
+import { logEducationPayoffSummary } from '../logMessaging.js';
+
+function buildMultiplierResult(amount, effect) {
+  if (!effect) {
+    return { amount, multiplier: 1, sources: [] };
+  }
+
+  const baseMultiplier = Number.isFinite(effect.multiplier) ? effect.multiplier : 1;
+  if (Array.isArray(effect.modifiers) && effect.modifiers.length) {
+    const result = applyModifiers(amount, effect.modifiers, { clamp: effect.clamp });
+    const finalAmount = Number.isFinite(result?.value) ? result.value : amount;
+    const appliedSources = (result?.applied || [])
+      .filter(entry => entry.type === 'multiplier')
+      .map(entry => ({ id: entry.id, label: entry.label, multiplier: entry.value }));
+    return {
+      amount: finalAmount,
+      multiplier: Number.isFinite(result?.multiplier) ? result.multiplier : baseMultiplier,
+      sources: appliedSources
+    };
+  }
+
+  if (!Number.isFinite(baseMultiplier) || baseMultiplier === 1) {
+    return { amount, multiplier: 1, sources: [] };
+  }
+  return {
+    amount: amount * baseMultiplier,
+    multiplier: baseMultiplier,
+    sources: effect.sources || []
+  };
+}
+
+export function createPayoutProcessing({ definition, metadata }) {
+  function applyHustlePayoutMultiplier(amount, context) {
+    if (!amount) {
+      return { amount: 0, multiplier: 1, sources: [] };
+    }
+    const effect = getHustleEffectMultiplier(definition, 'payout_mult', {
+      state: context.state,
+      actionType: 'payout'
+    });
+    return buildMultiplierResult(amount, effect);
+  }
+
+  function calculatePayoutContext(baseAmount, context) {
+    if (!baseAmount || baseAmount <= 0 || context.__skipDefaultPayout) {
+      return null;
+    }
+
+    const { amount: educationAdjusted, applied: appliedBonuses } = applyInstantHustleEducationBonus({
+      hustleId: metadata.id,
+      baseAmount,
+      state: context.state
+    });
+
+    const upgradeResult = applyHustlePayoutMultiplier(educationAdjusted, context);
+    const roundedPayout = Math.max(0, Math.round(upgradeResult.amount));
+
+    return {
+      basePayout: baseAmount,
+      educationAdjustedPayout: educationAdjusted,
+      appliedEducationBoosts: appliedBonuses,
+      upgradeMultiplier: upgradeResult.multiplier,
+      upgradeSources: upgradeResult.sources,
+      finalPayout: roundedPayout,
+      payoutGranted: roundedPayout,
+      educationSummary: appliedBonuses.length ? formatEducationBonusSummary(appliedBonuses) : null
+    };
+  }
+
+  function applyPayoutSideEffects(context, payoutDetails) {
+    if (!payoutDetails || payoutDetails.finalPayout <= 0) {
+      return;
+    }
+
+    const bonusNote = payoutDetails.appliedEducationBoosts?.length ? ' Education bonus included!' : '';
+    const upgradeNote = payoutDetails.upgradeSources?.length ? ' Upgrades amplified the payout!' : '';
+
+    const template = metadata.payout?.message;
+    let message;
+    if (typeof template === 'function') {
+      message = template({ ...context, ...payoutDetails });
+    } else if (template) {
+      message = template;
+    } else {
+      message = `${definition.name} paid $${formatMoney(payoutDetails.finalPayout)}.${bonusNote}${upgradeNote}`;
+    }
+
+    addMoney(payoutDetails.finalPayout, message, metadata.payout?.logType);
+    applyMetric(recordPayoutContribution, metadata.metrics?.payout, { amount: payoutDetails.finalPayout });
+
+    if (payoutDetails.educationSummary) {
+      logEducationPayoffSummary(payoutDetails.educationSummary);
+    }
+  }
+
+  return { applyHustlePayoutMultiplier, calculatePayoutContext, applyPayoutSideEffects };
+}

--- a/src/game/content/schema/assetActions/timeManagement.js
+++ b/src/game/content/schema/assetActions/timeManagement.js
@@ -1,0 +1,28 @@
+import { getState } from '../../../../core/state.js';
+import { getHustleEffectMultiplier } from '../../../upgrades/effects/index.js';
+
+export function createTimeHelpers({ definition, metadata }) {
+  function resolveEffectiveTime(state = getState()) {
+    if (!metadata.time) return metadata.time;
+    const { multiplier } = getHustleEffectMultiplier(definition, 'setup_time_mult', {
+      state,
+      actionType: 'setup'
+    });
+    const adjusted = metadata.time * (Number.isFinite(multiplier) ? multiplier : 1);
+    return Number.isFinite(adjusted) ? Math.max(0, adjusted) : metadata.time;
+  }
+
+  function computeCompletionHours(instance, fallback = metadata.time) {
+    const logged = Number(instance?.hoursLogged);
+    if (Number.isFinite(logged) && logged >= 0) {
+      return logged;
+    }
+    const progressHours = Number(instance?.progress?.hoursRequired);
+    if (Number.isFinite(progressHours) && progressHours >= 0) {
+      return progressHours;
+    }
+    return Number.isFinite(fallback) && fallback >= 0 ? fallback : 0;
+  }
+
+  return { resolveEffectiveTime, computeCompletionHours };
+}

--- a/tests/game/assetActions.modules.test.js
+++ b/tests/game/assetActions.modules.test.js
@@ -9,7 +9,7 @@ const { initializeState, getState } = stateModule;
 const registryService = await import('../../src/game/registryService.js');
 const { ensureRegistryReady } = await import('../../src/game/registryBootstrap.js');
 const { createInstantHustle } = await import('../../src/game/content/schema/assetActions.js');
-const { createDailyLimitTracker } = await import('../../src/game/content/schema/assetActions/execution.js');
+const { createDailyLimitTracker } = await import('../../src/game/content/schema/assetActions/dailyLimitTracker.js');
 
 function ensureConfigured() {
   registryService.resetRegistry();


### PR DESCRIPTION
## Summary
- extract daily limit tracking logic into a dedicated module reused by execution hooks
- add focused helpers for time resolution, payout processing, and acceptance cost side-effects
- streamline execution orchestration to consume the new modules and update module tests

## Testing
- npm test
- node - <<'EOF' ... (manual smoke to verify createInstantHustle action)


------
https://chatgpt.com/codex/tasks/task_e_68e56922ff70832c8eb7957668b9fa3f