### PR TITLE
Remove hustle market compatibility helpers

### DIFF
--- a/src/core/state/slices/actionMarket/state.js
+++ b/src/core/state/slices/actionMarket/state.js
@@ -231,18 +231,6 @@ export function clearActionMarketCategoryState(state, category = 'default') {
   categoryState.accepted = [];
 }
 
-export function createDefaultHustleMarketStateCompatibility() {
-  return createDefaultActionMarketCategoryState({ category: 'hustle' });
-}
-
-export function cloneHustleMarketStateCompatibility(state) {
-  return cloneActionMarketCategoryState(state, 'hustle');
-}
-
-export function clearHustleMarketStateCompatibility(state) {
-  clearActionMarketCategoryState(state, 'hustle');
-}
-
 export function createAcceptedEntryForCategory(offer, details = {}, {
   fallbackDay = 1,
   category


### PR DESCRIPTION
## Summary
- remove the hustle market compatibility helper exports from the action market state slice
- rely on the dedicated hustle compatibility module for hustle-specific state management

## Testing
- `npm test -- tests/hustleMarket.test.js`

## Manual Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e57db90e38832c883f5089086686f6