### PR TITLE
Prevent duplicate study enrollment logs when orchestrator handles messaging

### DIFF
--- a/src/game/hustles/knowledge/enrollment.js
+++ b/src/game/hustles/knowledge/enrollment.js
@@ -106,9 +106,16 @@ export function createStudyAcceptHook(track) {
         });
       }
 
+      const orchestratorHandlesMessaging = Boolean(
+        metadata?.enrollment?.orchestratorHandlesMessaging
+          || acceptedEntry?.metadata?.enrollment?.orchestratorHandlesMessaging
+      );
+
       syncInstanceProgress({ instance, track });
 
-      announceStudyEnrollment(track, tuition);
+      if (!orchestratorHandlesMessaging) {
+        announceStudyEnrollment(track, tuition);
+      }
       markStudySectionsDirty();
 
       if (instance && typeof instance === 'object') {


### PR DESCRIPTION
## Summary
- skip the study enrollment celebratory log when the orchestrator already promised to handle messaging

## Testing
- `npm test -- tests/requirements.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68e58f35abdc832cabe2527b6d9538fe