### PR TITLE
Rework blog visit base formula

### DIFF
--- a/tests/assetVisits.test.js
+++ b/tests/assetVisits.test.js
@@ -19,6 +19,9 @@ function setupActiveBlog() {
   assetState.instances = [instance];
   instance.maintenanceFundedToday = true;
   instance.quality.level = 3;
+  instance.quality.progress.posts = 18;
+  instance.metrics.seoScore = 62;
+  instance.metrics.backlinks = 4;
   return { blogDefinition, assetState, instance };
 }
 
@@ -70,4 +73,29 @@ test('endDay rolls daily visit progress into lifetime totals', () => {
     'lifetime views should include the full day worth of visits'
   );
   assert.equal(metrics.lastViewBreakdown?.total || 0, Math.round(visitsPerDay));
+});
+
+test('blog visit projections respond to content and backlinks', () => {
+  const baseline = setupActiveBlog();
+  const baseVisits = computeProjectedDailyVisits({
+    definition: baseline.blogDefinition,
+    assetState: baseline.assetState,
+    instance: baseline.instance
+  });
+
+  // Expand the blog footprint with more posts, stronger SEO, and extra backlinks
+  baseline.instance.quality.progress.posts = 36;
+  baseline.instance.metrics.seoScore = 85;
+  baseline.instance.metrics.backlinks = 12;
+  const boostedVisits = computeProjectedDailyVisits({
+    definition: baseline.blogDefinition,
+    assetState: baseline.assetState,
+    instance: baseline.instance
+  });
+
+  assert.ok(baseVisits > 0, 'baseline blog should generate traffic');
+  assert.ok(
+    boostedVisits > baseVisits,
+    `expected boosted metrics to increase visits (baseline=${baseVisits}, boosted=${boostedVisits})`
+  );
 });


### PR DESCRIPTION
## Summary
- implement a blog-specific base visit calculation driven by posts, SEO, and backlinks while preserving downstream modifiers
- infer content counts from quality levels when progress is missing and fall back safely on legacy scaling
- extend visit projection tests with seeded metrics and coverage for scaling behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fbcd0846a0832c8eb681bc5683dfce