### PR TITLE
Remove unused hustle market config helper

### DIFF
--- a/src/game/data/hustleMarketConfig.js
+++ b/src/game/data/hustleMarketConfig.js
@@ -81,11 +81,3 @@ export function getHustleMarketConfig(key, baseConfig = {}) {
   return config ? structuredClone(config) : null;
 }
 
-export function getAllHustleMarketConfigs(baseConfigs = {}) {
-  const entries = Object.entries(MARKET_BUILDERS).map(([key, builder]) => {
-    const base = baseConfigs[key] || {};
-    const config = builder(base);
-    return [key, config ? structuredClone(config) : null];
-  });
-  return Object.fromEntries(entries);
-}


### PR DESCRIPTION
## Summary
- remove the unused `getAllHustleMarketConfigs` helper from the hustle market data module

## Testing
- npm test -- tests/hustleMarket.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e57db52778832ca8769c0cdb1ab1d8