### PR TITLE
Filter todo fallback to DownWork hustles

### DIFF
--- a/tests/ui/actions/fallbacks/findFreelanceWork.test.js
+++ b/tests/ui/actions/fallbacks/findFreelanceWork.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { __testables as findFreelanceTestables } from '../../../../src/ui/actions/fallbacks/findFreelanceWork.js';
+
+const { isOfferDownworkAligned } = findFreelanceTestables;
+
+test('isOfferDownworkAligned rejects study-aligned offers', () => {
+  const template = {
+    id: 'study-template',
+    category: 'study',
+    tag: { type: 'study' },
+    progress: { type: 'study' },
+    market: { category: 'study' }
+  };
+  const offer = {
+    templateId: template.id,
+    templateCategory: 'study',
+    metadata: { templateCategory: 'study' }
+  };
+
+  assert.equal(isOfferDownworkAligned(offer, template), false);
+});
+
+test('isOfferDownworkAligned accepts hustle-aligned offers', () => {
+  const template = {
+    id: 'freelance-template',
+    category: 'writing',
+    tag: { type: 'instant' },
+    progress: { type: 'instant' },
+    market: { category: 'writing' }
+  };
+  const offer = {
+    templateId: template.id,
+    templateCategory: 'writing',
+    metadata: { templateCategory: 'writing' }
+  };
+
+  assert.equal(isOfferDownworkAligned(offer, template), true);
+});


### PR DESCRIPTION
## Summary
- filter the DownWork fallback so study-aligned offers are ignored by the todo widget
- expose the alignment helper for tests and cover the new filtering logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e596214df4832c98d79acf7f3d990d