### PR TITLE
Refactor browser layout presenter into modular controllers

### DIFF
--- a/src/ui/views/browser/layout/navigationEventsController.js
+++ b/src/ui/views/browser/layout/navigationEventsController.js
@@ -1,0 +1,108 @@
+import { getElement } from '../../../elements/registry.js';
+
+export function createNavigationEventsController({
+  navigationController,
+  workspaceManager,
+  pageResolver,
+  dom
+}) {
+  const { homepageId, findPageById, findPageBySlug } = pageResolver;
+  const { buildWorkspaceUrl } = dom;
+
+  function handleSiteClick(event) {
+    const control = event.target.closest('[data-site-target]');
+    if (!control || !(control instanceof HTMLElement)) {
+      return;
+    }
+    event.preventDefault();
+    const target = control.dataset.siteTarget || homepageId;
+    if (target === homepageId) {
+      workspaceManager.setActivePage(homepageId, {
+        focus: true,
+        recordHistory: true,
+        ensureTab: false
+      });
+    } else {
+      workspaceManager.openWorkspace(target, { focus: true, recordHistory: true });
+    }
+  }
+
+  function init() {
+    const { backButton, forwardButton, refreshButton } = workspaceManager.getNavigationRefs();
+    if (backButton) {
+      backButton.addEventListener('click', event => {
+        event.preventDefault();
+        navigationController.navigateBack(pageId => {
+          workspaceManager.setActivePage(pageId, {
+            recordHistory: false,
+            focus: true,
+            ensureTab: false
+          });
+        });
+      });
+    }
+
+    if (forwardButton) {
+      forwardButton.addEventListener('click', event => {
+        event.preventDefault();
+        navigationController.navigateForward(pageId => {
+          workspaceManager.setActivePage(pageId, {
+            recordHistory: false,
+            focus: true,
+            ensureTab: false
+          });
+        });
+      });
+    }
+
+    if (refreshButton) {
+      refreshButton.addEventListener('click', workspaceManager.refreshActivePage);
+    }
+
+    const controls = workspaceManager.getSessionControls();
+    if (controls?.homeButton) {
+      controls.homeButton.addEventListener('click', () =>
+        workspaceManager.setActivePage(homepageId, { focus: true, ensureTab: false })
+      );
+    }
+
+    const address = workspaceManager.getAddressBar();
+    if (address.form) {
+      const handler = navigationController.createAddressSubmitHandler({
+        getValue: () => String(address.input?.value || ''),
+        setValue: value => {
+          if (address.input) {
+            address.input.value = value;
+          }
+        },
+        onNavigate: pageId => workspaceManager.setActivePage(pageId),
+        findPageById,
+        findPageBySlug,
+        formatAddress: page => buildWorkspaceUrl(page)
+      });
+      address.form.addEventListener('submit', handler);
+    }
+
+    const siteList = getElement('siteList');
+    if (siteList) {
+      siteList.addEventListener('click', handleSiteClick);
+    }
+
+    const homepage = dom.getHomepageElement();
+    if (homepage) {
+      homepage.addEventListener('click', handleSiteClick);
+    }
+
+    workspaceManager.setActivePage(navigationController.getCurrentPage(), {
+      recordHistory: false,
+      ensureTab: false
+    });
+    navigationController.updateButtons(workspaceManager.getNavigationRefs());
+  }
+
+  return {
+    init
+  };
+}
+
+export default createNavigationEventsController;

--- a/src/ui/views/browser/layout/tabSessionController.js
+++ b/src/ui/views/browser/layout/tabSessionController.js
@@ -1,0 +1,14 @@
+export function createTabSessionController({ initTabControls, workspaceManager }) {
+  function init() {
+    initTabControls({
+      onSelectTab: workspaceManager.handleTabSelect,
+      onCloseTab: workspaceManager.handleTabClose
+    });
+  }
+
+  return {
+    init
+  };
+}
+
+export default createTabSessionController;

--- a/src/ui/views/browser/layout/viewportManager.js
+++ b/src/ui/views/browser/layout/viewportManager.js
@@ -1,0 +1,33 @@
+export function createViewportManager({ windowRef = typeof window !== 'undefined' ? window : null, documentRef = typeof document !== 'undefined' ? document : null } = {}) {
+  function scrollToTop({ smooth = false } = {}) {
+    if (!windowRef && !documentRef) return;
+
+    const behavior = smooth ? 'smooth' : 'auto';
+
+    if (windowRef && typeof windowRef.scrollTo === 'function') {
+      try {
+        windowRef.scrollTo({ top: 0, behavior });
+        return;
+      } catch (error) {
+        windowRef.scrollTo(0, 0);
+        return;
+      }
+    }
+
+    if (!documentRef) return;
+
+    if (documentRef.documentElement) {
+      documentRef.documentElement.scrollTop = 0;
+    }
+
+    if (documentRef.body) {
+      documentRef.body.scrollTop = 0;
+    }
+  }
+
+  return {
+    scrollToTop
+  };
+}
+
+export default createViewportManager;

--- a/src/ui/views/browser/layout/workspaceViewManager.js
+++ b/src/ui/views/browser/layout/workspaceViewManager.js
@@ -1,0 +1,302 @@
+import { getElement } from '../../../elements/registry.js';
+
+export function createWorkspaceViewManager({
+  navigationController,
+  viewportManager,
+  tabs,
+  dom,
+  pageResolver
+}) {
+  const {
+    openTab,
+    closeTab,
+    setActiveTab,
+    isOpen,
+    getFallbackTab
+  } = tabs;
+  const {
+    getLaunchStage,
+    getWorkspaceHost,
+    getHomepageElement,
+    getWorkspaceElement,
+    buildWorkspaceUrl,
+    setWorkspacePathDom
+  } = dom;
+  const { findPageById, findPageBySlug, homepageId } = pageResolver;
+
+  let navigationRefs = null;
+  let sessionControls = null;
+
+  function getNavigationRefs() {
+    if (!navigationRefs) {
+      navigationRefs = getElement('browserNavigation') || {};
+    }
+    return navigationRefs;
+  }
+
+  function getSessionControls() {
+    if (!sessionControls) {
+      sessionControls = getElement('browserSessionControls') || {};
+    }
+    return sessionControls;
+  }
+
+  function getAddressBar() {
+    return getElement('browserAddress') || {};
+  }
+
+  function updateAddressBar(page) {
+    const address = getAddressBar();
+    const input = address.input;
+    if (!input) return;
+    const url = buildWorkspaceUrl(page);
+    input.value = url;
+  }
+
+  function revealPage(pageId, { focus = false } = {}) {
+    const isHome = pageId === homepageId;
+    const launchStage = getLaunchStage();
+    if (launchStage) {
+      launchStage.hidden = !isHome;
+      launchStage.classList.toggle('is-active', isHome);
+    }
+
+    const workspaceHost = getWorkspaceHost();
+    if (workspaceHost) {
+      workspaceHost.hidden = isHome;
+      workspaceHost.classList.toggle('is-active', !isHome);
+    }
+
+    const homepageContent = getHomepageElement();
+    if (homepageContent) {
+      homepageContent.hidden = !isHome;
+      homepageContent.classList.toggle('is-active', isHome);
+    }
+
+    if (workspaceHost) {
+      workspaceHost.querySelectorAll('[data-browser-page]').forEach(section => {
+        const active = section.dataset.browserPage === pageId;
+        section.hidden = !active;
+        section.classList.toggle('is-active', active);
+      });
+    }
+
+    if (focus) {
+      viewportManager.scrollToTop({ smooth: true });
+    }
+  }
+
+  function markActiveSite(pageId) {
+    const containers = [];
+    const list = getElement('siteList');
+    if (list) containers.push(list);
+
+    const homepage = getHomepageElement();
+    if (homepage) {
+      homepage
+        .querySelectorAll('[data-role="browser-app-launcher"]').forEach(node => {
+          if (node instanceof HTMLElement) {
+            containers.push(node);
+          }
+        });
+    }
+
+    if (!containers.length) return;
+
+    containers.forEach(container => {
+      container.querySelectorAll('[data-site-target]').forEach(control => {
+        if (!(control instanceof HTMLElement)) {
+          return;
+        }
+        const isActive = control.dataset.siteTarget === pageId;
+        control.classList.toggle('is-active', isActive);
+        if (control instanceof HTMLButtonElement) {
+          control.setAttribute('aria-pressed', String(isActive));
+        } else if (isActive) {
+          control.setAttribute('aria-current', 'page');
+        } else {
+          control.removeAttribute('aria-current');
+        }
+      });
+    });
+  }
+
+  function refreshActivePage() {
+    const { refreshButton } = getNavigationRefs();
+    const currentPage = navigationController.getCurrentPage();
+    const target = getWorkspaceElement(currentPage);
+    if (refreshButton) {
+      refreshButton.classList.add('is-spinning');
+      window.setTimeout(() => refreshButton.classList.remove('is-spinning'), 420);
+    }
+    if (target) {
+      target.classList.add('is-refreshing');
+      window.setTimeout(() => target.classList.remove('is-refreshing'), 420);
+    }
+  }
+
+  function setActivePage(targetId, {
+    recordHistory = true,
+    focus = false,
+    ensureTab: shouldEnsureTab = true
+  } = {}) {
+    const resolved =
+      findPageById(targetId) || findPageBySlug(targetId) || findPageById(homepageId);
+    const pageId = resolved?.id || homepageId;
+
+    if (shouldEnsureTab) {
+      openTab(pageId);
+    }
+
+    if (!isOpen(pageId)) {
+      return;
+    }
+
+    const element = getWorkspaceElement(pageId);
+    if (!element) {
+      const result = closeTab(pageId);
+      navigationController.purge(pageId);
+      if (pageId !== homepageId) {
+        setActivePage(homepageId, { recordHistory: false, focus: false, ensureTab: false });
+      }
+      if (result.closed && result.wasActive) {
+        const fallback = result.fallbackId || homepageId;
+        setActivePage(fallback, { recordHistory: false, focus: false, ensureTab: false });
+      }
+      return;
+    }
+
+    setActiveTab(pageId);
+    revealPage(pageId, { focus });
+    markActiveSite(pageId);
+    updateAddressBar(resolved || findPageById(pageId));
+    navigationController.handleNavigation(pageId, { recordHistory });
+    navigationController.updateButtons(getNavigationRefs());
+  }
+
+  function openWorkspace(pageId, { focus = true, recordHistory = true } = {}) {
+    if (!pageId) return;
+    const resolved = findPageById(pageId) || findPageBySlug(pageId);
+    if (!resolved) return;
+    setActivePage(resolved.id, { recordHistory, focus, ensureTab: true });
+  }
+
+  function handleTabSelect(pageId) {
+    if (!pageId) return;
+    setActivePage(pageId, { recordHistory: false, focus: true, ensureTab: false });
+  }
+
+  function handleTabClose(pageId) {
+    if (!pageId) return;
+    const result = closeTab(pageId);
+    if (!result.closed) return;
+
+    navigationController.purge(pageId);
+
+    const host = getWorkspaceHost();
+    const section = host?.querySelector(`[data-browser-page="${pageId}"]`);
+    if (section) {
+      section.hidden = true;
+      section.classList.remove('is-active');
+    }
+
+    if (result.wasActive) {
+      const fallback = result.fallbackId || getFallbackTab(pageId) || homepageId;
+      setActivePage(fallback, { recordHistory: false, focus: true, ensureTab: false });
+    } else {
+      navigationController.updateButtons(getNavigationRefs());
+    }
+  }
+
+  function applyHustleFilters(model = {}) {
+    const list = document.querySelector('[data-role="browser-hustle-list"]');
+    if (!list) return;
+    const cards = Array.from(list.querySelectorAll('[data-hustle]'));
+    const cardMap = new Map(cards.map(card => [card.dataset.hustle, card]));
+    const fragment = document.createDocumentFragment();
+    const orderedIds = Array.isArray(model.orderedIds) ? model.orderedIds : [];
+    const hiddenSet = new Set(Array.isArray(model.hiddenIds) ? model.hiddenIds : []);
+
+    orderedIds.forEach(id => {
+      const card = cardMap.get(id);
+      if (!card) return;
+      card.hidden = hiddenSet.has(id);
+      fragment.appendChild(card);
+      cardMap.delete(id);
+      hiddenSet.delete(id);
+    });
+
+    cardMap.forEach((card, id) => {
+      const hidden = hiddenSet.has(id);
+      card.hidden = hidden;
+      fragment.appendChild(card);
+    });
+
+    list.appendChild(fragment);
+  }
+
+  function applyUpgradeFilters(model = {}) {
+    const hiddenSet = new Set(Array.isArray(model.hiddenIds) ? model.hiddenIds : []);
+    const visibleSet = new Set(Array.isArray(model.visibleIds) ? model.visibleIds : []);
+    document.querySelectorAll('[data-upgrade]').forEach(card => {
+      const id = card.dataset.upgrade;
+      if (!id) return;
+      if (hiddenSet.has(id)) {
+        card.hidden = true;
+        return;
+      }
+      if (visibleSet.size && !visibleSet.has(id)) {
+        card.hidden = true;
+        return;
+      }
+      card.hidden = false;
+    });
+  }
+
+  function applyStudyFilters(model = {}) {
+    const hiddenSet = new Set(Array.isArray(model.hiddenIds) ? model.hiddenIds : []);
+    const visibleSet = new Set(Array.isArray(model.visibleIds) ? model.visibleIds : []);
+    document.querySelectorAll('[data-track]').forEach(card => {
+      const id = card.dataset.track;
+      if (!id) return;
+      if (hiddenSet.has(id)) {
+        card.hidden = true;
+        return;
+      }
+      if (visibleSet.size && !visibleSet.has(id)) {
+        card.hidden = true;
+        return;
+      }
+      card.hidden = false;
+    });
+  }
+
+  function applyFilters(model = {}) {
+    if (!model) return;
+    applyHustleFilters(model.hustles);
+    applyUpgradeFilters(model.upgrades);
+    applyStudyFilters(model.study);
+  }
+
+  function setWorkspacePath(pageId, path) {
+    setWorkspacePathDom(pageId, path);
+    if (navigationController.getCurrentPage() === pageId) {
+      updateAddressBar(findPageById(pageId));
+    }
+  }
+
+  return {
+    setActivePage,
+    openWorkspace,
+    handleTabSelect,
+    handleTabClose,
+    refreshActivePage,
+    applyFilters,
+    setWorkspacePath,
+    getNavigationRefs,
+    getSessionControls,
+    getAddressBar
+  };
+}
+
+export default createWorkspaceViewManager;

--- a/src/ui/views/browser/layoutPresenter.js
+++ b/src/ui/views/browser/layoutPresenter.js
@@ -1,15 +1,7 @@
-import { getElement } from '../../elements/registry.js';
 import { HOMEPAGE_ID, findPageById, findPageBySlug } from './config.js';
 import { initThemeControls } from './layout/theme.js';
 import { createNavigationController } from './layout/navigation.js';
-import {
-  initTabControls,
-  openTab,
-  closeTab,
-  setActiveTab,
-  isOpen,
-  getFallbackTab
-} from './layout/tabs.js';
+import { initTabControls, openTab, closeTab, setActiveTab, isOpen, getFallbackTab } from './layout/tabs.js';
 import {
   getLaunchStage,
   getWorkspaceHost,
@@ -18,380 +10,69 @@ import {
   buildWorkspaceUrl,
   setWorkspacePath as setWorkspacePathDom
 } from './layout/workspaces.js';
-
-let navigationRefs = null;
-let sessionControls = null;
+import createViewportManager from './layout/viewportManager.js';
+import createWorkspaceViewManager from './layout/workspaceViewManager.js';
+import createTabSessionController from './layout/tabSessionController.js';
+import createNavigationEventsController from './layout/navigationEventsController.js';
 
 const navigationController = createNavigationController({ homepageId: HOMEPAGE_ID });
+const viewportManager = createViewportManager();
 
-function scrollViewportToTop({ smooth = false } = {}) {
-  if (typeof window === 'undefined') return;
-  const behavior = smooth ? 'smooth' : 'auto';
-  if (typeof window.scrollTo === 'function') {
-    try {
-      window.scrollTo({ top: 0, behavior });
-      return;
-    } catch (error) {
-      window.scrollTo(0, 0);
-      return;
-    }
+const workspaceManager = createWorkspaceViewManager({
+  navigationController,
+  viewportManager,
+  tabs: {
+    openTab,
+    closeTab,
+    setActiveTab,
+    isOpen,
+    getFallbackTab
+  },
+  dom: {
+    getLaunchStage,
+    getWorkspaceHost,
+    getHomepageElement,
+    getWorkspaceElement,
+    buildWorkspaceUrl,
+    setWorkspacePathDom
+  },
+  pageResolver: {
+    homepageId: HOMEPAGE_ID,
+    findPageById,
+    findPageBySlug
   }
+});
 
-  if (typeof document !== 'undefined') {
-    if (document.documentElement) {
-      document.documentElement.scrollTop = 0;
-    }
-    if (document.body) {
-      document.body.scrollTop = 0;
-    }
+const tabSessionController = createTabSessionController({
+  initTabControls,
+  workspaceManager
+});
+
+const navigationEventsController = createNavigationEventsController({
+  navigationController,
+  workspaceManager,
+  pageResolver: {
+    homepageId: HOMEPAGE_ID,
+    findPageById,
+    findPageBySlug
+  },
+  dom: {
+    buildWorkspaceUrl,
+    getHomepageElement
   }
-}
-
-function getNavigationRefs() {
-  if (!navigationRefs) {
-    navigationRefs = getElement('browserNavigation') || {};
-  }
-  return navigationRefs;
-}
-
-function getSessionControls() {
-  if (!sessionControls) {
-    sessionControls = getElement('browserSessionControls') || {};
-  }
-  return sessionControls;
-}
-
-function updateAddressBar(page) {
-  const address = getElement('browserAddress') || {};
-  const input = address.input;
-  if (!input) return;
-  const url = buildWorkspaceUrl(page);
-  input.value = url;
-}
-
-function revealPage(pageId, { focus = false } = {}) {
-  const isHome = pageId === HOMEPAGE_ID;
-  const launchStage = getLaunchStage();
-  if (launchStage) {
-    launchStage.hidden = !isHome;
-    launchStage.classList.toggle('is-active', isHome);
-  }
-
-  const workspaceHost = getWorkspaceHost();
-  if (workspaceHost) {
-    workspaceHost.hidden = isHome;
-    workspaceHost.classList.toggle('is-active', !isHome);
-  }
-
-  const homepageContent = getHomepageElement();
-  if (homepageContent) {
-    homepageContent.hidden = !isHome;
-    homepageContent.classList.toggle('is-active', isHome);
-  }
-
-  if (workspaceHost) {
-    workspaceHost.querySelectorAll('[data-browser-page]').forEach(section => {
-      const active = section.dataset.browserPage === pageId;
-      section.hidden = !active;
-      section.classList.toggle('is-active', active);
-    });
-  }
-
-  if (focus) {
-    scrollViewportToTop({ smooth: true });
-  }
-}
-
-function markActiveSite(pageId) {
-  const containers = [];
-  const list = getElement('siteList');
-  if (list) containers.push(list);
-
-  const homepage = getHomepageElement();
-  if (homepage) {
-    homepage.querySelectorAll('[data-role="browser-app-launcher"]').forEach(node => {
-      if (node instanceof HTMLElement) {
-        containers.push(node);
-      }
-    });
-  }
-
-  if (!containers.length) return;
-
-  containers.forEach(container => {
-    container.querySelectorAll('[data-site-target]').forEach(control => {
-      if (!(control instanceof HTMLElement)) {
-        return;
-      }
-      const isActive = control.dataset.siteTarget === pageId;
-      control.classList.toggle('is-active', isActive);
-      if (control instanceof HTMLButtonElement) {
-        control.setAttribute('aria-pressed', String(isActive));
-      } else if (isActive) {
-        control.setAttribute('aria-current', 'page');
-      } else {
-        control.removeAttribute('aria-current');
-      }
-    });
-  });
-}
-
-function refreshActivePage() {
-  const { refreshButton } = getNavigationRefs();
-  const currentPage = navigationController.getCurrentPage();
-  const target = getWorkspaceElement(currentPage);
-  if (refreshButton) {
-    refreshButton.classList.add('is-spinning');
-    window.setTimeout(() => refreshButton.classList.remove('is-spinning'), 420);
-  }
-  if (target) {
-    target.classList.add('is-refreshing');
-    window.setTimeout(() => target.classList.remove('is-refreshing'), 420);
-  }
-}
-
-function handleSiteClick(event) {
-  const control = event.target.closest('[data-site-target]');
-  if (!control || !(control instanceof HTMLElement)) {
-    return;
-  }
-  event.preventDefault();
-  const target = control.dataset.siteTarget || HOMEPAGE_ID;
-  if (target === HOMEPAGE_ID) {
-    setActivePage(HOMEPAGE_ID, { focus: true, recordHistory: true, ensureTab: false });
-  } else {
-    openWorkspace(target, { focus: true, recordHistory: true });
-  }
-}
-
-function handleTabSelect(pageId) {
-  if (!pageId) return;
-  setActivePage(pageId, { recordHistory: false, focus: true, ensureTab: false });
-}
-
-function handleTabClose(pageId) {
-  if (!pageId) return;
-  const result = closeTab(pageId);
-  if (!result.closed) return;
-
-  navigationController.purge(pageId);
-
-  const host = getWorkspaceHost();
-  const section = host?.querySelector(`[data-browser-page="${pageId}"]`);
-  if (section) {
-    section.hidden = true;
-    section.classList.remove('is-active');
-  }
-
-  if (result.wasActive) {
-    const fallback = result.fallbackId || getFallbackTab(pageId) || HOMEPAGE_ID;
-    setActivePage(fallback, { recordHistory: false, focus: true, ensureTab: false });
-  } else {
-    navigationController.updateButtons(getNavigationRefs());
-  }
-}
-
-function setActivePage(targetId, {
-  recordHistory = true,
-  focus = false,
-  ensureTab: shouldEnsureTab = true
-} = {}) {
-  const resolved =
-    findPageById(targetId) || findPageBySlug(targetId) || findPageById(HOMEPAGE_ID);
-  const pageId = resolved?.id || HOMEPAGE_ID;
-
-  if (shouldEnsureTab) {
-    openTab(pageId);
-  }
-
-  if (!isOpen(pageId)) {
-    return;
-  }
-
-  const element = getWorkspaceElement(pageId);
-  if (!element) {
-    const result = closeTab(pageId);
-    navigationController.purge(pageId);
-    if (pageId !== HOMEPAGE_ID) {
-      setActivePage(HOMEPAGE_ID, { recordHistory: false, focus: false, ensureTab: false });
-    }
-    if (result.closed && result.wasActive) {
-      const fallback = result.fallbackId || HOMEPAGE_ID;
-      setActivePage(fallback, { recordHistory: false, focus: false, ensureTab: false });
-    }
-    return;
-  }
-
-  setActiveTab(pageId);
-  revealPage(pageId, { focus });
-  markActiveSite(pageId);
-  updateAddressBar(resolved || findPageById(pageId));
-  navigationController.handleNavigation(pageId, { recordHistory });
-  navigationController.updateButtons(getNavigationRefs());
-}
-
-function openWorkspace(pageId, { focus = true, recordHistory = true } = {}) {
-  if (!pageId) return;
-  const resolved = findPageById(pageId) || findPageBySlug(pageId);
-  if (!resolved) return;
-  setActivePage(resolved.id, { recordHistory, focus, ensureTab: true });
-}
-
-function initTabs() {
-  initTabControls({ onSelectTab: handleTabSelect, onCloseTab: handleTabClose });
-}
-
-function initNavigation() {
-  const { backButton, forwardButton, refreshButton } = getNavigationRefs();
-  if (backButton) {
-    backButton.addEventListener('click', event => {
-      event.preventDefault();
-      navigationController.navigateBack(pageId => {
-        setActivePage(pageId, { recordHistory: false, focus: true, ensureTab: false });
-      });
-    });
-  }
-
-  if (forwardButton) {
-    forwardButton.addEventListener('click', event => {
-      event.preventDefault();
-      navigationController.navigateForward(pageId => {
-        setActivePage(pageId, { recordHistory: false, focus: true, ensureTab: false });
-      });
-    });
-  }
-
-  if (refreshButton) {
-    refreshButton.addEventListener('click', refreshActivePage);
-  }
-
-  const controls = getSessionControls();
-  if (controls?.homeButton) {
-    controls.homeButton.addEventListener('click', () =>
-      setActivePage(HOMEPAGE_ID, { focus: true, ensureTab: false })
-    );
-  }
-
-  const address = getElement('browserAddress') || {};
-  if (address.form) {
-    const handler = navigationController.createAddressSubmitHandler({
-      getValue: () => String(address.input?.value || ''),
-      setValue: value => {
-        if (address.input) {
-          address.input.value = value;
-        }
-      },
-      onNavigate: pageId => setActivePage(pageId),
-      findPageById,
-      findPageBySlug,
-      formatAddress: page => buildWorkspaceUrl(page)
-    });
-    address.form.addEventListener('submit', handler);
-  }
-
-  const siteList = getElement('siteList');
-  if (siteList) {
-    siteList.addEventListener('click', handleSiteClick);
-  }
-
-  const homepage = getHomepageElement();
-  if (homepage) {
-    homepage.addEventListener('click', handleSiteClick);
-  }
-
-  setActivePage(navigationController.getCurrentPage(), {
-    recordHistory: false,
-    ensureTab: false
-  });
-  navigationController.updateButtons(getNavigationRefs());
-}
-
-function initControls() {
-  initTabs();
-  initNavigation();
-  initThemeControls();
-}
-
-function applyHustleFilters(model = {}) {
-  const list = document.querySelector('[data-role="browser-hustle-list"]');
-  if (!list) return;
-  const cards = Array.from(list.querySelectorAll('[data-hustle]'));
-  const cardMap = new Map(cards.map(card => [card.dataset.hustle, card]));
-  const fragment = document.createDocumentFragment();
-  const orderedIds = Array.isArray(model.orderedIds) ? model.orderedIds : [];
-  const hiddenSet = new Set(Array.isArray(model.hiddenIds) ? model.hiddenIds : []);
-
-  orderedIds.forEach(id => {
-    const card = cardMap.get(id);
-    if (!card) return;
-    card.hidden = hiddenSet.has(id);
-    fragment.appendChild(card);
-    cardMap.delete(id);
-    hiddenSet.delete(id);
-  });
-
-  cardMap.forEach((card, id) => {
-    const hidden = hiddenSet.has(id);
-    card.hidden = hidden;
-    fragment.appendChild(card);
-  });
-
-  list.appendChild(fragment);
-}
-
-function applyUpgradeFilters(model = {}) {
-  const hiddenSet = new Set(Array.isArray(model.hiddenIds) ? model.hiddenIds : []);
-  const visibleSet = new Set(Array.isArray(model.visibleIds) ? model.visibleIds : []);
-  document.querySelectorAll('[data-upgrade]').forEach(card => {
-    const id = card.dataset.upgrade;
-    if (!id) return;
-    if (hiddenSet.has(id)) {
-      card.hidden = true;
-      return;
-    }
-    if (visibleSet.size && !visibleSet.has(id)) {
-      card.hidden = true;
-      return;
-    }
-    card.hidden = false;
-  });
-}
-
-function applyStudyFilters(model = {}) {
-  const hiddenSet = new Set(Array.isArray(model.hiddenIds) ? model.hiddenIds : []);
-  const visibleSet = new Set(Array.isArray(model.visibleIds) ? model.visibleIds : []);
-  document.querySelectorAll('[data-track]').forEach(card => {
-    const id = card.dataset.track;
-    if (!id) return;
-    if (hiddenSet.has(id)) {
-      card.hidden = true;
-      return;
-    }
-    if (visibleSet.size && !visibleSet.has(id)) {
-      card.hidden = true;
-      return;
-    }
-    card.hidden = false;
-  });
-}
-
-function applyFilters(model = {}) {
-  if (!model) return;
-  applyHustleFilters(model.hustles);
-  applyUpgradeFilters(model.upgrades);
-  applyStudyFilters(model.study);
-}
+});
 
 const layoutPresenter = {
-  initControls,
-  applyFilters
+  initControls() {
+    tabSessionController.init();
+    navigationEventsController.init();
+    initThemeControls();
+  },
+  applyFilters: workspaceManager.applyFilters
 };
 
 export default layoutPresenter;
 
 export function setWorkspacePath(pageId, path) {
-  setWorkspacePathDom(pageId, path);
-  if (navigationController.getCurrentPage() === pageId) {
-    updateAddressBar(findPageById(pageId));
-  }
+  workspaceManager.setWorkspacePath(pageId, path);
 }


### PR DESCRIPTION
## Summary
- extract viewport, workspace view, tab session, and navigation event responsibilities from the browser layout presenter into dedicated modules
- orchestrate the new controllers inside a slimmed-down presenter while preserving existing workspace filter utilities

## Testing
- npm test
- Manual browser walkthrough (not run in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5693c3b74832c8dde79cb797721b2