### PR TITLE
Flatten DownWork offer cards

### DIFF
--- a/src/ui/views/browser/apps/hustles/index.js
+++ b/src/ui/views/browser/apps/hustles/index.js
@@ -2,7 +2,7 @@ import { formatHours, formatMoney } from '../../../../../core/helpers.js';
 import { getState } from '../../../../../core/state.js';
 import { getPageByType } from '../pageLookup.js';
 import { formatRoi } from '../../components/widgets.js';
-import { createOfferList } from './offers.js';
+import { createOfferItem } from './offers.js';
 import { createCommitmentList } from './commitments.js';
 import {
   ASSISTANT_CONFIG,
@@ -1058,27 +1058,6 @@ function resolveFocusHoursLeft(context = {}, models = []) {
   return Math.max(0, fallback);
 }
 
-const DEFAULT_COPY = {
-  ready: {},
-  upcoming: {},
-  commitments: {}
-};
-
-function mergeCopy(base = {}, overrides = {}) {
-  return {
-    ready: { ...DEFAULT_COPY.ready, ...base.ready, ...overrides.ready },
-    upcoming: { ...DEFAULT_COPY.upcoming, ...base.upcoming, ...overrides.upcoming },
-    commitments: { ...DEFAULT_COPY.commitments, ...base.commitments, ...overrides.commitments }
-  };
-}
-
-function createCardSection(_copy = {}) {
-  const section = document.createElement('section');
-  section.className = 'browser-card__section downwork-card__group';
-
-  return section;
-}
-
 export function describeMetaSummary({ potentialPayout = 0, acceptedCommitments = 0 } = {}) {
   const payout = Number.isFinite(potentialPayout) ? Math.max(0, potentialPayout) : 0;
   const commitments = Number.isFinite(acceptedCommitments)
@@ -1107,7 +1086,6 @@ export function createOfferCard(entry = {}) {
     definition = {},
     model = {},
     descriptorOverrides = {},
-    copyOverrides = {},
     categoryConfig = DEFAULT_CATEGORY_CONFIG,
     categoryKey = '',
     hustleId = '',
@@ -1133,8 +1111,6 @@ export function createOfferCard(entry = {}) {
       : {}),
     ...(typeof descriptorOverrides === 'object' && descriptorOverrides !== null ? descriptorOverrides : {})
   };
-
-  const copy = mergeCopy(descriptorBundle.copy, copyOverrides);
 
   const card = document.createElement('article');
   card.className = 'browser-card browser-card--action browser-card--hustle downwork-card';
@@ -1411,14 +1387,14 @@ export function createOfferCard(entry = {}) {
   }
 
   if (Array.isArray(commitments) && commitments.length > 0) {
-    const commitmentsSection = createCardSection(copy.commitments);
     const list = createCommitmentList(commitments);
-    commitmentsSection.appendChild(list);
-    card.appendChild(commitmentsSection);
+    const wrapper = document.createElement('div');
+    wrapper.className = 'downwork-card__commitments';
+    wrapper.appendChild(list);
+    card.appendChild(wrapper);
   }
 
   if (offer) {
-    const primarySection = createCardSection(status === 'ready' ? copy.ready : copy.upcoming);
     const offerModel =
       detailModel === model
         ? model
@@ -1427,9 +1403,9 @@ export function createOfferCard(entry = {}) {
     if (status !== 'ready') {
       offerOptions.upcoming = true;
     }
-    const primaryList = createOfferList([offer], offerOptions);
-    primarySection.appendChild(primaryList);
-    card.appendChild(primarySection);
+    const offerCard = createOfferItem(offer, offerOptions);
+    offerCard.classList.add('downwork-card__offer');
+    card.appendChild(offerCard);
   }
 
   if (expiryCandidates.length) {

--- a/src/ui/views/browser/apps/hustles/offers.js
+++ b/src/ui/views/browser/apps/hustles/offers.js
@@ -25,8 +25,8 @@ export function createOfferItem(
   offer = {},
   { upcoming = false, onAccept, model, actionModel } = {}
 ) {
-  const item = document.createElement('li');
-  item.className = 'browser-card__list-item hustle-card__offer downwork-marketplace__offer downwork-offer';
+  const item = document.createElement('article');
+  item.className = 'downwork-offer downwork-marketplace__offer';
 
   if (!offer.ready || upcoming) {
     item.classList.add('is-upcoming');
@@ -34,28 +34,58 @@ export function createOfferItem(
 
   decorateUrgency(item, offer.expiresIn);
 
-  const header = document.createElement('div');
-  header.className = 'downwork-offer__header';
+  const topRow = document.createElement('div');
+  topRow.className = 'downwork-offer__top';
 
-  const titleBlock = document.createElement('div');
-  titleBlock.className = 'downwork-offer__title';
-
-  const title = document.createElement('span');
-  title.className = 'hustle-card__title';
+  const title = document.createElement('h3');
+  title.className = 'downwork-offer__title';
   title.textContent = offer.label || 'Contract offer';
-  titleBlock.appendChild(title);
+  topRow.appendChild(title);
 
-  if (offer.payout) {
+  const payoutValue = resolvePayout(offer, model);
+  if (Number.isFinite(payoutValue) && payoutValue > 0) {
     const payout = document.createElement('span');
     payout.className = 'downwork-offer__value';
-    payout.textContent = `$${formatMoney(offer.payout)}`;
-    titleBlock.appendChild(payout);
+    payout.textContent = `$${formatMoney(payoutValue)}`;
+    topRow.appendChild(payout);
   }
 
-  header.appendChild(titleBlock);
+  item.appendChild(topRow);
 
-  const actionWrapper = document.createElement('div');
-  actionWrapper.className = 'downwork-offer__actions';
+  const metrics = [];
+  if (Number.isFinite(payoutValue) && payoutValue > 0) {
+    metrics.push(`💵 $${formatMoney(payoutValue)}`);
+  }
+  const focusHours = resolveFocusHours(offer, model);
+  if (Number.isFinite(focusHours) && focusHours > 0) {
+    metrics.push(`⏱️ ${focusHours === 1 ? '1 hour' : `${focusHours} hours`}`);
+  }
+
+  if (metrics.length > 0) {
+    const metricRow = document.createElement('div');
+    metricRow.className = 'downwork-offer__metrics';
+    metrics.forEach(entry => {
+      const chip = document.createElement('span');
+      chip.className = 'downwork-offer__metric';
+      chip.textContent = entry;
+      metricRow.appendChild(chip);
+    });
+    item.appendChild(metricRow);
+  }
+
+  if (offer.description) {
+    const summary = document.createElement('p');
+    summary.className = 'downwork-offer__description';
+    summary.textContent = offer.description;
+    item.appendChild(summary);
+  }
+
+  if (offer.meta) {
+    const meta = document.createElement('p');
+    meta.className = 'downwork-offer__meta';
+    meta.textContent = offer.meta;
+    item.appendChild(meta);
+  }
 
   const button = document.createElement('button');
   button.type = 'button';
@@ -106,40 +136,7 @@ export function createOfferItem(
     }
   }
 
-  actionWrapper.appendChild(button);
-  header.appendChild(actionWrapper);
-  item.appendChild(header);
-
-  const stats = [];
-  const payout = resolvePayout(offer, model);
-  if (Number.isFinite(payout) && payout > 0) {
-    stats.push(`💵 $${formatMoney(payout)}`);
-  }
-  const focusHours = resolveFocusHours(offer, model);
-  if (Number.isFinite(focusHours) && focusHours > 0) {
-    stats.push(`⏱️ ${focusHours === 1 ? '1 hour' : `${focusHours} hours`}`);
-  }
-
-  if (stats.length > 0) {
-    const statList = document.createElement('p');
-    statList.className = 'downwork-offer__stats';
-    statList.textContent = stats.join(' • ');
-    item.appendChild(statList);
-  }
-
-  if (offer.description) {
-    const summary = document.createElement('p');
-    summary.className = 'hustle-card__description';
-    summary.textContent = offer.description;
-    item.appendChild(summary);
-  }
-
-  if (offer.meta) {
-    const meta = document.createElement('p');
-    meta.className = 'hustle-card__meta';
-    meta.textContent = offer.meta;
-    item.appendChild(meta);
-  }
+  item.appendChild(button);
 
   if (locked && offer.unlockHint) {
     const note = document.createElement('p');
@@ -152,9 +149,8 @@ export function createOfferItem(
 }
 
 export function createOfferList(offers = [], options = {}) {
-  const { upcoming = false } = options;
-  const list = document.createElement('ul');
-  list.className = 'browser-card__list downwork-marketplace__offer-list';
+  const list = document.createElement('div');
+  list.className = 'downwork-marketplace__offer-list';
 
   offers.filter(Boolean).forEach(offer => {
     const item = createOfferItem(offer, options);

--- a/styles/widgets/widgets.css
+++ b/styles/widgets/widgets.css
@@ -950,13 +950,15 @@
   margin-top: 1.25rem;
 }
 
-.downwork-card__group {
-  gap: 0.85rem;
+.downwork-card__commitments {
   margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
-.downwork-card__group:first-of-type {
-  margin-top: 0.9rem;
+.downwork-card__offer {
+  margin-top: 1.25rem;
 }
 
 .browser-card__section-title {
@@ -992,10 +994,17 @@
 }
 
 .downwork-offer {
-  gap: 0.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: var(--browser-radius-md);
+  border: 1px solid var(--browser-panel-border);
+  background: var(--browser-panel);
+  box-shadow: var(--browser-shadow-sm);
 }
 
-.downwork-offer__header {
+.downwork-offer__top {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
@@ -1003,40 +1012,55 @@
 }
 
 .downwork-offer__title {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.downwork-offer__value {
-  font-size: 0.95rem;
+  margin: 0;
+  font-size: 1rem;
   font-weight: 600;
   color: var(--browser-text);
 }
 
-.downwork-offer__actions {
+.downwork-offer__value {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--browser-accent, var(--browser-text));
+}
+
+.downwork-offer__metrics {
   display: flex;
-  align-items: center;
   flex-wrap: wrap;
   gap: 0.5rem;
 }
 
-.downwork-offer__button {
-  padding: 0.35rem 0.85rem;
-  font-size: 0.85rem;
-}
-
-.downwork-offer__stats {
-  margin: 0;
-  color: var(--browser-muted);
+.downwork-offer__metric {
+  padding: 0.3rem 0.55rem;
+  border-radius: var(--browser-radius-sm);
+  background: var(--browser-panel-elevated);
   font-size: 0.85rem;
   font-weight: 600;
+  color: var(--browser-muted-strong, var(--browser-muted));
+}
+
+.downwork-offer__description {
+  margin: 0;
+  color: var(--browser-text);
+  line-height: 1.45;
+}
+
+.downwork-offer__meta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--browser-muted);
+}
+
+.downwork-offer__button {
+  align-self: flex-start;
+  padding: 0.45rem 1rem;
+  font-size: 0.9rem;
 }
 
 .downwork-offer__hint {
   margin: 0;
-  color: var(--browser-muted);
   font-size: 0.85rem;
+  color: var(--browser-muted);
 }
 
 .downwork-marketplace__offer-list {

--- a/tests/ui/views/browser/apps/hustles/renderers.test.js
+++ b/tests/ui/views/browser/apps/hustles/renderers.test.js
@@ -66,7 +66,7 @@ test('createOfferList builds upcoming entries with lock hints', () => {
 
     document.body.appendChild(list);
 
-    const item = list.querySelector('.hustle-card__offer');
+    const item = list.querySelector('.downwork-offer');
     assert.ok(item, 'expected list item to render');
     assert.equal(item.classList.contains('is-upcoming'), true);
     assert.equal(item.classList.contains('is-warning'), false, 'no urgency tone for distant expiry');

--- a/tests/ui/views/browser/hustlesApp.test.js
+++ b/tests/ui/views/browser/hustlesApp.test.js
@@ -547,7 +547,7 @@ test('renderHustles renders unified offer feed with metrics, CTA wiring, and fil
     ]);
 
     cards.forEach(card => {
-      const label = card.dataset.offerLabel || card.querySelector('.hustle-card__title')?.textContent;
+      const label = card.dataset.offerLabel || card.querySelector('.downwork-offer__title')?.textContent;
       const expectation = label ? cardExpectations.get(label) : null;
       const summary = card.querySelector('.browser-card__summary');
       assert.ok(summary, `expected summary copy for ${label || 'card'}`);
@@ -587,9 +587,9 @@ test('renderHustles renders unified offer feed with metrics, CTA wiring, and fil
     assert.equal(topCard.querySelectorAll('.browser-card__badge').length, 2, 'expected high payout card badges');
     assert.equal(topCard.querySelectorAll('.downwork-card__tag').length, 2, 'expected high payout card tags');
     assert.equal(topCard.querySelector('.browser-card__meta'), null);
-    assert.equal(topCard.querySelectorAll('.hustle-card__offer').length, 1, 'expected high payout card to show one ready offer');
+    assert.equal(topCard.querySelectorAll('.downwork-offer').length, 1, 'expected high payout card to show one ready offer');
     assert.equal(
-      topCard.querySelectorAll('.hustle-card__offer.is-upcoming').length,
+      topCard.querySelectorAll('.downwork-offer.is-upcoming').length,
       0,
       'expected high payout card to omit nested upcoming offers'
     );
@@ -616,7 +616,7 @@ test('renderHustles renders unified offer feed with metrics, CTA wiring, and fil
     assert.ok(priorityUpcomingCard, 'expected upcoming writing card to render separately');
     assert.equal(priorityUpcomingCard.dataset.offerLabel, 'Scope Next Sprint');
     assert.equal(
-      priorityUpcomingCard.querySelectorAll('.hustle-card__offer').length,
+      priorityUpcomingCard.querySelectorAll('.downwork-offer').length,
       1,
       'expected upcoming card to render a single queued offer'
     );
@@ -657,7 +657,7 @@ test('renderHustles renders unified offer feed with metrics, CTA wiring, and fil
     const standaloneActions = nextCard.querySelector('.browser-card__actions');
     assert.equal(standaloneActions, null, 'expected inline offer layout to remove duplicate action bar');
 
-    const readyOfferButton = nextCard.querySelector('.hustle-card__offer:not(.is-upcoming) .browser-card__button');
+    const readyOfferButton = nextCard.querySelector('.downwork-offer:not(.is-upcoming) .browser-card__button');
     assert.ok(readyOfferButton, 'expected ready offer button to render');
     assert.equal(readyOfferButton.textContent, 'Queue this lead');
     readyOfferButton.click();
@@ -860,7 +860,7 @@ test('renderHustles omits locked offers from DownWork feed', () => {
     const cards = list ? [...list.querySelectorAll('.downwork-card')] : [];
     assert.equal(cards.length, 2, 'expected unlocked offers to render on separate cards');
 
-    const offerTitles = [...document.querySelectorAll('.hustle-card__title')]
+    const offerTitles = [...document.querySelectorAll('.downwork-offer__title')]
       .map(node => node.textContent.trim());
     assert.ok(offerTitles.includes('Open Ready Offer'), 'expected unlocked offer to remain visible');
     assert.ok(!offerTitles.includes('Locked Ready Offer'), 'expected locked offer to be hidden');
@@ -969,13 +969,13 @@ test('renderHustles renders multiple upcoming-only offers without duplication', 
     assert.equal(cards.length, upcomingOffers.length, 'expected one card per upcoming offer');
 
     upcomingOffers.forEach(offer => {
-      const occurrences = [...document.querySelectorAll('.hustle-card__title')]
+      const occurrences = [...document.querySelectorAll('.downwork-offer__title')]
         .filter(node => node.textContent.trim() === offer.label).length;
       assert.equal(occurrences, 1, `expected ${offer.label} to appear once`);
     });
 
     cards.forEach(card => {
-      const upcomingOffers = card.querySelectorAll('.hustle-card__offer.is-upcoming');
+      const upcomingOffers = card.querySelectorAll('.downwork-offer.is-upcoming');
       assert.equal(upcomingOffers.length, 1, 'expected a single upcoming offer per card');
       assert.equal(
         card.querySelectorAll('.browser-card__section-title').length,


### PR DESCRIPTION
## Summary
- redesign DownWork offer markup to render as a single flat card and drop nested sections
- refresh DownWork CSS to match the new layout, including stat chips and inline metadata styling
- update browser tests to target the new offer structure

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68fc87dfb784832c8c19a2c9ced87653