### PR TITLE
Remove deprecated HUSTLES alias

### DIFF
--- a/src/game/hustles.js
+++ b/src/game/hustles.js
@@ -25,7 +25,6 @@ import { markDirty } from '../core/events/invalidationBus.js';
 import { abandonActionInstance } from './actions/progress/instances.js';
 
 export const HUSTLE_TEMPLATES = [...INSTANT_ACTIONS, ...STUDY_ACTIONS];
-export const HUSTLES = HUSTLE_TEMPLATES;
 export const KNOWLEDGE_HUSTLES = STUDY_ACTIONS;
 
 const HUSTLE_ACTION_CATEGORY = 'hustle';


### PR DESCRIPTION
## Summary
- remove the deprecated `HUSTLES` alias export from the hustles module to avoid redundant naming

## Testing
- npm test -- tests/hustles.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e57dd0fd78832cbe9fe369c7d03880