### PR TITLE
Flatten DownWork hustle cards

### DIFF
--- a/src/ui/cards/model/hustles.js
+++ b/src/ui/cards/model/hustles.js
@@ -32,18 +32,9 @@ function formatCategoryLabel(value) {
 function buildDescriptorCopy(categoryLabel) {
   const noun = (categoryLabel || 'action').toLowerCase();
   return {
-    ready: {
-      title: 'Ready to accept',
-      description: `Claim your next ${noun} and keep your worklist humming.`
-    },
-    upcoming: {
-      title: 'Queued for later',
-      description: `These ${noun} leads unlock with tomorrow's refresh. Prep so you can accept quickly.`
-    },
-    commitments: {
-      title: 'In progress',
-      description: `Step 2 • Work: Log hours until this ${noun} is complete.`
-    }
+    ready: {},
+    upcoming: {},
+    commitments: {}
   };
 }
 
@@ -414,7 +405,7 @@ export default function buildHustleModels(definitions = [], helpers = {}) {
     };
     const actionCategory = descriptors.category || normalizedCategory;
     const categoryNoun = (descriptors.categoryLabel || 'Action').toLowerCase();
-    const defaultReadyGuidance = `Claim your next ${categoryNoun} to keep momentum rolling.`;
+    const defaultReadyGuidance = `Queue this ${categoryNoun} whenever you're ready.`;
     const defaultWaitingGuidance = `Next wave unlocks tomorrow. Prep now so you can jump in fast.`;
     const defaultRerollGuidance = `Need something now? Roll a fresh ${categoryNoun} to keep work flowing.`;
     const defaultEmptyGuidance = `Fresh leads roll in with tomorrow's refresh. Queue the next ${categoryNoun} to stay sharp.`;

--- a/src/ui/views/browser/apps/hustles/index.js
+++ b/src/ui/views/browser/apps/hustles/index.js
@@ -1059,15 +1059,9 @@ function resolveFocusHoursLeft(context = {}, models = []) {
 }
 
 const DEFAULT_COPY = {
-  ready: {
-    title: 'Open contracts'
-  },
-  upcoming: {
-    title: 'Opening soon'
-  },
-  commitments: {
-    title: 'In progress'
-  }
+  ready: {},
+  upcoming: {},
+  commitments: {}
 };
 
 function mergeCopy(base = {}, overrides = {}) {
@@ -1078,23 +1072,9 @@ function mergeCopy(base = {}, overrides = {}) {
   };
 }
 
-function createCardSection(copy = {}) {
+function createCardSection(_copy = {}) {
   const section = document.createElement('section');
-  section.className = 'browser-card__section';
-
-  if (copy.title) {
-    const heading = document.createElement('h3');
-    heading.className = 'browser-card__section-title';
-    heading.textContent = copy.title;
-    section.appendChild(heading);
-  }
-
-  if (copy.description) {
-    const note = document.createElement('p');
-    note.className = 'browser-card__section-note';
-    note.textContent = copy.description;
-    section.appendChild(note);
-  }
+  section.className = 'browser-card__section downwork-card__group';
 
   return section;
 }
@@ -1360,19 +1340,6 @@ export function createOfferCard(entry = {}) {
   const hasSkillTag = typeof detailModel.tag?.label === 'string' && /skill/i.test(detailModel.tag.label);
   card.dataset.skillXp = hasSkillBadge || hasSkillTag ? 'true' : 'false';
 
-  const meta = document.createElement('p');
-  meta.className = 'browser-card__meta';
-  meta.textContent = (() => {
-    const candidates = [
-      detailModel?.requirements?.summary,
-      offer?.requirements?.summary,
-      model?.requirements?.summary
-    ];
-    const summary = candidates.find(value => typeof value === 'string' && value.trim().length > 0);
-    return summary || 'No requirements';
-  })();
-  card.appendChild(meta);
-
   const seatSummary =
     typeof detailModel?.seat?.summary === 'string' && detailModel.seat.summary.trim().length > 0
       ? detailModel.seat.summary
@@ -1384,19 +1351,6 @@ export function createOfferCard(entry = {}) {
     seat.className = 'browser-card__note';
     seat.textContent = seatSummary;
     card.appendChild(seat);
-  }
-
-  const limitSummary =
-    typeof detailModel?.limit?.summary === 'string' && detailModel.limit.summary.trim().length > 0
-      ? detailModel.limit.summary
-      : typeof offer?.limit?.summary === 'string' && offer.limit.summary.trim().length > 0
-        ? offer.limit.summary
-        : null;
-  if (limitSummary) {
-    const limit = document.createElement('p');
-    limit.className = 'browser-card__note';
-    limit.textContent = limitSummary;
-    card.appendChild(limit);
   }
 
   const offerAction = offer && typeof offer.action === 'object' && offer.action !== null ? offer.action : null;

--- a/styles/widgets/widgets.css
+++ b/styles/widgets/widgets.css
@@ -950,6 +950,15 @@
   margin-top: 1.25rem;
 }
 
+.downwork-card__group {
+  gap: 0.85rem;
+  margin-top: 1rem;
+}
+
+.downwork-card__group:first-of-type {
+  margin-top: 0.9rem;
+}
+
 .browser-card__section-title {
   margin: 0;
   font-size: 1rem;

--- a/tests/ui/cardsModel.test.js
+++ b/tests/ui/cardsModel.test.js
@@ -173,7 +173,7 @@ test('buildHustleModels prefers accepting ready offers and queues upcoming separ
   assert.equal(readyModel.action.label, 'Accept Ready Offer');
   assert.equal(readyModel.action.disabled, false);
   assert.equal(readyModel.action.className, 'primary');
-  assert.match(readyModel.action.guidance, /Claim your next/i);
+  assert.match(readyModel.action.guidance, /Queue this/i);
 
   const upcomingModel = models.find(entry => entry.offerId === 'offer-upcoming');
   assert.ok(upcomingModel, 'expected upcoming offer model');

--- a/tests/ui/views/browser/hustlesApp.test.js
+++ b/tests/ui/views/browser/hustlesApp.test.js
@@ -252,7 +252,7 @@ test('renderHustles renders unified offer feed with metrics, CTA wiring, and fil
         label: 'Accept Ready Offer',
         className: 'primary',
         onClick: () => actionLog.push('model-action'),
-        guidance: 'Fresh hustles just landed! Claim your next gig and keep momentum rolling.'
+        guidance: 'Fresh hustles just landed! Queue your next gig whenever you\'re ready.'
       }
     },
     {
@@ -278,7 +278,7 @@ test('renderHustles renders unified offer feed with metrics, CTA wiring, and fil
     roiValue: 30
   });
   const writingGuidance =
-    'Fresh hustles just landed! Claim your next gig and keep momentum rolling.';
+    'Fresh hustles just landed! Queue your next gig whenever you\'re ready.';
 
   const models = [
     createOfferModel({
@@ -561,12 +561,7 @@ test('renderHustles renders unified offer feed with metrics, CTA wiring, and fil
       const tags = card.querySelectorAll('.downwork-card__tag');
       assert.ok(tags.length > 0, `expected tags for ${label || 'card'}`);
       const requirements = card.querySelector('.browser-card__meta');
-      assert.ok(requirements, `expected requirement summary for ${label || 'card'}`);
-      if (expectation) {
-        assert.equal(requirements.textContent, expectation.requirements);
-      } else {
-        assert.ok(requirements.textContent.trim().length > 0, 'expected requirement text to render');
-      }
+      assert.equal(requirements, null, `expected requirements to stay hidden for ${label || 'card'}`);
     });
 
     const writingCards = cards.filter(card => card.dataset.category === 'writing');
@@ -591,10 +586,7 @@ test('renderHustles renders unified offer feed with metrics, CTA wiring, and fil
     assert.equal(topSummary.textContent, 'Deliver thought leadership threads with quick turnaround.');
     assert.equal(topCard.querySelectorAll('.browser-card__badge').length, 2, 'expected high payout card badges');
     assert.equal(topCard.querySelectorAll('.downwork-card__tag').length, 2, 'expected high payout card tags');
-    assert.equal(
-      topCard.querySelector('.browser-card__meta')?.textContent,
-      'Requires writing samples and onboarding call.'
-    );
+    assert.equal(topCard.querySelector('.browser-card__meta'), null);
     assert.equal(topCard.querySelectorAll('.hustle-card__offer').length, 1, 'expected high payout card to show one ready offer');
     assert.equal(
       topCard.querySelectorAll('.hustle-card__offer.is-upcoming').length,
@@ -611,15 +603,13 @@ test('renderHustles renders unified offer feed with metrics, CTA wiring, and fil
     assert.equal(nextSummary.textContent, 'Repurpose newsletters into punchy social updates.');
     assert.equal(nextCard.querySelectorAll('.browser-card__badge').length, 2, 'expected second card badges');
     assert.equal(nextCard.querySelectorAll('.downwork-card__tag').length, 2, 'expected second card tags');
+    assert.equal(nextCard.querySelector('.browser-card__meta'), null);
+    const commitmentItems = nextCard.querySelectorAll('.hustle-card__commitment');
+    assert.ok(commitmentItems.length > 0, 'expected second card to surface commitment entries');
     assert.equal(
-      nextCard.querySelector('.browser-card__meta')?.textContent,
-      'Requires two focus sprints available.'
-    );
-    assert.ok(
-      [...nextCard.querySelectorAll('.browser-card__section-title')].some(
-        node => node.textContent === 'In progress'
-      ),
-      'expected second card to surface commitment section'
+      nextCard.querySelectorAll('.browser-card__section-title').length,
+      0,
+      'expected lean layout to omit commitment headings'
     );
 
     const priorityUpcomingCard = writingCards.find(card => card.dataset.available === 'false');
@@ -631,9 +621,9 @@ test('renderHustles renders unified offer feed with metrics, CTA wiring, and fil
       'expected upcoming card to render a single queued offer'
     );
     assert.equal(
-      priorityUpcomingCard.querySelector('.browser-card__section-title')?.textContent,
-      'Opening soon',
-      'expected upcoming card to retain upcoming section heading'
+      priorityUpcomingCard.querySelectorAll('.browser-card__section-title').length,
+      0,
+      'expected upcoming card to render without extra section headings'
     );
 
     const upcomingCard = cards.find(card => card.dataset.category === 'community');
@@ -641,10 +631,10 @@ test('renderHustles renders unified offer feed with metrics, CTA wiring, and fil
     assert.equal(upcomingCard.dataset.available, 'false');
     assert.equal(upcomingCard.dataset.offerLabel, 'Community Warmup Sprint');
     assert.ok(upcomingCard.querySelector('.browser-card__summary'), 'expected community summary');
-    assert.ok(
-      [...upcomingCard.querySelectorAll('.browser-card__section-title')]
-        .some(node => node.textContent === 'Opening soon'),
-      'expected community card to surface opening soon section'
+    assert.equal(
+      upcomingCard.querySelectorAll('.browser-card__section-title').length,
+      0,
+      'expected community card to flatten upcoming layout'
     );
 
     writingFilter.click();
@@ -985,9 +975,13 @@ test('renderHustles renders multiple upcoming-only offers without duplication', 
     });
 
     cards.forEach(card => {
-      const upcomingHeadings = [...card.querySelectorAll('.browser-card__section-title')]
-        .filter(node => node.textContent === 'Opening soon');
-      assert.equal(upcomingHeadings.length, 1, 'expected a single upcoming section per card');
+      const upcomingOffers = card.querySelectorAll('.hustle-card__offer.is-upcoming');
+      assert.equal(upcomingOffers.length, 1, 'expected a single upcoming offer per card');
+      assert.equal(
+        card.querySelectorAll('.browser-card__section-title').length,
+        0,
+        'expected upcoming cards to render without section headings'
+      );
     });
   } finally {
     dom.window.close();
@@ -1270,7 +1264,7 @@ test('renderHustles falls back to empty-state language when no offers exist', ()
     const placeholderSummary = placeholderCard?.querySelector('.browser-card__summary');
     assert.equal(placeholderSummary?.textContent, 'Waiting on the next drop.');
     const placeholderRequirements = placeholderCard?.querySelector('.browser-card__meta');
-    assert.equal(placeholderRequirements?.textContent, 'No requirements');
+    assert.equal(placeholderRequirements, null);
     assert.ok(!list?.querySelector('.browser-empty--compact'), 'expected placeholder card instead of empty message');
 
     const button = document.querySelector('.browser-card__actions .browser-card__button');


### PR DESCRIPTION
## Summary
- flatten the DownWork hustle offer cards by removing section headers and requirement metadata
- update copy and styling to keep the layout lean while adjusting default guidance
- refresh UI and model tests to match the streamlined presentation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fbce3223f8832c81c929804acf0cbc