### PR TITLE
refactor: share hustle detection helper

### DIFF
--- a/src/core/state/registry.js
+++ b/src/core/state/registry.js
@@ -5,39 +5,9 @@ import {
   getUpgradeDefinition as getUpgradeDefinitionFromService,
   getMetricDefinition as getMetricDefinitionFromService
 } from '../../game/registryService.js';
+import { isHustleDefinition } from '../../game/registryShared.js';
 
 let registry = { actions: [], hustles: [], assets: [], upgrades: [] };
-
-function isHustleDefinition(definition) {
-  if (!definition || typeof definition !== 'object') {
-    return false;
-  }
-  const category = typeof definition.category === 'string'
-    ? definition.category.trim().toLowerCase()
-    : null;
-  if (category === 'hustle') {
-    return true;
-  }
-  const templateKind = typeof definition.templateKind === 'string'
-    ? definition.templateKind.trim().toLowerCase()
-    : null;
-  if (templateKind === 'hustle') {
-    return true;
-  }
-  const type = typeof definition.type === 'string'
-    ? definition.type.trim().toLowerCase()
-    : null;
-  if (type === 'hustle') {
-    return true;
-  }
-  if (definition.market) {
-    return true;
-  }
-  const tagType = typeof definition.tag?.type === 'string'
-    ? definition.tag.type.trim().toLowerCase()
-    : null;
-  return tagType === 'instant';
-}
 
 function deriveHustles(actions = [], fallback = []) {
   if (!Array.isArray(actions) || !actions.length) {

--- a/src/game/registryService.js
+++ b/src/game/registryService.js
@@ -1,41 +1,11 @@
 import { attachRegistryMetricIds, buildMetricIndex } from './schema/metrics.js';
+import { isHustleDefinition } from './registryShared.js';
 
 let registrySnapshot = null;
 let actionMap = new Map();
 let assetMap = new Map();
 let upgradeMap = new Map();
 let metricIndex = new Map();
-
-function isHustleDefinition(definition) {
-  if (!definition || typeof definition !== 'object') {
-    return false;
-  }
-  const category = typeof definition.category === 'string'
-    ? definition.category.trim().toLowerCase()
-    : null;
-  if (category === 'hustle') {
-    return true;
-  }
-  const templateKind = typeof definition.templateKind === 'string'
-    ? definition.templateKind.trim().toLowerCase()
-    : null;
-  if (templateKind === 'hustle') {
-    return true;
-  }
-  const type = typeof definition.type === 'string'
-    ? definition.type.trim().toLowerCase()
-    : null;
-  if (type === 'hustle') {
-    return true;
-  }
-  if (definition.market) {
-    return true;
-  }
-  const tagType = typeof definition.tag?.type === 'string'
-    ? definition.tag.type.trim().toLowerCase()
-    : null;
-  return tagType === 'instant';
-}
 
 function deriveHustleView(actions = [], fallback = []) {
   if (!Array.isArray(actions) || !actions.length) {

--- a/src/game/registryShared.js
+++ b/src/game/registryShared.js
@@ -1,0 +1,32 @@
+export function isHustleDefinition(definition) {
+  if (!definition || typeof definition !== 'object') {
+    return false;
+  }
+  const category = typeof definition.category === 'string'
+    ? definition.category.trim().toLowerCase()
+    : null;
+  if (category === 'hustle') {
+    return true;
+  }
+  const templateKind = typeof definition.templateKind === 'string'
+    ? definition.templateKind.trim().toLowerCase()
+    : null;
+  if (templateKind === 'hustle') {
+    return true;
+  }
+  const type = typeof definition.type === 'string'
+    ? definition.type.trim().toLowerCase()
+    : null;
+  if (type === 'hustle') {
+    return true;
+  }
+  if (definition.market) {
+    return true;
+  }
+  const tagType = typeof definition.tag?.type === 'string'
+    ? definition.tag.type.trim().toLowerCase()
+    : null;
+  return tagType === 'instant';
+}
+
+export default isHustleDefinition;


### PR DESCRIPTION
## Summary
- add a shared helper for identifying hustle definitions
- update registry service and state modules to consume the shared helper

## Testing
- npm test -- tests/registryConsistency.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e57dcdeff8832c89a82976115ffab9